### PR TITLE
Fix HTTP API Startup Message Suppression

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -378,6 +378,7 @@ func run(c *cobra.Command, normalizedNames []string) {
 	enableUpdateAPI, _ := c.PersistentFlags().GetBool("http-api-update")
 	enableMetricsAPI, _ := c.PersistentFlags().GetBool("http-api-metrics")
 	unblockHTTPAPI, _ := c.PersistentFlags().GetBool("http-api-periodic-polls")
+	noStartupMessage, _ := c.PersistentFlags().GetBool("no-startup-message")
 	apiToken, _ := c.PersistentFlags().GetString("http-api-token")
 	healthCheck, _ := c.PersistentFlags().GetBool("health-check")
 
@@ -429,6 +430,7 @@ func run(c *cobra.Command, normalizedNames []string) {
 		EnableUpdateAPI:  enableUpdateAPI,
 		EnableMetricsAPI: enableMetricsAPI,
 		UnblockHTTPAPI:   unblockHTTPAPI,
+		NoStartupMessage: noStartupMessage,
 		APIToken:         apiToken,
 		APIHost:          apiHost,
 		APIPort:          apiPort,
@@ -620,7 +622,7 @@ func runMain(cfg config.RunConfig) int {
 	defer cancel()
 
 	// Configure and start the HTTP API, handling any startup errors.
-	if err := api.SetupAndStartAPI(ctx, cfg.APIHost, cfg.APIPort, cfg.APIToken, cfg.EnableUpdateAPI, cfg.EnableMetricsAPI, cfg.UnblockHTTPAPI, cfg.Filter, cfg.Command, cfg.FilterDesc, updateLock, cleanup, client, notifier, scope, meta.Version, runUpdatesWithNotifications, filters.FilterByImage, metrics.Default, logging.WriteStartupMessage); err != nil {
+	if err := api.SetupAndStartAPI(ctx, cfg.APIHost, cfg.APIPort, cfg.APIToken, cfg.EnableUpdateAPI, cfg.EnableMetricsAPI, cfg.UnblockHTTPAPI, cfg.NoStartupMessage, cfg.Filter, cfg.Command, cfg.FilterDesc, updateLock, cleanup, client, notifier, scope, meta.Version, runUpdatesWithNotifications, filters.FilterByImage, metrics.Default, logging.WriteStartupMessage); err != nil {
 		return 1
 	}
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -44,6 +44,7 @@ func GetAPIAddr(host, port string) string {
 //   - enableUpdateAPI: Enables the HTTP update API endpoint.
 //   - enableMetricsAPI: Enables the HTTP metrics API endpoint.
 //   - unblockHTTPAPI: Allows periodic polling alongside the HTTP API.
+//   - noStartupMessage: Suppresses startup messages if true.
 //   - filter: The types.Filter determining which containers are targeted for updates.
 //   - command: The cobra.Command instance representing the executed command.
 //   - filterDesc: A human-readable description of the applied filter.
@@ -63,7 +64,7 @@ func GetAPIAddr(host, port string) string {
 func SetupAndStartAPI(
 	ctx context.Context,
 	apiHost, apiPort, apiToken string,
-	enableUpdateAPI, enableMetricsAPI, unblockHTTPAPI bool,
+	enableUpdateAPI, enableMetricsAPI, unblockHTTPAPI, noStartupMessage bool,
 	filter types.Filter,
 	command *cobra.Command,
 	filterDesc string,
@@ -125,7 +126,7 @@ func SetupAndStartAPI(
 	}
 
 	// Start the API server, logging errors unless it's a clean shutdown.
-	if err := httpAPI.Start(ctx, enableUpdateAPI && !unblockHTTPAPI); err != nil &&
+	if err := httpAPI.Start(ctx, enableUpdateAPI && !unblockHTTPAPI, noStartupMessage); err != nil &&
 		!errors.Is(err, http.ErrServerClosed) {
 		logrus.WithError(err).Error("Failed to start API")
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -90,7 +90,7 @@ var _ = ginkgo.Describe("SetupAndStartAPI", func() {
 			err := apiPkg.SetupAndStartAPI(
 				timeoutCtx,
 				"", "0", "test-token",
-				true, false, false,
+				true, false, false, false,
 				filters.NoFilter,
 				cmd,
 				"test filter",
@@ -147,7 +147,7 @@ var _ = ginkgo.Describe("SetupAndStartAPI", func() {
 			err := apiPkg.SetupAndStartAPI(
 				timeoutCtx,
 				"", "0", "test-token",
-				true, true, false,
+				true, true, false, false,
 				filters.NoFilter,
 				cmd,
 				"test filter",
@@ -195,7 +195,7 @@ var _ = ginkgo.Describe("SetupAndStartAPI", func() {
 			err := apiPkg.SetupAndStartAPI(
 				ctx,
 				"", "0", "test-token",
-				false, false, false,
+				false, false, false, false,
 				filters.NoFilter,
 				cmd,
 				"test filter",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,4 +39,6 @@ type RunConfig struct {
 	APIHost string
 	// APIPort is the port for the HTTP API server, set via the --http-api-port flag (defaults to "8080").
 	APIPort string
+	// NoStartupMessage suppresses startup messages if true, set via the --no-startup-message flag.
+	NoStartupMessage bool
 }

--- a/internal/logging/startup_test.go
+++ b/internal/logging/startup_test.go
@@ -80,6 +80,28 @@ var _ = ginkgo.Describe("WriteStartupMessage", func() {
 		gomega.Expect(buffer.String()).To(gomega.BeEmpty())
 	})
 
+	ginkgo.It(
+		"should suppress startup messages including HTTP API when no-startup-message is set",
+		func() {
+			cmd.PersistentFlags().Bool("no-startup-message", true, "")
+			cmd.PersistentFlags().Bool("http-api-update", true, "")
+
+			logging.WriteStartupMessage(
+				cmd,
+				time.Time{},
+				"Watching all containers",
+				"",
+				client,
+				nil,
+				"v1.0.0",
+				nil, // read from flags
+			)
+
+			// Should not log to buffer when suppressed, even with HTTP API enabled
+			gomega.Expect(buffer.String()).To(gomega.BeEmpty())
+		},
+	)
+
 	ginkgo.It("should log scope information when provided", func() {
 		cmd.PersistentFlags().Bool("no-startup-message", false, "")
 		cmd.PersistentFlags().Bool("http-api-update", false, "")

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -111,7 +111,7 @@ func (api *API) RegisterHandler(path string, handler http.Handler) {
 }
 
 // Start launches the API server over HTTP, requiring a non-empty token.
-func (api *API) Start(ctx context.Context, block bool) error {
+func (api *API) Start(ctx context.Context, block bool, noStartupMessage bool) error {
 	if !api.hasHandlers {
 		logrus.WithField("addr", api.Addr).Debug("No handlers registered, skipping API start")
 
@@ -142,7 +142,9 @@ func (api *API) Start(ctx context.Context, block bool) error {
 		}
 	}
 
-	logrus.WithField("addr", api.Addr).Info("Starting HTTP API server")
+	if !noStartupMessage {
+		logrus.WithField("addr", api.Addr).Info("Starting HTTP API server")
+	}
 
 	if block {
 		return RunHTTPServer(ctx, server)

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -87,7 +87,7 @@ var _ = ginkgo.Describe("API", func() {
 
 		ginkgo.It("should skip starting the server when no handlers are registered", func() {
 			apiInstance := api.New(testToken, ":8080")
-			err := apiInstance.Start(context.Background(), true)
+			err := apiInstance.Start(context.Background(), true, false)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Eventually(logBuffer.String, 100*time.Millisecond).
 				Should(gomega.ContainSubstring("No handlers registered, skipping API start"))
@@ -109,7 +109,7 @@ var _ = ginkgo.Describe("API", func() {
 			originalExit := logrus.StandardLogger().ExitFunc
 			logrus.StandardLogger().ExitFunc = func(int) { panic("fatal exit") }
 			defer func() { logrus.StandardLogger().ExitFunc = originalExit }()
-			gomega.Expect(func() { _ = emptyTokenAPI.Start(context.Background(), true) }).
+			gomega.Expect(func() { _ = emptyTokenAPI.Start(context.Background(), true, false) }).
 				To(gomega.Panic())
 			gomega.Expect(logOutput).
 				To(gomega.ContainSubstring("API token is empty or unset"))
@@ -134,7 +134,7 @@ var _ = ginkgo.Describe("API", func() {
 			errChan := make(chan error, 1)
 			go func() {
 				defer ginkgo.GinkgoRecover()
-				errChan <- apiInstance.Start(ctx, true)
+				errChan <- apiInstance.Start(ctx, true, false)
 			}()
 
 			gomega.Eventually(func() error {
@@ -194,7 +194,7 @@ var _ = ginkgo.Describe("API", func() {
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			err = apiInstance.Start(ctx, false)
+			err = apiInstance.Start(ctx, false, false)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			gomega.Eventually(func() error {
@@ -254,7 +254,7 @@ var _ = ginkgo.Describe("API", func() {
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			err := apiInstance.Start(ctx, false)
+			err := apiInstance.Start(ctx, false, false)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			gomega.Eventually(logBuffer.String, 1*time.Second, 50*time.Millisecond).Should(
@@ -291,7 +291,7 @@ var _ = ginkgo.Describe("API", func() {
 			errChan := make(chan error, 1)
 			go func() {
 				defer ginkgo.GinkgoRecover()
-				errChan <- apiInstance.Start(context.Background(), true)
+				errChan <- apiInstance.Start(context.Background(), true, false)
 			}()
 
 			select {
@@ -325,7 +325,7 @@ var _ = ginkgo.Describe("API", func() {
 			errChan := make(chan error, 1)
 			go func() {
 				defer ginkgo.GinkgoRecover()
-				errChan <- apiInstance.Start(ctx, true)
+				errChan <- apiInstance.Start(ctx, true, false)
 			}()
 
 			select {
@@ -403,7 +403,7 @@ var _ = ginkgo.Describe("API", func() {
 			errChan := make(chan error, 1)
 			go func() {
 				defer ginkgo.GinkgoRecover()
-				errChan <- apiInstance.Start(ctx, true)
+				errChan <- apiInstance.Start(ctx, true, false)
 			}()
 
 			gomega.Eventually(func() error {


### PR DESCRIPTION
This PR fixes issue #977 where the `WATCHTOWER_NO_STARTUP_MESSAGE=true` environment variable was not suppressing the "Starting HTTP API server" message that appears during Watchtower startup.

## Problem

When users set `WATCHTOWER_NO_STARTUP_MESSAGE=true` to disable startup messages, they still saw:
```
Starting HTTP API server | addr=<address>
```

This occurred because the HTTP API server startup logging was implemented independently of the general startup message suppression logic.

## Solution

Extended the existing `no-startup-message` flag to also control HTTP API server startup logging by:

1. **Configuration Layer**: Added `NoStartupMessage` field to `RunConfig` struct
2. **API Layer**: Modified `API.Start()` method to accept a `noStartupMessage` parameter
3. **Integration Layer**: Updated `SetupAndStartAPI` to pass the flag through the chain
4. **Command Layer**: Modified root command to read and pass the flag value

## Changes Made

- `cmd/root.go`: Read `no-startup-message` flag and pass to config
- `internal/config/config.go`: Add `NoStartupMessage` field to `RunConfig`
- `internal/api/api.go`: Accept and forward `noStartupMessage` parameter
- `pkg/api/api.go`: Conditionally log "Starting HTTP API server" based on flag
- `internal/logging/startup_test.go`: Add test case for HTTP API message suppression
- Updated all test files with new API method signatures


Closes #977

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--no-startup-message` flag to suppress API startup messages for cleaner console output when running the application, useful for CI/CD environments and automated deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->