### PR TITLE
Fix: Digest retrieval failed, falling back to full pull

### DIFF
--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -229,11 +229,13 @@ func extractChallengeHost(realm string, fields logrus.Fields) string {
 //   - container: Container with image info.
 //   - registryAuth: Base64-encoded auth string.
 //   - client: Client for HTTP requests.
+//   - redirected: True if the challenge request was redirected.
 //   - fields: Logging fields for context.
 //
 // Returns:
 //   - string: Bearer token header (e.g., "Bearer ...").
 //   - string: Challenge host (e.g., "ghcr.io").
+//   - bool: Redirect flag (passed through).
 //   - error: Non-nil if processing fails, nil on success.
 func handleBearerAuth(
 	ctx context.Context,
@@ -241,8 +243,9 @@ func handleBearerAuth(
 	container types.Container,
 	registryAuth string,
 	client Client,
+	redirected bool,
 	fields logrus.Fields,
-) (string, string, error) {
+) (string, string, bool, error) {
 	logrus.WithFields(fields).Debug("Entering Bearer auth path")
 
 	var challengeHost string
@@ -276,7 +279,7 @@ func handleBearerAuth(
 	if err != nil {
 		logrus.WithError(err).WithFields(fields).Debug("Failed to parse image name")
 
-		return "", "", fmt.Errorf("%w: %w", errFailedParseImageName, err)
+		return "", "", redirected, fmt.Errorf("%w: %w", errFailedParseImageName, err)
 	}
 
 	token, err := GetBearerHeader(
@@ -289,13 +292,16 @@ func handleBearerAuth(
 	if err != nil {
 		logrus.WithError(err).WithFields(fields).Debug("Failed to get bearer token")
 
-		return "", "", fmt.Errorf("%w: %w", errFailedDecodeResponse, err)
+		return "", "", redirected, fmt.Errorf("%w: %w", errFailedDecodeResponse, err)
 	}
 
 	if token == "" {
 		logrus.WithFields(fields).Debug("Empty bearer token received")
 
-		return "", "", fmt.Errorf("%w: empty token in response", errFailedDecodeResponse)
+		return "", "", redirected, fmt.Errorf(
+			"%w: empty token in response",
+			errFailedDecodeResponse,
+		)
 	}
 
 	logrus.WithFields(fields).
@@ -303,7 +309,7 @@ func handleBearerAuth(
 		WithField("challenge_host", challengeHost).
 		Debug("Returning Bearer token and challenge host")
 
-	return token, challengeHost, nil
+	return token, challengeHost, redirected, nil
 }
 
 // GetToken fetches a token and the challenge host for the registry hosting the provided image.
@@ -317,13 +323,14 @@ func handleBearerAuth(
 // Returns:
 //   - string: Authentication token (e.g., "Basic ..." or "Bearer ...").
 //   - string: Challenge host (e.g., "ghcr.io"), empty if not applicable.
+//   - bool: True if the challenge request was redirected, false otherwise.
 //   - error: Non-nil if operation fails, nil on success.
 func GetToken(
 	ctx context.Context,
 	container types.Container,
 	registryAuth string,
 	client Client,
-) (string, string, error) {
+) (string, string, bool, error) {
 	fields := logrus.Fields{
 		"image": container.ImageName(),
 	}
@@ -333,7 +340,7 @@ func GetToken(
 	if err != nil {
 		logrus.WithError(err).WithFields(fields).Debug("Failed to parse image name")
 
-		return "", "", fmt.Errorf("%w: %w", errFailedParseImageName, err)
+		return "", "", false, fmt.Errorf("%w: %w", errFailedParseImageName, err)
 	}
 
 	// Generate the challenge URL.
@@ -347,7 +354,7 @@ func GetToken(
 	if err != nil {
 		logrus.WithError(err).WithFields(fields).Debug("Failed to create challenge request")
 
-		return "", "", fmt.Errorf("%w: %w", errFailedCreateChallengeRequest, err)
+		return "", "", false, fmt.Errorf("%w: %w", errFailedCreateChallengeRequest, err)
 	}
 
 	res, err := client.Do(req)
@@ -357,9 +364,12 @@ func GetToken(
 			WithField("url", challengeURL.String()).
 			Debug("Failed to execute challenge request")
 
-		return "", "", fmt.Errorf("%w: %w", errFailedExecuteChallengeRequest, err)
+		return "", "", false, fmt.Errorf("%w: %w", errFailedExecuteChallengeRequest, err)
 	}
 	defer res.Body.Close()
+
+	// Detect if the request was redirected.
+	redirected := res.Request.URL.Host != challengeURL.Host
 
 	// Handle 200 OK response (no auth required).
 	if res.StatusCode == http.StatusOK {
@@ -367,7 +377,7 @@ func GetToken(
 			WithField("url", challengeURL.String()).
 			Debug("No authentication required (200 OK)")
 
-		return "", "", nil
+		return "", "", redirected, nil
 	}
 
 	// Extract the challenge header.
@@ -383,7 +393,7 @@ func GetToken(
 			WithField("url", challengeURL.String()).
 			Debug("Empty WWW-Authenticate header; assuming no authentication required")
 
-		return "", "", nil
+		return "", "", redirected, nil
 	}
 
 	// Normalize challenge for comparison.
@@ -395,17 +405,25 @@ func GetToken(
 		if registryAuth == "" {
 			logrus.WithFields(fields).Debug("No credentials provided for Basic auth")
 
-			return "", "", fmt.Errorf("%w: basic auth required", errNoCredentials)
+			return "", "", redirected, fmt.Errorf("%w: basic auth required", errNoCredentials)
 		}
 
 		logrus.WithFields(fields).Debug("Using Basic auth")
 
-		return "Basic " + registryAuth, "", nil
+		return "Basic " + registryAuth, "", redirected, nil
 	}
 
 	// Handle Bearer auth.
 	if strings.HasPrefix(challenge, "bearer") {
-		return handleBearerAuth(ctx, wwwAuthHeader, container, registryAuth, client, fields)
+		return handleBearerAuth(
+			ctx,
+			wwwAuthHeader,
+			container,
+			registryAuth,
+			client,
+			redirected,
+			fields,
+		)
 	}
 
 	// Handle unknown challenge types.
@@ -413,7 +431,7 @@ func GetToken(
 		WithField("challenge", challenge).
 		Error("Unsupported challenge type from registry")
 
-	return "", "", fmt.Errorf("%w: %s", errUnsupportedChallenge, challenge)
+	return "", "", redirected, fmt.Errorf("%w: %s", errUnsupportedChallenge, challenge)
 }
 
 // processChallenge parses the WWW-Authenticate header to extract authentication details.

--- a/pkg/registry/digest/digest_test.go
+++ b/pkg/registry/digest/digest_test.go
@@ -248,7 +248,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerEmptyDigests, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerEmptyDigests, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerEmptyDigests)
@@ -316,7 +316,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -356,7 +356,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			_, _, err := auth.GetToken(ctx, mockContainerUnreachable, registryAuth, client)
+			_, _, _, err := auth.GetToken(ctx, mockContainerUnreachable, registryAuth, client)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).
 				To(gomega.ContainSubstring("failed to execute challenge request"))
@@ -387,7 +387,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			_, _, err := auth.GetToken(ctx, mockContainerInvalidImage, registryAuth, client)
+			_, _, _, err := auth.GetToken(ctx, mockContainerInvalidImage, registryAuth, client)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to parse image name"))
 		})
@@ -407,7 +407,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			_, _, err := auth.GetToken(ctx, mockContainerInvalidURL, registryAuth, client)
+			_, _, _, err := auth.GetToken(ctx, mockContainerInvalidURL, registryAuth, client)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to parse image name"))
 		})
@@ -455,7 +455,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -517,7 +517,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -585,7 +585,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(
+			token, _, _, err := auth.GetToken(
 				ctx,
 				mockContainerWithInvalidDigest,
 				registryAuth,
@@ -652,7 +652,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 			registryAuth := auth.TransformAuth("token")
-			_, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			_, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).
 				To(gomega.ContainSubstring("challenge header did not include all values needed to construct an auth url"))
@@ -886,7 +886,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -952,7 +952,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -1020,7 +1020,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -1087,7 +1087,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -1229,20 +1229,28 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.BeforeEach(func() {
 			defer ginkgo.GinkgoRecover()
+			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			mux = http.NewServeMux()
-			server = httptest.NewTLSServer(mux)
+			server = httptest.NewServer(mux)
 			logrus.WithField("server_addr", server.Listener.Addr().String()).
 				Debug("Starting test server")
 		})
 
 		ginkgo.AfterEach(func() {
 			defer ginkgo.GinkgoRecover()
+			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 			logrus.Debug("Closing test server")
 			server.Close()
 		})
 
 		ginkgo.It("should fetch a digest successfully", func() {
 			defer ginkgo.GinkgoRecover()
+			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+			scheme := "https"
+			if viper.GetBool("WATCHTOWER_REGISTRY_TLS_SKIP") {
+				scheme = "http"
+			}
 			serverAddr := server.Listener.Addr().String()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
@@ -1256,7 +1264,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
 				logrus.Debug("Handled GET /v2/ request")
 				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="https://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="%s://%s/token",service="test-service",scope="repository:test/image:pull"`, scheme, serverAddr))
 				w.WriteHeader(http.StatusUnauthorized)
 			})
 			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
@@ -1275,7 +1283,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -1302,6 +1310,8 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should return an error if GET request fails after token", func() {
 			defer ginkgo.GinkgoRecover()
+			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 			serverAddr := server.Listener.Addr().String()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
@@ -1315,7 +1325,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
 				logrus.Debug("Handled GET /v2/ request")
 				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="https://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
 				w.WriteHeader(http.StatusUnauthorized)
 			})
 			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
@@ -1339,7 +1349,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -1362,6 +1372,8 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should return an error if TLS handshake times out", func() {
 			defer ginkgo.GinkgoRecover()
+			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 			serverAddr := server.Listener.Addr().String()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
@@ -1374,8 +1386,12 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
 				logrus.Debug("Handled GET /v2/ request")
+				scheme := "https"
+				if viper.GetBool("WATCHTOWER_REGISTRY_TLS_SKIP") {
+					scheme = "http"
+				}
 				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="https://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="%s://%s/token",service="test-service",scope="repository:test/image:pull"`, scheme, serverAddr))
 				w.WriteHeader(http.StatusUnauthorized)
 			})
 			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
@@ -1397,7 +1413,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			defer cancel()
 
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -1437,7 +1453,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			_, _, err := auth.GetToken(ctx, mockContainerUnreachable, registryAuth, client)
+			_, _, _, err := auth.GetToken(ctx, mockContainerUnreachable, registryAuth, client)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.MatchRegexp("no such host|server misbehaving"))
 		})
