### PR TITLE
ci: resolve detached HEAD issue in changelog job

### DIFF
--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -33,6 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
         with:
+          ref: 'main'
           fetch-depth: 0
 
       - name: Import GPG key


### PR DESCRIPTION
Modify checkout step in release-prod.yaml to checkout main branch instead of tag, allowing create-pull-request action to function properly when generating changelog PRs.