### PR TITLE
docs: Add dev as default version to suppress warning

### DIFF
--- a/build/mkdocs/mkdocs.yaml
+++ b/build/mkdocs/mkdocs.yaml
@@ -83,7 +83,9 @@ extra:
   version:
     provider: mike
     alias: true
-    default: latest
+    default:
+      - latest
+      - dev
   # Social links displayed as icons in the footer (Material theme).
   # https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-footer/#social-links
   social:

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -12,7 +12,4 @@
     background-color: var(--md-default-bg-color);
   }
 </style>
-{% endblock %} {% block outdated %} {% if not config.site_url.endswith('/dev/')
-%} You're not viewing the latest version.
-<a href="/latest/">Click here to go to latest.</a>
-{% endif %} {% endblock %}
+{% endblock %}


### PR DESCRIPTION
## Description
Adds `dev` as a default version alias in the configuration to suppress the outdated version warning on the dev version.

## Changes
- Update build/mkdocs/mkdocs.yaml to set extra.version.default as a list including latest and dev.
- Remove custom outdated block conditions from docs/overrides/main.html.