### PR TITLE
feat(client): add WarnOnPinnedPull flag to control notifications for pinned image pulls

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -317,6 +317,7 @@ func preRun(cmd *cobra.Command, _ []string) {
 	reviveStopped, _ := flagsSet.GetBool("revive-stopped")
 	removeVolumes, _ := flagsSet.GetBool("remove-volumes")
 	warnOnHeadPullFailed, _ := flagsSet.GetString("warn-on-head-failure")
+	warnOnPinnedPull, _ := flagsSet.GetBool("warn-on-pinned-pull")
 	disableMemorySwappiness, _ := flagsSet.GetBool("disable-memory-swappiness")
 	cpuCopyMode, _ = flagsSet.GetString("cpu-copy-mode")
 
@@ -337,6 +338,7 @@ func preRun(cmd *cobra.Command, _ []string) {
 		DisableMemorySwappiness: disableMemorySwappiness,
 		CPUCopyMode:             cpuCopyMode,
 		WarnOnHeadFailed:        container.WarningStrategy(warnOnHeadPullFailed),
+		WarnOnPinnedPull:        warnOnPinnedPull,
 	})
 
 	// Set up the notification system with types specified via flags (e.g., email, Slack).

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -501,6 +501,11 @@ func RegisterNotificationFlags(rootCmd *cobra.Command) {
 		"When to warn about HEAD pull requests failing. Possible values: always, auto or never")
 
 	flags.Bool(
+		"warn-on-pinned-pull",
+		envBool("WATCHTOWER_WARN_ON_PINNED_PULL"),
+		"Send notifications when skipping pull of pinned sha256 images")
+
+	flags.Bool(
 		"notification-log-stdout",
 		envBool("WATCHTOWER_NOTIFICATION_LOG_STDOUT"),
 		"Write notification logs to stdout instead of logging (to stderr)")
@@ -703,6 +708,7 @@ func SetDefaults() {
 	viper.SetDefault("WATCHTOWER_CPU_COPY_MODE", "auto")
 	viper.SetDefault("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 	viper.SetDefault("WATCHTOWER_REGISTRY_TLS_MIN_VERSION", "TLS1.2")
+	viper.SetDefault("WATCHTOWER_WARN_ON_PINNED_PULL", true)
 }
 
 // EnvConfig sets Docker environment variables from flags.

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -144,6 +144,7 @@ type ClientOptions struct {
 	DisableMemorySwappiness bool
 	CPUCopyMode             string
 	WarnOnHeadFailed        WarningStrategy
+	WarnOnPinnedPull        bool
 	Fs                      afero.Fs
 }
 
@@ -492,7 +493,7 @@ func (c client) IsContainerStale(
 	params types.UpdateParams,
 ) (bool, types.ImageID, error) {
 	// Use image client to perform staleness check.
-	imgClient := newImageClient(c.api)
+	imgClient := newImageClient(c.api, c.WarnOnPinnedPull)
 
 	stale, newestImage, err := imgClient.IsContainerStale(container, params, c.WarnOnHeadFailed)
 	if err != nil {
@@ -792,7 +793,7 @@ func (c client) waitForExecOrTimeout(
 //   - error: Non-nil if removal fails, nil on success.
 func (c client) RemoveImageByID(imageID types.ImageID, imageName string) error {
 	// Use image client to remove the image.
-	imgClient := newImageClient(c.api)
+	imgClient := newImageClient(c.api, c.WarnOnPinnedPull)
 
 	err := imgClient.RemoveImageByID(imageID, imageName)
 	if err != nil {

--- a/pkg/container/image_test.go
+++ b/pkg/container/image_test.go
@@ -63,7 +63,7 @@ var _ = ginkgo.Describe("the client", func() {
 	ginkgo.When("pulling the latest image", func() {
 		ginkgo.When("the image consist of a pinned hash", func() {
 			ginkgo.It("should gracefully fail with a useful message", func() {
-				i := newImageClient(docker)
+				i := newImageClient(docker, false)
 				pinnedContainer := MockContainer(
 					WithImageName(
 						"sha256:fa5269854a5e615e51a72b17ad3fd1e01268f278a6684c8ed3c5f0cdce3f230b",


### PR DESCRIPTION
Added a new `--warn-on-pinned-pull` flag and corresponding `WATCHTOWER_WARN_ON_PINNED_PULL` environment variable to control notifications when skipping pulls of pinned sha256 images. The default is set to `true`.

This can be useful for example when running watchtower on the same host as a gitlab ci runner, currently I get notifications for those containers.