### PR TITLE
fix(goreleaser): align dockers with builds and update Dockerfile for binary paths

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,4 +1,9 @@
 ARG BASE_IMAGE=alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
+ARG GOOS=linux
+ARG GOARCH
+ARG GOAMD64
+ARG GOARM
+ARG GORISCV64
 
 FROM --platform=$BUILDPLATFORM $BASE_IMAGE AS builder
 
@@ -21,8 +26,8 @@ LABEL "org.opencontainers.image.url"="https://nicholas-fedor.github.io/watchtowe
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 
-# Copy prebuilt binary (GoReleaser places it as 'watchtower' in context)
-COPY watchtower /watchtower
+# Copy binary based on GOOS, GOARCH, and variant
+COPY dist/watchtower_${GOOS}_${GOARCH}${GOAMD64:+_${GOAMD64}}${GOARM:+_${GOARM}}${GORISCV64:+_${GORISCV64}}/watchtower /watchtower
 
 EXPOSE 8080
 

--- a/build/goreleaser/dev.yml
+++ b/build/goreleaser/dev.yml
@@ -13,6 +13,10 @@ builds:
       - arm
       - arm64
       - riscv64
+    goamd64:
+      - v1
+    goarm:
+      - "6"
     goriscv64:
       - rva20u64
     ignore:
@@ -25,6 +29,9 @@ builds:
 
 dockers:
   - use: buildx
+    goos: linux
+    goarch: amd64
+    goamd64: "v1"
     dockerfile: build/docker/Dockerfile
     image_templates:
       - nickfedor/watchtower:amd64-dev
@@ -34,12 +41,16 @@ dockers:
       - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
       - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
       - "--platform=linux/amd64"
+      - "--build-arg=GOOS=linux"
+      - "--build-arg=GOARCH=amd64"
+      - "--build-arg=GOAMD64=v1"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version=dev"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
   - use: buildx
-    dockerfile: build/docker/Dockerfile
+    goos: linux
     goarch: "386"
+    dockerfile: build/docker/Dockerfile
     image_templates:
       - nickfedor/watchtower:i386-dev
       - ghcr.io/nicholas-fedor/watchtower:i386-dev
@@ -48,13 +59,16 @@ dockers:
       - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
       - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
       - "--platform=linux/386"
+      - "--build-arg=GOOS=linux"
+      - "--build-arg=GOARCH=386"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version=dev"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
   - use: buildx
-    dockerfile: build/docker/Dockerfile
+    goos: linux
     goarch: arm
     goarm: "6"
+    dockerfile: build/docker/Dockerfile
     image_templates:
       - nickfedor/watchtower:armhf-dev
       - ghcr.io/nicholas-fedor/watchtower:armhf-dev
@@ -63,12 +77,16 @@ dockers:
       - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
       - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
       - "--platform=linux/arm/v6"
+      - "--build-arg=GOOS=linux"
+      - "--build-arg=GOARCH=arm"
+      - "--build-arg=GOARM=6"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version=dev"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
   - use: buildx
-    dockerfile: build/docker/Dockerfile
+    goos: linux
     goarch: arm64
+    dockerfile: build/docker/Dockerfile
     image_templates:
       - nickfedor/watchtower:arm64v8-dev
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-dev
@@ -77,12 +95,15 @@ dockers:
       - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
       - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
       - "--platform=linux/arm64"
+      - "--build-arg=GOOS=linux"
+      - "--build-arg=GOARCH=arm64"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version=dev"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
   - use: buildx
-    dockerfile: build/docker/Dockerfile
+    goos: linux
     goarch: riscv64
+    dockerfile: build/docker/Dockerfile
     image_templates:
       - nickfedor/watchtower:riscv64-dev
       - ghcr.io/nicholas-fedor/watchtower:riscv64-dev
@@ -91,6 +112,9 @@ dockers:
       - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
       - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
       - "--platform=linux/riscv64"
