### PR TITLE
fix(container): refine MAC address validation logging messages

### DIFF
--- a/pkg/container/container_source.go
+++ b/pkg/container/container_source.go
@@ -521,14 +521,14 @@ func validateMacAddresses(
 		// Running containers should have MAC addresses, but absence may indicate
 		// either a lack of support or a configuration issue.
 		clog.WithField("state", containerState).
-			Debug("No MAC address for running container in non-host network")
+			Debug("No MAC address found in non-host network config")
 
 		return errNoMacInNonHost
 	}
 
 	// MAC address found in a running container with a modern API; this is the expected case.
 	// Log at debug level to confirm successful validation.
-	clog.Debug("MAC address validation passed for running container")
+	clog.Debug("MAC address validation passed")
 
 	return nil
 }

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -857,8 +857,7 @@ var _ = ginkgo.Describe("Container", func() {
 				err := validateMacAddresses(config, container.ID(), "1.49", false, container)
 				gomega.Expect(err).To(gomega.Equal(errNoMacInNonHost))
 				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring(
-					"No MAC address for running container in non-host network"))
-				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("state=running"))
+					"No MAC address found in non-host network config"))
 				gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("state=running"))
 			},
 		)
@@ -930,7 +929,7 @@ var _ = ginkgo.Describe("Container", func() {
 			gomega.Expect(logOutput.String()).
 				To(gomega.ContainSubstring("MAC address found in network configuration"))
 			gomega.Expect(logOutput.String()).
-				To(gomega.ContainSubstring("MAC address validation passed for running container"))
+				To(gomega.ContainSubstring("MAC address validation passed"))
 		})
 
 		ginkgo.It("returns nil and logs debug for nil container state", func() {


### PR DESCRIPTION
Improve MAC address validation logging to use debug level instead of warning for expected behavior.

## Problem
Users reported a warning message "Negotiated API version 1.51 is at least 1.44 but no MAC address found; preservation may not be supported" appearing during normal container updates, causing unnecessary alarm as this is expected behavior for containers without explicit MAC addresses.

## Solution
Change the logging level from WARN to DEBUG for running containers without MAC addresses, as this indicates expected behavior rather than an error. Refine related debug messages for clarity and consistency.

## Changes
- Modified `validateMacAddresses` in `pkg/container/container_source.go` to log at DEBUG level instead of WARN for missing MAC addresses in running containers.
- Updated debug messages throughout the function for better clarity.
- Adjusted test cases in `pkg/container/container_test.go` to expect DEBUG level logging and updated message expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified and standardized MAC address validation messages for better readability.
  * Reduced logging noise by lowering verbosity of non-critical/diagnostic messages.

* **Tests**
  * Updated tests and expectations to align with revised log wording and adjusted log levels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->