@@ -1457,7 +1473,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			_, _, err := auth.GetToken(ctx, mockContainerInvalidImage, registryAuth, client)
+			_, _, _, err := auth.GetToken(ctx, mockContainerInvalidImage, registryAuth, client)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to parse image name"))
 		})
@@ -1477,7 +1493,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
 				logrus.Debug("Handled GET /v2/ request")
 				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="https://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
 				w.WriteHeader(http.StatusUnauthorized)
 			})
 			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
@@ -1488,13 +1504,15 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			_, _, err := auth.GetToken(ctx, mockContainerInvalidURL, registryAuth, client)
+			_, _, _, err := auth.GetToken(ctx, mockContainerInvalidURL, registryAuth, client)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to parse image name"))
 		})
 
 		ginkgo.It("should return an error if response decoding fails", func() {
 			defer ginkgo.GinkgoRecover()
+			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 			serverAddr := server.Listener.Addr().String()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
@@ -1508,7 +1526,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
 				logrus.Debug("Handled GET /v2/ request")
 				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="https://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
 				w.WriteHeader(http.StatusUnauthorized)
 			})
 			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
@@ -1526,7 +1544,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -1554,6 +1572,8 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should fall back to header when JSON decoding fails", func() {
 			defer ginkgo.GinkgoRecover()
+			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 			serverAddr := server.Listener.Addr().String()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
@@ -1567,7 +1587,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
 				logrus.Debug("Handled GET /v2/ request")
 				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="https://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
 				w.WriteHeader(http.StatusUnauthorized)
 			})
 			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
@@ -1588,7 +1608,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -1615,6 +1635,8 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should parse JSON manifest for digest extraction", func() {
 			defer ginkgo.GinkgoRecover()
