### PR TITLE
fix(workflows): add attestations and id-token permissions to release-dev

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -22,6 +22,8 @@ on:
 permissions:
   contents: read
   packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   test:


### PR DESCRIPTION
- Add `attestations: write` and `id-token: write` to `release-dev.yaml` permissions to resolve validation error when calling `build.yaml`, ensuring Docker image attestations can be generated