### PR TITLE
docs: use root-relative URL for outdated warning link

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -14,5 +14,5 @@
 </style>
 {% endblock %} {% block outdated %} {% if "dev" not in page.url %} You're not
 viewing the latest version.
-<a href="{{ config.site_url }}latest/">Click here to go to latest.</a>
+<a href="/latest/">Click here to go to latest.</a>
 {% endif %} {% endblock %}


### PR DESCRIPTION
- Update docs/overrides/main.html to use `/latest/` for outdated warning link instead of `config.site_url`.