### PR TITLE
Fix missing space between fields in notifications

### DIFF
--- a/pkg/notifications/common_templates.go
+++ b/pkg/notifications/common_templates.go
@@ -43,7 +43,7 @@ var commonTemplates = map[string]string{
     Successfully removed {{index $e.Data "removed_instances"}} excess Watchtower{{if eq (index $e.Data "removed_instances") 1}} instance{{else}} instances{{end}}
 {{- else if $e.Data -}}
     {{- /* For messages with data, show message and key=value pairs */ -}}
-    {{$msg}} | {{range $k, $v := $e.Data -}}{{$k}}={{$v}} {{- end}}
+    {{$msg}} | {{range $k, $v := $e.Data}}{{$k}}={{$v}} {{end}}
 {{- else -}}
     {{- /* For messages without data, show just the message */ -}}
     {{$msg}}


### PR DESCRIPTION
This PR fixes a minor formatting error in notifications where fields were being concatenated without spaces, e.g. "container=dozzleerror=" instead of "container=dozzle error=".

## Problem
Notification messages were showing incorrectly formatted fields with no space between them because the template was trimming all whitespace around the fields.

## Solution
Modified the default notification template in `pkg/notifications/common_templates.go` to remove the whitespace-trimming hyphens from the range loop that formats log entry data fields.

## Changes
- Remove whitespace-trimming hyphens from log entry data field formatting in notification template
- Fixes missing space between container name and error message in notifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected whitespace handling in notification templates for key-value pair formatting, ensuring consistent spacing in data output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->