### PR TITLE
fix(api): prevent I/O blocking in API update handler

### DIFF
--- a/pkg/api/update/update.go
+++ b/pkg/api/update/update.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -68,8 +67,8 @@ func (handle *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 		"path":   r.URL.Path,
 	}).Info("Received HTTP API update request")
 
-	// Log request body to stdout for debugging.
-	_, err := io.Copy(os.Stdout, r.Body)
+	// Discard request body to prevent I/O blocking in tests and CI environments.
+	_, err := io.Copy(io.Discard, r.Body)
 	if err != nil {
 		logrus.WithError(err).Debug("Failed to read request body")
 		http.Error(w, "Failed to read request body", http.StatusInternalServerError)


### PR DESCRIPTION
Fixed I/O blocking in the HTTP API update handler that was causing `TestConcurrentScheduledAndAPIUpdate` to timeout after 10 minutes in CI environments. The handler was attempting to copy the request body to stdout, which blocks when stdout is piped in test/CI environments.

# Changes
- **pkg/api/update/update.go**:
  - Replaced `io.Copy(os.Stdout, r.Body)` with `io.Copy(io.Discard, r.Body)` to safely discard the request body
  - Removed unused `"os"` import
  - Updated comment from "Log request body to stdout for debugging" to "Discard request body to prevent I/O blocking in tests and CI environments"