### PR TITLE
ci: Pin Go version to mitigate version mismatch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - 1.25.x
+          - 1.25.1
         platform:
           - macos-latest
           - windows-latest


### PR DESCRIPTION
Pin Go version to 1.25.1 to resolve failures due to mismatched version.
