### PR TITLE
fix(build): resolve docker build error and enable attestations with imagetools

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,3 +1,4 @@
+# build.yaml
 name: Build Release
 
 on:
@@ -54,6 +55,11 @@ jobs:
           driver: docker-container
           platforms: linux/amd64,linux/386,linux/arm/v6,linux/arm64/v8,linux/riscv64
           use: true
+
+      - name: Enable containerd snapshotter
+        run: |
+          sudo bash -c 'echo "{\"features\": {\"containerd-snapshotter\": true}}" > /etc/docker/daemon.json'
+          sudo systemctl restart docker
 
       - name: Login to Docker Hub
         if: ${{ !inputs.dry-run }}

--- a/.github/workflows/create-manifests.yaml
+++ b/.github/workflows/create-manifests.yaml
@@ -1,0 +1,88 @@
+name: Create Docker Manifests
+
+on:
+  workflow_call:
+    inputs:
+      build-type:
+        description: "Type of build (prod or dev)"
+        required: true
+        type: string
+      version:
+        description: "Version tag for production builds (ignored for dev)"
+        required: false
+        type: string
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f
+        with:
+          fetch-depth: 0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@3d100841f68d4548bf57e52eb27bd33ec5069f55
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@3d100841f68d4548bf57e52eb27bd33ec5069f55
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Create Docker manifests for dev
+        if: ${{ inputs.build-type == 'dev' }}
+        run: |
+          docker buildx imagetools create -t nickfedor/watchtower:latest-dev \
+            nickfedor/watchtower:amd64-dev \
+            nickfedor/watchtower:i386-dev \
+            nickfedor/watchtower:armhf-dev \
+            nickfedor/watchtower:arm64v8-dev \
+            nickfedor/watchtower:riscv64-dev
+          docker buildx imagetools create -t ghcr.io/nicholas-fedor/watchtower:latest-dev \
+            ghcr.io/nicholas-fedor/watchtower:amd64-dev \
+            ghcr.io/nicholas-fedor/watchtower:i386-dev \
+            ghcr.io/nicholas-fedor/watchtower:armhf-dev \
+            ghcr.io/nicholas-fedor/watchtower:arm64v8-dev \
+            ghcr.io/nicholas-fedor/watchtower:riscv64-dev
+
+      - name: Create Docker manifests for prod
+        if: ${{ inputs.build-type == 'prod' }}
+        run: |
+          docker buildx imagetools create -t nickfedor/watchtower:${{ inputs.version }} \
+            nickfedor/watchtower:amd64-${{ inputs.version }} \
+            nickfedor/watchtower:i386-${{ inputs.version }} \
+            nickfedor/watchtower:armhf-${{ inputs.version }} \
+            nickfedor/watchtower:arm64v8-${{ inputs.version }} \
+            nickfedor/watchtower:riscv64-${{ inputs.version }}
+          docker buildx imagetools create -t nickfedor/watchtower:latest \
+            nickfedor/watchtower:amd64-latest \
+            nickfedor/watchtower:i386-latest \
+            nickfedor/watchtower:armhf-latest \
+            nickfedor/watchtower:arm64v8-latest \
+            nickfedor/watchtower:riscv64-latest
+          docker buildx imagetools create -t ghcr.io/nicholas-fedor/watchtower:${{ inputs.version }} \
+            ghcr.io/nicholas-fedor/watchtower:amd64-${{ inputs.version }} \
+            ghcr.io/nicholas-fedor/watchtower:i386-${{ inputs.version }} \
+            ghcr.io/nicholas-fedor/watchtower:armhf-${{ inputs.version }} \
+            ghcr.io/nicholas-fedor/watchtower:arm64v8-${{ inputs.version }} \
+            ghcr.io/nicholas-fedor/watchtower:riscv64-${{ inputs.version }}
+          docker buildx imagetools create -t ghcr.io/nicholas-fedor/watchtower:latest \
+            ghcr.io/nicholas-fedor/watchtower:amd64-latest \
+            ghcr.io/nicholas-fedor/watchtower:i386-latest \
+            ghcr.io/nicholas-fedor/watchtower:armhf-latest \
+            ghcr.io/nicholas-fedor/watchtower:arm64v8-latest \
+            ghcr.io/nicholas-fedor/watchtower:riscv64-latest

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -40,3 +40,11 @@ jobs:
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  manifest:
+    needs: build
+    if: ${{ !inputs.dry-run }}
+    uses: ./.github/workflows/create-manifests.yaml
+    secrets: inherit
+    with:
+      build-type: dev

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -34,8 +34,17 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
+  manifest:
+    needs: build
+    if: ${{ !inputs.dry-run }}
+    uses: ./.github/workflows/create-manifests.yaml
+    secrets: inherit
+    with:
+      build-type: prod
+      version: ${{ github.ref_name }}
+
   update-go-docs:
