### PR TITLE
Fix random test failures in CI by improving timing reliability

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -468,9 +468,14 @@ func TestAwaitDockerClient(t *testing.T) {
 
 	elapsed := time.Since(start)
 
-	// Should take at least 1 second but not more than 2 (to account for timing variations)
-	assert.GreaterOrEqual(t, elapsed, time.Second, "Should sleep for at least 1 second")
-	assert.Less(t, elapsed, 2*time.Second, "Should not sleep for more than 2 seconds")
+	// Should take at least 900ms but not more than 3 seconds (to account for CI timing variations)
+	assert.GreaterOrEqual(
+		t,
+		elapsed,
+		900*time.Millisecond,
+		"Should sleep for at least 900 milliseconds",
+	)
+	assert.Less(t, elapsed, 3*time.Second, "Should not sleep for more than 3 seconds")
 }
 
 func TestLifecycleFlags(t *testing.T) {
@@ -586,8 +591,8 @@ func TestUpdateLockSerialization(t *testing.T) {
 
 			atomic.AddInt32(&started, 1)
 
-			// Simulate update work with a small delay
-			time.Sleep(10 * time.Millisecond)
+			// Simulate update work with a delay
+			time.Sleep(100 * time.Millisecond)
 
 			atomic.AddInt32(&running, -1)
 			atomic.AddInt32(&completed, 1)
@@ -635,7 +640,7 @@ func TestConcurrentScheduledAndAPIUpdate(t *testing.T) {
 	// Mock update function for API handler that signals start and completion
 	updateFn := func(_ []string) *metrics.Metric {
 		close(apiStarted)
-		time.Sleep(50 * time.Millisecond) // Simulate API update work
+		time.Sleep(100 * time.Millisecond) // Simulate API update work
 		close(apiCompleted)
 
 		return &metrics.Metric{Scanned: 1, Updated: 1, Failed: 0}
@@ -649,7 +654,7 @@ func TestConcurrentScheduledAndAPIUpdate(t *testing.T) {
 		select {
 		case v := <-updateLock:
 			close(scheduledStarted)
-			time.Sleep(100 * time.Millisecond) // Simulate scheduled update work (longer than API)
+			time.Sleep(200 * time.Millisecond) // Simulate scheduled update work (longer than API)
 			close(scheduledCompleted)
 
 			updateLock <- v

--- a/internal/actions/update_test.go
+++ b/internal/actions/update_test.go
@@ -99,7 +99,7 @@ var _ = ginkgo.Describe("the update action", func() {
 				types.UpdateParams{
 					Cleanup:          true,
 					Filter:           filters.WatchtowerContainersFilter,
-					PullFailureDelay: 1 * time.Millisecond, // Test-specific very short delay
+					PullFailureDelay: 10 * time.Millisecond, // Test-specific short delay
 					CPUCopyMode:      "auto",
 				},
 			)
@@ -1160,7 +1160,7 @@ var _ = ginkgo.Describe("the update action", func() {
 				types.UpdateParams{
 					Cleanup:          true,
 					Filter:           filters.WatchtowerContainersFilter,
-					PullFailureDelay: 1 * time.Millisecond, // Test-specific very short delay
+					PullFailureDelay: 10 * time.Millisecond, // Test-specific very short delay
 					CPUCopyMode:      "auto",
 				},
 			)
@@ -1172,9 +1172,9 @@ var _ = ginkgo.Describe("the update action", func() {
 			gomega.Expect(cleanupImageIDs).
 				To(gomega.BeEmpty(), "No cleanup should occur on pull failure")
 
-			// Verify that the delay was applied (using test-specific very short delay from PullFailureDelay)
+			// Verify that the delay was applied (using test-specific short delay from PullFailureDelay)
 			gomega.Expect(elapsedTime).
-				To(gomega.BeNumerically(">=", 1*time.Millisecond), "Delay should have been applied")
+				To(gomega.BeNumerically(">=", 10*time.Millisecond), "Delay should have been applied")
 		})
 	})
 })


### PR DESCRIPTION
This PR addresses random test failures observed in GitHub Actions CI. The failures were caused by timing-sensitive tests that behaved inconsistently under CI load and across different operating systems.

**Changes:**
- **cmd/root_test.go**: Made timing assertions more resilient to CI variability
  - `TestAwaitDockerClient`: Widened timing assertion range from `>=1s <2s` to `>=900ms <3s`
  - `TestUpdateLockSerialization`: Increased simulation sleep from 10ms to 100ms
  - `TestConcurrentScheduledAndAPIUpdate`: Increased sleeps from 50ms/100ms to 100ms/200ms

- **internal/actions/update_test.go**: Fixed safeguard delay test
  - Changed `PullFailureDelay` from 1ms to 10ms to prevent timing failures on slower systems