### PR TITLE
ci(test); add latest version checking

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-go@c0137caad775660c0844396c52da96e560aba63d
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
           cache: true
           cache-dependency-path: "**/go.sum"
 


### PR DESCRIPTION
This PR is meant to help alleviate issues when Go's patch version is updated.

## Changes
- Add option to check for latest Go version
