### PR TITLE
Add support for file-based notification templates

### DIFF
--- a/docs/configuration/arguments/index.md
+++ b/docs/configuration/arguments/index.md
@@ -828,6 +828,17 @@ Environment Variable: WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN
              Default: None
 ```
 
+### Notification Template File
+
+Specifies the path to a file containing the Shoutrrr text/template for notification messages.
+
+```text
+             Argument: --notification-template-file
+ Environment Variable: WATCHTOWER_NOTIFICATION_TEMPLATE_FILE
+                 Type: String
+              Default: None
+```
+
 ### Disable Startup Message
 
 Suppresses the info-level notification sent when Watchtower starts.

--- a/docs/notifications/overview/index.md
+++ b/docs/notifications/overview/index.md
@@ -147,6 +147,23 @@ docker run -d \
   nickfedor/watchtower
 ```
 
+## Notification Templates
+
+Watchtower allows you to customize the format and content of notification messages using Go templates. You can define templates either inline or load them from a file.
+
+### Inline Templates
+
+Use the `--notification-template` argument or `WATCHTOWER_NOTIFICATION_TEMPLATE` environment variable to specify a template directly as a string.
+
+### File-Based Templates
+
+For more complex templates or better maintainability, use the `--notification-template-file` argument or `WATCHTOWER_NOTIFICATION_TEMPLATE_FILE` environment variable to specify a path to a template file.
+
+!!! Note
+    When both inline and file-based templates are specified, the file-based template takes precedence.
+
+For detailed information about template syntax, available data structures, and examples, see the [Notification Templates](../templates/index.md) documentation.
+
 ## Email Notifications
 
 Watchtower uses Shoutrrr's [smtp service](https://shoutrrr.nickfedor.com/services/email/){target="_blank" rel="noopener noreferrer"} to send email notifications.

--- a/docs/notifications/templates/index.md
+++ b/docs/notifications/templates/index.md
@@ -15,6 +15,32 @@ Environment Variable: WATCHTOWER_NOTIFICATION_TEMPLATE
              Default: See default templates below
 ```
 
+### Notification Template File
+
+Sets the path to a file containing the Go template used for formatting notification messages.
+
+```text
+            Argument: --notification-template-file
+Environment Variable: WATCHTOWER_NOTIFICATION_TEMPLATE_FILE
+                Type: String
+             Default: (empty)
+```
+
+When both `--notification-template` and `--notification-template-file` are specified, the file-based template takes precedence over the inline template.
+
+#### Examples
+
+Create a template file named `custom-template.txt` with your desired template content, then mount it into the container and specify the path:
+
+```bash
+docker run -d \
+  --name watchtower \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /path/to/custom-template.txt:/custom-template.txt \
+  -e WATCHTOWER_NOTIFICATION_TEMPLATE_FILE="/custom-template.txt" \
+  nickfedor/watchtower:latest
+```
+
 ### Notification Report
 
 Enables the session report as the notification template data, including container statuses and logs.

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -474,6 +474,11 @@ func RegisterNotificationFlags(rootCmd *cobra.Command) {
 		envString("WATCHTOWER_NOTIFICATION_TEMPLATE"),
 		"The shoutrrr text/template for the messages")
 
+	flags.String(
+		"notification-template-file",
+		envString("WATCHTOWER_NOTIFICATION_TEMPLATE_FILE"),
+		"Path to a file containing the Shoutrrr text/template for the messages")
+
 	flags.StringArray(
 		"notification-url",
 		filterEmptyStrings(splitNotificationValues(envString("WATCHTOWER_NOTIFICATION_URL"))),
@@ -947,7 +952,8 @@ func getSecretFromFile(flags *pflag.FlagSet, secret string) error {
 
 					return fmt.Errorf("%w: %w", errOpenFileFailed, err)
 				}
-				defer file.Close()
+
+				defer func() { _ = file.Close() }()
 
 				scanner := bufio.NewScanner(file)
 				for scanner.Scan() {

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -651,6 +651,7 @@ func TestFlagsArePresentInDocumentation(t *testing.T) {
 		"WATCHTOWER_NOTIFICATION_SLACK_ICON_EMOJI": "legacy",
 		"WATCHTOWER_NOTIFICATION_SLACK_ICON_URL":   "legacy",
 		"DOCKER_CERT_PATH":                         "new feature",
+		"WATCHTOWER_NOTIFICATION_TEMPLATE_FILE":    "new feature",
 	}
 
 	ignoredFlags := map[string]string{
@@ -658,6 +659,7 @@ func TestFlagsArePresentInDocumentation(t *testing.T) {
 		"notification-slack-icon-emoji": "legacy",
 		"notification-slack-icon-url":   "legacy",
 		"cert-path":                     "new feature",
+		"notification-template-file":    "new feature",
 	}
 
 	cmd := new(cobra.Command)

--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -40,7 +40,21 @@ func NewNotifier(c *cobra.Command) types.Notifier {
 	// Extract notification settings.
 	reportTemplate, _ := flag.GetBool("notification-report")
 	stdout, _ := flag.GetBool("notification-log-stdout")
+
 	tplString, _ := flag.GetString("notification-template")
+	if tplFile, _ := flag.GetString("notification-template-file"); tplFile != "" {
+		content, err := os.ReadFile(tplFile)
+		if err != nil {
+			clog.WithError(err).
+				WithField("file", tplFile).
+				Fatal("Failed to read notification template file")
+		}
+
+		tplString = string(content)
+
+		clog.WithField("file", tplFile).Debug("Loaded notification template from file")
+	}
+
 	urls, _ := flag.GetStringArray("notification-url")
 
 	data := GetTemplateData(c)

--- a/pkg/notifications/notifier_test.go
+++ b/pkg/notifications/notifier_test.go
@@ -141,6 +141,33 @@ var _ = ginkgo.Describe("notifications", func() {
 				},
 			)
 		})
+		ginkgo.When("notification template file is specified", func() {
+			ginkgo.It("should load template from file", func() {
+				content := "{{.Data.Host}} updated"
+				tmpFile, err := os.CreateTemp("", "template")
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				defer os.Remove(tmpFile.Name())
+
+				_, err = tmpFile.WriteString(content)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				tmpFile.Close()
+
+				command := cmd.NewRootCommand()
+				flags.RegisterNotificationFlags(command)
+
+				err = command.ParseFlags([]string{
+					"--notification-url",
+					"logger://",
+					"--notification-template-file",
+					tmpFile.Name(),
+				})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				notifier := notifications.NewNotifier(command)
+				gomega.Expect(notifier).NotTo(gomega.BeNil())
+				gomega.Expect(notifier.GetNames()).To(gomega.ContainElement("logger"))
+			})
+		})
 	})
 	ginkgo.Describe("the slack notifier", func() {
 		// builderFn := notifications.NewSlackNotifier


### PR DESCRIPTION
This PR adds support for loading notification templates from files, resolving issues with complex templates in container orchestration tools like Portainer. Users can now specify --notification-template-file to load templates from external files instead of inline strings.

## Problem

Users configuring Watchtower through Portainer encounter template parsing errors because Portainer's variable substitution conflicts with Go template syntax. Complex notification templates with {{ }} sequences get corrupted during deployment.

## Solution

Introduce --notification-template-file flag and WATCHTOWER_NOTIFICATION_TEMPLATE_FILE environment variable to load templates from files, bypassing Portainer's substitution entirely.

## Changes

- Add --notification-template-file flag and environment variable to flags.go
- Implement file reading logic in notifier.go with precedence over inline templates
- Update documentation with usage examples and flag reference
- Add unit tests for file-based template loading
- Update flag tests to include new feature