### PR TITLE
Fix Notification Propagation for Startup Failures

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -633,6 +633,8 @@ func logNotify(msg string, err error) {
 	}
 
 	logrus.WithError(err).Error(msg)
+	notifier.StartNotification(false)
+	notifier.SendNotification(nil)
 	notifier.Close()
 }
 


### PR DESCRIPTION
## Pull Request: 
Ensures that critical startup errors like sanity check failures are properly communicated via notifications before Watchtower exits, improving visibility into configuration issues.

## Problem

Sanity check failures (such as dependency conflicts when using `--rolling-restart` with linked containers) were only logged to stderr but not sent as notifications to configured channels. This made it difficult to monitor and respond to configuration errors that prevent Watchtower from starting properly.

## Solution

Modified the `logNotify` function in `cmd/root.go` to start a notification session and send pending notifications before closing the notifier. This ensures that errors logged via the notification system's logrus hook are properly transmitted to external services (Gotify, Slack, etc.) before process termination.

## Changes

- **cmd/root.go**: Added notification initialization and sending in `logNotify` function
  - `notifier.StartNotification(false)` - Starts notification session for error propagation
  - `notifier.SendNotification(nil)` - Sends queued error notifications before shutdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error notification delivery to ensure notifications are reliably sent when system errors are encountered, enhancing error visibility and system responsiveness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->