+			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 			serverAddr := server.Listener.Addr().String()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
@@ -1628,7 +1650,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
 				logrus.Debug("Handled GET /v2/ request")
 				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="https://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
 				w.WriteHeader(http.StatusUnauthorized)
 			})
 			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
@@ -1649,7 +1671,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -1676,6 +1698,8 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should handle empty body error", func() {
 			defer ginkgo.GinkgoRecover()
+			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 			serverAddr := server.Listener.Addr().String()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
@@ -1689,7 +1713,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
 				logrus.Debug("Handled GET /v2/ request")
 				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="https://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
 				w.WriteHeader(http.StatusUnauthorized)
 			})
 			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
@@ -1708,7 +1732,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -1736,6 +1760,8 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should handle malformed JSON manifest", func() {
 			defer ginkgo.GinkgoRecover()
+			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 			serverAddr := server.Listener.Addr().String()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
@@ -1749,7 +1775,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
 				logrus.Debug("Handled GET /v2/ request")
 				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="https://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
 				w.WriteHeader(http.StatusUnauthorized)
 			})
 			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
@@ -1768,7 +1794,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -1836,6 +1862,8 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should parse valid JSON manifest with digest field", func() {
 			defer ginkgo.GinkgoRecover()
+			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 			serverAddr := server.Listener.Addr().String()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
@@ -1849,7 +1877,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
 				logrus.Debug("Handled GET /v2/ request")
 				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="https://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
 				w.WriteHeader(http.StatusUnauthorized)
 			})
 			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
@@ -1871,7 +1899,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -1898,6 +1926,8 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should handle JSON manifest with empty digest field", func() {
 			defer ginkgo.GinkgoRecover()
+			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 			serverAddr := server.Listener.Addr().String()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
@@ -1911,7 +1941,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
 				logrus.Debug("Handled GET /v2/ request")
 				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="https://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
 				w.WriteHeader(http.StatusUnauthorized)
 			})
 			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
@@ -1933,7 +1963,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -1961,6 +1991,8 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should handle JSON manifest without digest field", func() {
 			defer ginkgo.GinkgoRecover()
+			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 			serverAddr := server.Listener.Addr().String()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
@@ -1974,7 +2006,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
 				logrus.Debug("Handled GET /v2/ request")
 				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="https://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
 				w.WriteHeader(http.StatusUnauthorized)
 			})
 			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
@@ -1996,7 +2028,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -2024,6 +2056,8 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should handle invalid plain text digest format", func() {
 			defer ginkgo.GinkgoRecover()
+			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 			serverAddr := server.Listener.Addr().String()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
@@ -2037,7 +2071,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
 				logrus.Debug("Handled GET /v2/ request")
 				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="https://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
 				w.WriteHeader(http.StatusUnauthorized)
 			})
 			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
@@ -2058,7 +2092,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -2086,6 +2120,8 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should handle short plain text digest", func() {
 			defer ginkgo.GinkgoRecover()
+			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 			serverAddr := server.Listener.Addr().String()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
@@ -2099,7 +2135,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
 				logrus.Debug("Handled GET /v2/ request")
 				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="https://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
 				w.WriteHeader(http.StatusUnauthorized)
 			})
 			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
@@ -2120,7 +2156,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer)
@@ -2178,9 +2214,8 @@ var _ = ginkgo.Describe("Digests", func() {
 			defer redirectServer.Close()
 
 			serverAddr := server.Listener.Addr().String()
-			redirectAddr := redirectServer.Listener.Addr().
-				String()
-				// Use actual redirect server address
+			redirectAddr := redirectServer.Listener.Addr().String()
+			// Use actual redirect server address
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
 				mockID,
@@ -2191,14 +2226,14 @@ var _ = ginkgo.Describe("Digests", func() {
 			)
 
 			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
-				logrus.Debug("Handled GET /v2/ request")
-				w.Header().Set(
-					"WWW-Authenticate",
-					fmt.Sprintf(
-						`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`,
-						redirectAddr,
-					),
-				)
+				logrus.Debug("Handled GET /v2/ request - redirecting")
+				w.Header().Set("Location", fmt.Sprintf("http://%s/v2/", redirectAddr))
+				w.WriteHeader(http.StatusFound)
+			})
+			redirectMux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
+				logrus.Debug("Handled GET /v2/ request on redirect server")
+				w.Header().
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, redirectAddr))
 				w.WriteHeader(http.StatusUnauthorized)
 			})
 			redirectMux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
@@ -2233,30 +2268,18 @@ var _ = ginkgo.Describe("Digests", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(result).To(gomega.Equal(digest.NormalizeDigest(mockDigestHash)))
 		})
