### PR TITLE
fix(ci): update GoReleaser dry run flags in prod workflow

### DIFF
--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -57,7 +57,7 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --config build/goreleaser/prod.yml ${{ inputs.dry_run && '--snapshot --clean --skip-publish' || '' }}
+          args: release --config build/goreleaser/prod.yml ${{ inputs.dry_run && '--snapshot --clean --skip=publish' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description
This PR fixes a flag compatibility issue in the production release workflow's dry run mode. GoReleaser v2 changed the skipping flag from --skip-publish to --skip=publish, causing errors in dry runs.

## Changes
- Updated `release-prod.yaml`:
  - Changed dry run args to '--snapshot --clean --skip=publish'.