### PR TITLE
docs: set latest release as default version

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -73,12 +73,18 @@ jobs:
             echo "aliases=latest" >> "$GITHUB_OUTPUT"
           else
             echo "version=dev" >> "$GITHUB_OUTPUT"
-            echo "aliases=latest" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and Deploy
         run: |
-          mike deploy \
-            --config-file build/mkdocs/mkdocs.yaml \
-            --push \
-            --update-aliases "${{ steps.mike.outputs.version }}" "${{ steps.mike.outputs.aliases }}"
+          if [ -n "${{ steps.mike.outputs.aliases }}" ]; then
+            mike deploy \
+              --config-file build/mkdocs/mkdocs.yaml \
+              --push \
+              --update-aliases "${{ steps.mike.outputs.version }}" "${{ steps.mike.outputs.aliases }}"
+          else
+            mike deploy \
+              --config-file build/mkdocs/mkdocs.yaml \
+              --push \
+              "${{ steps.mike.outputs.version }}"
+          fi

--- a/build/mkdocs/mkdocs.yaml
+++ b/build/mkdocs/mkdocs.yaml
@@ -186,6 +186,7 @@ plugins:
   - mike:
       version_selector: true
       css_dir: assets/styles
+      alias_type: redirect
   # Displays last updated dates on pages, formatted as time ago.
   - git-revision-date-localized:
       enable_creation_date: true


### PR DESCRIPTION
## Description
Configures the documentation site to default to the latest release version instead of `dev`, addressing the "You're not viewing the latest version" message.

## Changes
- Modified `publish-docs.yaml` to assign `latest` alias only during releases, deploying non-release pushes to `dev` without aliases.
- Added `alias_type: redirect` to `mkdocs.yaml` to ensure aliases use HTML redirects compatible with GitHub Pages.