### PR TITLE
ci: add push trigger and test job to dev release workflow

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -8,13 +8,29 @@ on:
         required: false
         default: false
         type: boolean
+  push:
+    branches:
+      - main
+    paths:
+      - cmd/**
+      - internal/**
+      - pkg/**
+      - go.mod
+      - go.sum
+      - main.go
 
 permissions:
   contents: read
   packages: write # For GHCR
 
 jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+    permissions:
+      contents: read
+
   build-images:
+    needs: test
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Integrate push event trigger to `release-dev.yaml` for automated runs on main pushes to specified paths. 
Add `test` job using `./.github/workflows/test.yaml` as a prerequisite for `build-images`, ensuring tests pass before building/pushing images.