### PR TITLE
fix(workflows): refactor build workflows and correct output types

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,8 +17,6 @@ on:
         required: true
       DOCKERHUB_TOKEN:
         required: true
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   build:
@@ -70,7 +68,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ github.token }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@0931acf1f7634c2ee911eea11a334fb00a5180ab
@@ -79,7 +77,7 @@ jobs:
           version: v2.3.2
           args: release --config build/goreleaser/${{ inputs.build-type }}.yml --snapshot --clean ${{ inputs.dry-run && '--skip=publish' || '' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Upload binary SBOMs
         if: ${{ !inputs.dry-run && inputs.build-type == 'prod' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,100 @@
+name: Build Release
+
+on:
+  workflow_call:
+    inputs:
+      build-type:
+        description: "Type of build (prod or dev)"
+        required: true
+        type: string
+      dry-run:
+        description: "Run in test mode without publishing artifacts"
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+      GITHUB_TOKEN:
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Validate build-type input
+        run: |
+          if [[ "${{ inputs.build-type }}" != "prod" && "${{ inputs.build-type }}" != "dev" ]]; then
+            echo "Error: build-type must be 'prod' or 'dev', got '${{ inputs.build-type }}'"
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@8e57b58e57be52ac95949151e2777ffda8501267
+        with:
+          go-version: 1.24.x
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@05340d1c670183e7caabdb33ae9f1c80fae3b0c2
+        with:
+          platforms: linux/amd64,linux/386,linux/arm/v6,linux/arm64/v8,linux/riscv64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+        with:
+          driver: docker-container
+          platforms: linux/amd64,linux/386,linux/arm/v6,linux/arm64/v8,linux/riscv64
+          use: true
+
+      - name: Login to Docker Hub
+        if: ${{ !inputs.dry-run }}
+        uses: docker/login-action@3d100841f68d4548bf57e52eb27bd33ec5069f55
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        if: ${{ !inputs.dry-run }}
+        uses: docker/login-action@3d100841f68d4548bf57e52eb27bd33ec5069f55
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@0931acf1f7634c2ee911eea11a334fb00a5180ab
+        with:
+          distribution: goreleaser
+          version: v2.3.2
+          args: release --config build/goreleaser/${{ inputs.build-type }}.yml --snapshot --clean ${{ inputs.dry-run && '--skip=publish' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload binary SBOMs
+        if: ${{ !inputs.dry-run && inputs.build-type == 'prod' }}
+        uses: actions/upload-artifact@de65e23aa2b7e23d713bb51fbfcb6d502f8667d8
+        with:
+          name: ${{ inputs.build-type }}-binary-sboms
+          path: dist/*.sbom
+          if-no-files-found: warn
+
+      - name: Generate artifact attestation
+        if: ${{ !inputs.dry-run && inputs.build-type == 'prod' }}
+        uses: actions/attest-build-provenance@f923cf69427d7ac614fbcc05e12232908c3f031b
+        with:
+          subject-checksums: ./dist/checksums.txt
+
+      - name: Clean up dist directory
+        if: always()
+        run: rm -rf dist

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -21,7 +21,7 @@ on:
 
 permissions:
   contents: read
-  packages: write # For GHCR
+  packages: write
 
 jobs:
   test:
@@ -29,46 +29,13 @@ jobs:
     permissions:
       contents: read
 
-  build-images:
+  build:
     needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f
-        with:
-          fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@8e57b58e57be52ac95949151e2777ffda8501267
-        with:
-          go-version: 1.24.x
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@05340d1c670183e7caabdb33ae9f1c80fae3b0c2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
-
-      - name: Login to Docker Hub
-        if: ${{ !inputs.dry-run }}
-        uses: docker/login-action@3d100841f68d4548bf57e52eb27bd33ec5069f55
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to GHCR
-        if: ${{ !inputs.dry-run }}
-        uses: docker/login-action@3d100841f68d4548bf57e52eb27bd33ec5069f55
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@0931acf1f7634c2ee911eea11a334fb00a5180ab
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          args: release --config build/goreleaser/dev.yml --snapshot --clean ${{ inputs.dry-run && '--skip=publish' || '' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/build.yaml
+    with:
+      build-type: dev
+      dry-run: ${{ inputs.dry-run }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -38,4 +38,3 @@ jobs:
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -1,4 +1,4 @@
-name: Release Dev Images
+name: Release Development
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -24,74 +24,19 @@ jobs:
     permissions:
       contents: read
 
-  build-binaries-and-release:
+  build:
     needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      attestations: write
-      id-token: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f
-        with:
-          fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@8e57b58e57be52ac95949151e2777ffda8501267
-        with:
-          go-version: 1.24.x
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@05340d1c670183e7caabdb33ae9f1c80fae3b0c2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
-
-      - name: Login to Docker Hub
-        if: ${{ !inputs.dry-run }}
-        uses: docker/login-action@3d100841f68d4548bf57e52eb27bd33ec5069f55
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to GHCR
-        if: ${{ !inputs.dry-run }}
-        uses: docker/login-action@3d100841f68d4548bf57e52eb27bd33ec5069f55
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@0931acf1f7634c2ee911eea11a334fb00a5180ab
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          args: release --config build/goreleaser/prod.yml ${{ inputs.dry-run && '--snapshot --clean --skip=publish' || '' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload binary SBOMs
-        if: ${{ !inputs.dry-run }}
-        uses: actions/upload-artifact@de65e23aa2b7e23d713bb51fbfcb6d502f8667d8
-        with:
-          name: prod-binary-sboms
-          path: dist/*.sbom
-          if-no-files-found: warn
-
-      - name: Generate artifact attestation
-        if: ${{ !inputs.dry-run }}
-        uses: actions/attest-build-provenance@f923cf69427d7ac614fbcc05e12232908c3f031b
-        with:
-          subject-checksums: ./dist/checksums.txt
-
-      - name: Clean up dist directory
-        if: always()
-        run: rm -rf dist
+    uses: ./.github/workflows/build.yaml
+    with:
+      build-type: prod
+      dry-run: ${{ inputs.dry-run }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   update-go-docs:
-    needs: [test, build-binaries-and-release]
+    needs: [test, build]
     if: ${{ !inputs.dry-run }}
     permissions:
       contents: read

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -1,4 +1,4 @@
-name: Release (Production)
+name: Release Production
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -33,7 +33,6 @@ jobs:
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   update-go-docs:
     needs: [test, build]

--- a/build/goreleaser/dev.yml
+++ b/build/goreleaser/dev.yml
@@ -30,7 +30,7 @@ dockers:
       - nickfedor/watchtower:amd64-dev
       - ghcr.io/nicholas-fedor/watchtower:amd64-dev
     build_flag_templates:
-      - "--output=type=docker"
+      - "--output=type=image"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/amd64"
@@ -44,7 +44,7 @@ dockers:
       - nickfedor/watchtower:i386-dev
       - ghcr.io/nicholas-fedor/watchtower:i386-dev
     build_flag_templates:
-      - "--output=type=docker"
+      - "--output=type=image"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/386"
@@ -59,7 +59,7 @@ dockers:
       - nickfedor/watchtower:armhf-dev
       - ghcr.io/nicholas-fedor/watchtower:armhf-dev
     build_flag_templates:
-      - "--output=type=docker"
+      - "--output=type=image"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/arm/v6"
@@ -73,7 +73,7 @@ dockers:
       - nickfedor/watchtower:arm64v8-dev
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-dev
     build_flag_templates:
-      - "--output=type=docker"
+      - "--output=type=image"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/arm64"
@@ -87,7 +87,7 @@ dockers:
       - nickfedor/watchtower:riscv64-dev
       - ghcr.io/nicholas-fedor/watchtower:riscv64-dev
     build_flag_templates:
-      - "--output=type=docker"
+      - "--output=type=image"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/riscv64"

--- a/build/goreleaser/prod.yml
+++ b/build/goreleaser/prod.yml
@@ -51,7 +51,7 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:amd64-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:amd64-latest
     build_flag_templates:
-      - "--output=type=registry"
+      - "--output=type=image"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/amd64"
@@ -67,7 +67,7 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:i386-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:i386-latest
     build_flag_templates:
-      - "--output=type=registry"
+      - "--output=type=image"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/386"
@@ -84,7 +84,7 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:armhf-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:armhf-latest
     build_flag_templates:
-      - "--output=type=registry"
+      - "--output=type=image"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/arm/v6"
@@ -100,7 +100,7 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-latest
     build_flag_templates:
-      - "--output=type=registry"
+      - "--output=type=image"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/arm64/v8"
@@ -116,7 +116,7 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:riscv64-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:riscv64-latest
     build_flag_templates:
-      - "--output=type=registry"
+      - "--output=type=image"
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/riscv64"


### PR DESCRIPTION
- Refactor `release-prod.yaml` and `release-dev.yaml` to call consolidated `build.yaml` workflow for production and development builds, improving maintainability and reducing duplication
- Rename jobs to `build` in `release-prod.yaml` and `release-dev.yaml` for consistency
- Correct `build_flag_templates` in `prod.yml` from `--output=type=registry` to `--output=type=image` to ensure proper Docker image creation
- Correct `build_flag_templates` in `dev.yml` from `--output=type=docker` to `--output=type=image` to fix invalid output type
- Remove redundant comment in `release-dev.yaml` permissions for clarity
- Rename `release-prod.yaml` to `Release Production` and `release-dev.yaml` to `Release Development` for consistent naming