### PR TITLE
Fix ShellCheck SC2086 Warnings in Publish Docs Workflow

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -69,11 +69,11 @@ jobs:
         id: mike
         run: |
           if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
-            echo "aliases=latest" >> $GITHUB_OUTPUT
+            echo "version=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+            echo "aliases=latest" >> "$GITHUB_OUTPUT"
           else
-            echo "version=dev" >> $GITHUB_OUTPUT
-            echo "aliases=latest" >> $GITHUB_OUTPUT
+            echo "version=dev" >> "$GITHUB_OUTPUT"
+            echo "aliases=latest" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and Deploy

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -77,4 +77,8 @@ jobs:
           fi
 
       - name: Build and Deploy
-        run: mike deploy --config-file build/mkdocs/mkdocs.yaml --push --update-aliases "${{ steps.mike.outputs.version }}" "${{ steps.mike.outputs.aliases }}"
+        run: |
+          mike deploy \
+            --config-file build/mkdocs/mkdocs.yaml \
+            --push \
+            --update-aliases "${{ steps.mike.outputs.version }}" "${{ steps.mike.outputs.aliases }}"


### PR DESCRIPTION
## Description
This PR resolves ShellCheck SC2086 warnings in `publish-docs.yaml` by addressing unquoted variables that could lead to globbing or word splitting.

## Changes
- Quoted `$GITHUB_OUTPUT` in `echo` commands in the `Determine Mike Version and Aliases` step.
- Reformatted `mike deploy` command to use multi-line syntax with backslash continuation, retaining quotes around `${{ steps.mike.outputs.version }}` and `${{ steps.mike.outputs.aliases }}`.