### PR TITLE
feat: add DisableMemorySwappiness flag for Podman compatibility

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -252,6 +252,7 @@ func preRun(cmd *cobra.Command, _ []string) {
 	reviveStopped, _ := flagsSet.GetBool("revive-stopped")
 	removeVolumes, _ := flagsSet.GetBool("remove-volumes")
 	warnOnHeadPullFailed, _ := flagsSet.GetString("warn-on-head-failure")
+	disableMemorySwappiness, _ := flagsSet.GetBool("disable-memory-swappiness")
 
 	// Warn about potential redundancy in flag combinations that could result in no action.
 	if monitorOnly && noPull {
@@ -263,11 +264,12 @@ func preRun(cmd *cobra.Command, _ []string) {
 
 	// Initialize the Docker client with options reflecting the desired container handling behavior.
 	client = container.NewClient(container.ClientOptions{
-		IncludeStopped:    includeStopped,
-		ReviveStopped:     reviveStopped,
-		RemoveVolumes:     removeVolumes,
-		IncludeRestarting: includeRestarting,
-		WarnOnHeadFailed:  container.WarningStrategy(warnOnHeadPullFailed),
+		IncludeStopped:          includeStopped,
+		ReviveStopped:           reviveStopped,
+		RemoveVolumes:           removeVolumes,
+		IncludeRestarting:       includeRestarting,
+		DisableMemorySwappiness: disableMemorySwappiness,
+		WarnOnHeadFailed:        container.WarningStrategy(warnOnHeadPullFailed),
 	})
 
 	// Set up the notification system with types specified via flags (e.g., email, Slack).

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -510,3 +510,15 @@ Environment Variable: WATCHTOWER_PORCELAIN
      Possible values: v1
              Default: -
 ```
+
+## Compatibility with podman (Disable memory swappiness)
+
+Disable memory swappiness. By default, podman sets the memory-swappiness value to 0 when no memory-swappiness is defined
+When this flag is specified, watchtower will set the memory-swappiness to nil, fixing a compatibility issue with podman running with crun and cgroupv2
+
+```text
+            Argument: --disable-memory-swappiness
+Environment Variable: WATCHTOWER_DISABLE_MEMORY_SWAPPINESS
+                Type: Boolean
+             Default: false
+```

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -260,6 +260,13 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		"",
 		envBool("WATCHTOWER_LABEL_TAKE_PRECEDENCE"),
 		"Label applied to containers take precedence over arguments")
+
+	flags.BoolP(
+		"disable-memory-swappiness",
+		"",
+		envBool("WATCHTOWER_DISABLE_MEMORY_SWAPPINESS"),
+		"Label used for setting memory swappiness as nil when recreating the container, used for compatibility with podman",
+	)
 }
 
 // RegisterNotificationFlags adds notification flags to the root command.
@@ -526,6 +533,7 @@ func SetDefaults() {
 	viper.SetDefault("WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER", "watchtower")
 	viper.SetDefault("WATCHTOWER_LOG_LEVEL", "info")
 	viper.SetDefault("WATCHTOWER_LOG_FORMAT", "auto")
+	viper.SetDefault("WATCHTOWER_DISABLE_MEMORY_SWAPPINESS", false)
 }
 
 // EnvConfig sets Docker environment variables from flags.

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -626,3 +626,17 @@ func testGetSecretsFromFiles(t *testing.T, flagName string, expected string, arg
 
 	assert.Equal(t, expected, value)
 }
+
+func TestDisableMemorySwappinessFlag(t *testing.T) {
+	cmd := new(cobra.Command)
+
+	SetDefaults()
+	RegisterSystemFlags(cmd)
+
+	err := cmd.ParseFlags([]string{"--disable-memory-swappiness"})
+	require.NoError(t, err)
+
+	disableMemorySwappiness, err := cmd.PersistentFlags().GetBool("disable-memory-swappiness")
+	require.NoError(t, err)
+	assert.True(t, disableMemorySwappiness, "disable-memory-swappiness flag should be true")
+}

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -85,11 +85,12 @@ type client struct {
 //
 // It controls container management and warning behaviors.
 type ClientOptions struct {
-	RemoveVolumes     bool
-	IncludeStopped    bool
-	ReviveStopped     bool
-	IncludeRestarting bool
-	WarnOnHeadFailed  WarningStrategy
+	RemoveVolumes           bool
+	IncludeStopped          bool
+	ReviveStopped           bool
+	IncludeRestarting       bool
+	DisableMemorySwappiness bool
+	WarnOnHeadFailed        WarningStrategy
 }
 
 // NewClient initializes a new Client instance for Docker API interactions.
@@ -223,6 +224,7 @@ func (c client) StartContainer(container types.Container) (types.ContainerID, er
 		c.ReviveStopped,
 		clientVersion,
 		flags.DockerAPIMinVersion,
+		c.DisableMemorySwappiness,
 	)
 	if err != nil {
 		logrus.WithFields(fields).WithError(err).Debug("Failed to start new container")

--- a/pkg/container/container_target.go
+++ b/pkg/container/container_target.go
@@ -24,6 +24,7 @@ import (
 //   - reviveStopped: Whether to start stopped containers.
 //   - clientVersion: API version of the client.
 //   - minSupportedVersion: Minimum API version for full features.
+//   - disableMemorySwappiness: Whether to disable memory swappiness for Podman compatibility.
 //
 // Returns:
 //   - types.ContainerID: ID of the new container.
@@ -35,6 +36,7 @@ func StartTargetContainer(
 	reviveStopped bool,
 	clientVersion string,
 	minSupportedVersion string,
+	disableMemorySwappiness bool,
 ) (types.ContainerID, error) {
 	ctx := context.Background()
 	clog := logrus.WithFields(logrus.Fields{
@@ -45,6 +47,13 @@ func StartTargetContainer(
 	// Extract configuration from the source container.
 	config := sourceContainer.GetCreateConfig()
 	hostConfig := sourceContainer.GetCreateHostConfig()
+
+	// Set MemorySwappiness to nil for Podman compatibility if flag is enabled.
+	if disableMemorySwappiness {
+		hostConfig.MemorySwappiness = nil
+
+		clog.Debug("Disabled memory swappiness for Podman compatibility")
+	}
 
 	// Log network details for debugging.
 	isHostNetwork := sourceContainer.ContainerInfo().HostConfig.NetworkMode.IsHost()


### PR DESCRIPTION
Add `--disable-memory-swappiness` flag to set container MemorySwappiness to nil, addressing Podman compatibility with crun and cgroupv2, as proposed by https://github.com/containrrr/watchtower/pull/2072.

Changes include:
- Implemented flag logic to set MemorySwappiness to nil
- Added flag parsing and validation
- Updated CLI command configuration
- Added unit tests for flag functionality
- Documented flag in arguments