### PR TITLE
docs: improve content width and background consistency

### DIFF
--- a/docs/assets/styles/extra.css
+++ b/docs/assets/styles/extra.css
@@ -1,4 +1,30 @@
+/* Center h1 elements with the default foreground color */
 .md-typeset h1 {
   color: var(--md-default-fg-color);
   text-align: center;
+}
+
+/* Style the main content grid to control width and margins */
+.md-grid {
+  margin-left: auto; /* Center horizontally */
+  margin-right: auto; /* Center horizontally */
+  max-width: 80rem; /* Set wider content width for large screens */
+  padding-left: 1rem; /* Add padding to prevent content from touching edges */
+  padding-right: 1rem; /* Add padding to prevent content from touching edges */
+}
+
+/* Adjust content width for smaller screens */
+@media screen and (max-width: 76.1875em) {
+  .md-grid {
+    max-width: 61rem; /* Use narrower width for medium screens */
+  }
+}
+
+/* Optimize content width for mobile devices */
+@media screen and (max-width: 48em) {
+  .md-grid {
+    max-width: 100%; /* Use full width on mobile */
+    padding-left: 0.5rem; /* Reduced padding for mobile */
+    padding-right: 0.5rem; /* Reduced padding for mobile */
+  }
 }

--- a/docs/assets/styles/theme.css
+++ b/docs/assets/styles/theme.css
@@ -1,12 +1,11 @@
 [data-md-color-scheme="watchtower"] {
   /* Primary and accent */
   --md-primary-fg-color: #406170;
-  --md-primary-fg-color--light:#acbfc7;
+  --md-primary-fg-color--light: #acbfc7;
   --md-primary-fg-color--dark: #003343;
   --md-accent-fg-color: #003343;
   --md-accent-fg-color--transparent: #00334310;
-
-  /* Typeset overrides */
+  --md-default-bg-color: #f5f5f5; /* Explicit background for light mode */
   --md-typeset-a-color: var(--md-primary-fg-color);
 }
 
@@ -14,67 +13,61 @@
   --md-hue: 199;
 
   /* Primary and accent */
-  --md-primary-fg-color:             hsl(199deg  27%  35% / 100%);
-  --md-primary-fg-color--link:       hsl(199deg  45%  65% / 100%);
-  --md-primary-fg-color--light:      hsl(198deg  19%  73% / 100%);
-  --md-primary-fg-color--dark:       hsl(194deg 100%  13% / 100%);
-  --md-accent-fg-color:              hsl(194deg  45%  50% / 100%);
-  --md-accent-fg-color--transparent: hsl(194deg  45%  50% / 6.3%);
+  --md-primary-fg-color: hsl(199deg 27% 35% / 100%);
+  --md-primary-fg-color--link: hsl(199deg 45% 65% / 100%);
+  --md-primary-fg-color--light: hsl(198deg 19% 73% / 100%);
+  --md-primary-fg-color--dark: hsl(194deg 100% 13% / 100%);
+  --md-accent-fg-color: hsl(194deg 45% 50% / 100%);
+  --md-accent-fg-color--transparent: hsl(194deg 45% 50% / 6.3%);
 
   /* Default */
