### PR TITLE
fix(goreleaser): update GoReleaser version to ~> v2 to support goriscv64

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,7 +74,7 @@ jobs:
         uses: goreleaser/goreleaser-action@0931acf1f7634c2ee911eea11a334fb00a5180ab
         with:
           distribution: goreleaser
-          version: v2.3.2
+          version: "~> v2"
           args: release --config build/goreleaser/${{ inputs.build-type }}.yml --snapshot --clean ${{ inputs.dry-run && '--skip=publish' || '' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
- Update GoReleaser version in `build.yaml` from v2.3.2 to ~> v2 to resolve YAML unmarshal error by supporting `goriscv64` field in `prod.yml` and `dev.yml`