### PR TITLE
fix(release-dev): correct misconfigured dev build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,12 +2,6 @@ name: Build
 
 on:
   workflow_call:
-    inputs:
-      snapshot:
-        description: "Whether to run in snapshot mode"
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   build:
@@ -51,7 +45,7 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release ${{ inputs.snapshot && '--snapshot' || '' }}
+          args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -19,15 +19,53 @@ jobs:
     permissions:
       contents: read
 
-  Build:
-    uses: ./.github/workflows/build.yaml
+  Build-and-Push:
+    needs:
+      - Test
     permissions:
-      contents: write
+      contents: read
       packages: write
       attestations: write
       id-token: write
-    secrets: inherit
-    needs:
-      - Test
-    with:
-      snapshot: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@fcd3152d8ad392d0e9c14d3f0de40f0a88b8ca0e
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@941183f0a080fa6be59a9e3d3f4108c19a528204
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Docker images
+        uses: docker/build-push-action@66147ca503440c95dd9a97e9047c11af18d5cfeb
+        with:
+          context: .
+          file: dockerfiles/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/386
+          push: true
+          tags: |
+            nickfedor/watchtower:amd64-latest-dev
+            nickfedor/watchtower:arm64v8-latest-dev
+            nickfedor/watchtower:armhf-latest-dev
+            nickfedor/watchtower:i386-latest-dev
+            ghcr.io/nicholas-fedor/watchtower:amd64-latest-dev
+            ghcr.io/nicholas-fedor/watchtower:arm64v8-latest-dev
+            ghcr.io/nicholas-fedor/watchtower:armhf-latest-dev
+            ghcr.io/nicholas-fedor/watchtower:i386-latest-dev

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -46,9 +46,9 @@ dockers:
     dockerfile: dockerfiles/Dockerfile
     image_templates:
       - nickfedor/watchtower:amd64-{{ .Version }}
-      - nickfedor/watchtower:amd64-{{ if .IsSnapshot }}latest-dev{{ else }}latest{{ end }}
+      - nickfedor/watchtower:amd64-latest
       - ghcr.io/nicholas-fedor/watchtower:amd64-{{ .Version }}
-      - ghcr.io/nicholas-fedor/watchtower:amd64-{{ if .IsSnapshot }}latest-dev{{ else }}latest{{ end }}
+      - ghcr.io/nicholas-fedor/watchtower:amd64-latest
   - use: buildx
     build_flag_templates:
       - "--platform=linux/i386"
@@ -61,9 +61,9 @@ dockers:
     dockerfile: dockerfiles/Dockerfile
     image_templates:
       - nickfedor/watchtower:i386-{{ .Version }}
-      - nickfedor/watchtower:i386-{{ if .IsSnapshot }}latest-dev{{ else }}latest{{ end }}
+      - nickfedor/watchtower:i386-latest
       - ghcr.io/nicholas-fedor/watchtower:i386-{{ .Version }}
-      - ghcr.io/nicholas-fedor/watchtower:i386-{{ if .IsSnapshot }}latest-dev{{ else }}latest{{ end }}
+      - ghcr.io/nicholas-fedor/watchtower:i386-latest
   - use: buildx
     build_flag_templates:
       - "--platform=linux/arm/v6"
@@ -76,9 +76,9 @@ dockers:
     dockerfile: dockerfiles/Dockerfile
     image_templates:
       - nickfedor/watchtower:armhf-{{ .Version }}
-      - nickfedor/watchtower:armhf-{{ if .IsSnapshot }}latest-dev{{ else }}latest{{ end }}
+      - nickfedor/watchtower:armhf-latest
       - ghcr.io/nicholas-fedor/watchtower:armhf-{{ .Version }}
-      - ghcr.io/nicholas-fedor/watchtower:armhf-{{ if .IsSnapshot }}latest-dev{{ else }}latest{{ end }}
+      - ghcr.io/nicholas-fedor/watchtower:armhf-latest
   - use: buildx
     build_flag_templates:
       - "--platform=linux/arm64/v8"
@@ -91,9 +91,9 @@ dockers:
     dockerfile: dockerfiles/Dockerfile
     image_templates:
       - nickfedor/watchtower:arm64v8-{{ .Version }}
-      - nickfedor/watchtower:arm64v8-{{ if .IsSnapshot }}latest-dev{{ else }}latest{{ end }}
+      - nickfedor/watchtower:arm64v8-latest
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-{{ .Version }}
-      - ghcr.io/nicholas-fedor/watchtower:arm64v8-{{ if .IsSnapshot }}latest-dev{{ else }}latest{{ end }}
+      - ghcr.io/nicholas-fedor/watchtower:arm64v8-latest
 
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
Incorrectly attempted to use Goreleaser's snapshot functionality. 
As not using Pro version, nightlies are not available. 
Migrating to different workflow that builds and publishes the Docker/GHCR images.