### PR TITLE
fix(ci): add unique IDs to GoReleaser build configs

### DIFF
--- a/build/goreleaser/dev.yml
+++ b/build/goreleaser/dev.yml
@@ -2,7 +2,8 @@
 version: 2
 
 builds:
-  - main: ./main.go
+  - id: watchtower-multiarch
+    main: ./main.go
     binary: watchtower
     goos:
       - linux
@@ -23,7 +24,8 @@ builds:
       - -s -w
       - -X github.com/nicholas-fedor/watchtower/internal/meta.Version={{ .Version }}
       - -X github.com/nicholas-fedor/watchtower/pkg/registry/digest.UserAgent=Watchtower/v{{ .Version }}
-  - main: ./main.go
+  - id: watchtower-armv6
+    main: ./main.go
     binary: watchtower
     goos:
       - linux

--- a/build/goreleaser/prod.yml
+++ b/build/goreleaser/prod.yml
@@ -2,7 +2,8 @@
 version: 2
 
 builds:
-  - main: ./main.go
+  - id: watchtower-multiarch
+    main: ./main.go
     binary: watchtower
     goos:
       - linux
@@ -23,7 +24,8 @@ builds:
       - -s -w
       - -X github.com/nicholas-fedor/watchtower/internal/meta.Version={{ .Version }}
       - -X github.com/nicholas-fedor/watchtower/pkg/registry/digest.UserAgent=Watchtower/v{{ .Version }}
-  - main: ./main.go
+  - id: watchtower-armv6
+    main: ./main.go
     binary: watchtower
     goos:
       - linux


### PR DESCRIPTION
## Description
This PR addresses an issue in the GoReleaser configuration where multiple build sections shared the same implicit ID, leading to the error: "found 2 builds with the ID 'watchtower', please fix your config".

By assigning unique IDs (`watchtower-multiarch` and `watchtower-armv6`) to the build configurations in `dev.yml` and `prod.yml`, the build process can now distinguish between the multi-architecture and ARMv6-specific builds.

## Changes
- Updated `build/goreleaser/dev.yml` with unique build IDs.
- Updated `build/goreleaser/prod.yml` with unique build IDs for consistency.