### PR TITLE
docs: implement mkdocs-mike versioning

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -6,11 +6,8 @@ on:
     branches: [main]
     paths:
       - docs/**
-  workflow_run:
-    workflows: ["Release Production"]
-    branches: [main]
-    types:
-      - completed
+  release:
+    types: [published]
 
 permissions:
   contents: write
@@ -51,7 +48,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@9322b3ca74000aeb2c01eb777b646334015ddd72
         with:
-          python-version: "3.13.7"
+          python-version: 3.x
           cache: "pip"
           cache-dependency-path: build/mkdocs/docs-requirements.txt
 
@@ -68,5 +65,16 @@ jobs:
         run: |
           pip install -r build/mkdocs/docs-requirements.txt
 
+      - name: Determine Mike Version and Aliases
+        id: mike
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+            echo "aliases=latest" >> $GITHUB_OUTPUT
+          else
+            echo "version=dev" >> $GITHUB_OUTPUT
+            echo "aliases=latest" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build and Deploy
-        run: mkdocs gh-deploy --force --verbose --config-file build/mkdocs/mkdocs.yaml
+        run: mike deploy --config-file build/mkdocs/mkdocs.yaml --push --update-aliases ${{ steps.mike.outputs.version }} ${{ steps.mike.outputs.aliases }}

--- a/build/mkdocs/mkdocs.yaml
+++ b/build/mkdocs/mkdocs.yaml
@@ -82,6 +82,8 @@ extra:
   # https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/#versioning
   version:
     provider: mike
+    alias: true
+    default: latest
   # Social links displayed as icons in the footer (Material theme).
   # https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-footer/#social-links
   social:


### PR DESCRIPTION
This implements the Mike plugin and uses "dev" tag for bleeding-edge and "latest" for releases. 
Default view is "latest".

- Enable versioning via the Mike plugin
- Add dynamic tagging to ensure correct versioning