### PR TITLE
feat: add riscv64 architecture support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@737ba1e397ec2caff0d098f75e1136f9a926dc0a
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@3f1544eb9eff0b4d4d279b33f704a06fcf8d0e43
+
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
         with:

--- a/.github/workflows/generate-manifests.yaml
+++ b/.github/workflows/generate-manifests.yaml
@@ -35,7 +35,7 @@ jobs:
           TAG="${GITHUB_REF_NAME#v}"
 
           # Architectures to include in manifests
-          ARCHES=("amd64" "i386" "armhf" "arm64v8")
+          ARCHES=("amd64" "i386" "armhf" "arm64v8" "riscv64")
 
           # Function to create and push manifests
           create_and_push_manifest() {

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ If that is you, you should be looking into using Kubernetes enabled with CI/CD, 
 This version of Watchtower has been tested to support v1.43 and higher; however, don't be surprised if you experience unexpected behavior when attempting to use newer features on older versions of Docker.
 This version autonegotiates the API version by default. If the `DOCKER_API_VERSION` [variable](https://nicholas-fedor.github.io/watchtower/arguments/#docker_api_version) is explicitly set, Watchtower validates the version and falls back to autonegotiation on failure.
 
+## Supported Architectures
+
+Watchtower supports the following architectures for its Docker images:
+
+- amd64
+- i386
+- armhf
+- arm64v8
+- riscv64
+
 ## Documentation
 
 The full documentation is available at <https://nicholas-fedor.github.io/watchtower/>.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -2,7 +2,7 @@ Watchtower is an application that will monitor your running Docker containers an
 
 With watchtower you can update the running version of your containerized app simply by pushing a new image to the Docker Hub or your own image registry. Watchtower will pull down your new image, gracefully shut down your existing container and restart it with the same options that were used when it was deployed initially.
 
-For example, let's say you were running watchtower along with an instance of _centurylink/wetty-cli_ image:
+For example, let's say you were running Watchtower along with an instance of _centurylink/wetty-cli_ image:
 
 ```text
 $ docker ps
@@ -11,4 +11,14 @@ CONTAINER ID   IMAGE                   STATUS          PORTS                    
 6cc4d2a9d1a5   nickfedor/watchtower   Up 15 minutes                            watchtower
 ```
 
-Every day watchtower will pull the latest _centurylink/wetty-cli_ image and compare it to the one that was used to run the "wetty" container. If it sees that the image has changed it will stop/remove the "wetty" container and then restart it using the new image and the same `docker run` options that were used to start the container initially (in this case, that would include the `-p 8080:3000` port mapping).
+Every day Watchtower will pull the latest _centurylink/wetty-cli_ image and compare it to the one that was used to run the "wetty" container. If it sees that the image has changed it will stop/remove the "wetty" container and then restart it using the new image and the same `docker run` options that were used to start the container initially (in this case, that would include the `-p 8080:3000` port mapping).
+
+## Supported Architectures
+
+Watchtower supports the following architectures for its Docker images:
+
+- amd64
+- i386
+- armhf
+- arm64v8
+- riscv64

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -11,6 +11,12 @@ builds:
       - "386"
       - arm
       - arm64
+      - riscv64
+    goriscv64:
+      - rva20u64
+    ignore:
+      - goos: windows
+        goarch: riscv64
     ldflags:
       - -s -w -X github.com/nicholas-fedor/watchtower/internal/meta.Version={{ .Version }}
       - -X github.com/nicholas-fedor/watchtower/pkg/registry/digest.UserAgent=Watchtower/v{{ .Version }}
@@ -24,6 +30,7 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else if eq .Arch "arm" }}armhf
       {{- else if eq .Arch "arm64" }}arm64v8
+      {{- else if eq .Arch "riscv64" }}riscv64
       {{- else }}{{ .Arch }}{{ end }}_
       {{- .Version -}}
     formats: ["tar.gz"]
@@ -94,6 +101,21 @@ dockers:
       - nickfedor/watchtower:arm64v8-latest
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-latest
+  - use: buildx
+    build_flag_templates:
+      - "--platform=linux/riscv64"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+    goos: linux
+    goarch: riscv64
+    goarm: ""
+    dockerfile: dockerfiles/Dockerfile
+    image_templates:
+      - nickfedor/watchtower:riscv64-{{ .Version }}
+      - nickfedor/watchtower:riscv64-latest
+      - ghcr.io/nicholas-fedor/watchtower:riscv64-{{ .Version }}
+      - ghcr.io/nicholas-fedor/watchtower:riscv64-latest
 
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
- Add riscv64 to goarch in goreleaser.yml builds section
- Include riscv64 Docker image build in goreleaser.yml
- Update generate-manifests.yaml to include riscv64 in multi-arch manifests
- Add QEMU and Buildx setup in build.yaml for riscv64 compatibility
- Document Docker image platform/arch support, including riscv64, in README.md and introduction.md