### PR TITLE
ci: Disable GITHUB_TOKEN in release-dev.yaml

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -76,7 +76,7 @@ jobs:
         env:
           OUTPUT: CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ secrets.CHANGELOG_PAT }}
+          # GITHUB_TOKEN: ${{ secrets.CHANGELOG_PAT }}
 
       - name: Create Pull Request for Changelog
         if: ${{ !fromJson(inputs.dry-run || 'false') }}


### PR DESCRIPTION
- Comment out the GITHUB_TOKEN line in the release workflow to test resolving duplicate auth header issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes in this release. This pull request contains internal workflow configuration updates only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->