### PR TITLE
fix: improve logging clarity and accuracy for scheduling modes

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -247,6 +247,8 @@ func preRun(cmd *cobra.Command, _ []string) {
 
 	// Get the cron schedule specification from flags or environment variables.
 	scheduleSpec, _ = flagsSet.GetString("schedule")
+	logrus.WithField("scheduleSpec", scheduleSpec).
+		Debug("Retrieved cron schedule specification from flags")
 
 	// Get secrets from files (e.g., for notifications) and read core operational flags.
 	flags.GetSecretsFromFiles(cmd)
@@ -563,7 +565,6 @@ func runMain(cfg RunConfig) int {
 
 	// Handle immediate update on startup, then continue with periodic updates.
 	if cfg.UpdateOnStart {
-		writeStartupMessage(cfg.Command, time.Time{}, cfg.FilterDesc, scope)
 		metric := runUpdatesWithNotifications(cfg.Filter, cleanup)
 		metrics.Default().RegisterScan(metric)
 	}
@@ -826,7 +827,7 @@ func writeStartupMessage(c *cobra.Command, sched time.Time, filtering string, sc
 	if scope != "" {
 		startupLog.WithField("scope", scope).Info("Only checking containers in scope")
 	} else {
-		startupLog.Info(filtering)
+		startupLog.Debug(filtering)
 	}
 
 	// Log scheduling or run mode information based on configuration.
@@ -898,18 +899,44 @@ func logNotifierInfo(log *logrus.Entry, notifierNames []string) {
 //   - c: The cobra.Command instance, providing access to flags like --run-once.
 //   - sched: The time.Time of the first scheduled run, or zero if no schedule is set.
 func logScheduleInfo(log *logrus.Entry, c *cobra.Command, sched time.Time) {
-	if !sched.IsZero() {
+	switch {
+	case !sched.IsZero(): // scheduled runs
 		until := formatDuration(time.Until(sched))
 		log.Info("Scheduling first run: " + sched.Format("2006-01-02 15:04:05 -0700 MST"))
 		log.Info("Note that the first check will be performed in " + until)
 
-		return
-	}
+	case func() bool { // one-time updates
+		v, _ := c.PersistentFlags().GetBool("run-once")
 
-	if runOnce, _ := c.PersistentFlags().GetBool("run-once"); runOnce {
+		return v
+	}():
 		log.Info("Running a one time update.")
-	} else {
-		log.Info("Periodic runs are not enabled.")
+
+	case func() bool { // update on start
+		v, _ := c.PersistentFlags().GetBool("update-on-start")
+
+		return v
+	}():
+		log.Info("Running update on start, then scheduling periodic updates.")
+
+	case func() bool { // HTTP API without periodic polling
+		a, _ := c.PersistentFlags().GetBool("http-api-update")
+		b, _ := c.PersistentFlags().GetBool("http-api-periodic-polls")
+
+		return a && !b
+	}():
+		log.Info("Updates via HTTP API enabled. Periodic updates are not enabled.")
+
+	case func() bool { // HTTP API with periodic polling
+		a, _ := c.PersistentFlags().GetBool("http-api-update")
+		b, _ := c.PersistentFlags().GetBool("http-api-periodic-polls")
+
+		return a && b
+	}():
+		log.Info("Updates via HTTP API enabled. Periodic updates are also enabled.")
+
+	default: // default periodic
+		log.Info("Periodic updates are enabled with default schedule.")
 	}
 }
 

--- a/docs/configuration/arguments/index.md
+++ b/docs/configuration/arguments/index.md
@@ -30,14 +30,14 @@ This command triggers an update attempt for "nginx" and "redis" containers, disp
 
 Certain flags support referencing a file, using its contents as the value, to securely handle sensitive data like passwords or tokens, avoiding exposure in configuration files or command lines.
 
-| Flag                            | Environment Variable                             |
-|---------------------------------|-------------------------------------------------|
-| `--notification-url`            | `WATCHTOWER_NOTIFICATION_URL`                   |
+| Flag                                   | Environment Variable                            |
+|----------------------------------------|-------------------------------------------------|
+| `--http-api-token`                     | `WATCHTOWER_HTTP_API_TOKEN`                     |
 | `--notification-email-server-password` | `WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD` |
-| `--notification-slack-hook-url` | `WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL`        |
-| `--notification-msteams-hook`   | `WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK`          |
-| `--notification-gotify-token`   | `WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN`          |
-| `--http-api-token`              | `WATCHTOWER_HTTP_API_TOKEN`                     |
+| `--notification-gotify-token`          | `WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN`          |
+| `--notification-msteams-hook`          | `WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK`          |
+| `--notification-slack-hook-url`        | `WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL`        |
+| `--notification-url`                   | `WATCHTOWER_NOTIFICATION_URL`                   |
 
 ### Example Docker Compose Usage
 
@@ -171,7 +171,8 @@ Environment Variable: WATCHTOWER_RUN_ONCE
 
 ### Update on Start
 
-Performs an update check on startup, then continues with periodic updates.
+Performs an update check on startup.
+If a schedule is configured (via --schedule or --interval), then Watchtower continues with periodic updates.
 
 ```text
             Argument: --update-on-start

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -925,12 +925,17 @@ func ProcessFlagAliases(flags *pflag.FlagSet) {
 	// Update schedule to match interval or default if needed.
 	if intervalChanged || !scheduleChanged {
 		interval, _ := flags.GetInt("interval")
-		if err := flags.Set("schedule", fmt.Sprintf("@every %ds", interval)); err != nil {
+
+		scheduleValue := fmt.Sprintf("@every %ds", interval)
+		if err := flags.Set("schedule", scheduleValue); err != nil {
 			logrus.WithError(err).
 				WithField("interval", interval).
 				Debug("Failed to set schedule from interval")
 		} else {
-			logrus.WithField("interval", interval).Debug("Set schedule from interval")
+			logrus.WithFields(logrus.Fields{
+				"interval": interval,
+				"schedule": scheduleValue,
+			}).Debug("Set default schedule from interval")
 		}
 	}
 


### PR DESCRIPTION
This PR addresses issues with misleading and verbose logging in Watchtower's scheduling and run modes, ensuring users receive accurate information about update behavior.

## Changes:
- **Refactored `logScheduleInfo`**: Replaced nested if-else with a switch statement for better readability and added specific cases for all run modes, including HTTP API variants.
- **Improved logging accuracy**: Corrected messages for `--update-on-start` and default periodic modes to reflect actual behavior.
- **Reduced verbosity**: Demoted non-essential startup logs (e.g., filtering info) to debug level.
- **Enhanced debug logging**: Added detailed logs for schedule spec retrieval and flag processing.
- **Updated documentation**: Clarified `--update-on-start` behavior in the arguments doc.
- **Code quality**: Eliminated redundant startup messages and improved switch logic to satisfy linter rules.