### PR TITLE
fix(goreleaser): disable CGO for static binaries

### DIFF
--- a/build/goreleaser/dev.yml
+++ b/build/goreleaser/dev.yml
@@ -2,7 +2,9 @@
 version: 2
 
 builds:
-  - main: ./main.go
+  - env:
+      - CGO_ENABLED=0
+    main: ./main.go
     binary: watchtower
     goos:
       - linux

--- a/build/goreleaser/prod.yml
+++ b/build/goreleaser/prod.yml
@@ -2,7 +2,9 @@
 version: 2
 
 builds:
-  - main: ./main.go
+  - env:
+      - CGO_ENABLED=0
+    main: ./main.go
     binary: watchtower
     goos:
       - linux


### PR DESCRIPTION
## Description
Disable CGO in GoReleaser configs to produce static binaries compatible with scratch image.

## Changes
- Add env: - CGO_ENABLED=0 to builds in prod.yml
- Add env: - CGO_ENABLED=0 to builds in dev.yml