-	})
-
-	ginkgo.When("testing fetchDigest function directly", func() {
-		var server *httptest.Server
-		var mux *http.ServeMux
-
-		ginkgo.BeforeEach(func() {
+		ginkgo.It("should conditionally update manifest URL host only when redirected", func() {
 			defer ginkgo.GinkgoRecover()
-			mux = http.NewServeMux()
-			server = httptest.NewTLSServer(mux)
-		})
+			mux := http.NewServeMux()
+			server := httptest.NewServer(mux)
+			defer server.Close()
 
-		ginkgo.AfterEach(func() {
-			defer ginkgo.GinkgoRecover()
-			server.Close()
-		})
+			redirectMux := http.NewServeMux()
+			redirectServer := httptest.NewServer(redirectMux)
+			defer redirectServer.Close()
 
-		ginkgo.It("should handle no authentication required", func() {
-			defer ginkgo.GinkgoRecover()
-			// Use HTTP server for this test since we set TLS_SKIP
-			httpServer := httptest.NewServer(mux)
-			defer httpServer.Close()
-
-			serverAddr := httpServer.Listener.Addr().String()
+			serverAddr := server.Listener.Addr().String()
+			redirectAddr := redirectServer.Listener.Addr().String()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
 				mockID,
@@ -2266,14 +2289,26 @@ var _ = ginkgo.Describe("Digests", func() {
 				mockDigest,
 			)
 
+			// Test case 1: redirected=true, should update host
 			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
-				logrus.Debug("Handled GET /v2/ request - no auth required")
-				w.WriteHeader(http.StatusOK)
+				logrus.Debug("Handled GET /v2/ request - redirecting")
+				w.Header().Set("Location", fmt.Sprintf("http://%s/v2/", redirectAddr))
+				w.WriteHeader(http.StatusFound)
 			})
-			mux.HandleFunc(
+			redirectMux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
+				logrus.Debug("Handled GET /v2/ request on redirect server")
+				w.Header().
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, redirectAddr))
+				w.WriteHeader(http.StatusUnauthorized)
+			})
+			redirectMux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+				logrus.Debug("Handled GET /token request")
+				w.Write([]byte(`{"token": "mock-token"}`))
+			})
+			redirectMux.HandleFunc(
 				"/v2/test/image/manifests/latest",
 				func(w http.ResponseWriter, _ *http.Request) {
-					logrus.Debug("Handled GET /v2/test/image/manifests/latest - no auth")
+					logrus.Debug("Handled manifest request on redirect server")
 					w.Header().Set(digest.ContentDigestHeader, mockDigestHash)
 					w.WriteHeader(http.StatusOK)
 				},
@@ -2282,51 +2317,18 @@ var _ = ginkgo.Describe("Digests", func() {
 			ctx := context.Background()
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
-			registryAuth := auth.TransformAuth("")
+			registryAuth := auth.TransformAuth("token")
 			result, err := digest.FetchDigest(ctx, mockContainerWithServer, registryAuth)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(result).To(gomega.Equal(digest.NormalizeDigest(mockDigestHash)))
 		})
 
-		ginkgo.It("should handle manifest URL with no host", func() {
+		ginkgo.It("should not update manifest URL host when not redirected", func() {
 			defer ginkgo.GinkgoRecover()
-			// Create a mock container that would result in a URL with no host
-			// This is tricky to test directly, so we'll test the error path by mocking
-			mockContainerInvalid := mocks.CreateMockContainerWithDigest(
-				mockID,
-				mockName,
-				"invalid-url", // This should cause manifest.BuildManifestURL to fail or return URL without host
-				mockCreated,
-				mockDigest,
-			)
+			mux := http.NewServeMux()
+			server := httptest.NewServer(mux)
+			defer server.Close()
 
-			ctx := context.Background()
-			registryAuth := auth.TransformAuth("token")
-			_, err := digest.FetchDigest(ctx, mockContainerInvalid, registryAuth)
-			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).
-				To(gomega.ContainSubstring("registry responded with invalid HEAD request"))
-		})
-
-		ginkgo.It("should handle URL parsing failure", func() {
-			defer ginkgo.GinkgoRecover()
-			mockContainerInvalidURL := mocks.CreateMockContainerWithDigest(
-				mockID,
-				mockName,
-				"http://invalid url with spaces/test/image:latest", // Invalid URL
-				mockCreated,
-				mockDigest,
-			)
-
-			ctx := context.Background()
-			registryAuth := auth.TransformAuth("token")
-			_, err := digest.FetchDigest(ctx, mockContainerInvalidURL, registryAuth)
-			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to build manifest URL"))
-		})
-
-		ginkgo.It("should handle plain text 404 responses (non-JSON body)", func() {
-			defer ginkgo.GinkgoRecover()
 			serverAddr := server.Listener.Addr().String()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
@@ -2337,10 +2339,11 @@ var _ = ginkgo.Describe("Digests", func() {
 				mockDigest,
 			)
 
+			// Test case 2: redirected=false, should not update host
 			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
-				logrus.Debug("Handled GET /v2/ request")
+				logrus.Debug("Handled GET /v2/ request - no redirect")
 				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="https://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
 				w.WriteHeader(http.StatusUnauthorized)
 			})
 			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
@@ -2350,232 +2353,396 @@ var _ = ginkgo.Describe("Digests", func() {
 			mux.HandleFunc(
 				"/v2/test/image/manifests/latest",
 				func(w http.ResponseWriter, _ *http.Request) {
-					logrus.Debug(
-						"Handled GET /v2/test/image/manifests/latest with plain text 404 body",
-					)
+					logrus.Debug("Handled manifest request on original server")
+					w.Header().Set(digest.ContentDigestHeader, mockDigestHash)
 					w.WriteHeader(http.StatusOK)
-					w.Write([]byte("404 Not Found")) // Plain text non-JSON body
 				},
 			)
 
-			client := newTestAuthClient()
 			ctx := context.Background()
+			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			result, err := digest.FetchDigest(ctx, mockContainerWithServer, registryAuth)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			req.Header.Set("Authorization", "Bearer "+token)
-			req.Header.Set(
-				"Accept",
-				"application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json",
-			)
-			req.Header.Set("User-Agent", digest.UserAgent)
-
-			resp, err := client.Do(req)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			defer resp.Body.Close()
-
-			_, err = digest.ExtractGetDigest(resp)
-			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).
-				To(gomega.ContainSubstring("invalid digest format in body"))
+			gomega.Expect(result).To(gomega.Equal(digest.NormalizeDigest(mockDigestHash)))
 		})
 
-		ginkgo.It("should handle OCI image index responses with proper Content-Type", func() {
-			defer ginkgo.GinkgoRecover()
-			serverAddr := server.Listener.Addr().String()
-			mockImageRef := serverAddr + "/test/image:latest"
-			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
-				mockID,
-				mockName,
-				mockImageRef,
-				mockCreated,
-				mockDigest,
-			)
+		ginkgo.When("testing fetchDigest function directly", func() {
+			var server *httptest.Server
+			var mux *http.ServeMux
 
-			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
-				logrus.Debug("Handled GET /v2/ request")
-				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="https://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
-				w.WriteHeader(http.StatusUnauthorized)
+			ginkgo.BeforeEach(func() {
+				defer ginkgo.GinkgoRecover()
+				mux = http.NewServeMux()
+				server = httptest.NewServer(mux)
 			})
-			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
-				logrus.Debug("Handled GET /token request")
-				w.Write([]byte(`{"token": "mock-token"}`))
+
+			ginkgo.AfterEach(func() {
+				defer ginkgo.GinkgoRecover()
+				server.Close()
 			})
-			mux.HandleFunc(
-				"/v2/test/image/manifests/latest",
-				func(w http.ResponseWriter, _ *http.Request) {
-					logrus.Debug("Handled GET /v2/test/image/manifests/latest with OCI image index")
-					w.Header().Set("Content-Type", "application/vnd.oci.image.index.v1+json")
+
+			ginkgo.It("should handle no authentication required", func() {
+				defer ginkgo.GinkgoRecover()
+				// Use HTTP server for this test since we set TLS_SKIP
+				httpServer := httptest.NewServer(mux)
+				defer httpServer.Close()
+
+				serverAddr := httpServer.Listener.Addr().String()
+				mockImageRef := serverAddr + "/test/image:latest"
+				mockContainerWithServer := mocks.CreateMockContainerWithDigest(
+					mockID,
+					mockName,
+					mockImageRef,
+					mockCreated,
+					mockDigest,
+				)
+
+				mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
+					logrus.Debug("Handled GET /v2/ request - no auth required")
 					w.WriteHeader(http.StatusOK)
-					w.Write(
-						[]byte(
-							`{"digest": "sha256:ociindexdigest123456789012345678901234567890123456789012345678901234567890"}`,
-						),
-					)
-				},
-			)
+				})
+				mux.HandleFunc(
+					"/v2/test/image/manifests/latest",
+					func(w http.ResponseWriter, _ *http.Request) {
+						logrus.Debug("Handled GET /v2/test/image/manifests/latest - no auth")
+						w.Header().Set(digest.ContentDigestHeader, mockDigestHash)
+						w.WriteHeader(http.StatusOK)
+					},
+				)
 
-			client := newTestAuthClient()
-			ctx := context.Background()
-			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			req.Header.Set("Authorization", "Bearer "+token)
-			req.Header.Set(
-				"Accept",
-				"application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json",
-			)
-			req.Header.Set("User-Agent", digest.UserAgent)
-
-			resp, err := client.Do(req)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			defer resp.Body.Close()
-
-			result, err := digest.ExtractGetDigest(resp)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(result).
-				To(gomega.Equal("ociindexdigest123456789012345678901234567890123456789012345678901234567890"))
-		})
-
-		ginkgo.It("should handle invalid Content-Type headers", func() {
-			defer ginkgo.GinkgoRecover()
-			serverAddr := server.Listener.Addr().String()
-			mockImageRef := serverAddr + "/test/image:latest"
-			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
-				mockID,
-				mockName,
-				mockImageRef,
-				mockCreated,
-				mockDigest,
-			)
-
-			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
-				logrus.Debug("Handled GET /v2/ request")
-				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="https://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
-				w.WriteHeader(http.StatusUnauthorized)
+				ctx := context.Background()
+				viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+				defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+				registryAuth := auth.TransformAuth("")
+				result, err := digest.FetchDigest(ctx, mockContainerWithServer, registryAuth)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(result).To(gomega.Equal(digest.NormalizeDigest(mockDigestHash)))
 			})
-			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
-				logrus.Debug("Handled GET /token request")
-				w.Write([]byte(`{"token": "mock-token"}`))
+
+			ginkgo.It("should handle manifest URL with no host", func() {
+				defer ginkgo.GinkgoRecover()
+				// Create a mock container that would result in a URL with no host
+				// This is tricky to test directly, so we'll test the error path by mocking
+				mockContainerInvalid := mocks.CreateMockContainerWithDigest(
+					mockID,
+					mockName,
+					"invalid-url", // This should cause manifest.BuildManifestURL to fail or return URL without host
+					mockCreated,
+					mockDigest,
+				)
+
+				ctx := context.Background()
+				registryAuth := auth.TransformAuth("token")
+				_, err := digest.FetchDigest(ctx, mockContainerInvalid, registryAuth)
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err.Error()).
+					To(gomega.ContainSubstring("registry responded with invalid HEAD request"))
 			})
-			mux.HandleFunc(
-				"/v2/test/image/manifests/latest",
-				func(w http.ResponseWriter, _ *http.Request) {
-					logrus.Debug(
-						"Handled GET /v2/test/image/manifests/latest with invalid Content-Type",
-					)
-					w.Header().Set("Content-Type", "text/plain") // Invalid Content-Type for JSON
-					w.WriteHeader(http.StatusOK)
-					w.Write([]byte(`{"digest": "sha256:invalidcontenttypedigest"}`))
-				},
-			)
 
-			client := newTestAuthClient()
-			ctx := context.Background()
-			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.It("should handle URL parsing failure", func() {
+				defer ginkgo.GinkgoRecover()
+				mockContainerInvalidURL := mocks.CreateMockContainerWithDigest(
+					mockID,
+					mockName,
+					"http://invalid url with spaces/test/image:latest", // Invalid URL
+					mockCreated,
+					mockDigest,
+				)
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			req.Header.Set("Authorization", "Bearer "+token)
-			req.Header.Set(
-				"Accept",
-				"application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json",
-			)
-			req.Header.Set("User-Agent", digest.UserAgent)
-
-			resp, err := client.Do(req)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			defer resp.Body.Close()
-
-			_, err = digest.ExtractGetDigest(resp)
-			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).
-				To(gomega.ContainSubstring("unsupported content type for JSON parsing"))
-		})
-
-		ginkgo.It("should handle missing or malformed Content-Type headers", func() {
-			defer ginkgo.GinkgoRecover()
-			serverAddr := server.Listener.Addr().String()
-			mockImageRef := serverAddr + "/test/image:latest"
-			mockContainerWithServer := mocks.CreateMockContainerWithDigest(
-				mockID,
-				mockName,
-				mockImageRef,
-				mockCreated,
-				mockDigest,
-			)
-
-			mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
-				logrus.Debug("Handled GET /v2/ request")
-				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="https://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
-				w.WriteHeader(http.StatusUnauthorized)
+				ctx := context.Background()
+				registryAuth := auth.TransformAuth("token")
+				_, err := digest.FetchDigest(ctx, mockContainerInvalidURL, registryAuth)
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err.Error()).
+					To(gomega.ContainSubstring("failed to build manifest URL"))
 			})
