### PR TITLE
Optimize CI Workflows for Non-Go Changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ setup: true
 
 # Orbs for reusable packages.
 orbs:
-  path-filtering: circleci/path-filtering@1.0.2
+  path-filtering: circleci/path-filtering@2.0.1
 
 # Orchestrate jobs using workflows.
 # See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,48 +1,27 @@
 # Use the latest 2.1 version of CircleCI pipeline process engine.
 # See: https://circleci.com/docs/configuration-reference
-
-# For a detailed guide to building and testing with Go, read the docs:
-# https://circleci.com/docs/language-go/ for more details
 version: 2.1
 
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/jobs-steps/#jobs-overview & https://circleci.com/docs/configuration-reference/#jobs
-jobs:
-  build:
-    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/executor-intro/ & https://circleci.com/docs/configuration-reference/#executor-job
-    docker:
-      # Specify the version you desire here
-      # See: https://circleci.com/developer/images/image/cimg/go
-      - image: cimg/go:1.24.5@sha256:c5ca0149ba30b60b85e229441e10e5666a00cebf0d6ad235d6f6839d19e2056e
+# Enable dynamic config for path-based filtering.
+setup: true
 
-    # Add steps to the job
-    # See: https://circleci.com/docs/jobs-steps/#steps-overview & https://circleci.com/docs/configuration-reference/#steps
-    steps:
-      # Checkout the code as the first step.
-      - checkout
-      - restore_cache:
-          keys:
-            - go-mod-v4-{{ checksum "go.sum" }}
-      - run:
-          name: Install Dependencies
-          command: go mod download
-      - save_cache:
-          key: go-mod-v4-{{ checksum "go.sum" }}
-          paths:
-            - "/go/pkg/mod"
-      - run:
-          name: Run tests
-          command: |
-            mkdir -p /tmp/test-reports
-            gotestsum --junitfile /tmp/test-reports/unit-tests.xml
-      - store_test_results:
-          path: /tmp/test-reports
+# Orbs for reusable packages.
+orbs:
+  path-filtering: circleci/path-filtering@1.0.2
 
-# Orchestrate jobs using workflows
+# Orchestrate jobs using workflows.
 # See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows
 workflows:
-  build-test: # This is the name of the workflow, feel free to change it to better match your workflow.
-    # Inside the workflow, you define the jobs you want to run.
+  setup-workflow: # This workflow checks changed files and decides whether to continue.
     jobs:
-      - build
+      - path-filtering/filter:
+          name: check-updated-files
+          mapping: | # Map file patterns to pipeline parameters (true/false).
+            cmd/.* run-tests true
+            internal/.* run-tests true
+            pkg/.* run-tests true
+            main.go run-tests true
+            go.mod run-tests true
+            go.sum run-tests true
+          base-revision: main # Compare against the base branch.
+          config-path: .circleci/continue-config.yml # Path to the continuation config if conditions match.

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -1,0 +1,55 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/configuration-reference
+version: 2.1
+
+# Pipeline parameters set by the setup config.
+parameters:
+  run-tests:
+    type: boolean
+    default: false
+
+# For a detailed guide to building and testing with Go, read the docs:
+# https://circleci.com/docs/language-go/ for more details
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/jobs-steps/#jobs-overview & https://circleci.com/docs/configuration-reference/#jobs
+jobs:
+  build:
+    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
+    # See: https://circleci.com/docs/executor-intro/ & https://circleci.com/docs/configuration-reference/#executor-job
+    docker:
+      # Specify the version you desire here
+      # See: https://circleci.com/developer/images/image/cimg/go
+      - image: cimg/go:1.24.5@sha256:c5ca0149ba30b60b85e229441e10e5666a00cebf0d6ad235d6f6839d19e2056e
+
+    # Add steps to the job
+    # See: https://circleci.com/docs/jobs-steps/#steps-overview & https://circleci.com/docs/configuration-reference/#steps
+    steps:
+      # Checkout the code as the first step.
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-v4-{{ checksum "go.sum" }}
+      - run:
+          name: Install Dependencies
+          command: go mod download
+      - save_cache:
+          key: go-mod-v4-{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
+      - run:
+          name: Run tests
+          command: |
+            mkdir -p /tmp/test-reports
+            gotestsum --junitfile /tmp/test-reports/unit-tests.xml
+      - store_test_results:
+          path: /tmp/test-reports
+
+# Orchestrate jobs using workflows
+# See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows
+workflows:
+  build-test: # This is the name of the workflow, feel free to change it to better match your workflow.
+    # Inside the workflow, you define the jobs you want to run.
+    when: << pipeline.parameters.run-tests >> # Only run if the parameter is true (set by path filtering).
+    jobs:
+      - build


### PR DESCRIPTION
This pull request optimizes CircleCI workflows to run tests conditionally only when Go-related files (e.g., cmd/, internal/, pkg/, main.go, go.mod, go.sum) are changed, using dynamic configuration with the path-filtering orb. This reduces inefficiency by skipping unnecessary test runs on non-production code changes like workflows or docs.

## Key Changes
- Split CircleCI config into `config.yml` (setup with path filtering) and `continue-config.yml` (conditional build job).