### PR TITLE
ci: use explicit Buildx outputs for dev and prod builds

### DIFF
--- a/build/goreleaser/dev.yml
+++ b/build/goreleaser/dev.yml
@@ -30,7 +30,7 @@ dockers:
       - nickfedor/watchtower:amd64-dev
       - ghcr.io/nicholas-fedor/watchtower:amd64-dev
     build_flag_templates:
-      - "--output=type=oci,dest=dist/oci/amd64"
+      - "--output=type=docker"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/amd64"
@@ -44,7 +44,7 @@ dockers:
       - nickfedor/watchtower:i386-dev
       - ghcr.io/nicholas-fedor/watchtower:i386-dev
     build_flag_templates:
-      - "--output=type=oci,dest=dist/oci/386"
+      - "--output=type=docker"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/386"
@@ -59,7 +59,7 @@ dockers:
       - nickfedor/watchtower:armhf-dev
       - ghcr.io/nicholas-fedor/watchtower:armhf-dev
     build_flag_templates:
-      - "--output=type=oci,dest=dist/oci/arm"
+      - "--output=type=docker"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/arm/v6"
@@ -73,7 +73,7 @@ dockers:
       - nickfedor/watchtower:arm64v8-dev
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-dev
     build_flag_templates:
-      - "--output=type=oci,dest=dist/oci/arm64"
+      - "--output=type=docker"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/arm64"
@@ -87,7 +87,7 @@ dockers:
       - nickfedor/watchtower:riscv64-dev
       - ghcr.io/nicholas-fedor/watchtower:riscv64-dev
     build_flag_templates:
-      - "--output=type=oci,dest=dist/oci/riscv64"
+      - "--output=type=docker"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/riscv64"

--- a/build/goreleaser/prod.yml
+++ b/build/goreleaser/prod.yml
@@ -51,7 +51,7 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:amd64-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:amd64-latest
     build_flag_templates:
-      - "--output=type=oci,dest=dist/oci/amd64"
+      - "--output=type=registry"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/amd64"
@@ -67,7 +67,7 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:i386-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:i386-latest
     build_flag_templates:
-      - "--output=type=oci,dest=dist/oci/386"
+      - "--output=type=registry"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/386"
@@ -84,7 +84,7 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:armhf-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:armhf-latest
     build_flag_templates:
-      - "--output=type=oci,dest=dist/oci/arm"
+      - "--output=type=registry"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/arm/v6"
@@ -100,7 +100,7 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-latest
     build_flag_templates:
-      - "--output=type=oci,dest=dist/oci/arm64"
+      - "--output=type=registry"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/arm64/v8"
@@ -116,7 +116,7 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:riscv64-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:riscv64-latest
     build_flag_templates:
-      - "--output=type=oci,dest=dist/oci/riscv64"
+      - "--output=type=registry"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/riscv64"


### PR DESCRIPTION
- Add --output=type=docker to dev.yml build_flag_templates for local image loading with --skip=publish.
- Add --output=type=registry to prod.yml for direct registry pushes.