### PR TITLE
fix(goreleaser): add architecture variants to builds and dockers

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,9 +1,11 @@
 ARG BASE_IMAGE=alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
 ARG GOOS=linux
 ARG GOARCH
-ARG GOAMD64
-ARG GOARM
-ARG GORISCV64
+ARG GOAMD64=v1
+ARG GO386=sse2
+ARG GOARM=6
+ARG GOARM64=v8.0
+ARG GORISCV64=rva20u64
 
 FROM --platform=$BUILDPLATFORM $BASE_IMAGE AS builder
 
@@ -27,7 +29,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 
 # Copy binary based on GOOS, GOARCH, and variant
-COPY dist/watchtower_${GOOS}_${GOARCH}${GOAMD64:+_${GOAMD64}}${GOARM:+_${GOARM}}${GORISCV64:+_${GORISCV64}}/watchtower /watchtower
+COPY dist/watchtower_${GOOS}_${GOARCH}${GOAMD64:+_${GOAMD64}}${GO386:+_${GO386}}${GOARM:+_${GOARM}}${GOARM64:+_${GOARM64}}${GORISCV64:+_${GORISCV64}}/watchtower /watchtower
 
 EXPOSE 8080
 

--- a/build/goreleaser/dev.yml
+++ b/build/goreleaser/dev.yml
@@ -13,12 +13,6 @@ builds:
       - arm
       - arm64
       - riscv64
-    goamd64:
-      - v1
-    goarm:
-      - "6"
-    goriscv64:
-      - rva20u64
     ignore:
       - goos: windows
         goarch: riscv64
@@ -29,9 +23,6 @@ builds:
 
 dockers:
   - use: buildx
-    goos: linux
-    goarch: amd64
-    goamd64: "v1"
     dockerfile: build/docker/Dockerfile
     image_templates:
       - nickfedor/watchtower:amd64-dev
@@ -48,9 +39,8 @@ dockers:
       - "--label=org.opencontainers.image.version=dev"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
   - use: buildx
-    goos: linux
-    goarch: "386"
     dockerfile: build/docker/Dockerfile
+    goarch: "386"
     image_templates:
       - nickfedor/watchtower:i386-dev
       - ghcr.io/nicholas-fedor/watchtower:i386-dev
@@ -61,14 +51,14 @@ dockers:
       - "--platform=linux/386"
       - "--build-arg=GOOS=linux"
       - "--build-arg=GOARCH=386"
+      - "--build-arg=GO386=sse2"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version=dev"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
   - use: buildx
-    goos: linux
+    dockerfile: build/docker/Dockerfile
     goarch: arm
     goarm: "6"
-    dockerfile: build/docker/Dockerfile
     image_templates:
       - nickfedor/watchtower:armhf-dev
       - ghcr.io/nicholas-fedor/watchtower:armhf-dev
@@ -84,9 +74,8 @@ dockers:
       - "--label=org.opencontainers.image.version=dev"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
   - use: buildx
-    goos: linux
-    goarch: arm64
     dockerfile: build/docker/Dockerfile
+    goarch: arm64
     image_templates:
       - nickfedor/watchtower:arm64v8-dev
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-dev
@@ -97,13 +86,13 @@ dockers:
       - "--platform=linux/arm64"
       - "--build-arg=GOOS=linux"
       - "--build-arg=GOARCH=arm64"
+      - "--build-arg=GOARM64=v8.0"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version=dev"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
   - use: buildx
-    goos: linux
-    goarch: riscv64
     dockerfile: build/docker/Dockerfile
+    goarch: riscv64
     image_templates:
       - nickfedor/watchtower:riscv64-dev
       - ghcr.io/nicholas-fedor/watchtower:riscv64-dev

--- a/build/goreleaser/prod.yml
+++ b/build/goreleaser/prod.yml
@@ -13,12 +13,6 @@ builds:
       - arm
       - arm64
       - riscv64
-    goamd64:
-      - v1
-    goarm:
-      - "6"
-    goriscv64:
-      - rva20u64
     ignore:
       - goos: windows
         goarch: riscv64
@@ -48,9 +42,6 @@ archives:
 
 dockers:
   - use: buildx
-    goos: linux
-    goarch: amd64
-    goamd64: "v1"
     dockerfile: build/docker/Dockerfile
     image_templates:
       - nickfedor/watchtower:amd64-{{ .Version }}
@@ -69,9 +60,8 @@ dockers:
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
   - use: buildx
-    goos: linux
-    goarch: "386"
     dockerfile: build/docker/Dockerfile
+    goarch: "386"
     image_templates:
       - nickfedor/watchtower:i386-{{ .Version }}
       - nickfedor/watchtower:i386-latest
@@ -84,14 +74,14 @@ dockers:
       - "--platform=linux/386"
       - "--build-arg=GOOS=linux"
       - "--build-arg=GOARCH=386"
+      - "--build-arg=GO386=sse2"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
   - use: buildx
-    goos: linux
+    dockerfile: build/docker/Dockerfile
     goarch: arm
     goarm: "6"
-    dockerfile: build/docker/Dockerfile
     image_templates:
       - nickfedor/watchtower:armhf-{{ .Version }}
       - nickfedor/watchtower:armhf-latest
@@ -109,9 +99,8 @@ dockers:
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
   - use: buildx
-    goos: linux
-    goarch: arm64
     dockerfile: build/docker/Dockerfile
+    goarch: arm64
     image_templates:
       - nickfedor/watchtower:arm64v8-{{ .Version }}
       - nickfedor/watchtower:arm64v8-latest
@@ -124,13 +113,13 @@ dockers:
       - "--platform=linux/arm64"
       - "--build-arg=GOOS=linux"
       - "--build-arg=GOARCH=arm64"
+      - "--build-arg=GOARM64=v8.0"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
   - use: buildx
-    goos: linux
-    goarch: riscv64
     dockerfile: build/docker/Dockerfile
+    goarch: riscv64
     image_templates:
       - nickfedor/watchtower:riscv64-{{ .Version }}
       - nickfedor/watchtower:riscv64-latest


### PR DESCRIPTION
- Add goamd64: v1, go386: sse2, goarm: "6", goarm64: v8.0, goriscv64: rva20u64 to builds section in dev.yml and prod.yml to explicitly set default variants and ensure consistent binary directory suffixes
- Add goamd64, go386, goarm, goarm64, goriscv64 to corresponding dockers entries to align with builds and enable GoReleaser to locate variant-specific binaries
- Update Dockerfile to include ARG GO386 and GOARM64, and extend the COPY command to handle all possible variant suffixes (${GOAMD64:+_${GOAMD64}}${GO386:+_${GO386}}${GOARM:+_${GOARM}}${GOARM64:+_${GOARM64}}${GORISCV64:+_${GORISCV64}})
- Retain --build-arg flags in build_flag_templates to pass GOOS, GOARCH, and variant values to Dockerfile, ensuring the correct binary is copied and fixing the "docker buildx build requires 1 argument" error