### PR TITLE
fix(ci): remove newlines in goreleaser arguments

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -94,12 +94,7 @@ jobs:
           # Generate snapshot versions for dev builds
           # Remove dist directory before building
           # Skip publishing during dry-run
-          args: |
-            release
-            --config build/goreleaser/${{ inputs.build-type }}.yml
-            ${{ inputs.build-type == 'dev' && '--snapshot' || '' }}
-            --clean
-            ${{ inputs.dry-run && '--skip=publish' || '' }}
+          args: release --config build/goreleaser/${{ inputs.build-type }}.yml ${{ inputs.build-type == 'dev' && '--snapshot' || '' }} --clean ${{ inputs.dry-run && '--skip=publish' || '' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
           DRY_RUN: ${{ inputs.dry-run }}


### PR DESCRIPTION
Resolve error: unknown command "release\n--config" for "goreleaser release"

- Remove newlines between arguments in GoReleaser initialization in build.yaml workflow.