### PR TITLE
fix(ci): remove dist/ from binary COPY in dev Dockerfile

### DIFF
--- a/build/docker/Dockerfile.dev
+++ b/build/docker/Dockerfile.dev
@@ -26,7 +26,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 
 # Copy prebuilt binary from GoReleaser dist/ (e.g., dist/watchtower_linux_amd64_v1/watchtower)
-COPY dist/${PREFIX}_${TARGETOS}_${TARGETARCH}/watchtower /watchtower
+COPY ${PREFIX}_${TARGETOS}_${TARGETARCH}/watchtower /watchtower
 
 HEALTHCHECK CMD ["/watchtower", "--health-check"]
 


### PR DESCRIPTION
## Description
This PR addresses ongoing failures in the dev image build process where binaries were not found due to an incorrect path in the Dockerfile. The artifacts from GoReleaser are downloaded to the root directory, but the COPY instruction referenced a nested `/dist` path.

By removing `/dist` from the COPY line, the build can now locate the binaries properly.

## Changes
- Updated `build/docker/Dockerfile.dev`:
  - Changed COPY to `${PREFIX}_${TARGETOS}_${TARGETARCH}/watchtower /watchtower`.