### PR TITLE
fix(ci): add registry creds to SBOM action for direct scan

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -151,6 +151,8 @@ jobs:
           format: spdx-json
           artifact-name: ${{ matrix.arch_tag }}-dev.sbom.json
           upload-artifact: true
+          registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Generate per-arch SBOM for GHCR
         if: github.event.inputs.dry_run != 'true'
@@ -160,6 +162,8 @@ jobs:
           format: spdx-json
           artifact-name: ghcr-${{ matrix.arch_tag }}-dev.sbom.json
           upload-artifact: true
+          registry-username: ${{ github.actor }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Attest per-arch Docker Hub image
         if: github.event.inputs.dry_run != 'true'
@@ -223,6 +227,8 @@ jobs:
           format: spdx-json
           artifact-name: latest-dev.sbom.json
           upload-artifact: true
+          registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Generate manifest SBOM for GHCR
         if: github.event.inputs.dry_run != 'true'
@@ -232,6 +238,8 @@ jobs:
           format: spdx-json
           artifact-name: ghcr-latest-dev.sbom.json
           upload-artifact: true
+          registry-username: ${{ github.actor }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Attest Docker Hub manifest
         if: github.event.inputs.dry_run != 'true'


### PR DESCRIPTION
## Description
This PR fixes SBOM generation failures for non-amd64 images in the dev workflow. The anchore/sbom-action uses Syft, which attempts a Docker pull by default, causing "no matching manifest" errors on amd64 runners for arm/riscv images. Providing registry credentials bypasses Docker and scans directly from the registry.

## Changes
- Updated `release-dev.yaml`:
  - Added registry-username/password to Docker Hub SBOM steps using DOCKERHUB secrets.
  - Added registry-username/password to GHCR SBOM steps using github.actor and GITHUB_TOKEN.
  - Applied to both per-arch and manifest SBOM generations.