### PR TITLE
Lower log level to debug for skipping pinned images

### DIFF
--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -155,7 +155,7 @@ func (c imageClient) PullImage(
 
 	// Skip pulling immutable sha256-pinned images.
 	if strings.HasPrefix(sourceContainer.ImageName(), "sha256:") {
-		clog.Warn("Skipping pull of pinned sha256 image")
+		clog.Debug("Skipping pull of pinned sha256 image")
 
 		return errPinnedImage
 	}


### PR DESCRIPTION
This PR lowers the log level when pinned images are skipped to the debug log level.

## Problem

When Watchtower is used in conjunction with Renovate or similar CI tooling, warning messages are needlessly sent.

## Solution

Demote the log level to debug when skipping updates on pinned images.

## Changes

- Lower log level for pinned image skip to debug