### PR TITLE
Optional tag filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <div align="center">
   <img src="./logo.png" width="450" />
-  
+
 # Watchtower
-  
+
   Automate Docker container image updates
   <br/><br/>
-  
+
   [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nicholas-fedor/watchtower/tree/main.svg?style=shield)](https://dl.circleci.com/status-badge/redirect/gh/nicholas-fedor/watchtower/tree/main)
   [![codecov](https://codecov.io/gh/nicholas-fedor/watchtower/branch/main/graph/badge.svg)](https://codecov.io/gh/nicholas-fedor/watchtower)
   [![GoDoc](https://godoc.org/github.com/nicholas-fedor/watchtower?status.svg)](https://godoc.org/github.com/nicholas-fedor/watchtower)
@@ -64,6 +64,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   <tbody>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/nicholas-fedor"><img src="https://avatars2.githubusercontent.com/u/71477161?v=4?s=100" width="100px;" alt="Nicholas Fedor"/><br /><sub><b>Nicholas Fedor</b></sub></a><br /><a href="https://github.com/nicholas-fedor/watchtower/commits?author=nicholas-fedor" title="Code">💻</a> <a href="https://github.com/nicholas-fedor/watchtower/commits?author=nicholas-fedor" title="Documentation">📖</a> <a href="#maintenance-nicholas-fedor" title="Maintenance">🚧</a> <a href="https://github.com/nicholas-fedor/watchtower/pulls?q=is%3Apr+reviewed-by%3Anicholas-fedor" title="Reviewed Pull Requests">👀</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://ko-fi.com/foxite"><img src="https://avatars.githubusercontent.com/u/20421657?v=4?s=100" width="100px;" alt="Dirk Kok"/><br /><sub><b>Dirk Kok</b></sub></a><br /><a href="https://github.com/nicholas-fedor/watchtower/commits?author=Foxite" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://piksel.se"><img src="https://avatars2.githubusercontent.com/u/807383?v=4?s=100" width="100px;" alt="nils måsén"/><br /><sub><b>nils måsén</b></sub></a><br /><a href="https://github.com/nicholas-fedor/watchtower/commits?author=piksel" title="Code">💻</a> <a href="https://github.com/nicholas-fedor/watchtower/commits?author=piksel" title="Documentation">📖</a> <a href="https://github.com/nicholas-fedor/watchtower/pulls?q=is%3Apr+reviewed-by%3Apiksel" title="Reviewed Pull Requests">👀</a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://simme.dev"><img src="https://avatars0.githubusercontent.com/u/1596025?v=4?s=100" width="100px;" alt="Simon Aronsson"/><br /><sub><b>Simon Aronsson</b></sub></a><br /><a href="https://github.com/nicholas-fedor/watchtower/commits?author=simskij" title="Code">💻</a> <a href="https://github.com/nicholas-fedor/watchtower/commits?author=simskij" title="Documentation">📖</a> <a href="https://github.com/nicholas-fedor/watchtower/pulls?q=is%3Apr+reviewed-by%3Asimskij" title="Reviewed Pull Requests">👀</a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://codelica.com"><img src="https://avatars3.githubusercontent.com/u/386101?v=4?s=100" width="100px;" alt="James"/><br /><sub><b>James</b></sub></a><br /><a href="https://github.com/nicholas-fedor/watchtower/commits?author=Codelica" title="Tests">⚠️</a> <a href="#ideas-Codelica" title="Ideas, Planning, & Feedback">🤔</a></td>
@@ -175,7 +176,6 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/hypnoglow"><img src="https://avatars.githubusercontent.com/u/4853075?v=4?s=100" width="100px;" alt="Igor Zibarev"/><br /><sub><b>Igor Zibarev</b></sub></a><br /><a href="https://github.com/nicholas-fedor/watchtower/commits?author=hypnoglow" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/patricegautier"><img src="https://avatars.githubusercontent.com/u/38435239?v=4?s=100" width="100px;" alt="Patrice"/><br /><sub><b>Patrice</b></sub></a><br /><a href="https://github.com/nicholas-fedor/watchtower/commits?author=patricegautier" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://jamesw.link/me"><img src="https://avatars.githubusercontent.com/u/8067792?v=4?s=100" width="100px;" alt="James White"/><br /><sub><b>James White</b></sub></a><br /><a href="https://github.com/nicholas-fedor/watchtower/commits?author=jamesmacwhite" title="Documentation">📖</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://ko-fi.com/foxite"><img src="https://avatars.githubusercontent.com/u/20421657?v=4?s=100" width="100px;" alt="Dirk Kok"/><br /><sub><b>Dirk Kok</b></sub></a><br /><a href="https://github.com/nicholas-fedor/watchtower/commits?author=Foxite" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/EDIflyer"><img src="https://avatars.githubusercontent.com/u/13610277?v=4?s=100" width="100px;" alt="EDIflyer"/><br /><sub><b>EDIflyer</b></sub></a><br /><a href="https://github.com/nicholas-fedor/watchtower/commits?author=EDIflyer" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/jauderho"><img src="https://avatars.githubusercontent.com/u/13562?v=4?s=100" width="100px;" alt="Jauder Ho"/><br /><sub><b>Jauder Ho</b></sub></a><br /><a href="https://github.com/nicholas-fedor/watchtower/commits?author=jauderho" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://tamal.vercel.app/"><img src="https://avatars.githubusercontent.com/u/72851613?v=4?s=100" width="100px;" alt="Tamal Das "/><br /><sub><b>Tamal Das </b></sub></a><br /><a href="https://github.com/nicholas-fedor/watchtower/commits?author=IAmTamal" title="Documentation">📖</a></td>

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -105,8 +105,8 @@ Environment Variable: WATCHTOWER_REMOVE_VOLUMES
 
 Enable debug mode with verbose logging.
 
-!!! note "Notes"  
-    Alias for `--log-level debug`. See [Maximum log level](#maximum-log-level).  
+!!! note "Notes"
+    Alias for `--log-level debug`. See [Maximum log level](#maximum-log-level).
     Does _not_ take an argument when used as an argument. Using `--debug true` will **not** work.
 
 ```text
@@ -120,8 +120,8 @@ Environment Variable: WATCHTOWER_DEBUG
 
 Enable trace mode with very verbose logging. Caution: exposes credentials!
 
-!!! note "Notes"  
-    Alias for `--log-level trace`. See [Maximum log level](#maximum-log-level).  
+!!! note "Notes"
+    Alias for `--log-level trace`. See [Maximum log level](#maximum-log-level).
     Does _not_ take an argument when used as an argument. Using `--trace true` will **not** work.
 
 ```text
@@ -351,6 +351,8 @@ Environment Variable: WATCHTOWER_RUN_ONCE
 ## HTTP API Mode
 
 Runs Watchtower in HTTP API mode, only allowing image updates to be triggered by an HTTP request.
+
+Supports filtering by specific image tags (e.g., `image=foo/bar:1.0`) in HTTP requests.
 For details see [HTTP API](https://nicholas-fedor.github.io/watchtower/http-api-mode).
 
 ```text
@@ -374,7 +376,7 @@ Environment Variable: WATCHTOWER_HTTP_API_TOKEN
 
 ## HTTP API periodic polls
 
-Keep running periodic updates if the HTTP API mode is enabled, otherwise the HTTP API would prevent periodic polls.  
+Keep running periodic updates if the HTTP API mode is enabled, otherwise the HTTP API would prevent periodic polls.
 
 ```text
             Argument: --http-api-periodic-polls
@@ -401,7 +403,7 @@ Environment Variable: WATCHTOWER_SCOPE
 
 ## HTTP API Metrics
 
-Enables a metrics endpoint, exposing prometheus metrics via HTTP. See [Metrics](metrics.md) for details.  
+Enables a metrics endpoint, exposing prometheus metrics via HTTP. See [Metrics](metrics.md) for details.
 
 ```text
             Argument: --http-api-metrics
@@ -493,8 +495,8 @@ Returns a success exit code to enable usage with docker `HEALTHCHECK`. This chec
 
 ## Programmatic Output (porcelain)
 
-Writes the session results to STDOUT using a stable, machine-readable format (indicated by the argument VERSION).  
-  
+Writes the session results to STDOUT using a stable, machine-readable format (indicated by the argument VERSION).
+
 Alias for:
 
 ```text

--- a/docs/http-api-mode.md
+++ b/docs/http-api-mode.md
@@ -45,3 +45,11 @@ In order to update only certain images, the image names can be provided as URL q
 ```bash
 curl -H "Authorization: Bearer mytoken" localhost:8080/v1/update?image=foo/bar,foo/baz
 ```
+
+You can also specify image tags to target containers running a specific version (e.g., `foo/bar:1.0`). For example, to update only containers using `foo/bar:1.0` and `foo/baz:latest`:
+
+```bash
+curl -H "Authorization: Bearer mytoken" localhost:8080/v1/update?image=foo/bar:1.0,foo/baz:latest
+```
+
+If no tag is provided, Watchtower matches containers regardless of their tag, maintaining compatibility with untagged image filtering.

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -251,6 +251,7 @@ func TestFilterByImage(t *testing.T) {
 	filterEmptyTagged := FilterByImage(nil, NoFilter)
 	filterSingleTagged := FilterByImage([]string{"registry:develop"}, NoFilter)
 	filterMultipleTagged := FilterByImage([]string{"registry:develop", "registry:latest"}, NoFilter)
+
 	assert.NotNil(t, filterSingleTagged)
 	assert.NotNil(t, filterMultipleTagged)
 

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -279,6 +279,31 @@ func TestFilterByImage(t *testing.T) {
 	container.AssertExpectations(t)
 }
 
+func TestFilterByImageMalformed(t *testing.T) {
+	t.Parallel()
+
+	filter := FilterByImage([]string{"valid:image", "invalid::tag", "image:", ":tag", ""}, NoFilter)
+	assert.NotNil(t, filter)
+
+	container := new(mocks.FilterableContainer)
+	container.On("ImageName").Return("valid:image")
+	container.On("Name").Return("/test")
+	assert.True(t, filter(container)) // Valid match
+	container.AssertExpectations(t)
+
+	container = new(mocks.FilterableContainer)
+	container.On("ImageName").Return("valid:other")
+	container.On("Name").Return("/test")
+	assert.False(t, filter(container)) // Tag mismatch
+	container.AssertExpectations(t)
+
+	container = new(mocks.FilterableContainer)
+	container.On("ImageName").Return("invalid:tag")
+	container.On("Name").Return("/test")
+	assert.False(t, filter(container)) // Malformed input ignored
+	container.AssertExpectations(t)
+}
+
 func TestBuildFilter(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -247,6 +247,36 @@ func TestFilterByImage(t *testing.T) {
 	assert.False(t, filterSingle(container))
 	assert.True(t, filterMultiple(container))
 	container.AssertExpectations(t)
+
+	filterEmptyTagged := FilterByImage(nil, NoFilter)
+	filterSingleTagged := FilterByImage([]string{"registry:develop"}, NoFilter)
+	filterMultipleTagged := FilterByImage([]string{"registry:develop", "registry:latest"}, NoFilter)
+	assert.NotNil(t, filterSingleTagged)
+	assert.NotNil(t, filterMultipleTagged)
+
+	container = new(mocks.FilterableContainer)
+	container.On("ImageName").Return("bla:latest")
+	container.On("Name").Return("/test")
+	assert.True(t, filterEmptyTagged(container))
+	assert.False(t, filterSingleTagged(container))
+	assert.False(t, filterMultipleTagged(container))
+	container.AssertExpectations(t)
+
+	container = new(mocks.FilterableContainer)
+	container.On("ImageName").Return("registry:latest")
+	container.On("Name").Return("/test")
+	assert.True(t, filterEmptyTagged(container))
+	assert.False(t, filterSingleTagged(container))
+	assert.True(t, filterMultipleTagged(container))
+	container.AssertExpectations(t)
+
+	container = new(mocks.FilterableContainer)
+	container.On("ImageName").Return("registry:develop")
+	container.On("Name").Return("/test")
+	assert.True(t, filterEmptyTagged(container))
+	assert.True(t, filterSingleTagged(container))
+	assert.True(t, filterMultipleTagged(container))
+	container.AssertExpectations(t)
 }
 
 func TestBuildFilter(t *testing.T) {


### PR DESCRIPTION
Adapted work from https://github.com/containrrr/watchtower/pull/2054.

> To be able to do finegrained updates to container running a specific tag of an image i added this.

If an API update includes a tag in its image filter, it will not be ignored, but it's still possible to provide a tagless image name.