### PR TITLE
Resolve container update failure with multiple networks (#346)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -235,7 +235,7 @@ func (c client) StopContainer(container types.Container, timeout time.Duration) 
 	return nil
 }
 
-// StartContainer creates and starts a new container from an existing one’s config.
+// StartContainer creates and starts a new container based on an existing container's configuration.
 //
 // Parameters:
 //   - container: Source container to replicate.

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -4,6 +4,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -12,10 +13,43 @@ import (
 
 	dockerContainerType "github.com/docker/docker/api/types/container"
 	dockerImageType "github.com/docker/docker/api/types/image"
+	dockerNetworkType "github.com/docker/docker/api/types/network"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/nicholas-fedor/watchtower/internal/util"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
+
+// Operations defines the minimal interface for container operations in Watchtower.
+type Operations interface {
+	ContainerCreate(
+		ctx context.Context,
+		config *dockerContainerType.Config,
+		hostConfig *dockerContainerType.HostConfig,
+		networkingConfig *dockerNetworkType.NetworkingConfig,
+		platform *ocispec.Platform,
+		containerName string,
+	) (dockerContainerType.CreateResponse, error)
+	ContainerStart(
+		ctx context.Context,
+		containerID string,
+		options dockerContainerType.StartOptions,
+	) error
+	ContainerRemove(
+		ctx context.Context,
+		containerID string,
+		options dockerContainerType.RemoveOptions,
+	) error
+	NetworkConnect(
+		ctx context.Context,
+		networkID, containerID string,
+		config *dockerNetworkType.EndpointSettings,
+	) error
+	ContainerRename(
+		ctx context.Context,
+		containerID, newContainerName string,
+	) error
+}
 
 // Constants for container operations.
 const (

--- a/pkg/container/container_target.go
+++ b/pkg/container/container_target.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/docker/docker/api/types/versions"
 	"github.com/sirupsen/logrus"
 
 	dockerContainerType "github.com/docker/docker/api/types/container"
@@ -16,6 +17,9 @@ import (
 // StartTargetContainer creates and starts a new container using the source container’s configuration.
 //
 // It applies the provided network configuration and respects the reviveStopped option.
+// For legacy Docker API versions (< 1.44) with multiple networks, it creates the container with a single
+// network and attaches others sequentially to avoid issues with multiple network endpoints in ContainerCreate.
+// For modern API versions (>= 1.44) or single networks, it attaches all networks at creation.
 //
 // Parameters:
 //   - api: Docker API client.
@@ -55,7 +59,7 @@ func StartTargetContainer(
 		clog.Debug("Disabled memory swappiness for Podman compatibility")
 	}
 
-	// Log network details for debugging.
+	// Log network details for debugging, including MAC address validation.
 	isHostNetwork := sourceContainer.ContainerInfo().HostConfig.NetworkMode.IsHost()
 	debugLogMacAddress(
 		networkConfig,
@@ -65,14 +69,36 @@ func StartTargetContainer(
 		isHostNetwork,
 	)
 
+	// Determine network config for container creation based on API version.
+	createNetworkConfig := networkConfig
+
+	if versions.LessThan(clientVersion, "1.44") && len(networkConfig.EndpointsConfig) > 1 {
+		// Legacy API (< 1.44) with multiple networks: use first network for creation.
+		var firstNetworkName string
+
+		createNetworkConfig = newEmptyNetworkConfig()
+
+		for name, endpoint := range networkConfig.EndpointsConfig {
+			firstNetworkName = name
+			createNetworkConfig.EndpointsConfig[name] = endpoint
+
+			clog.WithField("network", firstNetworkName).
+				Debug("Selected first network for container creation")
+
+			break // Use only the first network initially.
+		}
+	} else {
+		clog.Debug("Using full network config for API version >= 1.44 or single network")
+	}
+
+	// Create container with the selected network config.
 	clog.Debug("Creating new container")
 
-	// Create the new container with source config and network settings.
 	createdContainer, err := api.ContainerCreate(
 		ctx,
 		config,
 		hostConfig,
-		networkConfig,
+		createNetworkConfig,
 		nil,
 		sourceContainer.Name(),
 	)
@@ -83,6 +109,20 @@ func StartTargetContainer(
 	}
 
 	createdContainerID := types.ContainerID(createdContainer.ID)
+	clog.WithField("new_id", createdContainerID.ShortID()).Debug("Created container successfully")
+
+	// Attach additional networks for legacy API if needed.
+	if versions.LessThan(clientVersion, "1.44") && len(networkConfig.EndpointsConfig) > 1 {
+		if err := attachNetworks(ctx, api, createdContainer.ID, networkConfig, createNetworkConfig, clog); err != nil {
+			// Clean up the created container to avoid orphaned resources.
+			if rmErr := api.ContainerRemove(ctx, createdContainer.ID, dockerContainerType.RemoveOptions{Force: true}); rmErr != nil {
+				clog.WithError(rmErr).
+					Warn("Failed to clean up container after network attachment error")
+			}
+
+			return "", err
+		}
+	}
 
 	// Skip starting if source isn’t running and revive isn’t enabled.
 	if !sourceContainer.IsRunning() && !reviveStopped {
@@ -107,6 +147,57 @@ func StartTargetContainer(
 	clog.WithField("new_id", createdContainerID.ShortID()).Info("Started new container")
 
 	return createdContainerID, nil
+}
+
+// attachNetworks connects a container to additional networks for legacy API versions.
+//
+// It iterates through the provided network config, attaching all networks not included in the initial
+// creation config, ensuring compatibility with Docker API < 1.44 where multiple network endpoints may fail.
+//
+// Parameters:
+//   - ctx: Context for API operations.
+//   - api: Docker API client.
+//   - containerID: ID of the container to attach networks to.
+//   - networkConfig: Full network configuration with all desired endpoints.
+//   - initialNetworkConfig: Network config used during container creation.
+//   - clog: Logger with container context for consistent logging.
+//
+// Returns:
+//   - error: Non-nil if attaching any network fails, nil on success.
+func attachNetworks(
+	ctx context.Context,
+	api dockerClient.APIClient,
+	containerID string,
+	networkConfig *dockerNetworkType.NetworkingConfig,
+	initialNetworkConfig *dockerNetworkType.NetworkingConfig,
+	clog *logrus.Entry,
+) error {
+	// Identify the initial network used during creation to skip it.
+	var initialNetworkName string
+	for name := range initialNetworkConfig.EndpointsConfig {
+		initialNetworkName = name
+
+		break
+	}
+
+	// Attach each additional network sequentially.
+	for name, endpoint := range networkConfig.EndpointsConfig {
+		if name != initialNetworkName && name != "" {
+			clog.WithField("network", name).Debug("Attaching additional network to container")
+
+			if err := api.NetworkConnect(ctx, name, containerID, endpoint); err != nil {
+				clog.WithError(err).
+					WithField("network", name).
+					Error("Failed to attach additional network")
+
+				return fmt.Errorf("failed to attach network %s: %w", name, err)
+			}
+
+			clog.WithField("network", name).Debug("Successfully attached additional network")
+		}
+	}
+
+	return nil
 }
 
 // RenameTargetContainer renames an existing container to the specified target name.

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -18,423 +18,393 @@ import (
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
-var _ = ginkgo.Describe("the container", func() {
-	ginkgo.Describe("VerifyConfiguration", func() {
-		ginkgo.When("verifying a container with no image info", func() {
-			ginkgo.It("should return an error", func() {
-				c := MockContainer(WithPortBindings())
-				c.imageInfo = nil
-				err := c.VerifyConfiguration()
-				gomega.Expect(err).To(gomega.Equal(errNoImageInfo))
-			})
+var _ = ginkgo.Describe("Container", func() {
+	ginkgo.Describe("Configuration Validation", func() {
+		ginkgo.It("returns an error when image info is nil", func() {
+			c := MockContainer(WithPortBindings())
+			c.imageInfo = nil
+			err := c.VerifyConfiguration()
+			gomega.Expect(err).To(gomega.Equal(errNoImageInfo))
 		})
-		ginkgo.When("verifying a container with no container info", func() {
-			ginkgo.It("should return an error", func() {
-				c := MockContainer(WithPortBindings())
-				c.containerInfo = nil
-				err := c.VerifyConfiguration()
-				gomega.Expect(err).To(gomega.Equal(errNoContainerInfo))
-			})
-		})
-		ginkgo.When("verifying a container with no config", func() {
-			ginkgo.It("should return an error", func() {
-				c := MockContainer(WithPortBindings())
-				c.containerInfo.Config = nil
-				err := c.VerifyConfiguration()
-				gomega.Expect(err).To(gomega.Equal(errInvalidConfig))
-			})
-		})
-		ginkgo.When("verifying a container with no host config", func() {
-			ginkgo.It("should return an error", func() {
-				c := MockContainer(WithPortBindings())
-				c.containerInfo.HostConfig = nil
-				err := c.VerifyConfiguration()
-				gomega.Expect(err).To(gomega.Equal(errInvalidConfig))
-			})
-		})
-		ginkgo.When("verifying a container with no port bindings", func() {
-			ginkgo.It("should not return an error", func() {
-				c := MockContainer(WithPortBindings())
-				err := c.VerifyConfiguration()
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			})
-		})
-		ginkgo.When("verifying a container with port bindings, but no exposed ports", func() {
-			ginkgo.It("should make the config compatible with updating", func() {
-				c := MockContainer(WithPortBindings("80/tcp"))
-				c.containerInfo.Config.ExposedPorts = nil
-				gomega.Expect(c.VerifyConfiguration()).To(gomega.Succeed())
 
-				gomega.Expect(c.containerInfo.Config.ExposedPorts).ToNot(gomega.BeNil())
-				gomega.Expect(c.containerInfo.Config.ExposedPorts).To(gomega.BeEmpty())
-			})
+		ginkgo.It("returns an error when container info is nil", func() {
+			c := MockContainer(WithPortBindings())
+			c.containerInfo = nil
+			err := c.VerifyConfiguration()
+			gomega.Expect(err).To(gomega.Equal(errNoContainerInfo))
 		})
-		ginkgo.When(
-			"verifying a container with port bindings and exposed ports is non-nil",
-			func() {
-				ginkgo.It("should not return an error", func() {
-					c := MockContainer(WithPortBindings("80/tcp"))
-					c.containerInfo.Config.ExposedPorts = map[dockerNat.Port]struct{}{"80/tcp": {}}
-					err := c.VerifyConfiguration()
-					gomega.Expect(err).ToNot(gomega.HaveOccurred())
-				})
-			},
-		)
+
+		ginkgo.It("returns an error when config is nil", func() {
+			c := MockContainer(WithPortBindings())
+			c.containerInfo.Config = nil
+			err := c.VerifyConfiguration()
+			gomega.Expect(err).To(gomega.Equal(errInvalidConfig))
+		})
+
+		ginkgo.It("returns an error when host config is nil", func() {
+			c := MockContainer(WithPortBindings())
+			c.containerInfo.HostConfig = nil
+			err := c.VerifyConfiguration()
+			gomega.Expect(err).To(gomega.Equal(errInvalidConfig))
+		})
+
+		ginkgo.It("succeeds with no port bindings", func() {
+			c := MockContainer(WithPortBindings())
+			err := c.VerifyConfiguration()
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("initializes exposed ports when nil with port bindings", func() {
+			c := MockContainer(WithPortBindings("80/tcp"))
+			c.containerInfo.Config.ExposedPorts = nil
+			gomega.Expect(c.VerifyConfiguration()).To(gomega.Succeed())
+			gomega.Expect(c.containerInfo.Config.ExposedPorts).ToNot(gomega.BeNil())
+			gomega.Expect(c.containerInfo.Config.ExposedPorts).To(gomega.BeEmpty())
+		})
+
+		ginkgo.It("succeeds with non-nil exposed ports and port bindings", func() {
+			c := MockContainer(WithPortBindings("80/tcp"))
+			c.containerInfo.Config.ExposedPorts = map[dockerNat.Port]struct{}{"80/tcp": {}}
+			err := c.VerifyConfiguration()
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		})
 	})
 
-	ginkgo.Describe("GetCreateConfig", func() {
-		ginkgo.When("container healthcheck config is equal to image config", func() {
-			ginkgo.It("should return empty healthcheck values", func() {
-				mockContainer := MockContainer(WithHealthcheck(dockerContainerType.HealthConfig{
-					Test: []string{"/usr/bin/sleep", "1s"},
-				}), WithImageHealthcheck(dockerContainerType.HealthConfig{
-					Test: []string{"/usr/bin/sleep", "1s"},
-				}))
-				gomega.Expect(mockContainer.GetCreateConfig().Healthcheck).
-					To(gomega.Equal(&dockerContainerType.HealthConfig{}))
-
-				mockContainer = MockContainer(WithHealthcheck(dockerContainerType.HealthConfig{
-					Timeout: 30,
-				}), WithImageHealthcheck(dockerContainerType.HealthConfig{
-					Timeout: 30,
-				}))
-				gomega.Expect(mockContainer.GetCreateConfig().Healthcheck).
-					To(gomega.Equal(&dockerContainerType.HealthConfig{}))
-
-				mockContainer = MockContainer(WithHealthcheck(dockerContainerType.HealthConfig{
-					StartPeriod: 30,
-				}), WithImageHealthcheck(dockerContainerType.HealthConfig{
-					StartPeriod: 30,
-				}))
-				gomega.Expect(mockContainer.GetCreateConfig().Healthcheck).
-					To(gomega.Equal(&dockerContainerType.HealthConfig{}))
-
-				mockContainer = MockContainer(WithHealthcheck(dockerContainerType.HealthConfig{
-					Retries: 30,
-				}), WithImageHealthcheck(dockerContainerType.HealthConfig{
-					Retries: 30,
-				}))
-				gomega.Expect(mockContainer.GetCreateConfig().Healthcheck).
-					To(gomega.Equal(&dockerContainerType.HealthConfig{}))
+	ginkgo.Describe("Create Configuration", func() {
+		ginkgo.Context("when container and image healthcheck configs are identical", func() {
+			ginkgo.It("returns an empty healthcheck config", func() {
+				tests := []dockerContainerType.HealthConfig{
+					{Test: []string{"/usr/bin/sleep", "1s"}},
+					{Timeout: 30},
+					{StartPeriod: 30},
+					{Retries: 30},
+				}
+				for _, healthConfig := range tests {
+					c := MockContainer(
+						WithHealthcheck(healthConfig),
+						WithImageHealthcheck(healthConfig),
+					)
+					gomega.Expect(c.GetCreateConfig().Healthcheck).
+						To(gomega.Equal(&dockerContainerType.HealthConfig{}))
+				}
 			})
 		})
-		ginkgo.When("container healthcheck config is different to image config", func() {
-			ginkgo.It("should return the container healthcheck values", func() {
-				mockContainer := MockContainer(WithHealthcheck(dockerContainerType.HealthConfig{
+
+		ginkgo.It("returns container healthcheck when configs differ", func() {
+			c := MockContainer(
+				WithHealthcheck(dockerContainerType.HealthConfig{
 					Test:        []string{"/usr/bin/sleep", "1s"},
 					Interval:    30,
 					Timeout:     30,
 					StartPeriod: 10,
 					Retries:     2,
-				}), WithImageHealthcheck(dockerContainerType.HealthConfig{
+				}),
+				WithImageHealthcheck(dockerContainerType.HealthConfig{
 					Test:        []string{"/usr/bin/sleep", "10s"},
 					Interval:    10,
 					Timeout:     60,
 					StartPeriod: 30,
 					Retries:     10,
-				}))
-				gomega.Expect(mockContainer.GetCreateConfig().Healthcheck).
-					To(gomega.Equal(&dockerContainerType.HealthConfig{
-						Test:        []string{"/usr/bin/sleep", "1s"},
-						Interval:    30,
-						Timeout:     30,
-						StartPeriod: 10,
-						Retries:     2,
-					}))
-			})
-		})
-		ginkgo.When("container healthcheck config is empty", func() {
-			ginkgo.It("should not panic", func() {
-				mockContainer := MockContainer(
-					WithImageHealthcheck(dockerContainerType.HealthConfig{
-						Test:        []string{"/usr/bin/sleep", "10s"},
-						Interval:    10,
-						Timeout:     60,
-						StartPeriod: 30,
-						Retries:     10,
-					}),
-				)
-				gomega.Expect(mockContainer.GetCreateConfig().Healthcheck).To(gomega.BeNil())
-			})
-		})
-		ginkgo.When("container image healthcheck config is empty", func() {
-			ginkgo.It("should not panic", func() {
-				mockContainer := MockContainer(WithHealthcheck(dockerContainerType.HealthConfig{
+				}),
+			)
+			gomega.Expect(c.GetCreateConfig().Healthcheck).
+				To(gomega.Equal(&dockerContainerType.HealthConfig{
 					Test:        []string{"/usr/bin/sleep", "1s"},
 					Interval:    30,
 					Timeout:     30,
 					StartPeriod: 10,
 					Retries:     2,
 				}))
-				gomega.Expect(mockContainer.GetCreateConfig().Healthcheck).
-					To(gomega.Equal(&dockerContainerType.HealthConfig{
-						Test:        []string{"/usr/bin/sleep", "1s"},
-						Interval:    30,
-						Timeout:     30,
-						StartPeriod: 10,
-						Retries:     2,
-					}))
-			})
+		})
+
+		ginkgo.It("handles empty container healthcheck config without panic", func() {
+			c := MockContainer(WithImageHealthcheck(dockerContainerType.HealthConfig{
+				Test:        []string{"/usr/bin/sleep", "10s"},
+				Interval:    10,
+				Timeout:     60,
+				StartPeriod: 30,
+				Retries:     10,
+			}))
+			gomega.Expect(c.GetCreateConfig().Healthcheck).To(gomega.BeNil())
+		})
+
+		ginkgo.It("handles empty image healthcheck config without panic", func() {
+			c := MockContainer(WithHealthcheck(dockerContainerType.HealthConfig{
+				Test:        []string{"/usr/bin/sleep", "1s"},
+				Interval:    30,
+				Timeout:     30,
+				StartPeriod: 10,
+				Retries:     2,
+			}))
+			gomega.Expect(c.GetCreateConfig().Healthcheck).
+				To(gomega.Equal(&dockerContainerType.HealthConfig{
+					Test:        []string{"/usr/bin/sleep", "1s"},
+					Interval:    30,
+					Timeout:     30,
+					StartPeriod: 10,
+					Retries:     2,
+				}))
 		})
 	})
 
-	ginkgo.When("asked for metadata", func() {
+	ginkgo.Describe("Metadata Retrieval", func() {
 		var container *Container
+
 		ginkgo.BeforeEach(func() {
 			container = MockContainer(WithLabels(map[string]string{
 				"com.centurylinklabs.watchtower.enable": "true",
 				"com.centurylinklabs.watchtower":        "true",
 			}))
 		})
-		ginkgo.It("should return its name on calls to .Name()", func() {
+
+		ginkgo.It("returns correct container name", func() {
 			name := container.Name()
 			gomega.Expect(name).To(gomega.Equal("test-watchtower"))
 			gomega.Expect(name).NotTo(gomega.Equal("wrong-name"))
 		})
-		ginkgo.It("should return its ID on calls to .ID()", func() {
-			id := container.ID()
 
+		ginkgo.It("returns correct container ID", func() {
+			id := container.ID()
 			gomega.Expect(id).To(gomega.BeEquivalentTo("container_id"))
 			gomega.Expect(id).NotTo(gomega.BeEquivalentTo("wrong-id"))
 		})
-		ginkgo.It("should return true, true if enabled on calls to .Enabled()", func() {
-			enabled, exists := container.Enabled()
 
+		ginkgo.It("returns true for enabled label when set to true", func() {
+			enabled, exists := container.Enabled()
 			gomega.Expect(enabled).To(gomega.BeTrue())
 			gomega.Expect(exists).To(gomega.BeTrue())
 		})
-		ginkgo.It(
-			"should return false, true if present but not true on calls to .Enabled()",
-			func() {
-				container = MockContainer(
-					WithLabels(map[string]string{"com.centurylinklabs.watchtower.enable": "false"}),
-				)
-				enabled, exists := container.Enabled()
 
-				gomega.Expect(enabled).To(gomega.BeFalse())
-				gomega.Expect(exists).To(gomega.BeTrue())
-			},
-		)
-		ginkgo.It("should return false, false if not present on calls to .Enabled()", func() {
+		ginkgo.It("returns false and true for enabled label when set to false", func() {
+			container = MockContainer(WithLabels(map[string]string{
+				"com.centurylinklabs.watchtower.enable": "false",
+			}))
+			enabled, exists := container.Enabled()
+			gomega.Expect(enabled).To(gomega.BeFalse())
+			gomega.Expect(exists).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("returns false and false when enabled label is not set", func() {
 			container = MockContainer(WithLabels(map[string]string{"lol": "false"}))
 			enabled, exists := container.Enabled()
-
 			gomega.Expect(enabled).To(gomega.BeFalse())
 			gomega.Expect(exists).To(gomega.BeFalse())
 		})
-		ginkgo.It("should return false, false if present but not parsable .Enabled()", func() {
-			container = MockContainer(
-				WithLabels(map[string]string{"com.centurylinklabs.watchtower.enable": "falsy"}),
-			)
+
+		ginkgo.It("returns false and false for invalid enabled label", func() {
+			container = MockContainer(WithLabels(map[string]string{
+				"com.centurylinklabs.watchtower.enable": "falsy",
+			}))
 			enabled, exists := container.Enabled()
-
 			gomega.Expect(enabled).To(gomega.BeFalse())
 			gomega.Expect(exists).To(gomega.BeFalse())
 		})
-		ginkgo.When("checking if its a watchtower instance", func() {
-			ginkgo.It("should return true if the label is set to true", func() {
+
+		ginkgo.Context("checking Watchtower instance", func() {
+			ginkgo.It("returns true when Watchtower label is true", func() {
 				isWatchtower := container.IsWatchtower()
 				gomega.Expect(isWatchtower).To(gomega.BeTrue())
 			})
-			ginkgo.It("should return false if the label is present but set to false", func() {
-				container = MockContainer(
-					WithLabels(map[string]string{"com.centurylinklabs.watchtower": "false"}),
-				)
+
+			ginkgo.It("returns false when Watchtower label is false", func() {
+				container = MockContainer(WithLabels(map[string]string{
+					"com.centurylinklabs.watchtower": "false",
+				}))
 				isWatchtower := container.IsWatchtower()
 				gomega.Expect(isWatchtower).To(gomega.BeFalse())
 			})
-			ginkgo.It("should return false if the label is not present", func() {
+
+			ginkgo.It("returns false when Watchtower label is not set", func() {
 				container = MockContainer(WithLabels(map[string]string{"funny.label": "false"}))
 				isWatchtower := container.IsWatchtower()
 				gomega.Expect(isWatchtower).To(gomega.BeFalse())
 			})
-			ginkgo.It("should return false if there are no labels", func() {
+
+			ginkgo.It("returns false when no labels are set", func() {
 				container = MockContainer(WithLabels(map[string]string{}))
 				isWatchtower := container.IsWatchtower()
 				gomega.Expect(isWatchtower).To(gomega.BeFalse())
 			})
 		})
-		ginkgo.When("fetching the custom stop signal", func() {
-			ginkgo.It("should return the signal if its set", func() {
+
+		ginkgo.Context("fetching stop signal", func() {
+			ginkgo.It("returns signal when set", func() {
 				container = MockContainer(WithLabels(map[string]string{
 					"com.centurylinklabs.watchtower.stop-signal": "SIGKILL",
 				}))
-				stopSignal := container.StopSignal()
-				gomega.Expect(stopSignal).To(gomega.Equal("SIGKILL"))
+				gomega.Expect(container.StopSignal()).To(gomega.Equal("SIGKILL"))
 			})
-			ginkgo.It("should return an empty string if its not set", func() {
+
+			ginkgo.It("returns empty string when signal is not set", func() {
 				container = MockContainer(WithLabels(map[string]string{}))
-				stopSignal := container.StopSignal()
-				gomega.Expect(stopSignal).To(gomega.Equal(""))
-			})
-		})
-		ginkgo.When("fetching the image name", func() {
-			ginkgo.When("the zodiac label is present", func() {
-				ginkgo.It("should fetch the image name from it", func() {
-					container = MockContainer(WithLabels(map[string]string{
-						"com.centurylinklabs.zodiac.original-image": "the-original-image",
-					}))
-					imageName := container.ImageName()
-					gomega.Expect(imageName).To(gomega.Equal("the-original-image:latest"))
-				})
-			})
-			ginkgo.It("should return the image name", func() {
-				name := "image-name:3"
-				container = MockContainer(WithImageName(name))
-				imageName := container.ImageName()
-				gomega.Expect(imageName).To(gomega.Equal(name))
-			})
-			ginkgo.It("should assume latest if no tag is supplied", func() {
-				name := "image-name"
-				container = MockContainer(WithImageName(name))
-				imageName := container.ImageName()
-				gomega.Expect(imageName).To(gomega.Equal(name + ":latest"))
+				gomega.Expect(container.StopSignal()).To(gomega.Equal(""))
 			})
 		})
 
-		ginkgo.When("fetching container links", func() {
-			ginkgo.When("the depends on label is present", func() {
-				ginkgo.It("should fetch depending containers from it", func() {
+		ginkgo.Context("fetching image name", func() {
+			ginkgo.It("uses zodiac label when present", func() {
+				container = MockContainer(WithLabels(map[string]string{
+					"com.centurylinklabs.zodiac.original-image": "the-original-image",
+				}))
+				gomega.Expect(container.ImageName()).To(gomega.Equal("the-original-image:latest"))
+			})
+
+			ginkgo.It("returns image name from config", func() {
+				name := "image-name:3"
+				container = MockContainer(WithImageName(name))
+				gomega.Expect(container.ImageName()).To(gomega.Equal(name))
+			})
+
+			ginkgo.It("appends latest tag when no tag is supplied", func() {
+				name := "image-name"
+				container = MockContainer(WithImageName(name))
+				gomega.Expect(container.ImageName()).To(gomega.Equal(name + ":latest"))
+			})
+		})
+
+		ginkgo.Context("fetching container links", func() {
+			ginkgo.When("depends-on label is present", func() {
+				ginkgo.It("returns single dependent container", func() {
 					container = MockContainer(WithLabels(map[string]string{
 						"com.centurylinklabs.watchtower.depends-on": "postgres",
 					}))
 					links := container.Links()
-					gomega.Expect(links).
-						To(gomega.SatisfyAll(gomega.ContainElement("/postgres"), gomega.HaveLen(1)))
+					gomega.Expect(links).To(gomega.SatisfyAll(
+						gomega.ContainElement("/postgres"),
+						gomega.HaveLen(1),
+					))
 				})
-				ginkgo.It("should fetch depending containers if there are many", func() {
+
+				ginkgo.It("returns multiple dependent containers", func() {
 					container = MockContainer(WithLabels(map[string]string{
 						"com.centurylinklabs.watchtower.depends-on": "postgres,redis",
 					}))
 					links := container.Links()
-					gomega.Expect(links).
-						To(gomega.SatisfyAll(gomega.ContainElement("/postgres"), gomega.ContainElement("/redis"), gomega.HaveLen(2)))
+					gomega.Expect(links).To(gomega.SatisfyAll(
+						gomega.ContainElement("/postgres"),
+						gomega.ContainElement("/redis"),
+						gomega.HaveLen(2),
+					))
 				})
-				ginkgo.It("should only add slashes to names when they are missing", func() {
+
+				ginkgo.It("normalizes container names with slashes", func() {
 					container = MockContainer(WithLabels(map[string]string{
 						"com.centurylinklabs.watchtower.depends-on": "/postgres,redis",
 					}))
 					links := container.Links()
-					gomega.Expect(links).
-						To(gomega.SatisfyAll(gomega.ContainElement("/postgres"), gomega.ContainElement("/redis")))
+					gomega.Expect(links).To(gomega.SatisfyAll(
+						gomega.ContainElement("/postgres"),
+						gomega.ContainElement("/redis"),
+					))
 				})
-				ginkgo.It("should fetch depending containers if label is blank", func() {
+
+				ginkgo.It("returns empty links for blank depends-on label", func() {
 					container = MockContainer(WithLabels(map[string]string{
 						"com.centurylinklabs.watchtower.depends-on": "",
 					}))
-					links := container.Links()
-					gomega.Expect(links).To(gomega.BeEmpty())
+					gomega.Expect(container.Links()).To(gomega.BeEmpty())
 				})
 			})
-			ginkgo.When("the depends on label is not present", func() {
-				ginkgo.It("should fetch depending containers from host config links", func() {
-					container = MockContainer(WithLinks([]string{
-						"redis:test-watchtower",
-						"postgres:test-watchtower",
-					}))
-					links := container.Links()
-					gomega.Expect(links).
-						To(gomega.SatisfyAll(gomega.ContainElement("redis"), gomega.ContainElement("postgres"), gomega.HaveLen(2)))
-				})
-			})
-		})
 
-		ginkgo.When("checking no-pull label", func() {
-			ginkgo.When("no-pull argument is not set", func() {
-				ginkgo.When("no-pull label is true", func() {
-					c := MockContainer(WithLabels(map[string]string{
-						"com.centurylinklabs.watchtower.no-pull": "true",
-					}))
-					ginkgo.It("should return true", func() {
-						gomega.Expect(c.IsNoPull(types.UpdateParams{})).To(gomega.BeTrue())
-					})
-				})
-				ginkgo.When("no-pull label is false", func() {
-					c := MockContainer(WithLabels(map[string]string{
-						"com.centurylinklabs.watchtower.no-pull": "false",
-					}))
-					ginkgo.It("should return false", func() {
-						gomega.Expect(c.IsNoPull(types.UpdateParams{})).To(gomega.BeFalse())
-					})
-				})
-				ginkgo.When("no-pull label is set to an invalid value", func() {
-					c := MockContainer(WithLabels(map[string]string{
-						"com.centurylinklabs.watchtower.no-pull": "maybe",
-					}))
-					ginkgo.It("should return false", func() {
-						gomega.Expect(c.IsNoPull(types.UpdateParams{})).To(gomega.BeFalse())
-					})
-				})
-				ginkgo.When("no-pull label is unset", func() {
-					container = MockContainer(WithLabels(map[string]string{}))
-					ginkgo.It("should return false", func() {
-						gomega.Expect(container.IsNoPull(types.UpdateParams{})).To(gomega.BeFalse())
-					})
-				})
-			})
-			ginkgo.When("no-pull argument is set to true", func() {
-				ginkgo.When("no-pull label is true", func() {
-					c := MockContainer(WithLabels(map[string]string{
-						"com.centurylinklabs.watchtower.no-pull": "true",
-					}))
-					ginkgo.It("should return true", func() {
-						gomega.Expect(c.IsNoPull(types.UpdateParams{NoPull: true})).
-							To(gomega.BeTrue())
-					})
-				})
-				ginkgo.When("no-pull label is false", func() {
-					c := MockContainer(WithLabels(map[string]string{
-						"com.centurylinklabs.watchtower.no-pull": "false",
-					}))
-					ginkgo.It("should return true", func() {
-						gomega.Expect(c.IsNoPull(types.UpdateParams{NoPull: true})).
-							To(gomega.BeTrue())
-					})
-				})
-				ginkgo.When("label-take-precedence argument is set to true", func() {
-					ginkgo.When("no-pull label is true", func() {
-						c := MockContainer(WithLabels(map[string]string{
-							"com.centurylinklabs.watchtower.no-pull": "true",
-						}))
-						ginkgo.It("should return true", func() {
-							gomega.Expect(c.IsNoPull(types.UpdateParams{LabelPrecedence: true, NoPull: true})).
-								To(gomega.BeTrue())
-						})
-					})
-					ginkgo.When("no-pull label is false", func() {
-						c := MockContainer(WithLabels(map[string]string{
-							"com.centurylinklabs.watchtower.no-pull": "false",
-						}))
-						ginkgo.It("should return false", func() {
-							gomega.Expect(c.IsNoPull(types.UpdateParams{LabelPrecedence: true, NoPull: true})).
-								To(gomega.BeFalse())
-						})
-					})
-				})
-			})
-		})
-
-		ginkgo.When("there is a pre or post update timeout", func() {
-			ginkgo.It("should return minute values", func() {
-				container = MockContainer(WithLabels(map[string]string{
-					"com.centurylinklabs.watchtower.lifecycle.pre-update-timeout":  "3",
-					"com.centurylinklabs.watchtower.lifecycle.post-update-timeout": "5",
+			ginkgo.It("returns links from host config when depends-on label is absent", func() {
+				container = MockContainer(WithLinks([]string{
+					"redis:test-watchtower",
+					"postgres:test-watchtower",
 				}))
-				preTimeout := container.PreUpdateTimeout()
-				gomega.Expect(preTimeout).To(gomega.Equal(3))
-				postTimeout := container.PostUpdateTimeout()
-				gomega.Expect(postTimeout).To(gomega.Equal(5))
+				links := container.Links()
+				gomega.Expect(links).To(gomega.SatisfyAll(
+					gomega.ContainElement("redis"),
+					gomega.ContainElement("postgres"),
+					gomega.HaveLen(2),
+				))
+			})
+		})
+
+		ginkgo.It("returns pre and post update timeout values", func() {
+			container = MockContainer(WithLabels(map[string]string{
+				"com.centurylinklabs.watchtower.lifecycle.pre-update-timeout":  "3",
+				"com.centurylinklabs.watchtower.lifecycle.post-update-timeout": "5",
+			}))
+			gomega.Expect(container.PreUpdateTimeout()).To(gomega.Equal(3))
+			gomega.Expect(container.PostUpdateTimeout()).To(gomega.Equal(5))
+		})
+	})
+
+	ginkgo.Describe("No-Pull Configuration", func() {
+		ginkgo.When("no-pull argument is not set", func() {
+			ginkgo.It("returns true when no-pull label is true", func() {
+				c := MockContainer(WithLabels(map[string]string{
+					"com.centurylinklabs.watchtower.no-pull": "true",
+				}))
+				gomega.Expect(c.IsNoPull(types.UpdateParams{})).To(gomega.BeTrue())
+			})
+
+			ginkgo.It("returns false when no-pull label is false", func() {
+				c := MockContainer(WithLabels(map[string]string{
+					"com.centurylinklabs.watchtower.no-pull": "false",
+				}))
+				gomega.Expect(c.IsNoPull(types.UpdateParams{})).To(gomega.BeFalse())
+			})
+
+			ginkgo.It("returns false for invalid no-pull label", func() {
+				c := MockContainer(WithLabels(map[string]string{
+					"com.centurylinklabs.watchtower.no-pull": "maybe",
+				}))
+				gomega.Expect(c.IsNoPull(types.UpdateParams{})).To(gomega.BeFalse())
+			})
+
+			ginkgo.It("returns false when no-pull label is unset", func() {
+				c := MockContainer(WithLabels(map[string]string{}))
+				gomega.Expect(c.IsNoPull(types.UpdateParams{})).To(gomega.BeFalse())
+			})
+		})
+
+		ginkgo.When("no-pull argument is true", func() {
+			ginkgo.It("returns true when no-pull label is true", func() {
+				c := MockContainer(WithLabels(map[string]string{
+					"com.centurylinklabs.watchtower.no-pull": "true",
+				}))
+				gomega.Expect(c.IsNoPull(types.UpdateParams{NoPull: true})).To(gomega.BeTrue())
+			})
+
+			ginkgo.It("returns true when no-pull label is false", func() {
+				c := MockContainer(WithLabels(map[string]string{
+					"com.centurylinklabs.watchtower.no-pull": "false",
+				}))
+				gomega.Expect(c.IsNoPull(types.UpdateParams{NoPull: true})).To(gomega.BeTrue())
+			})
+
+			ginkgo.When("label-take-precedence is true", func() {
+				ginkgo.It("returns true when no-pull label is true", func() {
+					c := MockContainer(WithLabels(map[string]string{
+						"com.centurylinklabs.watchtower.no-pull": "true",
+					}))
+					gomega.Expect(c.IsNoPull(types.UpdateParams{LabelPrecedence: true, NoPull: true})).
+						To(gomega.BeTrue())
+				})
+
+				ginkgo.It("returns false when no-pull label is false", func() {
+					c := MockContainer(WithLabels(map[string]string{
+						"com.centurylinklabs.watchtower.no-pull": "false",
+					}))
+					gomega.Expect(c.IsNoPull(types.UpdateParams{LabelPrecedence: true, NoPull: true})).
+						To(gomega.BeFalse())
+				})
 			})
 		})
 	})
 
 	ginkgo.Describe("Network Configuration", func() {
-		ginkgo.When("using bridge network mode", func() {
-			ginkgo.It("should preserve IP and MAC addresses for running containers", func() {
-				logOutput := &bytes.Buffer{}
-				logrus.SetOutput(logOutput)
-				logrus.SetLevel(logrus.DebugLevel)
+		var logOutput *bytes.Buffer
 
+		ginkgo.BeforeEach(func() {
+			logOutput = &bytes.Buffer{}
+			logrus.SetOutput(logOutput)
+			logrus.SetLevel(logrus.DebugLevel)
+		})
+
+		ginkgo.Context("using bridge network mode", func() {
+			ginkgo.It("preserves IP and MAC addresses for running containers", func() {
 				container := MockContainer(
 					WithNetworkMode("bridge"),
 					WithContainerState(dockerContainerType.State{Running: true, Status: "running"}),
@@ -455,16 +425,12 @@ var _ = ginkgo.Describe("the container", func() {
 				gomega.Expect(endpoint.DNSNames).To(gomega.BeEmpty(), "DNSNames should not be set")
 				gomega.Expect(endpoint.IPAddress).To(gomega.Equal("172.17.0.2"))
 				gomega.Expect(endpoint.MacAddress).To(gomega.Equal("02:42:ac:11:00:02"))
-
 				gomega.Expect(logOutput.String()).
 					To(gomega.ContainSubstring("Found MAC address in config"))
 			})
 
-			ginkgo.It("should warn for missing MAC address in running containers", func() {
-				logOutput := &bytes.Buffer{}
-				logrus.SetOutput(logOutput)
+			ginkgo.It("logs warning for missing MAC address in running containers", func() {
 				logrus.SetLevel(logrus.WarnLevel)
-
 				container := MockContainer(
 					WithNetworkMode("bridge"),
 					WithContainerState(dockerContainerType.State{Running: true, Status: "running"}),
@@ -487,11 +453,7 @@ var _ = ginkgo.Describe("the container", func() {
 			})
 
 			ginkgo.Context("for non-running containers", func() {
-				ginkgo.It("should log debug for missing MAC address in created state", func() {
-					logOutput := &bytes.Buffer{}
-					logrus.SetOutput(logOutput)
-					logrus.SetLevel(logrus.DebugLevel)
-
+				ginkgo.It("logs debug message for missing MAC address in created state", func() {
 					container := MockContainer(
 						WithNetworkMode("bridge"),
 						WithContainerState(
@@ -510,19 +472,13 @@ var _ = ginkgo.Describe("the container", func() {
 					config := getNetworkConfig(container, "1.49")
 					gomega.Expect(config.EndpointsConfig).To(gomega.HaveKey("bridge"))
 					gomega.Expect(logOutput.String()).To(gomega.ContainSubstring(
-						"No MAC address found for non-running container",
-					))
+						"No MAC address found for non-running container"))
 					gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("state=created"))
 					gomega.Expect(logOutput.String()).NotTo(gomega.ContainSubstring(
-						"Negotiated API version 1.49 is at least 1.44 but no MAC address found",
-					))
+						"Negotiated API version 1.49 is at least 1.44 but no MAC address found"))
 				})
 
-				ginkgo.It("should log debug for missing MAC address in exited state", func() {
-					logOutput := &bytes.Buffer{}
-					logrus.SetOutput(logOutput)
-					logrus.SetLevel(logrus.DebugLevel)
-
+				ginkgo.It("logs debug message for missing MAC address in exited state", func() {
 					container := MockContainer(
 						WithNetworkMode("bridge"),
 						WithContainerState(
@@ -541,22 +497,16 @@ var _ = ginkgo.Describe("the container", func() {
 					config := getNetworkConfig(container, "1.49")
 					gomega.Expect(config.EndpointsConfig).To(gomega.HaveKey("bridge"))
 					gomega.Expect(logOutput.String()).To(gomega.ContainSubstring(
-						"No MAC address found for non-running container",
-					))
+						"No MAC address found for non-running container"))
 					gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("state=exited"))
 					gomega.Expect(logOutput.String()).NotTo(gomega.ContainSubstring(
-						"Negotiated API version 1.49 is at least 1.44 but no MAC address found",
-					))
+						"Negotiated API version 1.49 is at least 1.44 but no MAC address found"))
 				})
 			})
 		})
 
-		ginkgo.When("using host network mode", func() {
-			ginkgo.It("should include host endpoint with no aliases or DNS names", func() {
-				logOutput := &bytes.Buffer{}
-				logrus.SetOutput(logOutput)
-				logrus.SetLevel(logrus.DebugLevel)
-
+		ginkgo.Context("using host network mode", func() {
+			ginkgo.It("includes host endpoint with no aliases or DNS names", func() {
 				container := MockContainer(
 					WithNetworkMode("host"),
 					WithContainerState(dockerContainerType.State{Running: true, Status: "running"}),
@@ -570,12 +520,14 @@ var _ = ginkgo.Describe("the container", func() {
 					}),
 				)
 
-				networkMode := container.containerInfo.HostConfig.NetworkMode
 				logrus.WithFields(logrus.Fields{
-					"network_mode":      networkMode,
-					"network_mode_type": fmt.Sprintf("%T", networkMode),
-					"network_mode_str":  string(networkMode),
-					"test":              "host_network_mode",
+					"network_mode": container.containerInfo.HostConfig.NetworkMode,
+					"network_mode_type": fmt.Sprintf(
+						"%T",
+						container.containerInfo.HostConfig.NetworkMode,
+					),
+					"network_mode_str": string(container.containerInfo.HostConfig.NetworkMode),
+					"test":             "host_network_mode",
 				}).Debug("Test network mode check")
 
 				config := getNetworkConfig(container, "1.44")
@@ -587,16 +539,11 @@ var _ = ginkgo.Describe("the container", func() {
 					To(gomega.BeEmpty(), "DNSNames should not be set for host mode")
 				gomega.Expect(endpoint.IPAddress).To(gomega.BeEmpty())
 				gomega.Expect(endpoint.MacAddress).To(gomega.BeEmpty())
-
-				gomega.Expect(container.containerInfo.HostConfig.NetworkMode).
-					To(gomega.Equal(dockerContainerType.NetworkMode("host")))
+				gomega.Expect(container.containerInfo.HostConfig.NetworkMode).To(gomega.Equal(
+					dockerContainerType.NetworkMode("host")))
 			})
 
-			ginkgo.It("should clear non-empty aliases and DNS names", func() {
-				logOutput := &bytes.Buffer{}
-				logrus.SetOutput(logOutput)
-				logrus.SetLevel(logrus.DebugLevel)
-
+			ginkgo.It("clears non-empty aliases and DNS names", func() {
 				container := MockContainer(
 					WithNetworkMode("host"),
 					WithContainerState(dockerContainerType.State{Running: true, Status: "running"}),
@@ -623,11 +570,7 @@ var _ = ginkgo.Describe("the container", func() {
 					To(gomega.BeEmpty(), "MacAddress should be cleared for host mode")
 			})
 
-			ginkgo.It("should log no MAC address as expected in debugLogMacAddress", func() {
-				logOutput := &bytes.Buffer{}
-				logrus.SetOutput(logOutput)
-				logrus.SetLevel(logrus.DebugLevel)
-
+			ginkgo.It("logs no MAC address for host mode in debugLogMacAddress", func() {
 				container := MockContainer(
 					WithNetworkMode("host"),
 					WithContainerState(dockerContainerType.State{Running: true, Status: "running"}),
@@ -649,17 +592,13 @@ var _ = ginkgo.Describe("the container", func() {
 					flags.DockerAPIMinVersion,
 					true,
 				)
-				gomega.Expect(logOutput.String()).
-					To(gomega.ContainSubstring("No MAC address in host network mode, as expected"))
+				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring(
+					"No MAC address in host network mode, as expected"))
 			})
 		})
 
-		ginkgo.When("using legacy API version (<1.44)", func() {
-			ginkgo.It("should clear MAC address and DNS names", func() {
-				logOutput := &bytes.Buffer{}
-				logrus.SetOutput(logOutput)
-				logrus.SetLevel(logrus.DebugLevel)
-
+		ginkgo.Context("using legacy API version (< 1.44)", func() {
+			ginkgo.It("clears MAC address and DNS names", func() {
 				container := MockContainer(
 					WithNetworkMode("bridge"),
 					WithContainerState(dockerContainerType.State{Running: true, Status: "running"}),
@@ -686,11 +625,7 @@ var _ = ginkgo.Describe("the container", func() {
 					To(gomega.BeEmpty(), "DNSNames should be cleared for legacy API")
 			})
 
-			ginkgo.It("should log no MAC address in debugLogMacAddress", func() {
-				logOutput := &bytes.Buffer{}
-				logrus.SetOutput(logOutput)
-				logrus.SetLevel(logrus.DebugLevel)
-
+			ginkgo.It("logs no MAC address in debugLogMacAddress", func() {
 				container := MockContainer(
 					WithNetworkMode("bridge"),
 					WithContainerState(dockerContainerType.State{Running: true, Status: "running"}),
@@ -710,183 +645,156 @@ var _ = ginkgo.Describe("the container", func() {
 					flags.DockerAPIMinVersion,
 					false,
 				)
-				gomega.Expect(logOutput.String()).
-					To(gomega.ContainSubstring("No MAC address in legacy config, as expected"))
+				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring(
+					"No MAC address in legacy config, as expected"))
 			})
 		})
-	})
 
-	ginkgo.Describe("validateMacAddresses", func() {
-		ginkgo.When("container is running with no MAC address", func() {
-			ginkgo.It("should return errNoMacInNonHost and log warning", func() {
-				logOutput := &bytes.Buffer{}
-				logrus.SetOutput(logOutput)
-				logrus.SetLevel(logrus.WarnLevel)
+		ginkgo.Context("with multiple networks", func() {
+			ginkgo.BeforeEach(func() {
+				logrus.SetLevel(logrus.DebugLevel)
+			})
 
+			ginkgo.It(
+				"preserves all networks and clears MAC addresses for legacy API (< 1.44)",
+				func() {
+					container := MockContainer(
+						WithNetworkMode("bridge"),
+						WithContainerState(
+							dockerContainerType.State{Running: true, Status: "running"},
+						),
+						WithNetworks("network1", "network2"),
+						WithImageName("test-image:latest"),
+					)
+
+					config := getNetworkConfig(container, "1.43")
+					gomega.Expect(config.EndpointsConfig).
+						To(gomega.HaveKey("network1"), "Should include first network")
+					gomega.Expect(config.EndpointsConfig).
+						To(gomega.HaveKey("network2"), "Should include second network")
+					gomega.Expect(config.EndpointsConfig["network1"].MacAddress).
+						To(gomega.BeEmpty(),
+							"MAC address should be cleared for network1")
+					gomega.Expect(config.EndpointsConfig["network2"].MacAddress).
+						To(gomega.BeEmpty(),
+							"MAC address should be cleared for network2")
+					gomega.Expect(config.EndpointsConfig["network1"].Aliases).
+						To(gomega.ContainElement("test-watchtower"),
+							"Aliases should match mock setup for network1")
+					gomega.Expect(config.EndpointsConfig["network2"].Aliases).
+						To(gomega.ContainElement("test-watchtower"),
+							"Aliases should match mock setup for network2")
+					gomega.Expect(logOutput.String()).
+						To(gomega.ContainSubstring("No MAC address in legacy config, as expected"))
+				},
+			)
+
+			ginkgo.It(
+				"preserves all networks with IP and MAC addresses for modern API (>= 1.44)",
+				func() {
+					container := MockContainer(
+						WithNetworkMode("bridge"),
+						WithContainerState(
+							dockerContainerType.State{Running: true, Status: "running"},
+						),
+						WithNetworkSettings(map[string]*dockerNetworkType.EndpointSettings{
+							"network1": {
+								NetworkID:  "network_network1_id",
+								IPAddress:  "172.17.0.2",
+								MacAddress: "02:42:ac:11:00:02",
+								Aliases:    []string{"test-watchtower"},
+							},
+							"network2": {
+								NetworkID:  "network_network2_id",
+								IPAddress:  "172.18.0.2",
+								MacAddress: "02:42:ac:12:00:02",
+								Aliases:    []string{"test-watchtower"},
+							},
+						}),
+						WithImageName("test-image:latest"),
+					)
+
+					config := getNetworkConfig(container, "1.44")
+					gomega.Expect(config.EndpointsConfig).
+						To(gomega.HaveKey("network1"), "Should include first network")
+					gomega.Expect(config.EndpointsConfig).
+						To(gomega.HaveKey("network2"), "Should include second network")
+					gomega.Expect(config.EndpointsConfig["network1"].IPAddress).
+						To(gomega.Equal("172.17.0.2"),
+							"IPAddress should be preserved for network1")
+					gomega.Expect(config.EndpointsConfig["network1"].MacAddress).
+						To(gomega.Equal("02:42:ac:11:00:02"),
+							"MAC address should be preserved for network1")
+					gomega.Expect(config.EndpointsConfig["network2"].IPAddress).
+						To(gomega.Equal("172.18.0.2"),
+							"IPAddress should be preserved for network2")
+					gomega.Expect(config.EndpointsConfig["network2"].MacAddress).
+						To(gomega.Equal("02:42:ac:12:00:02"),
+							"MAC address should be preserved for network2")
+					gomega.Expect(config.EndpointsConfig["network1"].Aliases).
+						To(gomega.ContainElement("test-watchtower"),
+							"Aliases should match mock setup for network1")
+					gomega.Expect(config.EndpointsConfig["network2"].Aliases).
+						To(gomega.ContainElement("test-watchtower"),
+							"Aliases should match mock setup for network2")
+					gomega.Expect(logOutput.String()).
+						To(gomega.ContainSubstring("Found MAC address in config"))
+				},
+			)
+
+			ginkgo.It("returns empty config when network settings are empty", func() {
 				container := MockContainer(
 					WithNetworkMode("bridge"),
 					WithContainerState(dockerContainerType.State{Running: true, Status: "running"}),
-					WithNetworkSettings(map[string]*dockerNetworkType.EndpointSettings{
-						"bridge": {
-							MacAddress: "",
-						},
-					}),
+					WithNetworkSettings(map[string]*dockerNetworkType.EndpointSettings{}),
+					WithImageName("test-image:latest"),
 				)
 
-				config := &dockerNetworkType.NetworkingConfig{
-					EndpointsConfig: map[string]*dockerNetworkType.EndpointSettings{
-						"bridge": {MacAddress: ""},
-					},
-				}
-
-				err := validateMacAddresses(config, container.ID(), "1.49", false, container)
-				gomega.Expect(err).To(gomega.Equal(errNoMacInNonHost))
+				config := getNetworkConfig(container, "1.44")
+				gomega.Expect(config.EndpointsConfig).
+					To(gomega.BeEmpty(), "Network config should have no endpoints")
 				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring(
-					"Negotiated API version 1.49 is at least 1.44 but no MAC address found",
-				))
-				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("state=running"))
+					"Negotiated API version 1.44 is at least 1.44 but no MAC address found"))
+				gomega.Expect(logOutput.String()).
+					To(gomega.ContainSubstring("no MAC address found in non-host network config"))
 			})
-		})
 
-		ginkgo.When("container is created with no MAC address", func() {
-			ginkgo.It("should return nil and log debug", func() {
-				logOutput := &bytes.Buffer{}
-				logrus.SetOutput(logOutput)
-				logrus.SetLevel(logrus.DebugLevel)
-
-				container := MockContainer(
-					WithNetworkMode("bridge"),
-					WithContainerState(
-						dockerContainerType.State{Running: false, Status: "created"},
-					),
-					WithNetworkSettings(map[string]*dockerNetworkType.EndpointSettings{
-						"bridge": {
-							MacAddress: "",
-						},
-					}),
-				)
-
-				config := &dockerNetworkType.NetworkingConfig{
-					EndpointsConfig: map[string]*dockerNetworkType.EndpointSettings{
-						"bridge": {MacAddress: ""},
-					},
-				}
-
-				err := validateMacAddresses(config, container.ID(), "1.49", false, container)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring(
-					"No MAC address found for non-running container",
-				))
-				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("state=created"))
-			})
-		})
-
-		ginkgo.When("container is exited with no MAC address", func() {
-			ginkgo.It("should return nil and log debug", func() {
-				logOutput := &bytes.Buffer{}
-				logrus.SetOutput(logOutput)
-				logrus.SetLevel(logrus.DebugLevel)
-
-				container := MockContainer(
-					WithNetworkMode("bridge"),
-					WithContainerState(dockerContainerType.State{Running: false, Status: "exited"}),
-					WithNetworkSettings(map[string]*dockerNetworkType.EndpointSettings{
-						"bridge": {
-							MacAddress: "",
-						},
-					}),
-				)
-
-				config := &dockerNetworkType.NetworkingConfig{
-					EndpointsConfig: map[string]*dockerNetworkType.EndpointSettings{
-						"bridge": {MacAddress: ""},
-					},
-				}
-
-				err := validateMacAddresses(config, container.ID(), "1.49", false, container)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring(
-					"No MAC address found for non-running container",
-				))
-				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("state=exited"))
-			})
-		})
-
-		ginkgo.When("container is running with a MAC address", func() {
-			ginkgo.It("should return nil and log debug", func() {
-				logOutput := &bytes.Buffer{}
-				logrus.SetOutput(logOutput)
-				logrus.SetLevel(logrus.DebugLevel)
-
+			ginkgo.It("returns empty config when network settings are nil", func() {
 				container := MockContainer(
 					WithNetworkMode("bridge"),
 					WithContainerState(dockerContainerType.State{Running: true, Status: "running"}),
-					WithNetworkSettings(map[string]*dockerNetworkType.EndpointSettings{
-						"bridge": {
-							MacAddress: "02:42:ac:11:00:01",
-						},
-					}),
-				)
-
-				config := &dockerNetworkType.NetworkingConfig{
-					EndpointsConfig: map[string]*dockerNetworkType.EndpointSettings{
-						"bridge": {MacAddress: "02:42:ac:11:00:02"},
-					},
-				}
-
-				err := validateMacAddresses(config, container.ID(), "1.49", false, container)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-				gomega.Expect(logOutput.String()).
-					To(gomega.ContainSubstring("Found MAC address in config"))
-				gomega.Expect(logOutput.String()).
-					To(gomega.ContainSubstring("Verified MAC address presence"))
-			})
-		})
-
-		ginkgo.When("containerInfo or State is nil", func() {
-			ginkgo.It("should return nil and log debug with unknown state", func() {
-				logOutput := &bytes.Buffer{}
-				logrus.SetOutput(logOutput)
-				logrus.SetLevel(logrus.DebugLevel)
-
-				container := MockContainer(
-					WithNetworkMode("bridge"),
-					// Explicitly omit State to simulate nil
+					WithImageName("test-image:latest"),
 					func(c *dockerContainerType.InspectResponse, _ *dockerImageType.InspectResponse) {
-						c.State = nil
+						c.NetworkSettings = nil
 					},
 				)
 
-				config := &dockerNetworkType.NetworkingConfig{
-					EndpointsConfig: map[string]*dockerNetworkType.EndpointSettings{
-						"bridge": {MacAddress: ""},
-					},
-				}
-
-				err := validateMacAddresses(config, container.ID(), "1.49", false, container)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring(
-					"No MAC address found for non-running container",
-				))
-				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("state=unknown"))
+				config := getNetworkConfig(container, "1.44")
+				gomega.Expect(config.EndpointsConfig).
+					To(gomega.BeEmpty(), "Network config should have no endpoints")
+				gomega.Expect(logOutput.String()).
+					To(gomega.ContainSubstring("No network settings available"))
 			})
 		})
 	})
 
-	ginkgo.Describe("validateMacAddresses", func() {
-		ginkgo.When("container is running with no MAC address", func() {
-			ginkgo.It("should return errNoMacInNonHost and log warning", func() {
-				logOutput := &bytes.Buffer{}
-				logrus.SetOutput(logOutput)
-				logrus.SetLevel(logrus.WarnLevel)
+	ginkgo.Describe("MAC Address Validation", func() {
+		var logOutput *bytes.Buffer
 
+		ginkgo.BeforeEach(func() {
+			logOutput = &bytes.Buffer{}
+			logrus.SetOutput(logOutput)
+			logrus.SetLevel(logrus.WarnLevel)
+		})
+
+		ginkgo.It(
+			"returns error and logs warning for running container with no MAC address",
+			func() {
 				container := MockContainer(
 					WithNetworkMode("bridge"),
 					WithContainerState(dockerContainerType.State{Running: true, Status: "running"}),
 					WithNetworkSettings(map[string]*dockerNetworkType.EndpointSettings{
-						"bridge": {
-							MacAddress: "",
-						},
+						"bridge": {MacAddress: ""},
 					}),
 				)
 
@@ -899,114 +807,114 @@ var _ = ginkgo.Describe("the container", func() {
 				err := validateMacAddresses(config, container.ID(), "1.49", false, container)
 				gomega.Expect(err).To(gomega.Equal(errNoMacInNonHost))
 				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring(
-					"Negotiated API version 1.49 is at least 1.44 but no MAC address found",
-				))
+					"Negotiated API version 1.49 is at least 1.44 but no MAC address found"))
 				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("state=running"))
-			})
+			},
+		)
+
+		ginkgo.It("returns nil and logs debug for created container with no MAC address", func() {
+			logrus.SetLevel(logrus.DebugLevel)
+			container := MockContainer(
+				WithNetworkMode("bridge"),
+				WithContainerState(dockerContainerType.State{Running: false, Status: "created"}),
+				WithNetworkSettings(map[string]*dockerNetworkType.EndpointSettings{
+					"bridge": {MacAddress: ""},
+				}),
+			)
+
+			config := &dockerNetworkType.NetworkingConfig{
+				EndpointsConfig: map[string]*dockerNetworkType.EndpointSettings{
+					"bridge": {MacAddress: ""},
+				},
+			}
+
+			err := validateMacAddresses(config, container.ID(), "1.49", false, container)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(logOutput.String()).To(gomega.ContainSubstring(
+				"No MAC address found for non-running container"))
+			gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("state=created"))
 		})
 
-		ginkgo.When("container is created with no MAC address", func() {
-			ginkgo.It("should return nil and log debug", func() {
-				logOutput := &bytes.Buffer{}
-				logrus.SetOutput(logOutput)
-				logrus.SetLevel(logrus.DebugLevel)
+		ginkgo.It("returns nil and logs debug for exited container with no MAC address", func() {
+			logrus.SetLevel(logrus.DebugLevel)
+			container := MockContainer(
+				WithNetworkMode("bridge"),
+				WithContainerState(dockerContainerType.State{Running: false, Status: "exited"}),
+				WithNetworkSettings(map[string]*dockerNetworkType.EndpointSettings{
+					"bridge": {MacAddress: ""},
+				}),
+			)
 
-				container := MockContainer(
-					WithNetworkMode("bridge"),
-					WithContainerState(
-						dockerContainerType.State{Running: false, Status: "created"},
-					),
-					WithNetworkSettings(map[string]*dockerNetworkType.EndpointSettings{
-						"bridge": {
-							MacAddress: "",
-						},
-					}),
-				)
+			config := &dockerNetworkType.NetworkingConfig{
+				EndpointsConfig: map[string]*dockerNetworkType.EndpointSettings{
+					"bridge": {MacAddress: ""},
+				},
+			}
 
-				config := &dockerNetworkType.NetworkingConfig{
-					EndpointsConfig: map[string]*dockerNetworkType.EndpointSettings{
-						"bridge": {MacAddress: ""},
-					},
-				}
-
-				err := validateMacAddresses(config, container.ID(), "1.49", false, container)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring(
-					"No MAC address found for non-running container",
-				))
-				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("state=created"))
-			})
+			err := validateMacAddresses(config, container.ID(), "1.49", false, container)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(logOutput.String()).To(gomega.ContainSubstring(
+				"No MAC address found for non-running container"))
+			gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("state=exited"))
 		})
 
-		ginkgo.When("container is exited with no MAC address", func() {
-			ginkgo.It("should return nil and log debug", func() {
-				logOutput := &bytes.Buffer{}
-				logrus.SetOutput(logOutput)
-				logrus.SetLevel(logrus.DebugLevel)
+		ginkgo.It("returns nil and logs debug for running container with MAC address", func() {
+			logrus.SetLevel(logrus.DebugLevel)
+			container := MockContainer(
+				WithNetworkMode("bridge"),
+				WithContainerState(dockerContainerType.State{Running: true, Status: "running"}),
+				WithNetworkSettings(map[string]*dockerNetworkType.EndpointSettings{
+					"bridge": {MacAddress: "02:42:ac:11:00:02"},
+				}),
+			)
 
-				container := MockContainer(
-					WithNetworkMode("bridge"),
-					WithContainerState(dockerContainerType.State{Running: false, Status: "exited"}),
-					WithNetworkSettings(map[string]*dockerNetworkType.EndpointSettings{
-						"bridge": {
-							MacAddress: "",
-						},
-					}),
-				)
+			config := &dockerNetworkType.NetworkingConfig{
+				EndpointsConfig: map[string]*dockerNetworkType.EndpointSettings{
+					"bridge": {MacAddress: "02:42:ac:11:00:02"},
+				},
+			}
 
-				config := &dockerNetworkType.NetworkingConfig{
-					EndpointsConfig: map[string]*dockerNetworkType.EndpointSettings{
-						"bridge": {MacAddress: ""},
-					},
-				}
-
-				err := validateMacAddresses(config, container.ID(), "1.49", false, container)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring(
-					"No MAC address found for non-running container",
-				))
-				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("state=exited"))
-			})
+			err := validateMacAddresses(config, container.ID(), "1.49", false, container)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(logOutput.String()).
+				To(gomega.ContainSubstring("Found MAC address in config"))
+			gomega.Expect(logOutput.String()).
+				To(gomega.ContainSubstring("Verified MAC address presence"))
 		})
 
-		ginkgo.When("container is running with a MAC address", func() {
-			ginkgo.It("should return nil and log debug", func() {
-				logOutput := &bytes.Buffer{}
-				logrus.SetOutput(logOutput)
-				logrus.SetLevel(logrus.DebugLevel)
+		ginkgo.It("returns nil and logs debug for nil container state", func() {
+			logrus.SetLevel(logrus.DebugLevel)
+			container := MockContainer(
+				WithNetworkMode("bridge"),
+				func(c *dockerContainerType.InspectResponse, _ *dockerImageType.InspectResponse) {
+					c.State = nil
+				},
+			)
 
-				container := MockContainer(
-					WithNetworkMode("bridge"),
-					WithContainerState(dockerContainerType.State{Running: true, Status: "running"}),
-					WithNetworkSettings(map[string]*dockerNetworkType.EndpointSettings{
-						"bridge": {
-							MacAddress: "02:42:ac:11:00:02",
-						},
-					}),
-				)
+			config := &dockerNetworkType.NetworkingConfig{
+				EndpointsConfig: map[string]*dockerNetworkType.EndpointSettings{
+					"bridge": {MacAddress: ""},
+				},
+			}
 
-				config := &dockerNetworkType.NetworkingConfig{
-					EndpointsConfig: map[string]*dockerNetworkType.EndpointSettings{
-						"bridge": {MacAddress: "02:42:ac:11:00:02"},
-					},
-				}
-
-				err := validateMacAddresses(config, container.ID(), "1.49", false, container)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-				gomega.Expect(logOutput.String()).
-					To(gomega.ContainSubstring("Found MAC address in config"))
-				gomega.Expect(logOutput.String()).
-					To(gomega.ContainSubstring("Verified MAC address presence"))
-			})
+			err := validateMacAddresses(config, container.ID(), "1.49", false, container)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(logOutput.String()).To(gomega.ContainSubstring(
+				"No MAC address found for non-running container"))
+			gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("state=unknown"))
 		})
 	})
 
-	ginkgo.Describe("DisableMemorySwappiness Configuration", func() {
-		var mockContainer *Container
-		var defaultMemorySwappiness int64 = 60
-		containerName := "test-container"
-		containerID := "test-container-id"
+	ginkgo.Describe("Memory Swappiness Configuration", func() {
+		var (
+			logOutput               *bytes.Buffer
+			mockContainer           *Container
+			defaultMemorySwappiness int64 = 60
+			containerName                 = "test-container"
+			containerID                   = "test-container-id"
+		)
 
+		// WithMemorySwappiness configures the container's MemorySwappiness value.
 		WithMemorySwappiness := func(swappiness int64) MockContainerUpdate {
 			return func(c *dockerContainerType.InspectResponse, _ *dockerImageType.InspectResponse) {
 				if c.HostConfig == nil {
@@ -1017,6 +925,9 @@ var _ = ginkgo.Describe("the container", func() {
 		}
 
 		ginkgo.BeforeEach(func() {
+			logOutput = &bytes.Buffer{}
+			logrus.SetOutput(logOutput)
+			logrus.SetLevel(logrus.DebugLevel)
 			mockContainer = MockContainer(WithMemorySwappiness(defaultMemorySwappiness))
 			inspectResponse := dockerContainerType.InspectResponse{
 				ContainerJSONBase: &dockerContainerType.ContainerJSONBase{
@@ -1030,87 +941,69 @@ var _ = ginkgo.Describe("the container", func() {
 			mockContainer.containerInfo = &inspectResponse
 		})
 
-		ginkgo.When("DisableMemorySwappiness is true", func() {
-			ginkgo.It("sets MemorySwappiness to nil and logs debug message", func() {
-				logOutput := &bytes.Buffer{}
-				logrus.SetOutput(logOutput)
-				logrus.SetLevel(logrus.DebugLevel)
-
-				clog := logrus.WithFields(logrus.Fields{
-					"container": mockContainer.Name(),
-					"id":        mockContainer.ID().ShortID(),
-				})
-				hostConfig := mockContainer.GetCreateHostConfig()
-				disableMemorySwappiness := true
-
-				if disableMemorySwappiness {
-					hostConfig.MemorySwappiness = nil
-					clog.Debug("Disabled memory swappiness for Podman compatibility")
-				}
-
-				gomega.Expect(hostConfig.MemorySwappiness).To(gomega.BeNil(),
-					"MemorySwappiness should be nil when DisableMemorySwappiness is true")
-				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring(
-					"Disabled memory swappiness for Podman compatibility"))
+		ginkgo.It("sets MemorySwappiness to nil when disabled", func() {
+			clog := logrus.WithFields(logrus.Fields{
+				"container": mockContainer.Name(),
+				"id":        mockContainer.ID().ShortID(),
 			})
+			hostConfig := mockContainer.GetCreateHostConfig()
+			disableMemorySwappiness := true
+
+			if disableMemorySwappiness {
+				hostConfig.MemorySwappiness = nil
+				clog.Debug("Disabled memory swappiness for Podman compatibility")
+			}
+
+			gomega.Expect(hostConfig.MemorySwappiness).To(gomega.BeNil(),
+				"MemorySwappiness should be nil when disabled")
+			gomega.Expect(logOutput.String()).To(gomega.ContainSubstring(
+				"Disabled memory swappiness for Podman compatibility"))
 		})
 
-		ginkgo.When("DisableMemorySwappiness is false", func() {
-			ginkgo.It("preserves MemorySwappiness and does not log debug message", func() {
-				logOutput := &bytes.Buffer{}
-				logrus.SetOutput(logOutput)
-				logrus.SetLevel(logrus.DebugLevel)
-
-				clog := logrus.WithFields(logrus.Fields{
-					"container": mockContainer.Name(),
-					"id":        mockContainer.ID().ShortID(),
-				})
-				hostConfig := mockContainer.GetCreateHostConfig()
-				disableMemorySwappiness := false
-
-				if disableMemorySwappiness {
-					hostConfig.MemorySwappiness = nil
-					clog.Debug("Disabled memory swappiness for Podman compatibility")
-				}
-
-				gomega.Expect(hostConfig.MemorySwappiness).
-					To(gomega.Equal(&defaultMemorySwappiness),
-						"MemorySwappiness should remain unchanged when DisableMemorySwappiness is false")
-				gomega.Expect(logOutput.String()).NotTo(gomega.ContainSubstring(
-					"Disabled memory swappiness for Podman compatibility"))
+		ginkgo.It("preserves MemorySwappiness when not disabled", func() {
+			clog := logrus.WithFields(logrus.Fields{
+				"container": mockContainer.Name(),
+				"id":        mockContainer.ID().ShortID(),
 			})
+			hostConfig := mockContainer.GetCreateHostConfig()
+			disableMemorySwappiness := false
+
+			if disableMemorySwappiness {
+				hostConfig.MemorySwappiness = nil
+				clog.Debug("Disabled memory swappiness for Podman compatibility")
+			}
+
+			gomega.Expect(hostConfig.MemorySwappiness).To(gomega.Equal(&defaultMemorySwappiness),
+				"MemorySwappiness should remain unchanged when not disabled")
+			gomega.Expect(logOutput.String()).NotTo(gomega.ContainSubstring(
+				"Disabled memory swappiness for Podman compatibility"))
 		})
 	})
 
-	ginkgo.Describe("GetCreateHostConfig", func() {
-		ginkgo.When("container has a volume mount with subpath", func() {
-			ginkgo.It("preserves the subpath in the host config mounts", func() {
-				volumeMount := dockerMountType.Mount{
-					Type:   dockerMountType.TypeVolume,
-					Source: "test_volume",
-					Target: "/config/nest",
-					VolumeOptions: &dockerMountType.VolumeOptions{
-						Subpath: "ha/nest",
-					},
-				}
+	ginkgo.Describe("Host Config Creation", func() {
+		ginkgo.It("preserves volume mount subpath in host config", func() {
+			volumeMount := dockerMountType.Mount{
+				Type:   dockerMountType.TypeVolume,
+				Source: "test_volume",
+				Target: "/config/nest",
+				VolumeOptions: &dockerMountType.VolumeOptions{
+					Subpath: "ha/nest",
+				},
+			}
 
-				container := MockContainer(WithMounts([]dockerMountType.Mount{volumeMount}))
+			container := MockContainer(WithMounts([]dockerMountType.Mount{volumeMount}))
+			hostConfig := container.GetCreateHostConfig()
 
-				hostConfig := container.GetCreateHostConfig()
-
-				gomega.Expect(hostConfig.Mounts).To(gomega.HaveLen(1), "Expected exactly one mount")
-				mount := hostConfig.Mounts[0]
-				gomega.Expect(mount.Type).
-					To(gomega.Equal(dockerMountType.TypeVolume), "Mount type should be volume")
-				gomega.Expect(mount.Source).
-					To(gomega.Equal("test_volume"), "Mount source should match")
-				gomega.Expect(mount.Target).
-					To(gomega.Equal("/config/nest"), "Mount target should match")
-				gomega.Expect(mount.VolumeOptions).
-					ToNot(gomega.BeNil(), "VolumeOptions should be set")
-				gomega.Expect(mount.VolumeOptions.Subpath).
-					To(gomega.Equal("ha/nest"), "Subpath should be preserved")
-			})
+			gomega.Expect(hostConfig.Mounts).To(gomega.HaveLen(1), "Expected exactly one mount")
+			mount := hostConfig.Mounts[0]
+			gomega.Expect(mount.Type).
+				To(gomega.Equal(dockerMountType.TypeVolume), "Mount type should be volume")
+			gomega.Expect(mount.Source).To(gomega.Equal("test_volume"), "Mount source should match")
+			gomega.Expect(mount.Target).
+				To(gomega.Equal("/config/nest"), "Mount target should match")
+			gomega.Expect(mount.VolumeOptions).ToNot(gomega.BeNil(), "VolumeOptions should be set")
+			gomega.Expect(mount.VolumeOptions.Subpath).
+				To(gomega.Equal("ha/nest"), "Subpath should be preserved")
 		})
 	})
 })


### PR DESCRIPTION
## Description
Fixes a bug where container updates failed when connected to multiple networks in Docker API versions < 1.44 (e.g., `grafana/grafana`, `ghcr.io/linuxserver/changedetection.io`). The issue occurred because `ContainerCreate` does not support multiple network endpoints in legacy APIs. The solution modifies `StartTargetContainer` to create containers with a single network and attach additional networks sequentially, with comprehensive test coverage.

Fixes #346.

## Changes
- Modified `StartTargetContainer` to handle multiple networks for API < 1.44 by using the first network for creation and attaching others via `attachNetworks`.
- Added `attachNetworks` function to connect additional networks sequentially for legacy API compatibility.
- Updated `container_test.go` with tests for `getNetworkConfig` in legacy (< 1.44) and modern (>= 1.44) API scenarios, covering single and multiple networks.
- Added `WithNetworks` helper in `container_mock_test.go` to support multi-network test setups.
- Added test cases in `container_test.go` to verify network handling for empty, single, multiple, and nil network settings in API versions 1.43 and 1.44+.
- Removed duplicate `validateMacAddresses` test block in `container_test.go` for clarity.
- Improved test naming and organization in `container_test.go` for better maintainability.