### PR TITLE
docs: refine outdated warning condition for dev version

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -12,7 +12,7 @@
     background-color: var(--md-default-bg-color);
   }
 </style>
-{% endblock %} {% block outdated %} {% if config.extra.version != "dev" %}
-You're not viewing the latest version.
+{% endblock %} {% block outdated %} {% if page.url != "dev/" and not
+page.url.startswith("dev/") %} You're not viewing the latest version.
 <a href="/latest/">Click here to go to latest.</a>
 {% endif %} {% endblock %}


### PR DESCRIPTION
- Update docs/overrides/main.html to use page.url with startswith check for dev suppression.