### PR TITLE
fix(workflow): add package write permissions and fix Dockerfile base image label

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,3 @@
-# build.yaml
 name: Build Release
 
 on:
@@ -24,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
       attestations: write
       id-token: write
     steps:

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -44,6 +44,9 @@ jobs:
   manifest:
     needs: build
     if: ${{ !inputs.dry-run }}
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/create-manifests.yaml
     secrets: inherit
     with:

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -37,6 +37,9 @@ jobs:
   manifest:
     needs: build
     if: ${{ !inputs.dry-run }}
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/create-manifests.yaml
     secrets: inherit
     with:

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,4 +1,3 @@
-# Dockerfile
 ARG BASE_IMAGE=alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
 ARG GOOS=linux
 ARG GOARCH
@@ -18,7 +17,7 @@ LABEL "org.opencontainers.image.url"="https://nicholas-fedor.github.io/watchtowe
   "org.opencontainers.image.licenses"="Apache-2.0" \
   "org.opencontainers.image.title"="Watchtower" \
   "org.opencontainers.image.description"="A process for automating Docker container base image updates." \
-  "org.opencontainers.image.base.name"="$BASE_IMAGE"
+  "org.opencontainers.image.base.name"="${BASE_IMAGE:-alpine:3.22.1}"
 
 # Copy ca-certs and timezone from builder
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/build/goreleaser/dev.yml
+++ b/build/goreleaser/dev.yml
@@ -1,4 +1,3 @@
-# dev.yml
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 version: 2
 

--- a/build/goreleaser/prod.yml
+++ b/build/goreleaser/prod.yml
@@ -1,4 +1,3 @@
-# prod.yml
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 version: 2
 


### PR DESCRIPTION
## Description
This PR fixes a GHCR push permission error in the development and production release workflows and resolves a Dockerfile warning for an undefined `BASE_IMAGE` variable. It also removes redundant filename comments from workflow and configuration files.

## Changes
- **build.yaml**: Added `packages: write` permission to ensure GHCR push access.
- **release-dev.yaml/release-prod.yaml**: Added `packages: write` to `manifest` job for consistent GHCR permissions.
- **Dockerfile**: Updated `org.opencontainers.image.base.name` label to use `${BASE_IMAGE:-alpine:3.22.1}` to fix undefined variable warning.
- **dev.yml/prod.yml**: Removed redundant filename comments.