### PR TITLE
Fix: Issue #64 - Watchtower Container Update Failure

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -177,13 +177,13 @@ Environment Variable: DOCKER_HOST
 
 ## Docker API version
 
-The API version to use by the Docker client for connecting to the Docker daemon. The minimum supported version is 1.24.
+The API version to use by the Docker client for connecting to the Docker daemon. The minimum supported version is 1.44.
 
 ```text
             Argument: --api-version, -a
 Environment Variable: DOCKER_API_VERSION
                 Type: String
-             Default: "1.24"
+             Default: "1.44"
 ```
 
 ## Include restarting

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -17,7 +17,7 @@ import (
 
 // DockerAPIMinVersion is the minimum version of the docker api required to
 // use watchtower
-const DockerAPIMinVersion string = "1.25"
+const DockerAPIMinVersion string = "1.44"
 
 var defaultInterval = int((time.Hour * 24).Seconds())
 

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -27,8 +27,7 @@ func TestEnvConfig_Defaults(t *testing.T) {
 
 	assert.Equal(t, "unix:///var/run/docker.sock", os.Getenv("DOCKER_HOST"))
 	assert.Equal(t, "", os.Getenv("DOCKER_TLS_VERIFY"))
-	// Re-enable this test when we've moved to github actions.
-	// assert.Equal(t, DockerAPIMinVersion, os.Getenv("DOCKER_API_VERSION"))
+	assert.Equal(t, DockerAPIMinVersion, os.Getenv("DOCKER_API_VERSION"))
 }
 
 func TestEnvConfig_Custom(t *testing.T) {
@@ -44,8 +43,7 @@ func TestEnvConfig_Custom(t *testing.T) {
 
 	assert.Equal(t, "some-custom-docker-host", os.Getenv("DOCKER_HOST"))
 	assert.Equal(t, "1", os.Getenv("DOCKER_TLS_VERIFY"))
-	// Re-enable this test when we've moved to github actions.
-	// assert.Equal(t, "1.99", os.Getenv("DOCKER_API_VERSION"))
+	assert.Equal(t, "1.99", os.Getenv("DOCKER_API_VERSION"))
 }
 
 func TestGetSecretsFromFilesWithString(t *testing.T) {


### PR DESCRIPTION
Updates minimum supported Docker API version.