### PR TITLE
fix: prevent nil pointer dereference in container cleanup

### DIFF
--- a/internal/actions/check.go
+++ b/internal/actions/check.go
@@ -165,7 +165,7 @@ func cleanupExcessWatchtowers(
 
 	// Get the newest container’s image ID (kept running).
 	newestContainer := containers[len(containers)-1]
-	newestImageID := newestContainer.ImageID()
+	newestImageID := newestContainer.SafeImageID()
 	logrus.WithFields(logrus.Fields{
 		"newest_container": newestContainer.Name(),
 		"newest_image_id":  newestImageID,
@@ -185,8 +185,8 @@ func cleanupExcessWatchtowers(
 
 		logrus.WithField("container", c.Name()).Debug("Stopped Watchtower instance")
 		// Skip cleanup if the image is used by the newest container.
-		if cleanup && c.ImageID() != newestImageID {
-			cleanupImageIDs[c.ImageID()] = true
+		if cleanup && c.SafeImageID() != newestImageID {
+			cleanupImageIDs[c.SafeImageID()] = true
 		}
 	}
 

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -184,8 +184,12 @@ func (c Container) Name() string {
 // ImageID returns the ID of the container’s image.
 //
 // Returns:
-//   - types.ImageID: Image ID (panics if imageInfo is nil).
+//   - types.ImageID: Image ID or empty string if imageInfo is nil.
 func (c Container) ImageID() types.ImageID {
+	if c.imageInfo == nil {
+		return ""
+	}
+
 	return types.ImageID(c.imageInfo.ID)
 }
 

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -265,6 +265,27 @@ var _ = ginkgo.Describe("Container", func() {
 			})
 		})
 
+		ginkgo.Context("fetching image ID", func() {
+			ginkgo.It("returns image ID when imageInfo is available", func() {
+				imageID := container.ImageID()
+				gomega.Expect(imageID).To(gomega.Equal(types.ImageID("image_id")))
+			})
+
+			ginkgo.It("returns empty string for ImageID when imageInfo is nil", func() {
+				container = MockContainer(WithPortBindings())
+				container.imageInfo = nil
+				imageID := container.ImageID()
+				gomega.Expect(imageID).To(gomega.Equal(types.ImageID("")))
+			})
+
+			ginkgo.It("returns empty string for SafeImageID when imageInfo is nil", func() {
+				container = MockContainer(WithPortBindings())
+				container.imageInfo = nil
+				imageID := container.SafeImageID()
+				gomega.Expect(imageID).To(gomega.Equal(types.ImageID("")))
+			})
+		})
+
 		ginkgo.Context("fetching container links", func() {
 			ginkgo.When("depends-on label is present", func() {
 				ginkgo.It("returns single dependent container", func() {


### PR DESCRIPTION
## Problem
Watchtower panics with "runtime error: invalid memory address or nil pointer dereference" when cleaning up multiple instances, as reported in [Issue #744](https://github.com/nicholas-fedor/watchtower/issues/744). This occurs when Docker's `ImageInspect` fails, leaving `imageInfo` as `nil`, and the `ImageID()` method attempts to dereference it without checking.

## Solution
- Modified `cleanupExcessWatchtowers` in `internal/actions/check.go` to use `SafeImageID()` instead of `ImageID()` for safe handling of containers with missing image info.
- Updated `Container.ImageID()` in `pkg/container/container.go` to include a nil check, returning an empty string when `imageInfo` is `nil`.
- Added unit tests in `pkg/container/container_test.go` to verify behavior with `nil` imageInfo.

## Changes
- `internal/actions/check.go`: Replace `c.ImageID()` with `c.SafeImageID()` in cleanup logic
- `pkg/container/container.go`: Add nil check to `ImageID()` method
- `pkg/container/container_test.go`: Add tests for nil imageInfo scenarios
