### PR TITLE
ci(golangci-lint): Exclude revive linter for api packages

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -217,6 +217,15 @@ linters:
         linters:
           - revive
         text: "avoid meaningless package names"
+      # Exclude revive from flagging the api package's name.
+      - path: "internal/api/.*"
+        linters:
+          - revive
+        text: "avoid meaningless package names"
+      - path: "pkg/api/.*"
+        linters:
+          - revive
+        text: "avoid meaningless package names"
       - path: "doc.go$"
         linters:
           - dupword


### PR DESCRIPTION
Added exclusions for revive linter on api packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality linting configuration to refine exclusion rules for API packages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->