### PR TITLE
ci: add check-latest to Go setup in workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@c0137caad775660c0844396c52da96e560aba63d
         with:
+          check-latest: true
           go-version: 1.25.x
 
       - name: Set up QEMU # Enable multi-platform emulation.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,6 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@c0137caad775660c0844396c52da96e560aba63d
         with:
+          check-latest: true
           go-version: ${{ env.GO_VERSION }}
 
       - name: Install dependencies

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -34,6 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@c0137caad775660c0844396c52da96e560aba63d
         with:
+          check-latest: true
           go-version: ${{ env.GO_VERSION }}
 
       - name: Set executable permissions for script

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,8 +28,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@c0137caad775660c0844396c52da96e560aba63d
         with:
-          go-version: ${{ matrix.go-version }}
           check-latest: true
+          go-version: ${{ matrix.go-version }}
           cache: true
           cache-dependency-path: "**/go.sum"
 


### PR DESCRIPTION
This PR is a continuation of a previous change that adds the 'check-latest: true' option to the setup-go step to alleviate issues when the Go patch version has been updated.

## Changes
- Adds the 'check-latest: true' option to the setup-go step in build, lint, publish-docs, and test GitHub Actions workflows to ensure the latest compatible Go version is used.