### PR TITLE
fix(notifications): make Close() method idempotent to prevent panic on multiple calls

### DIFF
--- a/pkg/notifications/shoutrrr_test.go
+++ b/pkg/notifications/shoutrrr_test.go
@@ -666,7 +666,7 @@ func sendNotificationsWithBlockingRouter(legacy bool) (*shoutrrrTypeNotifier, *b
 	shoutrrr := &shoutrrrTypeNotifier{
 		template:       tpl,
 		messages:       make(chan string, 1),
-		done:           make(chan bool),
+		done:           make(chan struct{}),
 		Router:         router,
 		legacyTemplate: legacy,
 		params:         &types.Params{},

--- a/pkg/registry/auth/auth_test.go
+++ b/pkg/registry/auth/auth_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/image"
@@ -1066,7 +1067,11 @@ var _ = ginkgo.Describe("the auth module", func() {
 		// Test case: Tests GetBearerHeader’s error handling when the HTTP request fails
 		// (e.g., due to an unreachable host). Ensures proper error propagation.
 		ginkgo.It("should fail on HTTP request error", func() {
-			client := auth.NewAuthClient()
+			client := &testAuthClient{
+				client: &http.Client{
+					Timeout: 1 * time.Second,
+				},
+			}
 			challenge := `bearer realm="http://nonexistent.local/token",service="test-service",scope="repository:test/image:pull"`
 			ref, _ := reference.ParseNormalizedNamed("test/image")
 			token, err := auth.GetBearerHeader(context.Background(), challenge, ref, "", client)


### PR DESCRIPTION
This pull request addresses a bug where the application crashes with a "close of closed channel" error during cleanup after successful update sessions.

## Problem

The application crashes with a "close of closed channel" panic in `shoutrrrTypeNotifier.Close()` when the method is called multiple times. This occurs because the `Close()` method attempts to close the `messages` channel each time it's invoked, but Go channels can only be closed once. The issue arises from duplicate `Close()` calls: one deferred in `RunUpdatesWithNotifications()` and another explicit call in `cmd/root.go`, leading to the panic during cleanup after successful update sessions.

## Solution

Make the `Close()` method idempotent by using `sync.Once` to ensure the close logic executes only once, regardless of how many times the method is called. Additionally, use atomic operations for thread-safe access to the `receiving` and `closed` flags, and add graceful handling in `sendEntries()` and `Fire()` to skip operations when the notifier is closed. Unit tests were added to verify idempotency, concurrent calls, and post-close behavior.

## Changes

- Modified `shoutrrrTypeNotifier` struct to use atomic uint32 for `receiving` and `closed` fields, and added `closeOnce sync.Once`
- Updated `AddLogHook()` to use atomic store for `receiving`
- Enhanced `sendEntries()` with select/default to handle closed channels gracefully
- Made `Close()` idempotent with `sync.Once` and atomic operations
- Added closed check in `Fire()` to skip operations after close
- Added unit tests for Close() idempotency, concurrent calls, and post-close operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust, thread-safe notifier shutdown: idempotent close, reliable stop signaling, and prevention of panics/races.
  * Improved queuing and backpressure handling so messages are skipped or logged instead of blocking or being dropped unpredictably.
  * Operations after notifier closure are safely no-ops and return predictable results.

* **Tests**
  * Expanded tests covering concurrent shutdown, repeated Close calls, and post-close behavior of notifier operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->