### PR TITLE
ci: correct actionlint issues in create-manifests.yaml

### DIFF
--- a/.github/workflows/create-manifests.yaml
+++ b/.github/workflows/create-manifests.yaml
@@ -65,8 +65,8 @@ jobs:
           # Strip the 'v' prefix from inputs.version
           VERSION="${{ inputs.version }}"
           VERSION="${VERSION#v}"
-          MAJOR=`echo $VERSION | cut -d. --fields=1`
-          MINOR=`echo $VERSION | cut -d. --fields=1,2`
+          MAJOR=$(echo "$VERSION" | cut -d. --fields=1)
+          MINOR=$(echo "$VERSION" | cut -d. --fields=1,2)
           docker buildx imagetools create -t "nickfedor/watchtower:${VERSION}" \
             "nickfedor/watchtower:amd64-${VERSION}" \
             "nickfedor/watchtower:i386-${VERSION}" \


### PR DESCRIPTION
- Replace legacy backticks with $(...) syntax in shell commands
- Quote $VERSION variable to prevent globbing and word splitting