### PR TITLE
Prevent spurious safeguard delay when SkipSelfUpdate is enabled

### DIFF
--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -234,7 +234,8 @@ func Update(
 			progress.AddSkipped(sourceContainer, err, config)
 
 			// Track if Watchtower self-update pull failed for safeguard.
-			if sourceContainer.IsWatchtower() {
+			// Only set to true if we actually attempted a self-update (i.e., SkipSelfUpdate is false)
+			if sourceContainer.IsWatchtower() && !config.SkipSelfUpdate {
 				watchtowerPullFailed = true
 			}
 		} else {

--- a/internal/scheduling/scheduling.go
+++ b/internal/scheduling/scheduling.go
@@ -130,7 +130,9 @@ func RunUpgradesOnSchedule(
 
 				nextRuns := scheduler.Entries()
 				if len(nextRuns) > 0 {
-					logrus.Debug("Scheduled next run: " + nextRuns[0].Next.String())
+					logrus.Debug(
+						"Scheduled next run: " + nextRuns[0].Schedule.Next(time.Now()).String(),
+					)
 				}
 
 				return
@@ -171,7 +173,7 @@ func RunUpgradesOnSchedule(
 
 		nextRuns := scheduler.Entries()
 		if len(nextRuns) > 0 {
-			logrus.Debug("Scheduled next run: " + nextRuns[0].Next.String())
+			logrus.Debug("Scheduled next run: " + nextRuns[0].Schedule.Next(time.Now()).String())
 		}
 	}
 


### PR DESCRIPTION
This PR addresses an issue where Watchtower was incorrectly triggering a safeguard delay when `SkipSelfUpdate` was enabled and the pull for the Watchtower image failed. The safeguard delay should only be triggered when we actually attempted to update Watchtower itself.

### Problem
When `SkipSelfUpdate` was set to `true`, Watchtower would still check if the Watchtower container was stale and if the pull failed, it would set the `watchtowerPullFailed` flag to `true`, which would trigger a safeguard delay. This was unnecessary because we weren't actually attempting to update Watchtower.

### Solution
1. Modify the logic to only set `watchtowerPullFailed` to `true` when `SkipSelfUpdate` is `false`
2. Ensure the staleness check is not performed for Watchtower containers when `SkipSelfUpdate` is `true`
3. Update tests to verify the fix

### Changes
- **internal/actions/update.go**: Modify flag check to include `!config.SkipSelfUpdate` condition
- **internal/actions/update_watchtower_test.go**: Add comprehensive tests for the fix
- **internal/scheduling/scheduling.go**: Fix logging to use correct schedule time retrieval

The fix ensures that when `SkipSelfUpdate` is enabled, Watchtower will skip both the staleness check and the safeguard delay for itself, focusing only on updating other containers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed safeguard delay for Watchtower self-update failures to only apply when self-updates are actually attempted.
  * Improved accuracy of next scheduled run time calculation and logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->