-  --md-default-fg-color:             hsl(var(--md-hue)  75%  95%  / 100%);
-  --md-default-fg-color--light:      hsl(var(--md-hue)  75%  90%  /  62%);
-  --md-default-fg-color--lighter:    hsl(var(--md-hue)  75%  90%  /  32%);
-  --md-default-fg-color--lightest:   hsl(var(--md-hue)  75%  90%  /  12%);
-  --md-default-bg-color:             hsl(var(--md-hue)  15%  21%  / 100%);
-  --md-default-bg-color--light:      hsl(var(--md-hue)  15%  21%  /  54%);
-  --md-default-bg-color--lighter:    hsl(var(--md-hue)  15%  21%  /  26%);
-  --md-default-bg-color--lightest:   hsl(var(--md-hue)  15%  21%  /   7%);
+  --md-default-fg-color: hsl(var(--md-hue) 75% 95% / 100%);
+  --md-default-fg-color--light: hsl(var(--md-hue) 75% 90% / 62%);
+  --md-default-fg-color--lighter: hsl(var(--md-hue) 75% 90% / 32%);
+  --md-default-fg-color--lightest: hsl(var(--md-hue) 75% 90% / 12%);
+  --md-default-bg-color: hsl(var(--md-hue) 15% 21% / 100%);
+  --md-default-bg-color--light: hsl(var(--md-hue) 15% 21% / 54%);
+  --md-default-bg-color--lighter: hsl(var(--md-hue) 15% 21% / 26%);
+  --md-default-bg-color--lightest: hsl(var(--md-hue) 15% 21% / 7%);
 
   /* Code */
-  --md-code-fg-color:                hsl(var(--md-hue) 18% 86%  / 100%);
-  --md-code-bg-color:                hsl(var(--md-hue) 15% 15%  / 100%);
-  --md-code-hl-color:                hsl(218deg 100%  63%  /  15%);
-  --md-code-hl-number-color:         hsl(346deg  74%  63%  / 100%);
-  --md-code-hl-special-color:        hsl(320deg  83%  66%  / 100%);
-  --md-code-hl-function-color:       hsl(271deg  57%  65%  / 100%);
-  --md-code-hl-constant-color:       hsl(230deg  62%  70%  / 100%);
-  --md-code-hl-keyword-color:        hsl(199deg  33%  64%  / 100%);
-  --md-code-hl-string-color:         hsl( 50deg  34%  74%  / 100%);
-  --md-code-hl-name-color:           var(--md-code-fg-color);
-  --md-code-hl-operator-color:       var(--md-default-fg-color--light);
-  --md-code-hl-punctuation-color:    var(--md-default-fg-color--light);
-  --md-code-hl-comment-color:        var(--md-default-fg-color--light);
-  --md-code-hl-generic-color:        var(--md-default-fg-color--light);
-  --md-code-hl-variable-color:       hsl(241deg  22%  60%  / 100%);
+  --md-code-fg-color: hsl(var(--md-hue) 18% 86% / 100%);
+  --md-code-bg-color: hsl(var(--md-hue) 15% 15% / 100%);
+  --md-code-hl-color: hsl(218deg 100% 63% / 15%);
+  --md-code-hl-number-color: hsl(346deg 74% 63% / 100%);
+  --md-code-hl-special-color: hsl(320deg 83% 66% / 100%);
+  --md-code-hl-function-color: hsl(271deg 57% 65% / 100%);
+  --md-code-hl-constant-color: hsl(230deg 62% 70% / 100%);
+  --md-code-hl-keyword-color: hsl(199deg 33% 64% / 100%);
+  --md-code-hl-string-color: hsl(50deg 34% 74% / 100%);
+  --md-code-hl-name-color: var(--md-code-fg-color);
+  --md-code-hl-operator-color: var(--md-default-fg-color--light);
+  --md-code-hl-punctuation-color: var(--md-default-fg-color--light);
+  --md-code-hl-comment-color: var(--md-default-fg-color--light);
+  --md-code-hl-generic-color: var(--md-default-fg-color--light);
+  --md-code-hl-variable-color: hsl(241deg 22% 60% / 100%);
 
   /* Typeset */
