### PR TITLE
chore(dockerfile): add ARG BASE_IMAGE in scratch stage

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -10,6 +10,8 @@ RUN apk add --no-cache \
 
 FROM scratch
 
+ARG BASE_IMAGE
+
 LABEL "com.centurylinklabs.watchtower"="true"
 LABEL "org.opencontainers.image.url"="https://nicholas-fedor.github.io/watchtower/" \
   "org.opencontainers.image.documentation"="https://nicholas-fedor.github.io/watchtower/" \
@@ -17,7 +19,7 @@ LABEL "org.opencontainers.image.url"="https://nicholas-fedor.github.io/watchtowe
   "org.opencontainers.image.licenses"="Apache-2.0" \
   "org.opencontainers.image.title"="Watchtower" \
   "org.opencontainers.image.description"="A process for automating Docker container base image updates." \
-  "org.opencontainers.image.base.name"="${BASE_IMAGE:-alpine:3.22.1}"
+  "org.opencontainers.image.base.name"="${BASE_IMAGE}"
 
 # Copy ca-certs and timezone from builder
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
Passes the BASE_IMAGE in the `build/docker/Dockerfile` to ensure successful builds and resolve linter warnings.

**Changes**:
- Added `ARG BASE_IMAGE` in the `scratch` stage to make `$BASE_IMAGE` available for the `org.opencontainers.image.base.name` label, resolving Buildkit's `UndefinedVar` warning.
- Simplified the `org.opencontainers.image.base.name` label by removing the redundant default value (`${BASE_IMAGE:-alpine:3.22.1}`).