### PR TITLE
fix(ci): skip docs update and artifact uploads in prod dry run

### DIFF
--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -62,6 +62,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload binary SBOMs
+        if: inputs.dry_run != true
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: prod-binary-sboms
@@ -199,6 +200,7 @@ jobs:
     needs:
       - Test
       - Build
+    if: inputs.dry_run != true
     permissions:
       contents: read
     uses: ./.github/workflows/update-go-docs.yaml


### PR DESCRIPTION
## Description
This PR ensures the production release workflow behaves appropriately during dry runs by skipping unnecessary steps, aligning with the intent of a test run. Previously, the workflow updated Go documentation and uploaded binary SBOMs even in dry runs, which could lead to unintended changes or artifacts.

## Changes
- Updated `release-prod.yaml`:
  - Added `if: inputs.dry_run != true` to the `Update-Go-docs` job.
  - Added `if: inputs.dry_run != true` to the `Upload binary SBOMs` step in the `Build` job.