### PR TITLE
ci: remove go lint step in favor of golangci-lint --fix

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,7 @@
 name: Lint
 
 on:
+  workflow_dispatch:
   workflow_call:
 
 permissions:
@@ -31,12 +32,8 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@14973f18c82b6d66679563f71666ccee11907cb2
         with:
-          args: --timeout=5m
-
-      - name: Format Go code
-        run: |
-          go fmt ./...
+          args: --timeout=5m --fix
 
       - name: Check for uncommitted changes after formatting
         run: |
-          git diff --exit-code || (echo "Detected unformatted files. Run 'go fmt' to format your code."; exit 1)
+          git diff --exit-code || (echo "Detected unformatted files. Run 'make fmt' to format your code."; exit 1)


### PR DESCRIPTION
- Add workflow dispatch trigger
- Add `--fix` argument to golangci-lint step
- Remove redundant `go fmt` step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced lint workflow with manual trigger capability.
  * Streamlined code formatting and linting process into a single automated step.
  * Updated formatting instructions in workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->