### PR TITLE
Fix crash due to concurrent Docker client access

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -567,6 +567,10 @@ func runMain(cfg RunConfig) int {
 		)
 	}
 
+	// Initialize a lock channel to prevent concurrent updates.
+	updateLock := make(chan bool, 1)
+	updateLock <- true
+
 	// Handle one-time update mode, executing updates and registering metrics.
 	if cfg.RunOnce {
 		writeStartupMessage(cfg.Command, time.Time{}, cfg.FilterDesc, scope)
@@ -579,13 +583,16 @@ func runMain(cfg RunConfig) int {
 
 	// Handle immediate update on startup, then continue with periodic updates.
 	if cfg.UpdateOnStart {
-		metric := runUpdatesWithNotifications(cfg.Filter, cleanup)
-		metrics.Default().RegisterScan(metric)
-	}
+		select {
+		case v := <-updateLock:
+			defer func() { updateLock <- v }()
 
-	// Initialize a lock channel to prevent concurrent updates.
-	updateLock := make(chan bool, 1)
-	updateLock <- true
+			metric := runUpdatesWithNotifications(cfg.Filter, cleanup)
+			metrics.Default().RegisterScan(metric)
+		default:
+			logrus.Debug("Skipped update on start as another update is already running.")
+		}
+	}
 
 	// Check for and resolve conflicts with multiple Watchtower instances.
 	cleanupImageIDs := make(map[types.ImageID]bool)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,9 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,7 +20,9 @@ import (
 	dockerContainer "github.com/docker/docker/api/types/container"
 
 	"github.com/nicholas-fedor/watchtower/internal/flags"
+	"github.com/nicholas-fedor/watchtower/pkg/api/update"
 	containerMock "github.com/nicholas-fedor/watchtower/pkg/container/mocks"
+	"github.com/nicholas-fedor/watchtower/pkg/metrics"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 	typeMock "github.com/nicholas-fedor/watchtower/pkg/types/mocks"
 )
@@ -539,4 +546,155 @@ func TestGetAPIAddr(t *testing.T) {
 			assert.NoError(t, err, "formatted address should be a valid TCP address")
 		})
 	}
+}
+
+// TestUpdateLockSerialization verifies that the updateLock mechanism properly serializes updates,
+// preventing concurrent access to the Docker client. This test simulates multiple update operations
+// running simultaneously, ensuring only one update executes at a time, mimicking the behavior
+// of updateOnStart and scheduled updates in the main application.
+func TestUpdateLockSerialization(t *testing.T) {
+	// Initialize the update lock channel with the same pattern as in runMain
+	updateLock := make(chan bool, 1)
+	updateLock <- true
+
+	// Atomic counters to track concurrent execution and completion
+	var (
+		running   int32
+		started   int32
+		completed int32
+	)
+
+	// WaitGroup to synchronize test completion
+	var wg sync.WaitGroup
+
+	// Simulate the update function used in runMain and runUpgradesOnSchedule
+	updateFunc := func(id int) {
+		select {
+		case v := <-updateLock:
+			// Acquired lock, perform update
+			defer func() { updateLock <- v }()
+
+			// Track that only one update is running at a time
+			current := atomic.AddInt32(&running, 1)
+			require.Equal(
+				t,
+				int32(1),
+				current,
+				"Only one update should be running at a time, but %d are running",
+				current,
+			)
+
+			atomic.AddInt32(&started, 1)
+
+			// Simulate update work with a small delay
+			time.Sleep(10 * time.Millisecond)
+
+			atomic.AddInt32(&running, -1)
+			atomic.AddInt32(&completed, 1)
+
+		default:
+			// Lock not available, skip update (same as in the actual code)
+			t.Logf("Update %d skipped due to concurrent update in progress", id)
+		}
+	}
+
+	// Simulate concurrent updateOnStart and scheduled updates
+	numUpdates := 2
+	for i := range numUpdates {
+		wg.Add(1)
+
+		go func(id int) {
+			defer wg.Done()
+
+			updateFunc(id)
+		}(i)
+	}
+
+	// Wait for all goroutines to complete
+	wg.Wait()
+
+	// Verify that only one update executed due to lock serialization
+	assert.Equal(t, int32(1), started, "Only one update should have started due to lock")
+	assert.Equal(t, int32(1), completed, "Only one update should have completed")
+	assert.Equal(t, int32(0), running, "No updates should be running after completion")
+}
+
+// TestConcurrentScheduledAndAPIUpdate verifies that API-triggered updates wait for scheduled updates to complete,
+// ensuring proper serialization and preventing race conditions between periodic updates and HTTP API calls.
+func TestConcurrentScheduledAndAPIUpdate(t *testing.T) {
+	// Initialize the update lock channel with the same pattern as in runMain
+	updateLock := make(chan bool, 1)
+	updateLock <- true
+
+	// Channels to signal when each update type starts and completes
+	scheduledStarted := make(chan struct{})
+	scheduledCompleted := make(chan struct{})
+	apiStarted := make(chan struct{})
+	apiCompleted := make(chan struct{})
+
+	// Mock update function for API handler that signals start and completion
+	updateFn := func(_ []string) *metrics.Metric {
+		close(apiStarted)
+		time.Sleep(50 * time.Millisecond) // Simulate API update work
+		close(apiCompleted)
+
+		return &metrics.Metric{Scanned: 1, Updated: 1, Failed: 0}
+	}
+
+	// Create the update handler with the shared lock
+	handler := update.New(updateFn, updateLock)
+
+	// Simulate scheduled update (longer duration)
+	go func() {
+		select {
+		case v := <-updateLock:
+			close(scheduledStarted)
+			time.Sleep(100 * time.Millisecond) // Simulate scheduled update work (longer than API)
+			close(scheduledCompleted)
+
+			updateLock <- v
+		default:
+			t.Error("Scheduled update should have acquired the lock")
+		}
+	}()
+
+	// Simulate API update request
+	go func() {
+		req, err := http.NewRequestWithContext(
+			context.Background(),
+			http.MethodPost,
+			"/v1/update",
+			http.NoBody,
+		)
+		if err != nil {
+			t.Errorf("Failed to create request: %v", err)
+
+			return
+		}
+
+		w := httptest.NewRecorder()
+		handler.Handle(w, req)
+	}()
+
+	// Wait for scheduled update to start
+	<-scheduledStarted
+
+	// Verify API update has not started yet (should be blocked by lock)
+	select {
+	case <-apiStarted:
+		t.Error("API update should not have started while scheduled update is running")
+	default:
+		// Expected: API is blocked
+	}
+
+	// Wait for scheduled update to complete
+	<-scheduledCompleted
+
+	// Now API update should start and complete
+	<-apiStarted
+	<-apiCompleted
+
+	// Verify the API response is successful
+	// Note: In a real scenario, we'd check the response body, but for this test,
+	// the completion signals are sufficient to verify serialization
 }


### PR DESCRIPTION
This PR resolves GitHub Issue #730 where Watchtower crashes with a "bad pointer" error in Go's garbage collector. 

A race condition in `cmd/root.go` allowed concurrent access to the Docker client from `updateOnStart` and scheduled updates, leading to memory corruption detected by GC.

This fix ensures all update operations are properly serialized, preventing crashes from concurrent Docker client access.

### Changes
- **cmd/root.go**: Serialize `updateOnStart` with scheduled updates using the existing `updateLock` mechanism
- **cmd/root_test.go**: Added `TestUpdateLockSerialization` and `TestConcurrentScheduledAndAPIUpdate` to verify serialization across all update paths (updateOnStart, scheduled, API)
