### PR TITLE
fix(goreleaser): enable dry-run builds with conditional output type

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,6 +78,7 @@ jobs:
           args: release --config build/goreleaser/${{ inputs.build-type }}.yml --snapshot --clean ${{ inputs.dry-run && '--skip=publish' || '' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          DRY_RUN: ${{ inputs.dry-run }}
 
       - name: Upload binary SBOMs
         if: ${{ !inputs.dry-run && inputs.build-type == 'prod' }}

--- a/build/goreleaser/dev.yml
+++ b/build/goreleaser/dev.yml
@@ -30,7 +30,7 @@ dockers:
       - nickfedor/watchtower:amd64-dev
       - ghcr.io/nicholas-fedor/watchtower:amd64-dev
     build_flag_templates:
-      - "--output=type=image"
+      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/amd64"
@@ -44,7 +44,7 @@ dockers:
       - nickfedor/watchtower:i386-dev
       - ghcr.io/nicholas-fedor/watchtower:i386-dev
     build_flag_templates:
-      - "--output=type=image"
+      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/386"
@@ -59,7 +59,7 @@ dockers:
       - nickfedor/watchtower:armhf-dev
       - ghcr.io/nicholas-fedor/watchtower:armhf-dev
     build_flag_templates:
-      - "--output=type=image"
+      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/arm/v6"
@@ -73,7 +73,7 @@ dockers:
       - nickfedor/watchtower:arm64v8-dev
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-dev
     build_flag_templates:
-      - "--output=type=image"
+      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/arm64"
@@ -87,7 +87,7 @@ dockers:
       - nickfedor/watchtower:riscv64-dev
       - ghcr.io/nicholas-fedor/watchtower:riscv64-dev
     build_flag_templates:
-      - "--output=type=image"
+      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/riscv64"
@@ -103,6 +103,7 @@ docker_manifests:
       - nickfedor/watchtower:armhf-dev
       - nickfedor/watchtower:arm64v8-dev
       - nickfedor/watchtower:riscv64-dev
+    skip_push: "{{ .Env.DRY_RUN }}"
   - name_template: ghcr.io/nicholas-fedor/watchtower:latest-dev
     image_templates:
       - ghcr.io/nicholas-fedor/watchtower:amd64-dev
@@ -110,3 +111,4 @@ docker_manifests:
       - ghcr.io/nicholas-fedor/watchtower:armhf-dev
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-dev
       - ghcr.io/nicholas-fedor/watchtower:riscv64-dev
+    skip_push: "{{ .Env.DRY_RUN }}"

--- a/build/goreleaser/prod.yml
+++ b/build/goreleaser/prod.yml
@@ -51,7 +51,7 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:amd64-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:amd64-latest
     build_flag_templates:
-      - "--output=type=image"
+      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/amd64"
@@ -67,7 +67,7 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:i386-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:i386-latest
     build_flag_templates:
-      - "--output=type=image"
+      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/386"
@@ -84,7 +84,7 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:armhf-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:armhf-latest
     build_flag_templates:
-      - "--output=type=image"
+      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/arm/v6"
@@ -100,7 +100,7 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-latest
     build_flag_templates:
-      - "--output=type=image"
+      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/arm64/v8"
@@ -116,7 +116,7 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:riscv64-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:riscv64-latest
     build_flag_templates:
-      - "--output=type=image"
+      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
       - "--attest=type=provenance,mode=max"
       - "--attest=type=sbom"
       - "--platform=linux/riscv64"
@@ -132,6 +132,7 @@ docker_manifests:
       - nickfedor/watchtower:armhf-{{ .Version }}
       - nickfedor/watchtower:arm64v8-{{ .Version }}
       - nickfedor/watchtower:riscv64-{{ .Version }}
+    skip_push: "{{ .Env.DRY_RUN }}"
   - name_template: nickfedor/watchtower:latest
     image_templates:
       - nickfedor/watchtower:amd64-latest
@@ -139,6 +140,7 @@ docker_manifests:
       - nickfedor/watchtower:armhf-latest
       - nickfedor/watchtower:arm64v8-latest
       - nickfedor/watchtower:riscv64-latest
+    skip_push: "{{ .Env.DRY_RUN }}"
   - name_template: ghcr.io/nicholas-fedor/watchtower:{{ .Version }}
     image_templates:
       - ghcr.io/nicholas-fedor/watchtower:amd64-{{ .Version }}
@@ -146,6 +148,7 @@ docker_manifests:
       - ghcr.io/nicholas-fedor/watchtower:armhf-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:riscv64-{{ .Version }}
+    skip_push: "{{ .Env.DRY_RUN }}"
   - name_template: ghcr.io/nicholas-fedor/watchtower:latest
     image_templates:
       - ghcr.io/nicholas-fedor/watchtower:amd64-latest
@@ -153,6 +156,7 @@ docker_manifests:
       - ghcr.io/nicholas-fedor/watchtower:armhf-latest
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-latest
       - ghcr.io/nicholas-fedor/watchtower:riscv64-latest
+    skip_push: "{{ .Env.DRY_RUN }}"
 
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
- Add `DRY_RUN` environment variable to `Run GoReleaser` step in `build.yaml` to enable conditional configuration based on dry-run status
- Update `build_flag_templates` in `dev.yml` and `prod.yml` to use `--output=type=docker` for dry-run and `--output=type=registry` for actual releases, resolving manifest list export error
- Add `skip_push: "{{ .Env.DRY_RUN }}"` to `docker_manifests` in `dev.yml` and `prod.yml` to prevent manifest pushing during dry-run, aligning with `--skip=publish` behavior