-			mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
-				logrus.Debug("Handled GET /token request")
-				w.Write([]byte(`{"token": "mock-token"}`))
+
+			ginkgo.It("should handle plain text 404 responses (non-JSON body)", func() {
+				defer ginkgo.GinkgoRecover()
+				viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+				defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+				serverAddr := server.Listener.Addr().String()
+				mockImageRef := serverAddr + "/test/image:latest"
+				mockContainerWithServer := mocks.CreateMockContainerWithDigest(
+					mockID,
+					mockName,
+					mockImageRef,
+					mockCreated,
+					mockDigest,
+				)
+
+				mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
+					logrus.Debug("Handled GET /v2/ request")
+					w.Header().
+						Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					w.WriteHeader(http.StatusUnauthorized)
+				})
+				mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+					logrus.Debug("Handled GET /token request")
+					w.Write([]byte(`{"token": "mock-token"}`))
+				})
+				mux.HandleFunc(
+					"/v2/test/image/manifests/latest",
+					func(w http.ResponseWriter, _ *http.Request) {
+						logrus.Debug(
+							"Handled GET /v2/test/image/manifests/latest with plain text 404 body",
+						)
+						w.WriteHeader(http.StatusOK)
+						w.Write([]byte("404 Not Found")) // Plain text non-JSON body
+					},
+				)
+
+				client := newTestAuthClient()
+				ctx := context.Background()
+				registryAuth := auth.TransformAuth("token")
+				token, _, _, err := auth.GetToken(
+					ctx,
+					mockContainerWithServer,
+					registryAuth,
+					client,
+				)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				url, err := manifest.BuildManifestURL(mockContainerWithServer)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				req.Header.Set("Authorization", "Bearer "+token)
+				req.Header.Set(
+					"Accept",
+					"application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json",
+				)
+				req.Header.Set("User-Agent", digest.UserAgent)
+
+				resp, err := client.Do(req)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				defer resp.Body.Close()
+
+				_, err = digest.ExtractGetDigest(resp)
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err.Error()).
+					To(gomega.ContainSubstring("invalid digest format in body"))
 			})
