### PR TITLE
fix(network): exclude Aliases and DNSNames on default bridge network

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nicholas-fedor/watchtower
 
-go 1.24.1
+go 1.24.2
 
 // Retract prematurely published versions
 retract [v1.7.2, v1.7.9]
@@ -11,7 +11,7 @@ require (
 	github.com/docker/docker v28.0.4+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/nicholas-fedor/shoutrrr v0.8.6
-	github.com/onsi/gomega v1.36.3
+	github.com/onsi/gomega v1.37.0
 	github.com/prometheus/client_golang v1.21.1
 	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/nicholas-fedor/shoutrrr v0.8.6 h1:HQ/LiTiTNqb2b8OajczoYYmgY7L6odcrI1a
 github.com/nicholas-fedor/shoutrrr v0.8.6/go.mod h1:WXcGULmqDuab9+yGjsZzFcZvXSXimsnxkBR6mXB4rq8=
 github.com/onsi/ginkgo/v2 v2.23.3 h1:edHxnszytJ4lD9D5Jjc4tiDkPBZ3siDeJJkUZJJVkp0=
 github.com/onsi/ginkgo/v2 v2.23.3/go.mod h1:zXTP6xIp3U8aVuXN8ENK9IXRaTjFnpVB9mGmaSRvxnM=
-github.com/onsi/gomega v1.36.3 h1:hID7cr8t3Wp26+cYnfcjR6HpJ00fdogN6dqZ1t6IylU=
-github.com/onsi/gomega v1.36.3/go.mod h1:8D9+Txp43QWKhM24yyOBEdpkzN8FvJyAwecBgsU4KU0=
+github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=
+github.com/onsi/gomega v1.37.0/go.mod h1:8D9+Txp43QWKhM24yyOBEdpkzN8FvJyAwecBgsU4KU0=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=

--- a/pkg/container/container_source.go
+++ b/pkg/container/container_source.go
@@ -382,11 +382,8 @@ func getNetworkConfig(sourceContainer types.Container) *dockerNetworkType.Networ
 	for networkName, originalEndpoint := range sourceContainer.ContainerInfo().NetworkSettings.Networks {
 		// Copy all fields from the original endpoint
 		endpoint := &dockerNetworkType.EndpointSettings{
-			IPAMConfig: originalEndpoint.IPAMConfig, // Preserve full IPAM config
-			Links:      originalEndpoint.Links,      // Preserve container links
-			Aliases: []string{
-				sourceContainer.Name()[1:],
-			}, // Reset to container name only
+			IPAMConfig:          originalEndpoint.IPAMConfig,          // Preserve full IPAM config
+			Links:               originalEndpoint.Links,               // Preserve container links
 			DriverOpts:          originalEndpoint.DriverOpts,          // Preserve driver options
 			GwPriority:          originalEndpoint.GwPriority,          // Preserve gateway priority
 			NetworkID:           originalEndpoint.NetworkID,           // Preserve network ID
@@ -398,9 +395,12 @@ func getNetworkConfig(sourceContainer types.Container) *dockerNetworkType.Networ
 			GlobalIPv6Address:   originalEndpoint.GlobalIPv6Address,   // Preserve global IPv6 address
 			GlobalIPv6PrefixLen: originalEndpoint.GlobalIPv6PrefixLen, // Preserve IPv6 prefix length
 			MacAddress:          originalEndpoint.MacAddress,          // Preserve endpoint MAC address if API Version > 1.43
-			DNSNames: []string{
-				sourceContainer.Name()[1:],
-			}, // Reset to container name only
+		}
+
+		// Only set Aliases and DNSNames for user-defined networks and not the default "bridge" network.
+		if networkName != "bridge" {
+			endpoint.Aliases = []string{sourceContainer.Name()[1:]}  // Reset to container name only
+			endpoint.DNSNames = []string{sourceContainer.Name()[1:]} // Reset to container name only
 		}
 
 		// Preserve IPAMConfig if present


### PR DESCRIPTION
This PR fixes an issue where Watchtower failed to recreate containers on the default `bridge` network due to invalid network settings. The error "invalid config for network bridge: invalid endpoint settings" occurred because `getNetworkConfig` set `Aliases` and `DNSNames`, which are unsupported on the default bridge network. 

Changes:
- Updated `getNetworkConfig` to exclude `Aliases` and `DNSNames` for the "bridge" network, preserving other settings like IP and MAC addresses.
- Tested with `redis:7-alpine` after pruning, verifying successful updates without errors.
- Updated to Go 1.24.2 and onsi/gomega v1.37.0