-    needs: [test, build]
+    needs: [test, build, manifest]
     if: ${{ !inputs.dry-run }}
     permissions:
       contents: read

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,11 +1,7 @@
+# Dockerfile
 ARG BASE_IMAGE=alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
 ARG GOOS=linux
 ARG GOARCH
-ARG GOAMD64=v1
-ARG GO386=sse2
-ARG GOARM=6
-ARG GOARM64=v8.0
-ARG GORISCV64=rva20u64
 
 FROM --platform=$BUILDPLATFORM $BASE_IMAGE AS builder
 
@@ -28,8 +24,8 @@ LABEL "org.opencontainers.image.url"="https://nicholas-fedor.github.io/watchtowe
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 
-# Copy binary based on GOOS, GOARCH, and variant
-COPY dist/watchtower_${GOOS}_${GOARCH}${GOAMD64:+_${GOAMD64}}${GO386:+_${GO386}}${GOARM:+_${GOARM}}${GOARM64:+_${GOARM64}}${GORISCV64:+_${GORISCV64}}/watchtower /watchtower
+# Copy binary (GoReleaser places the platform-specific binary at the context root as 'watchtower')
+COPY watchtower /watchtower
 
 EXPOSE 8080
 

--- a/build/goreleaser/dev.yml
+++ b/build/goreleaser/dev.yml
@@ -1,3 +1,4 @@
+# dev.yml
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 version: 2
 
@@ -29,12 +30,11 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:amd64-dev
     build_flag_templates:
       - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - --attest=type=provenance,mode=max
+      - --attest=type=sbom
       - "--platform=linux/amd64"
       - "--build-arg=GOOS=linux"
       - "--build-arg=GOARCH=amd64"
-      - "--build-arg=GOAMD64=v1"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version=dev"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
@@ -46,12 +46,11 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:i386-dev
     build_flag_templates:
       - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - --attest=type=provenance,mode=max
+      - --attest=type=sbom
       - "--platform=linux/386"
       - "--build-arg=GOOS=linux"
       - "--build-arg=GOARCH=386"
-      - "--build-arg=GO386=sse2"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version=dev"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
@@ -64,12 +63,11 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:armhf-dev
     build_flag_templates:
       - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - --attest=type=provenance,mode=max
+      - --attest=type=sbom
       - "--platform=linux/arm/v6"
       - "--build-arg=GOOS=linux"
       - "--build-arg=GOARCH=arm"
-      - "--build-arg=GOARM=6"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version=dev"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
@@ -81,12 +79,11 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-dev
     build_flag_templates:
       - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - --attest=type=provenance,mode=max
+      - --attest=type=sbom
       - "--platform=linux/arm64"
       - "--build-arg=GOOS=linux"
       - "--build-arg=GOARCH=arm64"
-      - "--build-arg=GOARM64=v8.0"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version=dev"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
@@ -98,30 +95,11 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:riscv64-dev
     build_flag_templates:
       - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - --attest=type=provenance,mode=max
+      - --attest=type=sbom
       - "--platform=linux/riscv64"
       - "--build-arg=GOOS=linux"
       - "--build-arg=GOARCH=riscv64"
-      - "--build-arg=GORISCV64=rva20u64"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version=dev"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-
-docker_manifests:
-  - name_template: nickfedor/watchtower:latest-dev
-    image_templates:
-      - nickfedor/watchtower:amd64-dev
-      - nickfedor/watchtower:i386-dev
-      - nickfedor/watchtower:armhf-dev
-      - nickfedor/watchtower:arm64v8-dev
-      - nickfedor/watchtower:riscv64-dev
-    skip_push: "{{ .Env.DRY_RUN }}"
-  - name_template: ghcr.io/nicholas-fedor/watchtower:latest-dev
-    image_templates:
-      - ghcr.io/nicholas-fedor/watchtower:amd64-dev
-      - ghcr.io/nicholas-fedor/watchtower:i386-dev
-      - ghcr.io/nicholas-fedor/watchtower:armhf-dev
-      - ghcr.io/nicholas-fedor/watchtower:arm64v8-dev
-      - ghcr.io/nicholas-fedor/watchtower:riscv64-dev
-    skip_push: "{{ .Env.DRY_RUN }}"

--- a/build/goreleaser/prod.yml
+++ b/build/goreleaser/prod.yml
@@ -1,3 +1,4 @@
+# prod.yml
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 version: 2
 
@@ -50,12 +51,11 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:amd64-latest
     build_flag_templates:
       - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - --attest=type=provenance,mode=max
+      - --attest=type=sbom
       - "--platform=linux/amd64"
       - "--build-arg=GOOS=linux"
       - "--build-arg=GOARCH=amd64"
