### PR TITLE
fix(ci): add password-stdin to Docker Hub auth verify in dev workflow

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -176,7 +176,7 @@ jobs:
       - name: Verify Docker Hub auth
         if: github.event.inputs.dry_run != 'true'
         run: |
-          docker login --username ${{ secrets.DOCKERHUB_USERNAME }} registry-1.docker.io || { echo "Docker Hub auth failed"; exit 1; }
+          echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin registry-1.docker.io || { echo "Docker Hub auth failed"; exit 1; }
 
       - name: Attest per-arch Docker Hub image
         if: github.event.inputs.dry_run != 'true'
@@ -261,7 +261,7 @@ jobs:
       - name: Verify Docker Hub auth
         if: github.event.inputs.dry_run != 'true'
         run: |
-          docker login --username ${{ secrets.DOCKERHUB_USERNAME }} registry-1.docker.io || { echo "Docker Hub auth failed"; exit 1; }
+          echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin registry-1.docker.io || { echo "Docker Hub auth failed"; exit 1; }
 
       - name: Attest Docker Hub manifest
         if: github.event.inputs.dry_run != 'true'


### PR DESCRIPTION
## Description
This PR fixes non-interactive login failures in the Verify Docker Hub auth step, which caused "Cannot perform an interactive login from a non TTY device" errors. The step now uses --password-stdin with the DOCKERHUB_TOKEN for secure, non-prompt login verification.

## Changes
- Updated `release-dev.yaml`:
  - Modified Verify Docker Hub auth run command to `echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin registry-1.docker.io`.
  - Applied to both Build-and-Push-Per-Arch and Create-Manifest-and-Attest jobs.