### PR TITLE
chore(goreleaser): add snapshot name template to dev configuration

### DIFF
--- a/build/goreleaser/dev.yml
+++ b/build/goreleaser/dev.yml
@@ -1,6 +1,9 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 version: 2
 
+snapshot:
+  name_template: "{{ .Tag }}-{{ .ShortCommit }}"
+
 builds:
   - env:
       - CGO_ENABLED=0


### PR DESCRIPTION
## Description
Remove "SNAPSHOT" from development build version strings by configuring GoReleaser's snapshot.name_template to use the latest tag and short commit hash.

## Changes
- Added snapshot.name_template in dev.yml to set version as {{ .Tag }}-{{ .ShortCommit }}