### PR TITLE
fix(ci): correct norm_arch for ARMv6 in dev workflow

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -82,7 +82,7 @@ jobs:
             prefix: watchtower-multiarch
           - platform: arm/v6
             arch_tag: armhf
-            norm_arch: arm_v6
+            norm_arch: arm_6
             prefix: watchtower-armv6
           - platform: arm64/v8
             arch_tag: arm64v8


### PR DESCRIPTION
## Description
This PR fixes the remaining build failure in the dev workflow for the ARMv6 architecture, where the binary path did not match GoReleaser's output directory naming.

By adjusting `norm_arch` to `arm_6`, the path now aligns with the generated directory (e.g., `watchtower-armv6_linux_arm_6/watchtower`).

## Changes
- Updated `.github/workflows/release-dev.yaml`:
  - Set `norm_arch` for `arm/v6` to `arm_6`.