-      - "--build-arg=GOAMD64=v1"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
@@ -69,12 +69,11 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:i386-latest
     build_flag_templates:
       - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - --attest=type=provenance,mode=max
+      - --attest=type=sbom
       - "--platform=linux/386"
       - "--build-arg=GOOS=linux"
       - "--build-arg=GOARCH=386"
-      - "--build-arg=GO386=sse2"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
@@ -89,12 +88,11 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:armhf-latest
     build_flag_templates:
       - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - --attest=type=provenance,mode=max
+      - --attest=type=sbom
       - "--platform=linux/arm/v6"
       - "--build-arg=GOOS=linux"
       - "--build-arg=GOARCH=arm"
-      - "--build-arg=GOARM=6"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
@@ -108,12 +106,11 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-latest
     build_flag_templates:
       - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - --attest=type=provenance,mode=max
+      - --attest=type=sbom
       - "--platform=linux/arm64"
       - "--build-arg=GOOS=linux"
       - "--build-arg=GOARCH=arm64"
-      - "--build-arg=GOARM64=v8.0"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
@@ -127,49 +124,14 @@ dockers:
       - ghcr.io/nicholas-fedor/watchtower:riscv64-latest
     build_flag_templates:
       - '--output={{ if eq .Env.DRY_RUN "true" }}type=docker{{ else }}type=registry{{ end }}'
-      - "{{ if not .Env.DRY_RUN }}--attest=type=provenance,mode=max{{ end }}"
-      - "{{ if not .Env.DRY_RUN }}--attest=type=sbom{{ end }}"
+      - --attest=type=provenance,mode=max
+      - --attest=type=sbom
       - "--platform=linux/riscv64"
       - "--build-arg=GOOS=linux"
       - "--build-arg=GOARCH=riscv64"
-      - "--build-arg=GORISCV64=rva20u64"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-
-docker_manifests:
-  - name_template: nickfedor/watchtower:{{ .Version }}
-    image_templates:
-      - nickfedor/watchtower:amd64-{{ .Version }}
-      - nickfedor/watchtower:i386-{{ .Version }}
-      - nickfedor/watchtower:armhf-{{ .Version }}
-      - nickfedor/watchtower:arm64v8-{{ .Version }}
-      - nickfedor/watchtower:riscv64-{{ .Version }}
-    skip_push: "{{ .Env.DRY_RUN }}"
-  - name_template: nickfedor/watchtower:latest
-    image_templates:
-      - nickfedor/watchtower:amd64-latest
-      - nickfedor/watchtower:i386-latest
-      - nickfedor/watchtower:armhf-latest
-      - nickfedor/watchtower:arm64v8-latest
-      - nickfedor/watchtower:riscv64-latest
-    skip_push: "{{ .Env.DRY_RUN }}"
-  - name_template: ghcr.io/nicholas-fedor/watchtower:{{ .Version }}
-    image_templates:
-      - ghcr.io/nicholas-fedor/watchtower:amd64-{{ .Version }}
-      - ghcr.io/nicholas-fedor/watchtower:i386-{{ .Version }}
-      - ghcr.io/nicholas-fedor/watchtower:armhf-{{ .Version }}
-      - ghcr.io/nicholas-fedor/watchtower:arm64v8-{{ .Version }}
-      - ghcr.io/nicholas-fedor/watchtower:riscv64-{{ .Version }}
-    skip_push: "{{ .Env.DRY_RUN }}"
-  - name_template: ghcr.io/nicholas-fedor/watchtower:latest
-    image_templates:
-      - ghcr.io/nicholas-fedor/watchtower:amd64-latest
-      - ghcr.io/nicholas-fedor/watchtower:i386-latest
-      - ghcr.io/nicholas-fedor/watchtower:armhf-latest
-      - ghcr.io/nicholas-fedor/watchtower:arm64v8-latest
-      - ghcr.io/nicholas-fedor/watchtower:riscv64-latest
-    skip_push: "{{ .Env.DRY_RUN }}"
 
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
## Description
This PR resolves the "docker buildx build requires 1 argument" error, enables consistent provenance and SBOM attestations in development and production builds, and addresses manifest creation issues with attestation-enabled images. It also cleans up unused ARGs in the Dockerfile and introduces a reusable manifest creation workflow.

### Changes
- **build.yaml**: Added containerd snapshotter to support attestations.
- **release-dev.yaml/release-prod.yaml**: Added `manifest` job using `create-manifests.yaml` with `docker buildx imagetools create` to replace GoReleaser's `docker manifest create`, fixing attestation compatibility.
- **Dockerfile**: Updated `COPY` to `watchtower /watchtower` for GoReleaser's context, removed unused ARGs (`GOAMD64`, `GO386`, `GOARM`, `GOARM64`, `GORISCV64`).
- **dev.yml/prod.yml**: Removed conditional `--attest` flags to prevent empty arguments, removed `docker_manifests` section.