### PR TITLE
chore(goreleaser): remove goreleaser binary build id

### DIFF
--- a/build/goreleaser/dev.yml
+++ b/build/goreleaser/dev.yml
@@ -11,7 +11,7 @@
 version: 2
 
 # https://goreleaser.com/customization/project/
-project_name: Watchtower
+project_name: watchtower
 
 ######################################################################################################
 # Snapshot Configuration

--- a/build/goreleaser/dev.yml
+++ b/build/goreleaser/dev.yml
@@ -29,10 +29,7 @@ snapshot:
 # https://goreleaser.com/customization/builds/go/
 ######################################################################################################
 builds:
-  - # ID of the build.
-    id: watchtower-multi-arch
-
-    # Path to main.go file or main package.
+  - # Path to main.go file or main package.
     main: ./main.go
 
     # Binary name.

--- a/build/goreleaser/prod.yml
+++ b/build/goreleaser/prod.yml
@@ -11,7 +11,7 @@
 version: 2
 
 # https://goreleaser.com/customization/project/
-project_name: Watchtower
+project_name: watchtower
 
 ######################################################################################################
 # Go Binary Build Configuration

--- a/build/goreleaser/prod.yml
+++ b/build/goreleaser/prod.yml
@@ -18,10 +18,7 @@ project_name: Watchtower
 # https://goreleaser.com/customization/builds/go/
 ######################################################################################################
 builds:
-  - # ID of the build.
-    id: watchtower-multi-arch
-
-    # Path to main.go file or main package.
+  - # Path to main.go file or main package.
     main: ./main.go
 
     # Binary name.


### PR DESCRIPTION
Remove build id from GoReleaser binary build configurations. This avoids issue of binaries with undesirable naming convention.