### PR TITLE
fix(ci): install Syft for SBOM generation in prod workflow

### DIFF
--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -46,6 +46,9 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
+      - name: Install Syft
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
       - name: Registry Logins
         if: inputs.dry_run != true
         uses: ./.github/workflows/registry-logins.yaml


### PR DESCRIPTION
## Description
This PR fixes an error in the production workflow where GoReleaser fails to generate SBOMs due to missing Syft executable. Syft is a dependency for the SBOM artifacts configured in prod.yml.

## Changes
- Updated `release-prod.yaml`:
  - Added "Install Syft" step before running GoReleaser using the official install script.