### PR TITLE
fix(workflow): remove additional platforms

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -58,14 +58,8 @@ jobs:
         with:
           context: .
           file: dockerfiles/Dockerfile.dev-self-contained
-          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/386
+          platforms: linux/amd64
           push: true
           tags: |
             nickfedor/watchtower:amd64-latest-dev
-            nickfedor/watchtower:arm64v8-latest-dev
-            nickfedor/watchtower:armhf-latest-dev
-            nickfedor/watchtower:i386-latest-dev
             ghcr.io/nicholas-fedor/watchtower:amd64-latest-dev
-            ghcr.io/nicholas-fedor/watchtower:arm64v8-latest-dev
-            ghcr.io/nicholas-fedor/watchtower:armhf-latest-dev
-            ghcr.io/nicholas-fedor/watchtower:i386-latest-dev


### PR DESCRIPTION
Limit to linux/amd64 to reduce GH action run time. 
Add additional platforms in the future, if necessary.