### PR TITLE
build: remove prefix from image tags

### DIFF
--- a/.github/workflows/create-manifests.yaml
+++ b/.github/workflows/create-manifests.yaml
@@ -62,24 +62,27 @@ jobs:
       - name: Create Docker manifests for prod
         if: ${{ inputs.build-type == 'prod' }}
         run: |
-          docker buildx imagetools create -t nickfedor/watchtower:${{ inputs.version }} \
-            nickfedor/watchtower:amd64-${{ inputs.version }} \
-            nickfedor/watchtower:i386-${{ inputs.version }} \
-            nickfedor/watchtower:armhf-${{ inputs.version }} \
-            nickfedor/watchtower:arm64v8-${{ inputs.version }} \
-            nickfedor/watchtower:riscv64-${{ inputs.version }}
+          # Strip the 'v' prefix from inputs.version
+          VERSION="${{ inputs.version }}"
+          VERSION="${VERSION#v}"
+          docker buildx imagetools create -t nickfedor/watchtower:${VERSION} \
+            nickfedor/watchtower:amd64-${VERSION} \
+            nickfedor/watchtower:i386-${VERSION} \
+            nickfedor/watchtower:armhf-${VERSION} \
+            nickfedor/watchtower:arm64v8-${VERSION} \
+            nickfedor/watchtower:riscv64-${VERSION}
           docker buildx imagetools create -t nickfedor/watchtower:latest \
             nickfedor/watchtower:amd64-latest \
             nickfedor/watchtower:i386-latest \
             nickfedor/watchtower:armhf-latest \
             nickfedor/watchtower:arm64v8-latest \
             nickfedor/watchtower:riscv64-latest
-          docker buildx imagetools create -t ghcr.io/nicholas-fedor/watchtower:${{ inputs.version }} \
-            ghcr.io/nicholas-fedor/watchtower:amd64-${{ inputs.version }} \
-            ghcr.io/nicholas-fedor/watchtower:i386-${{ inputs.version }} \
-            ghcr.io/nicholas-fedor/watchtower:armhf-${{ inputs.version }} \
-            ghcr.io/nicholas-fedor/watchtower:arm64v8-${{ inputs.version }} \
-            ghcr.io/nicholas-fedor/watchtower:riscv64-${{ inputs.version }}
+          docker buildx imagetools create -t ghcr.io/nicholas-fedor/watchtower:${VERSION} \
+            ghcr.io/nicholas-fedor/watchtower:amd64-${VERSION} \
+            ghcr.io/nicholas-fedor/watchtower:i386-${VERSION} \
+            ghcr.io/nicholas-fedor/watchtower:armhf-${VERSION} \
+            ghcr.io/nicholas-fedor/watchtower:arm64v8-${VERSION} \
+            ghcr.io/nicholas-fedor/watchtower:riscv64-${VERSION}
           docker buildx imagetools create -t ghcr.io/nicholas-fedor/watchtower:latest \
             ghcr.io/nicholas-fedor/watchtower:amd64-latest \
             ghcr.io/nicholas-fedor/watchtower:i386-latest \

--- a/build/goreleaser/prod.yml
+++ b/build/goreleaser/prod.yml
@@ -174,9 +174,9 @@ dockers:
     # Templates of the Docker image names.
     # Templates: allowed.
     image_templates:
-      - nickfedor/watchtower:amd64-{{ .Tag }}
+      - nickfedor/watchtower:amd64-{{ .Version }}
       - nickfedor/watchtower:amd64-latest
-      - ghcr.io/nicholas-fedor/watchtower:amd64-{{ .Tag }}
+      - ghcr.io/nicholas-fedor/watchtower:amd64-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:amd64-latest
 
     # Path to the Dockerfile (from the project root).
@@ -227,9 +227,9 @@ dockers:
     # Templates of the Docker image names.
     # Templates: allowed.
     image_templates:
-      - nickfedor/watchtower:i386-{{ .Tag }}
+      - nickfedor/watchtower:i386-{{ .Version }}
       - nickfedor/watchtower:i386-latest
-      - ghcr.io/nicholas-fedor/watchtower:i386-{{ .Tag }}
+      - ghcr.io/nicholas-fedor/watchtower:i386-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:i386-latest
 
     # Path to the Dockerfile (from the project root).
@@ -284,9 +284,9 @@ dockers:
     # Templates of the Docker image names.
     # Templates: allowed.
     image_templates:
-      - nickfedor/watchtower:armhf-{{ .Tag }}
+      - nickfedor/watchtower:armhf-{{ .Version }}
       - nickfedor/watchtower:armhf-latest
-      - ghcr.io/nicholas-fedor/watchtower:armhf-{{ .Tag }}
+      - ghcr.io/nicholas-fedor/watchtower:armhf-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:armhf-latest
 
     # Path to the Dockerfile (from the project root).
@@ -340,9 +340,9 @@ dockers:
     # Templates of the Docker image names.
     # Templates: allowed.
     image_templates:
-      - nickfedor/watchtower:arm64v8-{{ .Tag }}
+      - nickfedor/watchtower:arm64v8-{{ .Version }}
       - nickfedor/watchtower:arm64v8-latest
-      - ghcr.io/nicholas-fedor/watchtower:arm64v8-{{ .Tag }}
+      - ghcr.io/nicholas-fedor/watchtower:arm64v8-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:arm64v8-latest
 
     # Path to the Dockerfile (from the project root).
@@ -394,9 +394,9 @@ dockers:
     # Templates of the Docker image names.
     # Templates: allowed.
     image_templates:
-      - nickfedor/watchtower:riscv64-{{ .Tag }}
+      - nickfedor/watchtower:riscv64-{{ .Version }}
       - nickfedor/watchtower:riscv64-latest
-      - ghcr.io/nicholas-fedor/watchtower:riscv64-{{ .Tag }}
+      - ghcr.io/nicholas-fedor/watchtower:riscv64-{{ .Version }}
       - ghcr.io/nicholas-fedor/watchtower:riscv64-latest
 
     # Path to the Dockerfile (from the project root).


### PR DESCRIPTION
This includes changes to both the GoReleaser configuration and the multi-platform image manifest generation workflow that removes the "v" prefix from image tags.

This reverts a previous change that inadvertently introduced them and should ensure the next release maintains the unprefixed tagging standard.

I anticipate that this should also resolve the issue noted in bug report #543 where inconsistent tagging resulted in the parsing failure.

Fixes #543 