### PR TITLE
ci: disable persist-credentials in release workflows

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -59,6 +59,7 @@ jobs:
         uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
@@ -76,7 +77,6 @@ jobs:
         env:
           OUTPUT: CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}
-          # GITHUB_TOKEN: ${{ secrets.CHANGELOG_PAT }}
 
       - name: Create Pull Request for Changelog
         if: ${{ !fromJson(inputs.dry-run || 'false') }}

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -35,6 +35,7 @@ jobs:
         with:
           ref: 'main'
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
@@ -52,7 +53,6 @@ jobs:
         env:
           OUTPUT: CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ secrets.CHANGELOG_PAT }}
 
       - name: Create Pull Request for Changelog
         if: ${{ !fromJson(inputs.dry-run || 'false') }}


### PR DESCRIPTION
- Disable persisting of credentials
- Remove github_token env var

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved credential handling security in automated release workflows by restricting credential persistence during checkout operations.
  * Updated authentication configuration in release processes to use dedicated token management for improved security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->