### PR TITLE
fix(notifications): enhance SMTP configuration with timeout constant and URL parameters

### DIFF
--- a/pkg/notifications/email.go
+++ b/pkg/notifications/email.go
@@ -17,6 +17,9 @@ import (
 // emailType is the identifier for email notifications.
 const emailType = "email"
 
+// defaultTimeout is the default duration for SMTP operations.
+const defaultTimeout = 10 * time.Second
+
 // Errors for email notification configuration.
 var (
 	// errInvalidPortRange indicates that the specified SMTP port is outside the valid range (0-65535).
@@ -125,6 +128,7 @@ func (e *emailTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 		Encryption:  smtp.EncMethods.Auto,
 		Auth:        smtp.AuthTypes.None,
 		ClientHost:  "localhost",
+		Timeout:     defaultTimeout,
 	}
 
 	// Enable authentication if credentials provided.

--- a/pkg/notifications/notifier_test.go
+++ b/pkg/notifications/notifier_test.go
@@ -517,7 +517,7 @@ func buildExpectedURL(
 	destAddress string,
 	auth string,
 ) string {
-	template := "smtp://%s:%s@%s:%d/?auth=%s&fromaddress=%s&fromname=Watchtower&subject=&toaddresses=%s"
+	template := "smtp://%s:%s@%s:%d/?auth=%s&clienthost=localhost&encryption=Auto&fromaddress=%s&fromname=Watchtower&subject=&toaddresses=%s&usehtml=No&usestarttls=Yes&timeout=10s"
 
 	return fmt.Sprintf(template,
 		url.QueryEscape(username),


### PR DESCRIPTION
- Added defaultTimeout constant for SMTP operations in email.go
- Included Timeout field in SMTP configuration struct
- Updated notifier_test.go to incorporate timeout, clienthost, encryption, usehtml, and usestarttls in expected URL template