### PR TITLE
Improve documentation regarding Docker API version

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -177,7 +177,8 @@ Environment Variable: DOCKER_HOST
 
 ## Docker API version
 
-The API version to use by the Docker client for connecting to the Docker daemon. The minimum supported version is 1.44.
+The API version to use by the Docker client for connecting to the Docker daemon. Using this argument/variable enables overriding the minimum supported version of 1.44.
+Use Docker's [API version matrix](https://docs.docker.com/reference/api/engine/#api-version-matrix) chart as a reference for comparing your version of Docker and the maximum supported API version.
 
 ```text
             Argument: --api-version, -a

--- a/docs/usage-overview.md
+++ b/docs/usage-overview.md
@@ -2,6 +2,8 @@ Watchtower is itself packaged as a Docker container so installation is as simple
 
 Since the watchtower code needs to interact with the Docker API in order to monitor the running containers, you need to mount _/var/run/docker.sock_ into the container with the `-v` flag when you run it.
 
+**⚠️ Note:** Docker v25 / API v1.44 is the minimum supported version. This can be checked using the [CLI command](https://docs.docker.com/reference/cli/docker/version/) `docker version`. Manually setting the `DOCKER_API_VERSION` [variable](https://nicholas-fedor.github.io/watchtower/arguments/#docker_api_version) is a temporary override until you are able to update to Docker version 25 or newer.
+
 Run the `watchtower` container with the following command:
 
 ```bash


### PR DESCRIPTION
Adds both a note in the usage and environment variable sections to help bring awareness regarding a known issue with Watchtower and Docker API versioning.

This issue is noted in https://github.com/nicholas-fedor/watchtower/issues/87

API Version-related issues have also been noted in Beatkind's fork of Watchtower after updating from the original repo:
https://github.com/beatkind/watchtower/issues/88
https://github.com/beatkind/watchtower/issues/114
https://github.com/beatkind/watchtower/issues/123

