### PR TITLE
fix(registry): handle unauthenticated registries and update linting (#366)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -50,7 +50,7 @@ linters:
     - usestdlibvars # A linter that detect the possibility to use variables/constants from the Go standard library.
     - usetesting # Reports uses of functions with replacement inside the testing package.
     - whitespace # Whitespace is a linter that checks for unnecessary newlines at the start and end of functions, if, for, etc.
-    - wsl # Add or remove empty lines.
+    - wsl_v5 # Add or remove empty lines.
     ##################################################################################################
     # Enabled linters that require manual issue resolution
     - asasalint # Check for pass []any as any in variadic func(...any).

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -208,6 +208,15 @@ linters:
           - promlinter
           - wrapcheck
           - varnamelen
+      # Exclude revive from flagging the util package's name.
+      - path: "internal/util/.*"
+        linters:
+          - revive
+        text: "avoid meaningless package names"
+      - path: "pkg/types/.*"
+        linters:
+          - revive
+        text: "avoid meaningless package names"
 
       # Run some linter only for test files by excluding its issues for everything else.
       # - path-except: _test\.go

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -391,6 +391,7 @@ func TestFlagsArePresentInDocumentation(t *testing.T) {
 // TestReadFlags_FlagErrors tests error handling in ReadFlags with mocked logrus.Fatal.
 func TestReadFlags_FlagErrors(t *testing.T) {
 	originalExit := logrus.StandardLogger().ExitFunc
+
 	defer func() { logrus.StandardLogger().ExitFunc = originalExit }()
 
 	logrus.StandardLogger().ExitFunc = func(_ int) { panic("FATAL") }
@@ -482,6 +483,7 @@ func TestEnvConfig_FlagRetrievalErrors(t *testing.T) {
 
 func TestReadFlags_Errors(t *testing.T) {
 	originalExit := logrus.StandardLogger().ExitFunc
+
 	defer func() { logrus.StandardLogger().ExitFunc = originalExit }()
 
 	logrus.StandardLogger().ExitFunc = func(_ int) { panic("FATAL") }
@@ -540,6 +542,7 @@ func TestGetSecretFromFile_SliceReplaceError(t *testing.T) {
 // TestProcessFlagAliases_InvalidPorcelain tests invalid porcelain version handling.
 func TestProcessFlagAliases_InvalidPorcelain(t *testing.T) {
 	originalExit := logrus.StandardLogger().ExitFunc
+
 	defer func() { logrus.StandardLogger().ExitFunc = originalExit }()
 
 	logrus.StandardLogger().ExitFunc = func(_ int) { panic("FATAL") }

--- a/pkg/api/update/update.go
+++ b/pkg/api/update/update.go
@@ -86,13 +86,16 @@ func (handle *Handler) Handle(_ http.ResponseWriter, r *http.Request) {
 	// Execute update with lock handling.
 	if len(images) > 0 {
 		chanValue := <-lock
+
 		defer func() { lock <- chanValue }()
+
 		logrus.WithField("images", images).Info("Executing targeted update")
 		handle.fn(images)
 	} else {
 		select {
 		case chanValue := <-lock:
 			defer func() { lock <- chanValue }()
+
 			logrus.Info("Executing full update")
 			handle.fn(images)
 		default:

--- a/pkg/container/cgroup_id_test.go
+++ b/pkg/container/cgroup_id_test.go
@@ -15,6 +15,7 @@ var (
 
 func TestGetRunningContainerID(t *testing.T) {
 	originalReadFileFunc := readFileFunc
+
 	defer func() {
 		readFileFunc = originalReadFileFunc
 	}()

--- a/pkg/container/container_source.go
+++ b/pkg/container/container_source.go
@@ -325,6 +325,7 @@ func waitForStopOrTimeout(
 				return true, nil // Container stopped.
 			}
 		}
+
 		time.Sleep(1 * time.Second)
 	}
 }

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -31,6 +31,7 @@ func TestFilterByNames(t *testing.T) {
 	t.Parallel()
 
 	var names []string
+
 	filter := FilterByNames(names, nil)
 	assert.Nil(t, filter)
 
@@ -354,6 +355,7 @@ func TestBuildFilterEnableLabel(t *testing.T) {
 	t.Parallel()
 
 	var names []string
+
 	names = append(names, "test")
 
 	filter, desc := BuildFilter(names, []string{}, true, "")

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -141,6 +141,7 @@ func TestMetrics_Register(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.m.Register(tt.args.metric)
+
 			select {
 			case got := <-tt.m.channel:
 				if !reflect.DeepEqual(got, tt.args.metric) {
@@ -236,6 +237,7 @@ func TestRegisterScan(t *testing.T) {
 			// Reset metrics and set up a fresh instance
 			metrics = &Metrics{channel: make(chan *Metric, 10)}
 			metrics.RegisterScan(tt.args.metric)
+
 			select {
 			case got := <-metrics.channel:
 				if !reflect.DeepEqual(got, tt.args.metric) {
@@ -301,6 +303,7 @@ func TestMetrics_HandleUpdate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Run HandleUpdate in a goroutine and wait briefly for it to process
 			go tt.m.HandleUpdate(tt.args.channel)
+
 			time.Sleep(100 * time.Millisecond) // Allow time for processing
 
 			// Check Prometheus metrics (simplified check since we can't directly access values easily in tests)

--- a/pkg/notifications/shoutrrr.go
+++ b/pkg/notifications/shoutrrr.go
@@ -258,6 +258,7 @@ func (n *shoutrrrTypeNotifier) sendEntries(entries []*logrus.Entry, report types
 	}
 
 	LocalLog.Debug("Queuing notification message")
+
 	n.messages <- msg
 }
 

--- a/pkg/notifications/shoutrrr_test.go
+++ b/pkg/notifications/shoutrrr_test.go
@@ -381,6 +381,7 @@ type blockingRouter struct {
 
 func (b blockingRouter) Send(_ string, _ *types.Params) []error {
 	<-b.unlock
+
 	b.sent <- true
 
 	return nil

--- a/pkg/session/progress_test.go
+++ b/pkg/session/progress_test.go
@@ -531,6 +531,7 @@ func TestProgress_MarkForUpdate(t *testing.T) {
 					t.Errorf("Progress.MarkForUpdate() panicked unexpectedly: %v", r)
 				}
 			}()
+
 			tt.m.MarkForUpdate(tt.args.containerID)
 
 			if len(tt.m) != len(tt.want) {

--- a/pkg/session/report_test.go
+++ b/pkg/session/report_test.go
@@ -647,8 +647,8 @@ func compareReports(got, want *report) bool {
 
 		for i := range gotSlice {
 			g := gotSlice[i].(*ContainerStatus)
-			w := wantSlice[i].(*ContainerStatus)
 
+			w := wantSlice[i].(*ContainerStatus)
 			if g.containerID != w.containerID ||
 				g.state != w.state ||
 				g.oldImage != w.oldImage ||


### PR DESCRIPTION
## Description
This pull request addresses [Issue #366](https://github.com/nicholas-fedor/watchtower/issues/366) by fixing HEAD request failures for unauthenticated registries, ensuring `fetchDigest` proceeds correctly when no authentication is required. It also includes linting updates to modernize the linter configuration and resolve warnings, maintaining code quality.

### Changes
- **chore(lint): deprecate wsl linter and update to wsl_v5**
  - Updated linter configuration to use `wsl_v5`, replacing the deprecated `wsl` linter.
- **fix(lint): suppress revive var-naming for util and types packages**
  - Added exclusion rules in `.golangci.yaml` to ignore 'avoid meaningless package names' for `internal/util` and `pkg/types`.
  - Resolved golangci-lint warnings in `doc.go` and `report.go`.
- **chore(lint): add newlines to comply with wsl_v5 linter rules**
  - Inserted newlines across files to meet `wsl_v5` formatting requirements.
- **fix(registry): handle unauthenticated registries in digest retrieval (#366)**
  - Modified `fetchDigest` in `digest.go` to proceed with HEAD requests when no authentication is required.
  - Updated test case in `digest_test.go` to expect successful digest retrieval for unauthenticated registries.

Closes #366