### PR TITLE
ci(docs): correct build directory

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -70,4 +70,6 @@ jobs:
           pip install -r build/mkdocs/docs-requirements.txt
 
       - name: Build and Deploy
-        run: mkdocs gh-deploy --force --verbose --config-file build/mkdocs/mkdocs.yaml
+        run: |
+          cd build/mkdocs
+          mkdocs gh-deploy --force --verbose


### PR DESCRIPTION
Change working directory before building and deploying mkdocs site