### PR TITLE
Improve punctuation in multiple Watchtower instances log message

### DIFF
--- a/docs/notifications/templates/index.md
+++ b/docs/notifications/templates/index.md
@@ -44,6 +44,8 @@ Simple templates are used when `--notification-report` is not set, formatting in
     Started new container: {{$e.Data.container}} ({{with $e.Data.new_id}}{{.}}{{else}}unknown{{end}})
 {{- else if eq $msg "Removing image" -}}
     Removed stale image: {{with $e.Data.image_id}}{{.}}{{else}}unknown{{end}}
+{{- else if eq $msg "Detected multiple Watchtower instances - initiating cleanup" -}}
+    Detected {{$e.Data.count}} Watchtower instances - initiating cleanup
 {{- else if $e.Data -}}
     {{$msg}} | {{range $k, $v := $e.Data -}}{{$k}}={{$v}} {{- end}}
 {{- else -}}
@@ -74,6 +76,8 @@ The [Template Preview Tool](../template-preview/index.md) uses a `notifications.
     Started new container: {{$e.Data.container}} ({{with $e.Data.new_id}}{{.}}{{else}}unknown{{end}})
 {{- else if eq $msg "Removing image" -}}
     Removed stale image: {{with $e.Data.image_id}}{{.}}{{else}}unknown{{end}}
+{{- else if eq $msg "Detected multiple Watchtower instances - initiating cleanup" -}}
+    Detected {{$e.Data.count}} Watchtower instances - initiating cleanup
 {{- else if $e.Data -}}
     {{$msg}} | {{range $k, $v := $e.Data -}}{{$k}}={{$v}} {{- end}}
 {{- else -}}

--- a/internal/actions/check.go
+++ b/internal/actions/check.go
@@ -115,7 +115,7 @@ func CheckForMultipleWatchtowerInstances(
 	}
 
 	logrus.WithField("count", len(containers)).
-		Info("Detected multiple Watchtower instances, initiating cleanup")
+		Info("Detected multiple Watchtower instances - initiating cleanup")
 
 	return cleanupExcessWatchtowers(containers, client, cleanup, cleanupImageInfos)
 }

--- a/pkg/notifications/common_templates.go
+++ b/pkg/notifications/common_templates.go
@@ -11,7 +11,8 @@ var commonTemplates = map[string]string{
 	// It iterates over .Entries, checking each entry's Message to format specific container lifecycle events.
 	// Handles messages: "Found new image" (new image available), "Stopping container" (stopping old container),
 	// "Started new container" (new container started), "Stopping linked container" (stopping linked container),
-	// "Started linked container" (linked container started), "Removing image" (image cleanup completed), "Container updated" (update completed).
+	// "Started linked container" (linked container started), "Removing image" (image cleanup completed), "Container updated" (update completed),
+	// "Detected multiple Watchtower instances - initiating cleanup" (multiple instances detected).
 	// For unrecognized messages, displays the message with key=value data pairs if Data exists, otherwise just the message.
 	// Expects .Entries []Entry where each Entry has Message string and Data map[string]interface{}.
 	"default-legacy": `
@@ -38,6 +39,8 @@ var commonTemplates = map[string]string{
     Updated container: {{with (index $e.Data "container")}}{{.}}{{else}}unknown{{end}} ({{with (index $e.Data "image")}}{{.}}{{else}}unknown{{end}}): {{with (index $e.Data "old_id")}}{{.}}{{else}}unknown{{end}} updated to {{with (index $e.Data "new_id")}}{{.}}{{else}}unknown{{end}}
 {{- else if eq $msg "Skipping Watchtower self-update in run-once mode" -}}
     Run once mode: Watchtower self-update skipped
+{{- else if eq $msg "Detected multiple Watchtower instances - initiating cleanup" -}}
+    Detected {{index $e.Data "count"}} Watchtower instances - initiating cleanup
 {{- else if $e.Data -}}
     {{- /* For messages with data, show message and key=value pairs */ -}}
     {{$msg}} | {{range $k, $v := $e.Data -}}{{$k}}={{$v}} {{- end}}

--- a/pkg/notifications/preview/data/preview_strings.go
+++ b/pkg/notifications/preview/data/preview_strings.go
@@ -92,7 +92,7 @@ var organizationNames = []string{
 // infoMessages is an array of realistic info-level log messages based on typical Watchtower operations.
 // These are derived from real Watchtower logs, including container operations, session management, and notifications.
 var infoMessages = []string{
-	"Detected multiple Watchtower instances, initiating cleanup",
+	"Detected multiple Watchtower instances - initiating cleanup",
 	"Stopping container",
 	"Removing image",
 	"Successfully cleaned up excess Watchtower instances",


### PR DESCRIPTION
This PR updates the log and notification messages for when multiple Watchtower instances are detected and cleaned-up.

## Problem

Original log message: `Detected multiple Watchtower instances, initiating cleanup`
Original notification: `Detected multiple Watchtower instances, initiating cleanup | count=2`

The use of a comma and the unformatted notification resulted in an awkward punctuation flow and the message was lacking a proper template entry. 

## Solution

Replace the comma with an em dash ("—") and add a default template entry while still retaining the count of applicable, scope-filtered Watchtower containers.

New log message: `Detected multiple Watchtower instances - initiating cleanup`
New notification: `Detected 2 Watchtower instances - initiating cleanup`

## Changes

- **internal/actions/check.go**: Updated log message to use em dash instead of comma
- **pkg/notifications/common_templates.go**: Added template handling for the new message format and updated comments
- **docs/notifications/templates/index.md**: Updated documentation examples to reflect the new message format
- **pkg/notifications/preview/data/preview_strings.go**: Updated preview data for testing consistency


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced notification handling and message formatting for multiple Watchtower instance detection events with cleanup operations, ensuring consistent display across notification templates and preview contexts.

* **Documentation**
  * Updated notification templates and preview documentation to maintain consistency with improved message formatting standards for multiple instance scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->