### PR TITLE
fix(goreleaser): use --load for dry-run and --push for releases

### DIFF
--- a/build/goreleaser/dev.yml
+++ b/build/goreleaser/dev.yml
@@ -30,9 +30,9 @@ dockers:
       - nickfedor/watchtower:amd64-dev
       - ghcr.io/nicholas-fedor/watchtower:amd64-dev
     build_flag_templates:
-      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - '{{ if eq .Env.DRY_RUN "true" }}--load{{ else }}--push{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true") }}--attest=type=provenance,mode=max{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true") }}--attest=type=sbom{{ end }}'
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version=dev"
@@ -44,9 +44,9 @@ dockers:
       - nickfedor/watchtower:i386-dev
       - ghcr.io/nicholas-fedor/watchtower:i386-dev
     build_flag_templates:
-      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - '{{ if eq .Env.DRY_RUN "true" }}--load{{ else }}--push{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true") }}--attest=type=provenance,mode=max{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true") }}--attest=type=sbom{{ end }}'
       - "--platform=linux/386"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version=dev"
@@ -59,9 +59,9 @@ dockers:
       - nickfedor/watchtower:armhf-dev
       - ghcr.io/nicholas-fedor/watchtower:armhf-dev
     build_flag_templates:
-      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - '{{ if eq .Env.DRY_RUN "true" }}--load{{ else }}--push{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true") }}--attest=type=provenance,mode=max{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true") }}--attest=type=sbom{{ end }}'
       - "--platform=linux/arm/v6"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version=dev"
@@ -73,9 +73,9 @@ dockers:
       - nickfedor/watchtower:arm64v8-dev
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-dev
     build_flag_templates:
-      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - '{{ if eq .Env.DRY_RUN "true" }}--load{{ else }}--push{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true" ) }}--attest=type=provenance,mode=max{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true" ) }}--attest=type=sbom{{ end }}'
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version=dev"
@@ -87,9 +87,9 @@ dockers:
       - nickfedor/watchtower:riscv64-dev
       - ghcr.io/nicholas-fedor/watchtower:riscv64-dev
     build_flag_templates:
-      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - '{{ if eq .Env.DRY_RUN "true" }}--load{{ else }}--push{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true" ) }}--attest=type=provenance,mode=max{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true" ) }}--attest=type=sbom{{ end }}'
       - "--platform=linux/riscv64"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version=dev"

--- a/build/goreleaser/prod.yml
+++ b/build/goreleaser/prod.yml
@@ -31,10 +31,9 @@ archives:
       {{- if eq .Arch "amd64" }}amd64
       {{- else if eq .Arch "386" }}i386
       {{- else if eq .Arch "arm" }}armhf
-      {{- else if eq .Arch "arm64" }}arm64v8
-      {{- else if eq .Arch "riscv64" }}riscv64
-      {{- else }}{{ .Arch }}{{ end }}_
-      {{- .Version -}}
+      - "{{ else if eq .Arch \"arm64\" }}arm64v8{{ end }}"
+      - "{{ if eq .Arch \"riscv64\" }}riscv64{{ end }}"
+      - "{{ .Version -}}"
     formats: ["tar.gz"]
     format_overrides:
       - goos: windows
@@ -51,9 +50,9 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:amd64-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:amd64-latest
     build_flag_templates:
-      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - '{{ if eq .Env.DRY_RUN "true" }}--load{{ else }}--push{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true") }}--attest=type=provenance,mode=max{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true") }}--attest=type=sbom{{ end }}'
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
@@ -67,9 +66,9 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:i386-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:i386-latest
     build_flag_templates:
-      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - '{{ if eq .Env.DRY_RUN "true" }}--load{{ else }}--push{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true") }}--attest=type=provenance,mode=max{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true" ) }}--attest=type=sbom{{ end }}'
       - "--platform=linux/386"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
@@ -84,9 +83,9 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:armhf-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:armhf-latest
     build_flag_templates:
-      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - '{{ if eq .Env.DRY_RUN "true" }}--load{{ else }}--push{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true" ) }}--attest=type=provenance,mode=max{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true" ) }}--attest=type=sbom{{ end }}'
       - "--platform=linux/arm/v6"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
@@ -100,9 +99,9 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-latest
     build_flag_templates:
-      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - '{{ if eq .Env.DRY_RUN "true" }}--load{{ else }}--push{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true" ) }}--attest=type=provenance,mode=max{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true" ) }}--attest=type=sbom{{ end }}'
       - "--platform=linux/arm64/v8"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
@@ -116,9 +115,9 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:riscv64-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:riscv64-latest
     build_flag_templates:
-      - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - '{{ if eq .Env.DRY_RUN "true" }}--load{{ else }}--push{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true" ) }}--attest=type=provenance,mode=max{{ end }}'
+      - '{{ if not (eq .Env.DRY_RUN "true" ) }}--attest=type=sbom{{ end }}'
       - "--platform=linux/riscv64"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"


### PR DESCRIPTION
- Update `build_flag_templates` in `dev.yml` and `prod.yml` to conditionally use --load for dry-run builds (local loading) and --push for actual releases (registry push), resolving syntax and manifest list export errors in dry-run mode
- Maintain conditional skipping of attestations in dry-run to ensure compatibility with local Docker exporter, while preserving full functionality for non-dry-run releases