### PR TITLE
feat: Enhance HTTP API update endpoint with structured JSON response

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -456,12 +456,14 @@ func setupAndStartAPI(ctx context.Context, cfg RunConfig, updateLock chan bool) 
 
 	// Register the update API endpoint if enabled, linking it to the update handler.
 	if cfg.EnableUpdateAPI {
-		updateHandler := update.New(func(images []string) {
+		updateHandler := update.New(func(images []string) *metrics.Metric {
 			metric := runUpdatesWithNotifications(
 				filters.FilterByImage(images, cfg.Filter),
 				cleanup,
 			)
 			metrics.Default().RegisterScan(metric)
+
+			return metric
 		}, updateLock)
 		httpAPI.RegisterFunc(updateHandler.Path, updateHandler.Handle)
 

--- a/docs/advanced-features/http-api/index.md
+++ b/docs/advanced-features/http-api/index.md
@@ -11,12 +11,48 @@ Watchtower has an [optional](../../configuration/arguments/index.md#http_api_mod
 
 |            **Name**            | **Endpoint**  |          **Parameters**           |                                    **Description**                                    |
 |:------------------------------:|:-------------:|:---------------------------------:|:-------------------------------------------------------------------------------------:|
-|   [Update](#http_api_update)   | `/v1/update`  | [`image`](#image_parameter_usage) |         Triggers an update of containers monitored by the Watchtower instance         |
-| [Metrics](../metrics/index.md) | `/v1/metrics` |                                   | Provides container scan and update information that's typically only seen via logging |
+|   [Update](#http_api_update)   | `/v1/update`  | [`image`](#image_parameter_usage) | Triggers container updates and returns JSON results of the operation                 |
+| [Metrics](../metrics/index.md) | `/v1/metrics` |                                   | Exposes Prometheus-compatible metrics for monitoring and alerting                     |
 
 ### HTTP API Update
 
 To enable this mode, use the `--http-api-update` CLI argument or the `WATCHTOWER_HTTP_API_UPDATE` environment variable.
+
+#### Response Format
+
+The `/v1/update` endpoint returns a JSON response containing the results of the update operation:
+
+```json
+{
+  "summary": {
+    "scanned": 8,
+    "updated": 0,
+    "failed": 0
+  },
+  "timing": {
+    "duration_ms": 1250,
+    "duration": "1.25s"
+  },
+  "timestamp": "2025-01-20T11:30:45Z",
+  "api_version": "v1"
+}
+```
+
+**Summary Section:**
+
+- `scanned`: Number of containers that were scanned for updates
+- `updated`: Number of containers that were successfully updated
+- `failed`: Number of containers where the update failed
+
+**Timing Section:**
+
+- `duration_ms`: Execution time in milliseconds
+- `duration`: Human-readable execution time
+
+**Metadata:**
+
+- `timestamp`: UTC timestamp when the response was generated (RFC3339 format)
+- `api_version`: API version identifier
 
 #### Requirements
 
@@ -85,7 +121,7 @@ services:
     image: nickfedor/watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    command: --http-api-update
+    command: --http-api-update --http-api-metrics
     environment:
       - WATCHTOWER_HTTP_API_TOKEN=mytoken
     labels:
@@ -94,3 +130,6 @@ services:
       - 8080:8080
     restart: unless-stopped
 ```
+
+!!! Note
+    Both `--http-api-update` and `--http-api-metrics` can be enabled simultaneously to provide both update triggering and monitoring capabilities.

--- a/docs/advanced-features/metrics/index.md
+++ b/docs/advanced-features/metrics/index.md
@@ -9,7 +9,10 @@ Metrics can be used to track how Watchtower behaves over time.
 To use this feature, you have to set an [API token](../../configuration/arguments/index.md#http_api_token) and [enable the metrics API](../../configuration/arguments/index.md#http_api_metrics),
 as well as creating a port mapping for your container for port `8080`.
 
-The metrics API endpoint is `/v1/metrics`.
+!!! Note
+    You can enable both the metrics API and the update API simultaneously by using both `--http-api-metrics` and `--http-api-update` flags.
+
+The metrics API endpoint is `/v1/metrics` and provides Prometheus-compatible metrics. This is separate from the [`/v1/update`](../http-api/index.md#http_api_update) endpoint which triggers updates and returns JSON results.
 
 ## Available Metrics
 


### PR DESCRIPTION
Enhances the HTTP API `/v1/update` endpoint to return structured JSON responses instead of plain text, providing comprehensive update operation results for better automation and monitoring capabilities.

## Changes

- **API Response Format**: Transformed `/v1/update` endpoint from plain text to structured JSON with summary, timing, and metadata sections
- **Enhanced Data**: Added execution timing (milliseconds and human-readable), UTC timestamps, and API version information
- **HTTP Status**: Changed from 202 Accepted to 200 OK for synchronous operations
- **Function Signatures**: Updated to return metrics for improved data flow and testability
- **Test Coverage**: Comprehensive JSON response validation with timing and metadata checks
- **Documentation**: Updated API docs with new response format, clarified endpoint distinctions, and added cross-references
- **Examples**: Enhanced Docker Compose examples to demonstrate simultaneous endpoint usage

**Note**: This changes the response output format from plain text to JSON and may be breaking for existing API consumers.