### PR TITLE
fix(build): add Syft installation step for prod builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,6 +61,10 @@ jobs:
           sudo bash -c 'echo "{\"features\": {\"containerd-snapshotter\": true}}" > /etc/docker/daemon.json'
           sudo systemctl restart docker
 
+      - name: Install Syft for SBOM generation
+        if: ${{ inputs.build-type == 'prod' }}
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
       - name: Login to Docker Hub
         if: ${{ !inputs.dry-run }}
         uses: docker/login-action@3d100841f68d4548bf57e52eb27bd33ec5069f55


### PR DESCRIPTION
## Description
This PR resolves an error in the production release workflow where SBOM generation failed due to the `syft` executable not being found. The fix adds a step to install Syft in the `build.yaml` workflow for production builds, ensuring compatibility with the `sboms` configuration in `prod.yml`.

## Changes
- **build.yaml**: Added a step to install Syft using the official installation script (`curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh`) before running GoReleaser, conditional on `build-type: prod`.