### PR TITLE
Fix ShellCheck SC2086 Warnings in CI Workflows

### DIFF
--- a/.github/workflows/create-manifests.yaml
+++ b/.github/workflows/create-manifests.yaml
@@ -65,27 +65,27 @@ jobs:
           # Strip the 'v' prefix from inputs.version
           VERSION="${{ inputs.version }}"
           VERSION="${VERSION#v}"
-          docker buildx imagetools create -t nickfedor/watchtower:${VERSION} \
-            nickfedor/watchtower:amd64-${VERSION} \
-            nickfedor/watchtower:i386-${VERSION} \
-            nickfedor/watchtower:armhf-${VERSION} \
-            nickfedor/watchtower:arm64v8-${VERSION} \
-            nickfedor/watchtower:riscv64-${VERSION}
-          docker buildx imagetools create -t nickfedor/watchtower:latest \
-            nickfedor/watchtower:amd64-latest \
-            nickfedor/watchtower:i386-latest \
-            nickfedor/watchtower:armhf-latest \
-            nickfedor/watchtower:arm64v8-latest \
-            nickfedor/watchtower:riscv64-latest
-          docker buildx imagetools create -t ghcr.io/nicholas-fedor/watchtower:${VERSION} \
-            ghcr.io/nicholas-fedor/watchtower:amd64-${VERSION} \
-            ghcr.io/nicholas-fedor/watchtower:i386-${VERSION} \
-            ghcr.io/nicholas-fedor/watchtower:armhf-${VERSION} \
-            ghcr.io/nicholas-fedor/watchtower:arm64v8-${VERSION} \
-            ghcr.io/nicholas-fedor/watchtower:riscv64-${VERSION}
-          docker buildx imagetools create -t ghcr.io/nicholas-fedor/watchtower:latest \
-            ghcr.io/nicholas-fedor/watchtower:amd64-latest \
-            ghcr.io/nicholas-fedor/watchtower:i386-latest \
-            ghcr.io/nicholas-fedor/watchtower:armhf-latest \
-            ghcr.io/nicholas-fedor/watchtower:arm64v8-latest \
-            ghcr.io/nicholas-fedor/watchtower:riscv64-latest
+          docker buildx imagetools create -t "nickfedor/watchtower:${VERSION}" \
+            "nickfedor/watchtower:amd64-${VERSION}" \
+            "nickfedor/watchtower:i386-${VERSION}" \
+            "nickfedor/watchtower:armhf-${VERSION}" \
+            "nickfedor/watchtower:arm64v8-${VERSION}" \
+            "nickfedor/watchtower:riscv64-${VERSION}"
+          docker buildx imagetools create -t "nickfedor/watchtower:latest" \
+            "nickfedor/watchtower:amd64-latest" \
+            "nickfedor/watchtower:i386-latest" \
+            "nickfedor/watchtower:armhf-latest" \
+            "nickfedor/watchtower:arm64v8-latest" \
+            "nickfedor/watchtower:riscv64-latest"
+          docker buildx imagetools create -t "ghcr.io/nicholas-fedor/watchtower:${VERSION}" \
+            "ghcr.io/nicholas-fedor/watchtower:amd64-${VERSION}" \
+            "ghcr.io/nicholas-fedor/watchtower:i386-${VERSION}" \
+            "ghcr.io/nicholas-fedor/watchtower:armhf-${VERSION}" \
+            "ghcr.io/nicholas-fedor/watchtower:arm64v8-${VERSION}" \
+            "ghcr.io/nicholas-fedor/watchtower:riscv64-${VERSION}"
+          docker buildx imagetools create -t "ghcr.io/nicholas-fedor/watchtower:latest" \
+            "ghcr.io/nicholas-fedor/watchtower:amd64-latest" \
+            "ghcr.io/nicholas-fedor/watchtower:i386-latest" \
+            "ghcr.io/nicholas-fedor/watchtower:armhf-latest" \
+            "ghcr.io/nicholas-fedor/watchtower:arm64v8-latest" \
+            "ghcr.io/nicholas-fedor/watchtower:riscv64-latest"

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -77,4 +77,4 @@ jobs:
           fi
 
       - name: Build and Deploy
-        run: mike deploy --config-file build/mkdocs/mkdocs.yaml --push --update-aliases ${{ steps.mike.outputs.version }} ${{ steps.mike.outputs.aliases }}
+        run: mike deploy --config-file build/mkdocs/mkdocs.yaml --push --update-aliases "${{ steps.mike.outputs.version }}" "${{ steps.mike.outputs.aliases }}"


### PR DESCRIPTION
## Description
This PR addresses ShellCheck SC2086 warnings in the `create-manifests.yaml` and `publish-docs.yaml` GitHub Actions workflows. The warnings were caused by unquoted variables, which could lead to globbing or word splitting issues.

## Changes
- `create-manifests.yaml`: Quoted `${VERSION}` in `docker buildx imagetools create` commands for production builds.
- `publish-docs.yaml`: Quoted `${{ steps.mike.outputs.version }}` and `${{ steps.mike.outputs.aliases }}` in the `mike deploy` command.