-			mux.HandleFunc(
-				"/v2/test/image/manifests/latest",
-				func(w http.ResponseWriter, _ *http.Request) {
-					logrus.Debug(
-						"Handled GET /v2/test/image/manifests/latest with missing Content-Type",
-					)
-					// No Content-Type header set
-					w.WriteHeader(http.StatusOK)
-					w.Write([]byte(`{"digest": "sha256:missingcontenttypedigest"}`))
-				},
-			)
 
-			client := newTestAuthClient()
-			ctx := context.Background()
-			registryAuth := auth.TransformAuth("token")
-			token, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.It("should handle OCI image index responses with proper Content-Type", func() {
+				defer ginkgo.GinkgoRecover()
+				viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+				defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+				serverAddr := server.Listener.Addr().String()
+				mockImageRef := serverAddr + "/test/image:latest"
+				mockContainerWithServer := mocks.CreateMockContainerWithDigest(
+					mockID,
+					mockName,
+					mockImageRef,
+					mockCreated,
+					mockDigest,
+				)
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
+					logrus.Debug("Handled GET /v2/ request")
+					w.Header().
+						Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					w.WriteHeader(http.StatusUnauthorized)
+				})
+				mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+					logrus.Debug("Handled GET /token request")
+					w.Write([]byte(`{"token": "mock-token"}`))
+				})
+				mux.HandleFunc(
+					"/v2/test/image/manifests/latest",
+					func(w http.ResponseWriter, _ *http.Request) {
+						logrus.Debug(
+							"Handled GET /v2/test/image/manifests/latest with OCI image index",
+						)
+						w.Header().Set("Content-Type", "application/vnd.oci.image.index.v1+json")
+						w.WriteHeader(http.StatusOK)
+						w.Write(
+							[]byte(
+								`{"digest": "sha256:ociindexdigest123456789012345678901234567890123456789012345678901234567890"}`,
+							),
+						)
+					},
+				)
 
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				client := newTestAuthClient()
+				ctx := context.Background()
+				registryAuth := auth.TransformAuth("token")
+				token, _, _, err := auth.GetToken(
+					ctx,
+					mockContainerWithServer,
+					registryAuth,
+					client,
+				)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			req.Header.Set("Authorization", "Bearer "+token)
-			req.Header.Set(
-				"Accept",
-				"application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json",
-			)
-			req.Header.Set("User-Agent", digest.UserAgent)
+				url, err := manifest.BuildManifestURL(mockContainerWithServer)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			resp, err := client.Do(req)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			defer resp.Body.Close()
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			_, err = digest.ExtractGetDigest(resp)
-			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).
-				To(gomega.ContainSubstring("unsupported content type for JSON parsing"))
+				req.Header.Set("Authorization", "Bearer "+token)
+				req.Header.Set(
+					"Accept",
+					"application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json",
+				)
+				req.Header.Set("User-Agent", digest.UserAgent)
+
+				resp, err := client.Do(req)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				defer resp.Body.Close()
+
+				result, err := digest.ExtractGetDigest(resp)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(result).
+					To(gomega.Equal("ociindexdigest123456789012345678901234567890123456789012345678901234567890"))
+			})
+
+			ginkgo.It("should handle invalid Content-Type headers", func() {
+				defer ginkgo.GinkgoRecover()
+				viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+				defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+				serverAddr := server.Listener.Addr().String()
+				mockImageRef := serverAddr + "/test/image:latest"
+				mockContainerWithServer := mocks.CreateMockContainerWithDigest(
+					mockID,
+					mockName,
+					mockImageRef,
+					mockCreated,
+					mockDigest,
+				)
+
+				mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
+					logrus.Debug("Handled GET /v2/ request")
+					w.Header().
+						Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					w.WriteHeader(http.StatusUnauthorized)
+				})
+				mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+					logrus.Debug("Handled GET /token request")
+					w.Write([]byte(`{"token": "mock-token"}`))
+				})
+				mux.HandleFunc(
+					"/v2/test/image/manifests/latest",
+					func(w http.ResponseWriter, _ *http.Request) {
+						logrus.Debug(
+							"Handled GET /v2/test/image/manifests/latest with invalid Content-Type",
+						)
+						w.Header().
+							Set("Content-Type", "text/plain")
+							// Invalid Content-Type for JSON
+						w.WriteHeader(http.StatusOK)
+						w.Write([]byte(`{"digest": "sha256:invalidcontenttypedigest"}`))
+					},
+				)
+
+				client := newTestAuthClient()
+				ctx := context.Background()
+				registryAuth := auth.TransformAuth("token")
+				token, _, _, err := auth.GetToken(
+					ctx,
+					mockContainerWithServer,
+					registryAuth,
+					client,
+				)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				url, err := manifest.BuildManifestURL(mockContainerWithServer)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				req.Header.Set("Authorization", "Bearer "+token)
+				req.Header.Set(
+					"Accept",
+					"application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json",
+				)
+				req.Header.Set("User-Agent", digest.UserAgent)
+
+				resp, err := client.Do(req)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				defer resp.Body.Close()
+
+				_, err = digest.ExtractGetDigest(resp)
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err.Error()).
+					To(gomega.ContainSubstring("unsupported content type for JSON parsing"))
+			})
+
+			ginkgo.It("should handle missing or malformed Content-Type headers", func() {
+				defer ginkgo.GinkgoRecover()
+				viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+				defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+				serverAddr := server.Listener.Addr().String()
+				mockImageRef := serverAddr + "/test/image:latest"
+				mockContainerWithServer := mocks.CreateMockContainerWithDigest(
+					mockID,
+					mockName,
+					mockImageRef,
+					mockCreated,
+					mockDigest,
+				)
+
+				mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
+					logrus.Debug("Handled GET /v2/ request")
+					w.Header().
+						Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, serverAddr))
+					w.WriteHeader(http.StatusUnauthorized)
+				})
+				mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+					logrus.Debug("Handled GET /token request")
+					w.Write([]byte(`{"token": "mock-token"}`))
+				})
+				mux.HandleFunc(
+					"/v2/test/image/manifests/latest",
+					func(w http.ResponseWriter, _ *http.Request) {
+						logrus.Debug(
+							"Handled GET /v2/test/image/manifests/latest with missing Content-Type",
+						)
+						// No Content-Type header set
+						w.WriteHeader(http.StatusOK)
+						w.Write([]byte(`{"digest": "sha256:missingcontenttypedigest"}`))
+					},
+				)
+
+				client := newTestAuthClient()
+				ctx := context.Background()
+				registryAuth := auth.TransformAuth("token")
+				token, _, _, err := auth.GetToken(
+					ctx,
+					mockContainerWithServer,
+					registryAuth,
+					client,
+				)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				url, err := manifest.BuildManifestURL(mockContainerWithServer)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				req.Header.Set("Authorization", "Bearer "+token)
+				req.Header.Set(
+					"Accept",
+					"application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json",
+				)
+				req.Header.Set("User-Agent", digest.UserAgent)
+
+				resp, err := client.Do(req)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				defer resp.Body.Close()
+
+				_, err = digest.ExtractGetDigest(resp)
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err.Error()).
+					To(gomega.ContainSubstring("unsupported content type for JSON parsing"))
+			})
 		})
 	})
 })

