### PR TITLE
Fix: Improve self-update handling with robust digest parsing

### DIFF
--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -234,14 +234,14 @@ func (c imageClient) shouldSkipPull(
 
 	switch {
 	case err != nil:
-		// HEAD request failed; log based on warning strategy and proceed with pull.
+		// Digest retrieval failed; log based on warning strategy and proceed with pull.
 		headLevel := logrus.DebugLevel
 		if warn {
 			headLevel = logrus.WarnLevel
 		}
 
 		clog.WithError(err).
-			Log(headLevel, "HEAD request failed, falling back to full pull")
+			Log(headLevel, "Digest retrieval failed, falling back to full pull")
 
 		return false
 	case match:


### PR DESCRIPTION
## Problem
Watchtower's self-update process was failing with misleading error messages due to improper handling of registry responses. The code attempted JSON unmarshaling on plain text 404 responses, causing "cannot unmarshal number into Go value" errors and logging "pull failed" even when updates succeeded.

## Root Cause
- Digest extraction assumed all responses were JSON manifests
- No validation of response format before parsing
- Misleading logging that confused manifest retrieval failures with image pull failures
- Lack of Content-Type header validation for different registry implementations

## Solution
Enhanced the digest parsing logic with:
- JSON format detection before unmarshaling
- Content-Type header validation for manifest responses
- Improved error handling and logging
- Comprehensive test coverage for edge cases

## Changes

**pkg/registry/digest/digest.go:**
- Add JSON format validation in `ExtractGetDigest` before unmarshaling
- Validate Content-Type headers against allowed manifest types
- Improve error messages for unsupported response formats

**pkg/container/image.go:**
- Update logging from "HEAD request failed" to "Digest retrieval failed" for accuracy

**pkg/registry/digest/digest_test.go:**
- Add test cases for plain text 404 responses
- Add tests for OCI image index Content-Types
- Add tests for invalid/missing Content-Type headers