### PR TITLE
Fix notification template error by removing redundant conditional logic

### DIFF
--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -41,7 +41,6 @@ func NewNotifier(c *cobra.Command) types.Notifier {
 
 	// Extract notification settings.
 	reportTemplate, _ := flag.GetBool("notification-report")
-	notificationSplitByContainer, _ := flag.GetBool("notification-split-by-container")
 	stdout, _ := flag.GetBool("notification-log-stdout")
 	tplString, _ := flag.GetString("notification-template")
 	urls, _ := flag.GetStringArray("notification-url")
@@ -49,13 +48,8 @@ func NewNotifier(c *cobra.Command) types.Notifier {
 	data := GetTemplateData(c)
 	urls, delay := AppendLegacyUrls(urls, c)
 
-	// Non-split notifications use legacy template unless report template is enabled.
-	// Split notifications use the report template when reportTemplate is true,
-	// otherwise fall back to legacy.
+	// Use report template when enabled, otherwise use legacy template.
 	legacy := !reportTemplate
-	if !notificationSplitByContainer && !reportTemplate {
-		legacy = true
-	}
 
 	clog.WithFields(logrus.Fields{
 		"urls":        urls,


### PR DESCRIPTION
Fix notification template error by removing redundant conditional logic.

## Problem

When `--notification-report` is enabled but `--notification-split-by-container` is not (default), report templates fail with "can't evaluate field Report in type []*logrus.Entry" because the code forces legacy template mode regardless of the report flag.

## Solution

Remove the redundant conditional logic that was unnecessarily forcing legacy mode. The effective logic should simply be: use report template when enabled, otherwise use legacy template. The split-by-container flag should only affect notification delivery, not template mode selection.

## Changes

- Updated `pkg/notifications/notifier.go` to remove redundant conditional logic and simplify template mode determination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified notification template selection by consolidating configuration dependencies and removing unnecessary flag logic.

* **Chores**
  * Cleaned up notification configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->