--- a/pkg/registry/digest/digest_test.go
+++ b/pkg/registry/digest/digest_test.go
@@ -31,6 +31,19 @@ import (
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
+const (
+	httpScheme  = "http"
+	httpsScheme = "https"
+)
+
+func getScheme() string {
+	if viper.GetBool("WATCHTOWER_REGISTRY_TLS_SKIP") {
+		return httpScheme
+	}
+
+	return httpsScheme
+}
+
 // FuzzExtractGetDigest fuzzes the body parsing in ExtractGetDigest to test for crashes or unexpected behavior with malformed inputs.
 func FuzzExtractGetDigest(f *testing.F) {
 	// Seed with known good and bad inputs
@@ -251,7 +264,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerEmptyDigests, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerEmptyDigests)
+			url, err := manifest.BuildManifestURL(mockContainerEmptyDigests, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
@@ -319,7 +332,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
@@ -458,7 +471,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
@@ -520,7 +533,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
@@ -593,7 +606,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithInvalidDigest)
+			url, err := manifest.BuildManifestURL(mockContainerWithInvalidDigest, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
@@ -889,7 +902,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
@@ -955,7 +968,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
@@ -1023,7 +1036,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
@@ -1090,7 +1103,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
@@ -1286,7 +1299,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -1352,7 +1365,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -1416,7 +1429,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -1547,7 +1560,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -1611,7 +1624,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -1674,7 +1687,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -1735,7 +1748,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -1797,7 +1810,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -1902,7 +1915,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -1966,7 +1979,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -2031,7 +2044,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -2095,7 +2108,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -2159,7 +2172,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			token, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			url, err := manifest.BuildManifestURL(mockContainerWithServer)
+			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -2230,10 +2243,18 @@ var _ = ginkgo.Describe("Digests", func() {
 				w.Header().Set("Location", fmt.Sprintf("http://%s/v2/", redirectAddr))
 				w.WriteHeader(http.StatusFound)
 			})
+			mux.HandleFunc("/v2/test/image/manifests/latest", func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodHead {
+					w.WriteHeader(http.StatusNotFound)
+				} else {
+					w.Header().Set(digest.ContentDigestHeader, mockDigestHash)
+					w.WriteHeader(http.StatusOK)
+				}
+			})
 			redirectMux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
 				logrus.Debug("Handled GET /v2/ request on redirect server")
 				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, redirectAddr))
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="%s://%s/token",service="test-service",scope="repository:test/image:pull"`, getScheme(), redirectAddr))
 				w.WriteHeader(http.StatusUnauthorized)
 			})
 			redirectMux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
@@ -2251,7 +2272,8 @@ var _ = ginkgo.Describe("Digests", func() {
 						w.Header().Set(
 							"WWW-Authenticate",
 							fmt.Sprintf(
-								`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`,
+								`Bearer realm="%s://%s/token",service="test-service",scope="repository:test/image:pull"`,
+								getScheme(),
 								redirectAddr,
 							),
 						)
@@ -2266,7 +2288,8 @@ var _ = ginkgo.Describe("Digests", func() {
 			registryAuth := auth.TransformAuth("token")
 			result, err := digest.FetchDigest(ctx, mockContainerWithServer, registryAuth)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(result).To(gomega.Equal(digest.NormalizeDigest(mockDigestHash)))
+			gomega.Expect(result).
+				To(gomega.Equal("d68e1e532088964195ad3a0a71526bc2f11a78de0def85629beb75e2265f0547"))
 		})
 		ginkgo.It("should conditionally update manifest URL host only when redirected", func() {
 			defer ginkgo.GinkgoRecover()
@@ -2295,10 +2318,18 @@ var _ = ginkgo.Describe("Digests", func() {
 				w.Header().Set("Location", fmt.Sprintf("http://%s/v2/", redirectAddr))
 				w.WriteHeader(http.StatusFound)
 			})
+			mux.HandleFunc("/v2/test/image/manifests/latest", func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodHead {
+					w.WriteHeader(http.StatusNotFound)
+				} else {
+					w.Header().Set(digest.ContentDigestHeader, mockDigestHash)
+					w.WriteHeader(http.StatusOK)
+				}
+			})
 			redirectMux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
 				logrus.Debug("Handled GET /v2/ request on redirect server")
 				w.Header().
-					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="http://%s/token",service="test-service",scope="repository:test/image:pull"`, redirectAddr))
+					Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="%s://%s/token",service="test-service",scope="repository:test/image:pull"`, getScheme(), redirectAddr))
 				w.WriteHeader(http.StatusUnauthorized)
 			})
 			redirectMux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
@@ -2320,7 +2351,8 @@ var _ = ginkgo.Describe("Digests", func() {
 			registryAuth := auth.TransformAuth("token")
 			result, err := digest.FetchDigest(ctx, mockContainerWithServer, registryAuth)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(result).To(gomega.Equal(digest.NormalizeDigest(mockDigestHash)))
+			gomega.Expect(result).
+				To(gomega.Equal("d68e1e532088964195ad3a0a71526bc2f11a78de0def85629beb75e2265f0547"))
 		})
 
 		ginkgo.It("should not update manifest URL host when not redirected", func() {
@@ -2505,7 +2537,7 @@ var _ = ginkgo.Describe("Digests", func() {
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				url, err := manifest.BuildManifestURL(mockContainerWithServer)
+				url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -2579,7 +2611,7 @@ var _ = ginkgo.Describe("Digests", func() {
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				url, err := manifest.BuildManifestURL(mockContainerWithServer)
+				url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -2651,7 +2683,7 @@ var _ = ginkgo.Describe("Digests", func() {
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				url, err := manifest.BuildManifestURL(mockContainerWithServer)
+				url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -2721,7 +2753,7 @@ var _ = ginkgo.Describe("Digests", func() {
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				url, err := manifest.BuildManifestURL(mockContainerWithServer)
+				url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)

--- a/pkg/registry/digest/digest_test.go
+++ b/pkg/registry/digest/digest_test.go
@@ -2243,14 +2243,17 @@ var _ = ginkgo.Describe("Digests", func() {
 				w.Header().Set("Location", fmt.Sprintf("http://%s/v2/", redirectAddr))
 				w.WriteHeader(http.StatusFound)
 			})
-			mux.HandleFunc("/v2/test/image/manifests/latest", func(w http.ResponseWriter, r *http.Request) {
-				if r.Method == http.MethodHead {
-					w.WriteHeader(http.StatusNotFound)
-				} else {
-					w.Header().Set(digest.ContentDigestHeader, mockDigestHash)
-					w.WriteHeader(http.StatusOK)
-				}
-			})
+			mux.HandleFunc(
+				"/v2/test/image/manifests/latest",
+				func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodHead {
+						w.WriteHeader(http.StatusNotFound)
+					} else {
+						w.Header().Set(digest.ContentDigestHeader, mockDigestHash)
+						w.WriteHeader(http.StatusOK)
+					}
+				},
+			)
 			redirectMux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
 				logrus.Debug("Handled GET /v2/ request on redirect server")
 				w.Header().
@@ -2318,14 +2321,17 @@ var _ = ginkgo.Describe("Digests", func() {
 				w.Header().Set("Location", fmt.Sprintf("http://%s/v2/", redirectAddr))
 				w.WriteHeader(http.StatusFound)
 			})
-			mux.HandleFunc("/v2/test/image/manifests/latest", func(w http.ResponseWriter, r *http.Request) {
-				if r.Method == http.MethodHead {
-					w.WriteHeader(http.StatusNotFound)
-				} else {
-					w.Header().Set(digest.ContentDigestHeader, mockDigestHash)
-					w.WriteHeader(http.StatusOK)
-				}
-			})
+			mux.HandleFunc(
+				"/v2/test/image/manifests/latest",
+				func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodHead {
+						w.WriteHeader(http.StatusNotFound)
+					} else {
+						w.Header().Set(digest.ContentDigestHeader, mockDigestHash)
+						w.WriteHeader(http.StatusOK)
+					}
+				},
+			)
 			redirectMux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
 				logrus.Debug("Handled GET /v2/ request on redirect server")
 				w.Header().

--- a/pkg/registry/manifest/manifest_test.go
+++ b/pkg/registry/manifest/manifest_test.go
@@ -136,5 +136,11 @@ func buildMockContainerManifestURL(imageRef string) (string, error) {
 		imageInfo,
 	)
 
-	return manifest.BuildManifestURL(mock)
+	// Determine scheme based on WATCHTOWER_REGISTRY_TLS_SKIP.
+	scheme := "https"
+	if viper.GetBool("WATCHTOWER_REGISTRY_TLS_SKIP") {
+		scheme = "http"
+	}
+
+	return manifest.BuildManifestURL(mock, scheme)
 }


### PR DESCRIPTION
This PR fixes a regression in version 1.12.0 where digest retrieval was failing with "registry responded with invalid HEAD request: status 404 Not Found" for many containers, causing watchtower to fall back to expensive full image pulls. The issue was caused by improper handling of HTTP redirects during authentication and manifest requests.

### Changes

- **pkg/registry/auth/auth.go**: Added redirect detection to `GetToken()` and `handleBearerAuth()`, special handling for lscr.io registry authentication to avoid regression, added `LSCRRegistry` constant
- **pkg/registry/auth/auth_test.go**: Updated tests to handle new return values, added test cases for redirect scenarios
- **pkg/registry/digest/digest.go**: Refactored manifest URL building, added redirect handling in `handleManifestResponse()`, special case for lscr.io host override to avoid regression
- **pkg/registry/digest/digest_test.go**: Updated tests for new function signatures, added comprehensive redirect test cases
- **pkg/registry/manifest/manifest.go**: Modified `BuildManifestURL()` to accept explicit scheme parameter
- **pkg/registry/manifest/manifest_test.go**: Updated test to pass scheme parameter