### PR TITLE
fix(container): Fix UTS mode hostname conflict during container recreation

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -285,6 +285,10 @@ func (c Container) GetCreateConfig() *dockerContainerType.Config {
 		config.Hostname = "" // Clear hostname for container network mode.
 	}
 
+	if hostConfig.UTSMode != "" {
+		config.Hostname = "" // Clear hostname for UTS mode.
+	}
+
 	if util.SliceEqual(config.Entrypoint, imageConfig.Entrypoint) {
 		config.Entrypoint = nil
 		if util.SliceEqual(config.Cmd, imageConfig.Cmd) {

--- a/pkg/container/container_mock_test.go
+++ b/pkg/container/container_mock_test.go
@@ -245,6 +245,40 @@ func WithNetworks(networkNames ...string) MockContainerUpdate {
 	}
 }
 
+// WithUTSMode sets the UTS mode for the mock container.
+//
+// Parameters:
+//   - mode: UTS mode to set (e.g., "host").
+//
+// Returns:
+//   - MockContainerUpdate: Function to set UTS mode in container HostConfig.
+func WithUTSMode(mode string) MockContainerUpdate {
+	return func(c *dockerContainerType.InspectResponse, _ *dockerImageType.InspectResponse) {
+		if c.HostConfig == nil {
+			c.HostConfig = &dockerContainerType.HostConfig{}
+		}
+
+		c.HostConfig.UTSMode = dockerContainerType.UTSMode(mode)
+	}
+}
+
+// WithHostname sets the hostname for the mock container.
+//
+// Parameters:
+//   - hostname: Hostname to set.
+//
+// Returns:
+//   - MockContainerUpdate: Function to set hostname in container Config.
+func WithHostname(hostname string) MockContainerUpdate {
+	return func(c *dockerContainerType.InspectResponse, _ *dockerImageType.InspectResponse) {
+		if c.Config == nil {
+			c.Config = &dockerContainerType.Config{}
+		}
+
+		c.Config.Hostname = hostname
+	}
+}
+
 // MockClient is a mock implementation of the Operations interface for testing container operations.
 type MockClient struct {
 	createFunc  func(context.Context, *dockerContainerType.Config, *dockerContainerType.HostConfig, *dockerNetworkType.NetworkingConfig, *ocispec.Platform, string) (dockerContainerType.CreateResponse, error)

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -148,6 +148,28 @@ var _ = ginkgo.Describe("Container", func() {
 					Retries:     2,
 				}))
 		})
+
+		ginkgo.Context("UTS mode hostname handling", func() {
+			ginkgo.It("clears hostname when UTS mode is non-empty", func() {
+				c := MockContainer(
+					WithUTSMode("host"),
+					WithHostname("test-hostname"),
+				)
+				config := c.GetCreateConfig()
+				gomega.Expect(config.Hostname).
+					To(gomega.Equal(""), "Hostname should be cleared when UTS mode is set")
+			})
+
+			ginkgo.It("preserves hostname when UTS mode is empty", func() {
+				c := MockContainer(
+					WithUTSMode(""),
+					WithHostname("test-hostname"),
+				)
+				config := c.GetCreateConfig()
+				gomega.Expect(config.Hostname).
+					To(gomega.Equal("test-hostname"), "Hostname should be preserved when UTS mode is empty")
+			})
+		})
 	})
 
 	ginkgo.Describe("Metadata Retrieval", func() {


### PR DESCRIPTION
When Watchtower recreates containers with UTS mode set (e.g., `uts: host`), it previously copied the hostname from the existing container, causing a Docker daemon error due to conflicting options. This fix clears the hostname when UTS mode is configured, preventing the conflict and allowing successful container updates.

## Problem

Containers configured with UTS mode (e.g., `uts: host`) share the host's UTS namespace, making hostname inheritance automatic. Watchtower's container recreation logic copied the hostname from the existing container's config, but Docker rejects requests specifying both a custom hostname and UTS mode, resulting in "conflicting options: hostname and the UTS mode" errors.

## Solution

Add hostname clearing logic in the `GetCreateConfig()` method when UTS mode is non-empty, similar to the existing network mode handling. This ensures only UTS mode is passed to Docker during recreation, avoiding the conflict.

## Changes

- **pkg/container/container.go**: Add hostname clearing for UTS mode in `GetCreateConfig()`
- **pkg/container/container_test.go**: Add unit tests for UTS mode hostname handling
- **pkg/container/container_mock_test.go**: Add mock helpers for UTS mode and hostname configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Container hostname is now properly cleared when UTS mode is explicitly set, consistent with existing network mode behavior.

* **Tests**
  * Added test coverage for hostname behavior with different UTS mode configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->