### PR TITLE
ci: resolve CI test failures and WASM bug

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - 1.25.1
+          - 1.25.x
         platform:
           - macos-latest
           - windows-latest
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run tests
         run: |
-          go test -v -coverprofile coverage.out -covermode atomic ./...
+          go test -race -p 1 -coverprofile=coverage.out ./...
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7

--- a/tools/tplprev/main_wasm.go
+++ b/tools/tplprev/main_wasm.go
@@ -44,7 +44,7 @@ func jsTplPrev(this js.Value, args []js.Value) any {
 	var levels []data.LogLevel
 
 	if levelsArg.Type() == js.TypeString {
-		levels = data.LevelsFromString(statesArg.String())
+		levels = data.LevelsFromString(levelsArg.String())
 	} else {
 		for i := 0; i < levelsArg.Length(); i++ {
 			level := data.LogLevel(levelsArg.Index(i).String())


### PR DESCRIPTION
- Fix variable reference bug in tools/tplprev/main_wasm.go LevelsFromString call
- Update CI workflow to use sequential test execution (-p 1) to prevent race detector hangups
- Revert Go version to 1.25.x for broader compatibility while maintaining fixes