### PR TITLE
ci: enable Buildx for attestations in dev and prod workflows

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -43,6 +43,12 @@ jobs:
         with:
           go-version: 1.24.x
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+
       - name: Login to Docker Hub
         if: ${{ !inputs.dry-run }}
         uses: docker/login-action@3d100841f68d4548bf57e52eb27bd33ec5069f55

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -42,6 +42,12 @@ jobs:
         with:
           go-version: 1.24.x
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+
       - name: Login to Docker Hub
         if: ${{ !inputs.dry-run }}
         uses: docker/login-action@3d100841f68d4548bf57e52eb27bd33ec5069f55


### PR DESCRIPTION
Enable Docker Buildx in `release-dev.yaml` and `release-prod.yaml` to support SBOM and provenance attestations:
- Add `setup-qemu-action@v3` for multi-platform emulation.
- Add `setup-buildx-action@v3` to create Buildx builder with containerd store.
- Place before "Run GoReleaser" to resolve "Attestation not supported for docker driver" error.