### PR TITLE
fix(notifications): send report notifications in monitor-only mode

### DIFF
--- a/docs/notifications/template-preview/index.md
+++ b/docs/notifications/template-preview/index.md
@@ -35,28 +35,27 @@ hide:
   </div>
 
   <!-- Textarea for user to edit the notification template, with default Go template content for report and logs -->
-  <textarea name="template" rows="20">{{- with .Report -}}
-    {{- if ( or .Updated .Failed ) -}}
-{{len .Scanned}} Scanned, {{len .Updated}} Updated, {{len .Failed}} Failed
-      {{- range .Updated}}
+  <textarea name="template" rows="20">{{- if .Report -}}
+ {{- with .Report -}}
+   {{len .Scanned}} Scanned, {{len .Updated}} Updated, {{len .Failed}} Failed
+   {{- if ( or .Updated .Failed ) -}}
+     {{- range .Updated}}
 - {{.Name}} ({{.ImageName}}): {{.CurrentImageID.ShortID}} updated to {{.LatestImageID.ShortID}}
-      {{- end -}}
-      {{- range .Fresh}}
+     {{- end -}}
+     {{- range .Fresh}}
 - {{.Name}} ({{.ImageName}}): {{.State}}
-      {{- end -}}
-      {{- range .Skipped}}
+     {{- end -}}
+     {{- range .Skipped}}
 - {{.Name}} ({{.ImageName}}): {{.State}}: {{.Error}}
-      {{- end -}}
-      {{- range .Failed}}
+     {{- end -}}
+     {{- range .Failed}}
 - {{.Name}} ({{.ImageName}}): {{.State}}: {{.Error}}
-        {{- end -}}
-    {{- end -}}
-  {{- end -}}
-  {{- if (and .Entries .Report) }}
-
-Logs:
-  {{ end -}}
-  {{range .Entries -}}{{.Time.Format "2006-01-02T15:04:05Z07:00"}} [{{.Level}}] {{.Message}}{{"\n"}}{{- end -}}</textarea>
+     {{- end -}}
+   {{- end -}}
+ {{- end -}}
+{{- else -}}
+ {{range .Entries -}}{{.Message}}{{"\n"}}{{- end -}}
+{{- end -}}</textarea>
 
 <!-- Closing div for template-wrapper -->
 </div>

--- a/docs/notifications/templates/index.md
+++ b/docs/notifications/templates/index.md
@@ -95,8 +95,8 @@ When `--notification-report` is set, the template processes a `notifications.Dat
 ```go title="Default Report Template"
 {{- if .Report -}}
   {{- with .Report -}}
+    {{len .Scanned}} Scanned, {{len .Updated}} Updated, {{len .Failed}} Failed
     {{- if ( or .Updated .Failed ) -}}
-{{len .Scanned}} Scanned, {{len .Updated}} Updated, {{len .Failed}} Failed
       {{- range .Updated}}
 - {{.Name}} ({{.ImageName}}): {{.CurrentImageID.ShortID}} updated to {{.LatestImageID.ShortID}}
       {{- end -}}
@@ -133,6 +133,7 @@ Logs:
     {{- if .Report -}}
       {{- with .Report -}}
     {{len .Scanned}} Scanned, {{len .Updated}} Updated, {{len .Failed}} Failed
+    {{- if ( or .Updated .Failed ) -}}
           {{- range .Updated}}
     - {{.Name}} ({{.ImageName}}): {{.CurrentImageID.ShortID}} updated to {{.LatestImageID.ShortID}}
           {{- end -}}
@@ -145,6 +146,7 @@ Logs:
           {{- range .Failed}}
     - {{.Name}} ({{.ImageName}}): {{.State}}: {{.Error}}
           {{- end -}}
+    {{- end -}}
       {{- end -}}
     {{- if .Entries -}}
 
@@ -172,6 +174,7 @@ Logs:
             {{- if .Report -}}
               {{- with .Report -}}
             {{len .Scanned}} Scanned, {{len .Updated}} Updated, {{len .Failed}} Failed
+            {{- if ( or .Updated .Failed ) -}}
                 {{- range .Updated}}
             - {{.Name}} ({{.ImageName}}): {{.CurrentImageID.ShortID}} updated to {{.LatestImageID.ShortID}}
                 {{- end -}}
@@ -184,6 +187,7 @@ Logs:
                 {{- range .Failed}}
             - {{.Name}} ({{.ImageName}}): {{.State}}: {{.Error}}
                 {{- end -}}
+            {{- end -}}
               {{- end -}}
             {{- if .Entries -}}
 

--- a/pkg/notifications/common_templates.go
+++ b/pkg/notifications/common_templates.go
@@ -23,8 +23,8 @@ var commonTemplates = map[string]string{
 	`default`: `
 {{- if .Report -}}
   {{- with .Report -}}
+    {{len .Scanned}} Scanned, {{len .Updated}} Updated, {{len .Failed}} Failed
     {{- if ( or .Updated .Failed ) -}}
-{{len .Scanned}} Scanned, {{len .Updated}} Updated, {{len .Failed}} Failed
       {{- range .Updated}}
 - {{.Name}} ({{.ImageName}}): {{.CurrentImageID.ShortID}} updated to {{.LatestImageID.ShortID}}
       {{- end -}}

--- a/pkg/notifications/shoutrrr_test.go
+++ b/pkg/notifications/shoutrrr_test.go
@@ -271,9 +271,9 @@ updt1 (mock/updt1:latest): Updated
 
 		ginkgo.Describe("the default template", func() {
 			ginkgo.When("all containers are fresh", func() {
-				ginkgo.It("should return an empty string", func() {
+				ginkgo.It("should return the summary", func() {
 					gomega.Expect(getTemplatedResult(``, false, mockDataAllFresh)).
-						To(gomega.Equal(""))
+						To(gomega.Equal("1 Scanned, 0 Updated, 0 Failed"))
 				})
 			})
 			ginkgo.When("at least one container was updated", func() {


### PR DESCRIPTION
## Description

Fixes missing report notifications in monitor-only mode when `WATCHTOWER_NOTIFICATION_REPORT=true`.

### Problem

When running Watchtower in monitor-only mode with report notifications enabled, the report notification was empty and skipped. The "default" template only displayed a session summary (scanned/updated/failed counts) if there were updated or failed containers. Since monitor-only mode doesn't perform updates, it fell back to displaying log entries—which are debug-level and not captured in notifications—resulting in empty messages.

### Solution

Modified the "default" notification template to always show the session summary when report data exists, regardless of update outcomes. This ensures monitor-only runs provide meaningful feedback (e.g., "49 Scanned, 0 Updated, 0 Failed").

### Changes

- Modify default template in `pkg/notifications/common_templates.go` to always display summary
- Update template preview in `docs/notifications/template-preview/index.md`
- Update documentation in `docs/notifications/templates/index.md`
- Adjust test expectations in `pkg/notifications/shoutrrr_test.go`

Closes #707