### PR TITLE
fix(ci): add default GO variants to norm_arch in dev workflow

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -78,7 +78,7 @@ jobs:
             prefix: watchtower-multiarch
           - platform: i386
             arch_tag: i386
-            norm_arch: 386
+            norm_arch: 386_sse2
             prefix: watchtower-multiarch
           - platform: arm/v6
             arch_tag: armhf
@@ -86,7 +86,7 @@ jobs:
             prefix: watchtower-armv6
           - platform: arm64/v8
             arch_tag: arm64v8
-            norm_arch: arm64
+            norm_arch: arm64_v8.0
             prefix: watchtower-multiarch
           - platform: riscv64
             arch_tag: riscv64


### PR DESCRIPTION
## Description
This PR resolves persistent "file not found" errors in the development workflow's Docker builds by aligning norm_arch with GoReleaser's default variants for unspecified GO* options.

## Changes
- Updated `.github/workflows/release-dev.yaml` matrix:
  - i386 norm_arch to 386_sse2
  - arm64 norm_arch to arm64_v8.0