### PR TITLE
fix(container): reduce MAC address warning to debug for non-running containers

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -124,6 +124,10 @@ func (c Container) ID() types.ContainerID {
 // Returns:
 //   - bool: True if running, false otherwise.
 func (c Container) IsRunning() bool {
+	if c.containerInfo == nil || c.containerInfo.State == nil {
+		return false
+	}
+
 	return c.containerInfo.State.Running
 }
 

--- a/pkg/container/container_mock_test.go
+++ b/pkg/container/container_mock_test.go
@@ -20,6 +20,10 @@ func MockContainer(updates ...MockContainerUpdate) *Container {
 			Image:      "image",
 			Name:       "test-watchtower",
 			HostConfig: &dockerContainerType.HostConfig{},
+			State: &dockerContainerType.State{
+				Running: true,
+				Status:  "running",
+			}, // Default to running
 		},
 		Config: &dockerContainerType.Config{
 			Labels: map[string]string{},


### PR DESCRIPTION
Resolves excessive warning logs for non-running containers (e.g., created state) when no MAC address is found, as reported in issue #313.

- Modified `validateMacAddresses` to log debug instead of warn for non-running containers.
- Added container state checks using `IsRunning()` and `State.Status`.
- Enhanced `validateMacAddresses` comments for clearer logical flow.
- Updated tests in `container_test.go` to cover running, created, and exited states.
- Made `IsRunning()` robust against nil `containerInfo` or `State`.
- Fixed test panics by setting default container state in affected tests.

Closes #313