### PR TITLE
Increase Default Container Stop Timeout to 30s and Demote Timeout Log to Debug

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -577,7 +577,7 @@ Sets the timeout (e.g., `30s`) before forcibly stopping a container during updat
             Argument: --stop-timeout
 Environment Variable: WATCHTOWER_TIMEOUT
                 Type: Duration
-             Default: 10s
+             Default: 30s
 ```
 
 ### Health Check

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -22,8 +22,8 @@ const DockerAPIMinVersion string = "1.24"
 // defaultPollIntervalSeconds sets the default polling interval (24 hours).
 const defaultPollIntervalSeconds = 86400 // 24 * 60 * 60 seconds
 
-// defaultStopTimeoutSeconds sets the default container stop timeout (10 seconds).
-const defaultStopTimeoutSeconds = 10
+// defaultStopTimeoutSeconds sets the default container stop timeout (30 seconds).
+const defaultStopTimeoutSeconds = 30
 
 // defaultEmailServerPort sets the default SMTP port (25).
 const defaultEmailServerPort = 25

--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -93,7 +93,7 @@ var _ = ginkgo.Describe("the client", func() {
 							http.StatusOK,
 							containerRunning.ContainerInfo(),
 						),
-						func(w http.ResponseWriter, r *http.Request) {
+						func(_ http.ResponseWriter, _ *http.Request) {
 							time.Sleep(200 * time.Millisecond) // Simulate delay
 						},
 					),

--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -77,7 +77,7 @@ var _ = ginkgo.Describe("the client", func() {
 			})
 		})
 		ginkgo.When("the container fails to stop within timeout", func() {
-			ginkgo.It("should log a warning but proceed with removal", func() {
+			ginkgo.It("should log a debug message but proceed with removal", func() {
 				mockContainer := MockContainer(
 					WithContainerState(dockerContainerType.State{Running: true}),
 				)
@@ -87,27 +87,33 @@ var _ = ginkgo.Describe("the client", func() {
 				cid := mockContainer.ContainerInfo().ID
 				mockServer.AppendHandlers(
 					mocks.KillContainerHandler(cid, mocks.Found),
-					mocks.GetContainerHandler(
-						cid,
-						containerRunning.ContainerInfo(),
-					), // First wait: still running
+					ghttp.CombineHandlers( // First wait: still running
+						ghttp.VerifyRequest("GET", gomega.HaveSuffix(cid+"/json")),
+						ghttp.RespondWithJSONEncoded(
+							http.StatusOK,
+							containerRunning.ContainerInfo(),
+						),
+						func(w http.ResponseWriter, r *http.Request) {
+							time.Sleep(200 * time.Millisecond) // Simulate delay
+						},
+					),
 					mocks.RemoveContainerHandler(cid, mocks.Found),
 					ghttp.CombineHandlers( // Second wait: removed
 						ghttp.VerifyRequest("GET", gomega.HaveSuffix(cid+"/json")),
 						ghttp.RespondWith(http.StatusNotFound, nil),
 					),
 				)
-				resetLogrus, logbuf := captureLogrus(logrus.WarnLevel)
+				resetLogrus, logbuf := captureLogrus(logrus.DebugLevel)
 				defer resetLogrus()
 				err := client{
 					api: docker,
 				}.StopContainer(
 					mockContainer,
-					1*time.Millisecond,
-				) // Short timeout
+					100*time.Millisecond,
+				)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-				gomega.Eventually(logbuf).
-					Should(gbytes.Say(`Container did not stop within timeout.*container=%s.*id=%s.*timeout=%v`, mockContainer.Name(), mockContainer.ID().ShortID(), 1*time.Millisecond))
+				gomega.Eventually(logbuf, 2*time.Second).
+					Should(gbytes.Say(`Container did not stop within timeout.*container=%s.*id=%s.*timeout=%v`, mockContainer.Name(), mockContainer.ID().ShortID(), 100*time.Millisecond))
 			})
 		})
 		ginkgo.When("waiting for stop fails with an unexpected error", func() {

--- a/pkg/container/container_source.go
+++ b/pkg/container/container_source.go
@@ -232,7 +232,7 @@ func stopAndRemoveContainer(
 	}
 
 	if !stopped {
-		clog.WithField("timeout", timeout).Warn("Container did not stop within timeout")
+		clog.WithField("timeout", timeout).Debug("Container did not stop within timeout")
 	}
 
 	// Skip removal if AutoRemove is enabled and container stopped.


### PR DESCRIPTION
## Description

This PR enhances the container stop functionality in Watchtower by increasing the default timeout and reducing log verbosity:

- **Increased default timeout**: Changed the default container stop timeout from 10 seconds to 30 seconds in `flags.go` (`defaultStopTimeoutSeconds`) to allow more time for containers to stop gracefully, improving reliability for slower workloads.
- **Demoted log level**: Modified the "Container did not stop within timeout" log message in `container_source.go` (`stopAndRemoveContainer`) from warning to debug to reduce user-facing log noise while preserving diagnostic details.
- **Updated test**: Fixed the failing `TestContainer` test in `client_test.go` by capturing debug-level logs, using a 100ms timeout, and adding a 200ms mock server delay to simulate timeout conditions accurately.

## Motivation and Context

The previous 10-second timeout was insufficient for some containers, risking forced terminations. The warning-level log for timeout failures was overly verbose for a common scenario. This PR improves reliability and user experience by extending the timeout and making logs less intrusive.