+      - "--build-arg=GOOS=linux"
+      - "--build-arg=GOARCH=riscv64"
+      - "--build-arg=GORISCV64=rva20u64"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version=dev"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"

--- a/build/goreleaser/prod.yml
+++ b/build/goreleaser/prod.yml
@@ -13,6 +13,10 @@ builds:
       - arm
       - arm64
       - riscv64
+    goamd64:
+      - v1
+    goarm:
+      - "6"
     goriscv64:
       - rva20u64
     ignore:
@@ -44,6 +48,9 @@ archives:
 
 dockers:
   - use: buildx
+    goos: linux
+    goarch: amd64
+    goamd64: "v1"
     dockerfile: build/docker/Dockerfile
     image_templates:
       - nickfedor/watchtower:amd64-{{ .Version }}
@@ -55,12 +62,16 @@ dockers:
       - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
       - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
       - "--platform=linux/amd64"
+      - "--build-arg=GOOS=linux"
+      - "--build-arg=GOARCH=amd64"
+      - "--build-arg=GOAMD64=v1"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
   - use: buildx
-    dockerfile: build/docker/Dockerfile
+    goos: linux
     goarch: "386"
+    dockerfile: build/docker/Dockerfile
     image_templates:
       - nickfedor/watchtower:i386-{{ .Version }}
       - nickfedor/watchtower:i386-latest
@@ -71,13 +82,16 @@ dockers:
       - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
       - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
       - "--platform=linux/386"
+      - "--build-arg=GOOS=linux"
+      - "--build-arg=GOARCH=386"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
   - use: buildx
-    dockerfile: build/docker/Dockerfile
+    goos: linux
     goarch: arm
     goarm: "6"
+    dockerfile: build/docker/Dockerfile
     image_templates:
       - nickfedor/watchtower:armhf-{{ .Version }}
       - nickfedor/watchtower:armhf-latest
@@ -88,12 +102,16 @@ dockers:
       - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
       - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
       - "--platform=linux/arm/v6"
+      - "--build-arg=GOOS=linux"
+      - "--build-arg=GOARCH=arm"
+      - "--build-arg=GOARM=6"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
   - use: buildx
-    dockerfile: build/docker/Dockerfile
+    goos: linux
     goarch: arm64
+    dockerfile: build/docker/Dockerfile
     image_templates:
       - nickfedor/watchtower:arm64v8-{{ .Version }}
       - nickfedor/watchtower:arm64v8-latest
@@ -103,13 +121,16 @@ dockers:
       - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
       - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
       - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
-      - "--platform=linux/arm64/v8"
+      - "--platform=linux/arm64"
+      - "--build-arg=GOOS=linux"
+      - "--build-arg=GOARCH=arm64"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
   - use: buildx
-    dockerfile: build/docker/Dockerfile
+    goos: linux
     goarch: riscv64
+    dockerfile: build/docker/Dockerfile
     image_templates:
       - nickfedor/watchtower:riscv64-{{ .Version }}
       - nickfedor/watchtower:riscv64-latest
@@ -120,6 +141,9 @@ dockers:
       - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
       - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
       - "--platform=linux/riscv64"
+      - "--build-arg=GOOS=linux"
+      - "--build-arg=GOARCH=riscv64"
+      - "--build-arg=GORISCV64=rva20u64"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"


### PR DESCRIPTION
- Add goos: linux, goarch, and goamd64: "v1" (for amd64) to dockers entries in dev.yml and prod.yml to align with the builds section and ensure correct binary matching
- Add goarm: "6" to arm dockers to match the linux_arm_6 binary path
- Add --build-arg flags to build_flag_templates to pass GOOS, GOARCH, GOAMD64, GOARM, and GORISCV64 to the Dockerfile, enabling dynamic binary path resolution
- Update Dockerfile to copy the binary from the variant-specific path (e.g., dist/watchtower_linux_arm64/watchtower) using build arguments, fixing the "docker buildx build requires 1 argument" error