### PR TITLE
Fix Gosec Flagging Issues in Test Files

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Run Gosec Security Scanner
         uses: securego/gosec@59ae7e9e275d7dce03bb9c37432b7b3575dbe5fc
         with:
-          args: "-no-fail -fmt sarif -out results.sarif -tests ./..."
+          args: "-no-fail -fmt sarif -out results.sarif ./..."
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3
         with:


### PR DESCRIPTION
This pull request resolves gosec flagging issues in test files by removing the `-tests` flag from the gosec action in `security.yaml`. This reverts to gosec's default behavior of skipping test files, focusing scans on production code only.

## Key Changes
- Updated `gosec` step args to: `-no-fail -fmt sarif -out results.sarif ./...`

No breaking changes; security scans remain effective for main code paths.