### PR TITLE
fix(ci): add build prefix handling in dev workflow and Dockerfile

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -75,18 +75,23 @@ jobs:
           - platform: amd64
             arch_tag: amd64
             norm_arch: amd64_v1
+            prefix: watchtower-multiarch
           - platform: i386
             arch_tag: i386
             norm_arch: 386
+            prefix: watchtower-multiarch
           - platform: arm/v6
             arch_tag: armhf
             norm_arch: arm_v6
+            prefix: watchtower-armv6
           - platform: arm64/v8
             arch_tag: arm64v8
             norm_arch: arm64
+            prefix: watchtower-multiarch
           - platform: riscv64
             arch_tag: riscv64
             norm_arch: riscv64_rva20u64
+            prefix: watchtower-multiarch
     steps:
       - name: Checkout
         uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f
@@ -127,6 +132,7 @@ jobs:
           build-args: |
             TARGETARCH=${{ matrix.norm_arch }}
             TARGETOS=linux
+            PREFIX=${{ matrix.prefix }}
 
       - name: Generate per-arch SBOM for Docker Hub
         if: github.event.inputs.dry_run != 'true'

--- a/build/docker/Dockerfile.dev
+++ b/build/docker/Dockerfile.dev
@@ -10,6 +10,7 @@ FROM scratch
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG PREFIX=watchtower-multiarch
 
 LABEL "com.centurylinklabs.watchtower"="true"
 LABEL "org.opencontainers.image.url"="https://nicholas-fedor.github.io/watchtower/" \
@@ -25,7 +26,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 
 # Copy prebuilt binary from GoReleaser dist/ (e.g., dist/watchtower_linux_amd64_v1/watchtower)
-COPY dist/watchtower_${TARGETOS}_${TARGETARCH}/watchtower /watchtower
+COPY dist/${PREFIX}_${TARGETOS}_${TARGETARCH}/watchtower /watchtower
 
 HEALTHCHECK CMD ["/watchtower", "--health-check"]
 


### PR DESCRIPTION
## Description
This PR fixes persistent path issues in the dev image build process where binaries were not found due to GoReleaser's separate build directories for multi-arch and ARMv6 configurations.

By introducing a `prefix` matrix variable and passing it as a build-arg, the Dockerfile can dynamically copy the correct binary, ensuring builds succeed for all architectures.

## Changes
- Updated `.github/workflows/release-dev.yaml`:
  - Added `prefix` to matrix entries.
  - Included `PREFIX=${{ matrix.prefix }}` in build-args.
- Updated `build/docker/Dockerfile.dev`:
  - Added `ARG PREFIX=watchtower-multiarch`.
  - Modified COPY to use `${PREFIX}_${TARGETOS}_${TARGETARCH}`.