### PR TITLE
fix(flags): resolve notification URL parsing regression with comma handling

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -943,7 +943,7 @@ func getSecretFromFile(flags *pflag.FlagSet, secret string) error {
 
 				scanner := bufio.NewScanner(file)
 				for scanner.Scan() {
-					line := scanner.Text()
+					line := strings.TrimSpace(scanner.Text())
 					if line != "" {
 						values = append(values, line)
 					}

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -346,7 +346,19 @@ func TestGetSecretsFromFiles(t *testing.T) {
 				{"urls.txt", "entry1\n\nentry2\n  \nentry3"},
 			},
 			flagName: "notification-url",
-			expected: "[entry1,entry2,\"  \",entry3]",
+			expected: "[entry1,entry2,entry3]",
+			args:     []string{"--notification-url", "urls.txt"},
+		},
+		{
+			name: "urls with trailing newlines",
+			files: []struct{ path, content string }{
+				{
+					"urls.txt",
+					"telegram://1234567890:AAEJ_AAAAABBBBBccccccccdddddddd@telegram/?channels=123456789&parseMode=html\nsmtp://test\n",
+				},
+			},
+			flagName: "notification-url",
+			expected: "[telegram://1234567890:AAEJ_AAAAABBBBBccccccccdddddddd@telegram/?channels=123456789&parseMode=html,smtp://test]",
 			args:     []string{"--notification-url", "urls.txt"},
 		},
 		{


### PR DESCRIPTION
This pull request fixes a critical regression in Watchtower's notification URL parsing that was introduced in version 1.12.4. Users reported fatal errors when using notification URLs that contained commas or had trailing whitespace/newlines. The issue occurred because the URL parsing logic incorrectly split URLs at commas, breaking legitimate URLs into multiple invalid fragments, and failed to trim whitespace from URLs read from secret files, causing Shoutrrr parsing failures and fatal errors during Watchtower startup, as reported in GitHub Issue #1067.

## Problem

Watchtower 1.12.4 introduced a regression where:
- Notification URLs containing commas (e.g., SMTP URLs with multiple recipients separated by commas in query parameters like `smtp://user:pass@host:port/?to=user1@example.com,user2@example.com`) were incorrectly split into separate URL fragments.
- URLs read from secret files with trailing whitespace or newlines (e.g., `telegram://1234567890:AAEJ_AAAAABBBBBccccccccdddddddd@telegram/?channels=123456789&parseMode=html\n`) were not trimmed, leading to invalid URLs passed to Shoutrrr.

This broke existing user configurations that relied on legitimate comma usage or file-based URL configuration.

## Solution

Replace the simple regex-based splitting with a delimiter-aware parsing function that tracks whether parts were separated by commas or spaces. Implement conditional recombination logic that only recombines URL fragments when they were originally split on commas, preserving URLs containing commas while maintaining proper separation for multiple URLs. Add robust URL validation with appropriate error handling and logging to ensure malformed URLs are handled gracefully. Additionally, trim whitespace from lines read from secret files to handle trailing newlines and spaces.

## Changes

- **internal/flags/flags.go**: 
  - Add `splitNotificationValues()` function with delimiter-aware parsing logic
  - Update notification-url flag registration to use the new parsing function
  - Trim whitespace from lines in `getSecretFromFile` to handle trailing newlines and spaces

- **internal/flags/flags_test.go**:
  - Add `TestNotificationURLParsingComprehensive` with 35+ test cases
  - Cover all Shoutrrr services (SMTP, Slack, Gotify, Discord, Teams, Generic)
  - Test all separator combinations and edge cases (IPv6, encoded chars, long URLs)
  - Ensure URLs with commas are preserved while maintaining proper splitting behavior
  - Update test case "empty lines" to reflect trimmed behavior
  - Add test case "urls with trailing newlines" including the Telegram URL from GitHub issue #1067

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification URL parsing to accept comma and space separators, recombine fragmented segments, validate URLs, and log warnings for malformed entries.
  * More robust handling of environment-provided notification lists to avoid empty or invalid entries.
  * Trim whitespace when reading secret values from files to prevent spurious empty or malformed entries.

* **Tests**
  * Expanded and consolidated test coverage for notification parsing (mixed separators, invalid values, edge cases), environment-variable flag handling, TLS/host edge cases, logging formats, secret-from-file scenarios, and related flag behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->