### PR TITLE
fix(dockerfile): correct binary copy path in Dockerfile

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -24,7 +24,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 
 # Copy binary (GoReleaser places the platform-specific binary at the context root as 'watchtower')
-COPY watchtower /watchtower
+COPY watchtower /
 
 EXPOSE 8080
 


### PR DESCRIPTION
This PR fixes an issue in the Dockerfile where the binary copy destination led to it not being found on container launch. The change reverts the destination to the root path (/) as previously configured.