### PR TITLE
docs: hide version warning for dev

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -12,6 +12,7 @@
     background-color: var(--md-default-bg-color);
   }
 </style>
-{% endblock %} {% block outdated %} You're not viewing the latest version.
+{% endblock %} {% block outdated %} {% if "dev" not in page.url %} You're not
+viewing the latest version.
 <a href="{{ config.site_url }}latest/">Click here to go to latest.</a>
-{% endblock %}
+{% endif %} {% endblock %}


### PR DESCRIPTION
## Description

This stops the warning header from appearing when viewing the dev version of the documentation.

## Changes

- Add an exclusion for dev to remove the version warning.