### PR TITLE
test(container): add unit test for volume subpath preservation

### DIFF
--- a/pkg/container/container_mock_test.go
+++ b/pkg/container/container_mock_test.go
@@ -5,6 +5,7 @@ import (
 
 	dockerContainerType "github.com/docker/docker/api/types/container"
 	dockerImageType "github.com/docker/docker/api/types/image"
+	dockerMountType "github.com/docker/docker/api/types/mount"
 	dockerNetworkType "github.com/docker/docker/api/types/network"
 	dockerNat "github.com/docker/go-connections/nat"
 )
@@ -106,5 +107,11 @@ func WithNetworkSettings(
 		}
 
 		c.NetworkSettings.Networks = networks
+	}
+}
+
+func WithMounts(mounts []dockerMountType.Mount) MockContainerUpdate {
+	return func(c *dockerContainerType.InspectResponse, _ *dockerImageType.InspectResponse) {
+		c.HostConfig.Mounts = mounts
 	}
 }


### PR DESCRIPTION
- Add a unit test to verify that `GetCreateHostConfig` preserves volume subpath in `HostConfig.Mounts`, addressing potential issues with subpath handling during container recreation.
- Add a `WithMounts` helper in `container_mock_test.go` to support mount configuration in tests.

Successful testing confirms that this fork of Watchtower honors Docker volume subpaths, including avoiding the issue described in https://github.com/containrrr/watchtower/issues/2017