### PR TITLE
fix: address container identification issue

### DIFF
--- a/internal/actions/mocks/client.go
+++ b/internal/actions/mocks/client.go
@@ -67,6 +67,11 @@ func (client MockClient) ListContainers(filter types.Filter) ([]types.Container,
 	return filtered, nil
 }
 
+// ListAllContainers returns all containers from TestData without filtering.
+func (client MockClient) ListAllContainers() ([]types.Container, error) {
+	   return client.TestData.Containers, nil
+}
+
 // StopContainer simulates stopping a container by marking it in the Stopped map.
 // It records the container’s ID as stopped, increments the StopContainerCount,
 // and returns nil for simplicity.

--- a/pkg/container/mocks/Client.go
+++ b/pkg/container/mocks/Client.go
@@ -184,6 +184,61 @@ func (_c *MockClient_GetContainer_Call) RunAndReturn(run func(containerID types.
 	return _c
 }
 
+// GetInfo provides a mock function for the type MockClient
+func (_mock *MockClient) GetInfo() (map[string]any, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetInfo")
+	}
+
+	var r0 map[string]any
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (map[string]any, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() map[string]any); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]any)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockClient_GetInfo_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetInfo'
+type MockClient_GetInfo_Call struct {
+	*mock.Call
+}
+
+// GetInfo is a helper method to define mock.On call
+func (_e *MockClient_Expecter) GetInfo() *MockClient_GetInfo_Call {
+	return &MockClient_GetInfo_Call{Call: _e.mock.On("GetInfo")}
+}
+
+func (_c *MockClient_GetInfo_Call) Run(run func()) *MockClient_GetInfo_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockClient_GetInfo_Call) Return(stringToV map[string]any, err error) *MockClient_GetInfo_Call {
+	_c.Call.Return(stringToV, err)
+	return _c
+}
+
+func (_c *MockClient_GetInfo_Call) RunAndReturn(run func() (map[string]any, error)) *MockClient_GetInfo_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetVersion provides a mock function for the type MockClient
 func (_mock *MockClient) GetVersion() string {
 	ret := _mock.Called()
@@ -296,6 +351,61 @@ func (_c *MockClient_IsContainerStale_Call) Return(b bool, imageID types.ImageID
 }
 
 func (_c *MockClient_IsContainerStale_Call) RunAndReturn(run func(container types.Container, params types.UpdateParams) (bool, types.ImageID, error)) *MockClient_IsContainerStale_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListAllContainers provides a mock function for the type MockClient
+func (_mock *MockClient) ListAllContainers() ([]types.Container, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListAllContainers")
+	}
+
+	var r0 []types.Container
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() ([]types.Container, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() []types.Container); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]types.Container)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockClient_ListAllContainers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListAllContainers'
+type MockClient_ListAllContainers_Call struct {
+	*mock.Call
+}
+
+// ListAllContainers is a helper method to define mock.On call
+func (_e *MockClient_Expecter) ListAllContainers() *MockClient_ListAllContainers_Call {
+	return &MockClient_ListAllContainers_Call{Call: _e.mock.On("ListAllContainers")}
+}
+
+func (_c *MockClient_ListAllContainers_Call) Run(run func()) *MockClient_ListAllContainers_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockClient_ListAllContainers_Call) Return(containers []types.Container, err error) *MockClient_ListAllContainers_Call {
+	_c.Call.Return(containers, err)
+	return _c
+}
+
+func (_c *MockClient_ListAllContainers_Call) RunAndReturn(run func() ([]types.Container, error)) *MockClient_ListAllContainers_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -640,61 +750,6 @@ func (_c *MockClient_WaitForContainerHealthy_Call) Return(err error) *MockClient
 }
 
 func (_c *MockClient_WaitForContainerHealthy_Call) RunAndReturn(run func(containerID types.ContainerID, timeout time.Duration) error) *MockClient_WaitForContainerHealthy_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetInfo provides a mock function for the type MockClient
-func (_mock *MockClient) GetInfo() (map[string]any, error) {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetInfo")
-	}
-
-	var r0 map[string]any
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (map[string]any, error)); ok {
-		return returnFunc()
-	}
-	if returnFunc, ok := ret.Get(0).(func() map[string]any); ok {
-		r0 = returnFunc()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]any)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockClient_GetInfo_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetInfo'
-type MockClient_GetInfo_Call struct {
-	*mock.Call
-}
-
-// GetInfo is a helper method to define mock.On call
-func (_e *MockClient_Expecter) GetInfo() *MockClient_GetInfo_Call {
-	return &MockClient_GetInfo_Call{Call: _e.mock.On("GetInfo")}
-}
-
-func (_c *MockClient_GetInfo_Call) Run(run func()) *MockClient_GetInfo_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockClient_GetInfo_Call) Return(info map[string]any, err error) *MockClient_GetInfo_Call {
-	_c.Call.Return(info, err)
-	return _c
-}
-
-func (_c *MockClient_GetInfo_Call) RunAndReturn(run func() (map[string]any, error)) *MockClient_GetInfo_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
This PR addresses the hostname/container name mismatch issues in Watchtower's scope derivation functionality, particularly on non-Linux platforms where the previous cgroup-based approach fails.

### Problem
The current implementation uses `/proc/self/cgroup` parsing to identify the current container for scope derivation during self-updates. This approach:
- Fails on Windows and macOS where `/proc/self/cgroup` doesn't exist
- Falls back to `HOSTNAME` environment variable, which may contain custom container hostnames that don't match Docker container IDs
- Results in "No such container" errors when attempting to inspect containers by invalid identifiers

### Solution
Replace the filesystem-dependent cgroup parsing with a cross-platform Docker API approach that:
- Uses `ContainerList` and `ContainerInspect` to enumerate all containers
- Matches the `HOSTNAME` environment variable with `container.Config.Hostname`
- Provides reliable container identification across all supported platforms

### Changes Made
- **New `getContainerID()` function**: API-based container identification using Docker client
- **Updated `Client` interface**: Added `ListAllContainers()` method
- **Modified `deriveScopeFromContainer()`**: Pass client to new identification function
- **Updated mock implementations**: Added missing methods to test mocks
- **Enhanced tests**: Comprehensive test coverage for new functionality
- **Code cleanup**: Removed unused cgroup-related code and fixed linting issues

### Related Issues
- Fixes hostname/container name mismatch in debug logs
- Addresses cross-platform compatibility concerns
- Enhances robustness of scope derivation for multi-instance deployments

This change makes Watchtower more reliable across different container runtimes and host operating systems while maintaining the same functional behavior.