-  --md-typeset-color:                var(--md-default-fg-color);
-  --md-typeset-a-color:              var(--md-primary-fg-color--link);
-  --md-typeset-mark-color:           hsl(218deg 100%  63%  / 30%);
-  --md-typeset-kbd-color:            hsl(var(--md-hue)  15%  94%  /  12%);
-  --md-typeset-kbd-accent-color:     hsl(var(--md-hue)  15%  94%  /  20%);
-  --md-typeset-kbd-border-color:     hsl(var(--md-hue)  15%  14%  / 100%);
-  --md-typeset-table-color:          hsl(var(--md-hue)  75%  95%  /  12%);
+  --md-typeset-color: var(--md-default-fg-color);
+  --md-typeset-a-color: var(--md-primary-fg-color--link);
+  --md-typeset-mark-color: hsl(218deg 100% 63% / 30%);
+  --md-typeset-kbd-color: hsl(var(--md-hue) 15% 94% / 12%);
+  --md-typeset-kbd-accent-color: hsl(var(--md-hue) 15% 94% / 20%);
+  --md-typeset-kbd-border-color: hsl(var(--md-hue) 15% 14% / 100%);
+  --md-typeset-table-color: hsl(var(--md-hue) 75% 95% / 12%);
 
   /* Admonition */
-  --md-admonition-fg-color:          var(--md-default-fg-color);
-  --md-admonition-bg-color:          var(--md-default-bg-color);
+  --md-admonition-fg-color: var(--md-default-fg-color);
+  --md-admonition-bg-color: var(--md-default-bg-color);
 
   /* Footer */
-  --md-footer-bg-color:              hsl(var(--md-hue)  15%  12% /  87%);
-  --md-footer-bg-color--dark:        hsl(var(--md-hue)  15%  10% / 100%);
+  --md-footer-bg-color: hsl(var(--md-hue) 15% 12% / 87%);
+  --md-footer-bg-color--dark: hsl(var(--md-hue) 15% 10% / 100%);
 
   /* Shadows */
-  --md-shadow-z1:
-    0 0.2rem 0.50rem rgba(0 0 0 20%),
-    0 0      0.05rem rgba(0 0 0 10%);
-  --md-shadow-z2:
-    0 0.2rem 0.50rem rgba(0 0 0 30%),
-    0 0      0.05rem rgba(0 0 0 25%);
-  --md-shadow-z3:
-    0 0.2rem 0.50rem rgba(0 0 0 40%),
-    0 0      0.05rem rgba(0 0 0 35%);
+  --md-shadow-z1: 0 0.2rem 0.5rem rgba(0 0 0 20%), 0 0 0.05rem rgba(0 0 0 10%);
+  --md-shadow-z2: 0 0.2rem 0.5rem rgba(0 0 0 30%), 0 0 0.05rem rgba(0 0 0 25%);
+  --md-shadow-z3: 0 0.2rem 0.5rem rgba(0 0 0 40%), 0 0 0.05rem rgba(0 0 0 35%);
 }
 
 .md-header-nav__button.md-logo {

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,6 +1,17 @@
-{% extends "base.html" %} {% block outdated %} You're not viewing the latest
-version.
-<a href="{{ '../' ~ base_url }}">
-  <strong>Click here to go to latest.</strong>
-</a>
+{% extends "base.html" %} {% block extrahead %}
+<meta name="color-scheme" content="light dark" />
+<style>
+  [data-md-color-scheme="watchtower"] {
+    --md-default-bg-color: #f5f5f5;
+  }
+  [data-md-color-scheme="watchtower-dark"] {
+    --md-default-bg-color: hsl(199deg 15% 21% / 100%);
+  }
+  .md-main,
+  .md-content {
+    background-color: var(--md-default-bg-color);
+  }
+</style>
+{% endblock %} {% block outdated %} You're not viewing the latest version.
+<a href="{{ config.site_url }}latest/">Click here to go to latest.</a>
 {% endblock %}


### PR DESCRIPTION
## Description
Improve the documentation site by widening the content area and ensuring consistent background rendering.

## Changes
- Increase `.md-grid` `max-width` to `80rem` with responsive breakpoints in `extra.css`
- Inline CSS in `main.html` to set background colors for light and dark modes
- Add link to latest version in `outdated` block using `config.site_url`