### PR TITLE
chore(docker): add .dockerignore to optimize Docker build context

### DIFF
--- a/build/docker/.dockerignore
+++ b/build/docker/.dockerignore
@@ -1,0 +1,41 @@
+# Ignore Git files and directories
+.git
+.gitignore
+.gitattributes
+
+# Ignore CI/CD and configuration files
+.circleci/
+.codacy.yml
+.editorconfig
+.all-contributorsrc
+.codecov.yaml
+.github/
+.golangci.yaml
+.mockery.yaml
+
+# Ignore documentation and examples
+*.md
+docs/
+docs-requirements.txt
+mkdocs.yml
+examples/
+
+# Ignore test directories and data
+test/
+internal/actions/mocks/
+pkg/*/mocks/
+
+# Ignore scripts and tools
+scripts/
+tools/
+
+# Ignore large images and assets
+*.png
+*.ico
+
+# Ignore GoReleaser build artifacts
+dist/
+
+# Ignore build directory except for docker-related files
+build/*
+!build/docker/


### PR DESCRIPTION
## Description
Added a new `.dockerignore` file to optimize the Docker build context for `Dockerfile`, `Dockerfile.self-local`, and `Dockerfile.self-github`, ensuring source files are included for `Dockerfile.self-local` while excluding non-essential files.

## Changes
- Added `.dockerignore` to support `Dockerfile.self-local` by including source files (`cmd/`, `internal/`, `pkg/`, `main.go`, `go.mod`, `go.sum`)
- Excluded Git, CI/CD, documentation, tests, mocks, scripts, tools, and images to reduce build context
- Excluded `dist/` for GoReleaser artifacts
- Excluded `build/*` with `!build/docker/` to include Docker-related files