### PR TITLE
fix(ci): pull images locally for SBOM scan in dev workflow

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -143,27 +143,35 @@ jobs:
             TARGETOS=linux
             PREFIX=${{ matrix.prefix }}
 
+      - name: Pull per-arch image for SBOM
+        if: github.event.inputs.dry_run != 'true'
+        run: |
+          docker pull --platform linux/${{ matrix.platform }} nickfedor/watchtower:${{ matrix.arch_tag }}-dev || { echo "Failed to pull Docker Hub image"; exit 1; }
+          docker pull --platform linux/${{ matrix.platform }} ghcr.io/nicholas-fedor/watchtower:${{ matrix.arch_tag }}-dev || { echo "Failed to pull GHCR image"; exit 1; }
+
       - name: Generate per-arch SBOM for Docker Hub
         if: github.event.inputs.dry_run != 'true'
         uses: anchore/sbom-action@9e07fd7fd4c7754e8b7de48b7823674442d75a35
         with:
-          image: nickfedor/watchtower:${{ matrix.arch_tag }}-dev
+          image: docker://nickfedor/watchtower:${{ matrix.arch_tag }}-dev
           format: spdx-json
           artifact-name: ${{ matrix.arch_tag }}-dev.sbom.json
           upload-artifact: true
-          registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
-          registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Generate per-arch SBOM for GHCR
         if: github.event.inputs.dry_run != 'true'
         uses: anchore/sbom-action@9e07fd7fd4c7754e8b7de48b7823674442d75a35
         with:
-          image: ghcr.io/nicholas-fedor/watchtower:${{ matrix.arch_tag }}-dev
+          image: docker://ghcr.io/nicholas-fedor/watchtower:${{ matrix.arch_tag }}-dev
           format: spdx-json
           artifact-name: ghcr-${{ matrix.arch_tag }}-dev.sbom.json
           upload-artifact: true
-          registry-username: ${{ github.actor }}
-          registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clean up pulled images
+        if: github.event.inputs.dry_run != 'true'
+        run: |
+          docker image rm nickfedor/watchtower:${{ matrix.arch_tag }}-dev || true
+          docker image rm ghcr.io/nicholas-fedor/watchtower:${{ matrix.arch_tag }}-dev || true
 
       - name: Attest per-arch Docker Hub image
         if: github.event.inputs.dry_run != 'true'
@@ -219,27 +227,29 @@ jobs:
             docker manifest push "$manifest"
           done
 
+      - name: Pull manifest images for SBOM
+        if: github.event.inputs.dry_run != 'true'
+        run: |
+          docker pull nickfedor/watchtower:latest-dev || { echo "Failed to pull Docker Hub manifest"; exit 1; }
+          docker pull ghcr.io/nicholas-fedor/watchtower:latest-dev || { echo "Failed to pull GHCR manifest"; exit 1; }
+
       - name: Generate manifest SBOM for Docker Hub
         if: github.event.inputs.dry_run != 'true'
         uses: anchore/sbom-action@9e07fd7fd4c7754e8b7de48b7823674442d75a35
         with:
-          image: nickfedor/watchtower:latest-dev
+          image: docker://nickfedor/watchtower:latest-dev
           format: spdx-json
           artifact-name: latest-dev.sbom.json
           upload-artifact: true
-          registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
-          registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Generate manifest SBOM for GHCR
         if: github.event.inputs.dry_run != 'true'
         uses: anchore/sbom-action@9e07fd7fd4c7754e8b7de48b7823674442d75a35
         with:
-          image: ghcr.io/nicholas-fedor/watchtower:latest-dev
+          image: docker://ghcr.io/nicholas-fedor/watchtower:latest-dev
           format: spdx-json
           artifact-name: ghcr-latest-dev.sbom.json
           upload-artifact: true
-          registry-username: ${{ github.actor }}
-          registry-password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Attest Docker Hub manifest
         if: github.event.inputs.dry_run != 'true'


### PR DESCRIPTION
## Description
This PR fixes SBOM generation failures for non-amd64 images in the dev workflow by pulling images locally with --platform and using docker:// source for Syft. This avoids platform mismatch errors (e.g., armhf on amd64 runners) by ensuring images are available in the Docker daemon. Error handling and cleanup steps improve reliability.

### Changes
- Updated `release-dev.yaml`:
  - Added "Pull per-arch image for SBOM" step with error handling.
  - Added "Pull manifest images for SBOM" step in Create-Manifest-and-Attest.
  - Used docker:// prefix in SBOM steps for explicit local scanning.
  - Added cleanup step to remove pulled images.