### PR TITLE
fix(Issue): #39 - Correct broken pkg.go.dev versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,3 +199,11 @@ jobs:
           # Push manifests to Docker Hub
           docker manifest push nickfedor/watchtower:latest
           docker manifest push nickfedor/watchtower:$(echo $TAG | sed 's/^v*//')
+
+  renew-docs:
+    name: Refresh pkg.go.dev
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Pull new module version
+      uses: andrewslotin/go-proxy-pull-action@89382de145eeb7a85de72f8a27f686a50727bc7a #master@v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/nicholas-fedor/watchtower
 
 go 1.23.5
 
+// Retract prematurely published versions
+retract [v1.7.2, v1.7.9]
+
 require (
 	github.com/containrrr/shoutrrr v0.8.0
 	github.com/distribution/reference v0.6.0


### PR DESCRIPTION
<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->

- Adds `go.mod` reference to retract prematurely released versions.
- Adds GitHub action to implement go.pkg.dev update with mandatory version increase to v1.7.10