### PR TITLE
Update golangci-lint configuration and format test files

### DIFF
--- a/build/golangci-lint/golangci-lint.yaml
+++ b/build/golangci-lint/golangci-lint.yaml
@@ -68,6 +68,21 @@ formatters:
     gofumpt:
       module-path: "github.com/nicholas-fedor/watchtower"
       extra-rules: true
+    golines:
+      # Target maximum line length.
+      # Default: 100
+      max-len: 200
+      # Length of a tabulation.
+      # Default: 4
+      tab-len: 4
+      # Shorten single-line comments.
+      # Default: false
+      shorten-comments: true
+      # Default: true
+      reformat-tags: true
+      # Split chained methods on the dots as opposed to the arguments.
+      # Default: true
+      chain-split-dots: true
 
 # Linters Configuration
 linters:
@@ -188,6 +203,34 @@ linters:
     - wsl # deprecated, replaced by wsl_v5 (whitespace linter)
     - zerologlint # Detects the wrong usage of zerolog that a user forgets to dispatch with Send or Msg.
   settings:
+    revive:
+      enable-all-rules: false
+      # Configure rules
+      rules:
+        # Rule to check for meaningless package names
+        # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#var-naming
+        - name: var-naming
+          severity: warning
+          disabled: false
+          exclude: [""]
+          arguments:
+            - [""] # AllowList
+            - [""] # DenyList
+            - - skip-initialism-name-checks: false
+                upper-case-const: true
+                skip-package-name-checks: true
+                skip-package-name-collision-with-go-std: true
+                extra-bad-package-names:
+                  - helpers
+                  - models
+        # Rule to check for package name conflicts
+        # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#package-comments
+        - name: package-comments
+          severity: warning
+          disabled: false
+          exclude:
+            - ".*pkg/api/metrics/.*"
+            - ".*pkg/metrics/.*"
     testifylint:
       enable-all: true
     varnamelen:
@@ -244,22 +287,6 @@ linters:
           - usetesting
           - wrapcheck
           - varnamelen
-      - path: "internal/util/.*"
-        linters:
-          - revive
-        text: "avoid meaningless package names"
-      - path: "pkg/types/.*"
-        linters:
-          - revive
-        text: "avoid meaningless package names"
-      - path: "internal/api/.*"
-        linters:
-          - revive
-        text: "avoid meaningless package names"
-      - path: "pkg/api/.*"
-        linters:
-          - revive
-        text: "avoid meaningless package names"
       - path: "doc.go$"
         linters:
           - dupword

--- a/internal/actions/actions_internal_test.go
+++ b/internal/actions/actions_internal_test.go
@@ -105,13 +105,16 @@ var _ = ginkgo.Describe("handleUpdateResult", func() {
 
 	ginkgo.It("should return zero metric when result is nil", func() {
 		var err error
+
 		result := handleUpdateResult(nil, err, nil)
 		gomega.Expect(result).To(gomega.Equal(&metrics.Metric{Scanned: 0, Updated: 0, Failed: 0}))
 	})
 
 	ginkgo.It("should return nil when result is not nil and error is nil", func() {
 		mockReport := mockTypes.NewMockReport(ginkgo.GinkgoT())
+
 		var err error
+
 		result := handleUpdateResult(mockReport, err, nil)
 		gomega.Expect(result).To(gomega.BeNil())
 	})
@@ -146,7 +149,9 @@ var _ = ginkgo.Describe("handleUpdateResult", func() {
 
 		// Call handleUpdateResult without an error
 		mockReport := mockTypes.NewMockReport(ginkgo.GinkgoT())
+
 		var err error
+
 		result := handleUpdateResult(mockReport, err, mockNotifier)
 
 		// Verify we got the expected result

--- a/internal/actions/actions_suite_test.go
+++ b/internal/actions/actions_suite_test.go
@@ -33,7 +33,9 @@ var _ = ginkgo.Describe("the actions package", func() {
 					false,
 					false,
 				)
+
 				var cleanupImageIDs []types.RemovedImageInfo
+
 				cleanupOccurred, err := actions.RemoveExcessWatchtowerInstances(
 					mockClient,
 					false,
@@ -71,7 +73,9 @@ var _ = ginkgo.Describe("the actions package", func() {
 					false,
 					false,
 				)
+
 				var cleanupImageIDs []types.RemovedImageInfo
+
 				cleanupOccurred, err := actions.RemoveExcessWatchtowerInstances(
 					client,
 					false,
@@ -87,6 +91,7 @@ var _ = ginkgo.Describe("the actions package", func() {
 		})
 		ginkgo.When("given multiple containers", func() {
 			var client mockActions.MockClient
+
 			ginkgo.BeforeEach(func() {
 				client = mockActions.CreateMockClient(
 					&mockActions.TestData{
@@ -129,6 +134,7 @@ var _ = ginkgo.Describe("the actions package", func() {
 
 			ginkgo.It("should stop all but the latest one", func() {
 				var cleanupImageIDs []types.RemovedImageInfo
+
 				cleanupOccurred, err := actions.RemoveExcessWatchtowerInstances(
 					client,
 					false,
@@ -148,6 +154,7 @@ var _ = ginkgo.Describe("the actions package", func() {
 
 			ginkgo.It("should collect image IDs and clean up when cleanup is enabled", func() {
 				var cleanupImageIDs []types.RemovedImageInfo
+
 				cleanupOccurred, err := actions.RemoveExcessWatchtowerInstances(
 					client,
 					true,
@@ -170,6 +177,7 @@ var _ = ginkgo.Describe("the actions package", func() {
 		})
 		ginkgo.When("simulating a self-update with excess Watchtower instances", func() {
 			var client mockActions.MockClient
+
 			ginkgo.BeforeEach(func() {
 				client = mockActions.CreateMockClient(
 					&mockActions.TestData{
@@ -208,6 +216,7 @@ var _ = ginkgo.Describe("the actions package", func() {
 
 			ginkgo.It("should stop the old instance and clean up its image", func() {
 				var cleanupImageIDs []types.RemovedImageInfo
+
 				cleanupOccurred, err := actions.RemoveExcessWatchtowerInstances(
 					client,
 					true,
@@ -232,6 +241,7 @@ var _ = ginkgo.Describe("the actions package", func() {
 
 		ginkgo.When("unscoped and scoped instances coexist", func() {
 			var client mockActions.MockClient
+
 			ginkgo.BeforeEach(func() {
 				client = mockActions.CreateMockClient(
 					&mockActions.TestData{
@@ -291,6 +301,7 @@ var _ = ginkgo.Describe("the actions package", func() {
 
 			ginkgo.It("should only clean up unscoped instances when scope is empty", func() {
 				var cleanupImageIDs []types.RemovedImageInfo
+
 				cleanupOccurred, err := actions.RemoveExcessWatchtowerInstances(
 					client,
 					false,
@@ -316,6 +327,7 @@ var _ = ginkgo.Describe("the actions package", func() {
 
 			ginkgo.It("should clean up within scoped instances when scope is specified", func() {
 				var cleanupImageIDs []types.RemovedImageInfo
+
 				cleanupOccurred, err := actions.RemoveExcessWatchtowerInstances(
 					client,
 					false,

--- a/internal/actions/actions_test.go
+++ b/internal/actions/actions_test.go
@@ -1000,6 +1000,7 @@ var _ = ginkgo.Describe("Actions", func() {
 
 				// Results channel to collect metrics from concurrent operations
 				results := make(chan *metrics.Metric, 2)
+
 				var wg sync.WaitGroup
 
 				// Launch concurrent updates for different scopes
@@ -1007,6 +1008,7 @@ var _ = ginkgo.Describe("Actions", func() {
 
 				go func() {
 					defer wg.Done()
+
 					params := RunUpdatesWithNotificationsParams{
 						Client:                       clientA,
 						Notifier:                     nil,
@@ -1029,12 +1031,14 @@ var _ = ginkgo.Describe("Actions", func() {
 						CPUCopyMode:      "auto",
 						PullFailureDelay: time.Duration(0),
 					}
+
 					metric := RunUpdatesWithNotifications(context.Background(), params)
 					results <- metric
 				}()
 
 				go func() {
 					defer wg.Done()
+
 					params := RunUpdatesWithNotificationsParams{
 						Client:                       clientB,
 						Notifier:                     nil,
@@ -1057,6 +1061,7 @@ var _ = ginkgo.Describe("Actions", func() {
 						CPUCopyMode:      "auto",
 						PullFailureDelay: time.Duration(0),
 					}
+
 					metric := RunUpdatesWithNotifications(context.Background(), params)
 					results <- metric
 				}()
@@ -1073,6 +1078,7 @@ var _ = ginkgo.Describe("Actions", func() {
 
 				// Verify we got results from both concurrent operations
 				gomega.Expect(metrics).To(gomega.HaveLen(2))
+
 				for _, metric := range metrics {
 					gomega.Expect(metric).NotTo(gomega.BeNil())
 					gomega.Expect(metric.Scanned).
@@ -1147,6 +1153,7 @@ var _ = ginkgo.Describe("Actions", func() {
 
 				go func() {
 					defer wg.Done()
+
 					params := RunUpdatesWithNotificationsParams{
 						Client:                       client1,
 						Notifier:                     nil,
@@ -1174,6 +1181,7 @@ var _ = ginkgo.Describe("Actions", func() {
 
 				go func() {
 					defer wg.Done()
+
 					params := RunUpdatesWithNotificationsParams{
 						Client:                       client2,
 						Notifier:                     nil,
@@ -1276,6 +1284,7 @@ var _ = ginkgo.Describe("Actions", func() {
 
 			go func() {
 				defer wg.Done()
+
 				params := RunUpdatesWithNotificationsParams{
 					Client:                       clientA,
 					Notifier:                     nil,
@@ -1303,6 +1312,7 @@ var _ = ginkgo.Describe("Actions", func() {
 
 			go func() {
 				defer wg.Done()
+
 				params := RunUpdatesWithNotificationsParams{
 					Client:                       clientB,
 					Notifier:                     nil,
@@ -1411,12 +1421,14 @@ var _ = ginkgo.Describe("Actions", func() {
 				clientDev := mockActions.CreateMockClient(testDataDev, false, false)
 
 				results := make(chan map[string]int, 2)
+
 				var wg sync.WaitGroup
 
 				wg.Add(2)
 
 				go func() {
 					defer wg.Done()
+
 					params := RunUpdatesWithNotificationsParams{
 						Client:                       clientProd,
 						Notifier:                     nil,
@@ -1439,12 +1451,14 @@ var _ = ginkgo.Describe("Actions", func() {
 						CPUCopyMode:      "auto",
 						PullFailureDelay: time.Duration(0),
 					}
+
 					metric := RunUpdatesWithNotifications(context.Background(), params)
 					results <- map[string]int{"prod-scanned": metric.Scanned, "prod-updated": metric.Updated}
 				}()
 
 				go func() {
 					defer wg.Done()
+
 					params := RunUpdatesWithNotificationsParams{
 						Client:                       clientDev,
 						Notifier:                     nil,
@@ -1467,6 +1481,7 @@ var _ = ginkgo.Describe("Actions", func() {
 						CPUCopyMode:      "auto",
 						PullFailureDelay: time.Duration(0),
 					}
+
 					metric := RunUpdatesWithNotifications(context.Background(), params)
 					results <- map[string]int{"dev-scanned": metric.Scanned, "dev-updated": metric.Updated}
 				}()
@@ -1485,11 +1500,13 @@ var _ = ginkgo.Describe("Actions", func() {
 				// Verify concurrent operations completed independently
 				totalScanned := 0
 				totalUpdated := 0
+
 				for _, resultMap := range resultMaps {
 					for key, value := range resultMap {
 						if key == "prod-scanned" || key == "dev-scanned" {
 							totalScanned += value
 						}
+
 						if key == "prod-updated" || key == "dev-updated" {
 							totalUpdated += value
 						}
@@ -1695,18 +1712,21 @@ var _ = ginkgo.Describe("Actions", func() {
 				}
 
 				var wg sync.WaitGroup
+
 				results := make(chan *metrics.Metric, 2)
 
 				wg.Add(2)
 
 				go func() {
 					defer wg.Done()
+
 					metric := RunUpdatesWithNotifications(context.Background(), paramsA)
 					results <- metric
 				}()
 
 				go func() {
 					defer wg.Done()
+
 					metric := RunUpdatesWithNotifications(context.Background(), paramsB)
 					results <- metric
 				}()
@@ -1722,6 +1742,7 @@ var _ = ginkgo.Describe("Actions", func() {
 
 				// Verify scope isolation in error handling
 				gomega.Expect(metrics).To(gomega.HaveLen(2))
+
 				for _, metric := range metrics {
 					gomega.Expect(metric).NotTo(gomega.BeNil())
 					// Each scope processes exactly one container
@@ -1784,12 +1805,14 @@ var _ = ginkgo.Describe("Actions", func() {
 
 					// Run concurrent operations
 					var wg sync.WaitGroup
+
 					results := make(chan *metrics.Metric, 2)
 
 					wg.Add(2)
 
 					go func() {
 						defer wg.Done()
+
 						params := RunUpdatesWithNotificationsParams{
 							Client:                       clientX,
 							Notifier:                     nil,
@@ -1812,12 +1835,14 @@ var _ = ginkgo.Describe("Actions", func() {
 							CPUCopyMode:      "auto",
 							PullFailureDelay: time.Duration(0),
 						}
+
 						metric := RunUpdatesWithNotifications(context.Background(), params)
 						results <- metric
 					}()
 
 					go func() {
 						defer wg.Done()
+
 						params := RunUpdatesWithNotificationsParams{
 							Client:                       clientY,
 							Notifier:                     nil,
@@ -1840,6 +1865,7 @@ var _ = ginkgo.Describe("Actions", func() {
 							CPUCopyMode:      "auto",
 							PullFailureDelay: time.Duration(0),
 						}
+
 						metric := RunUpdatesWithNotifications(context.Background(), params)
 						results <- metric
 					}()
@@ -1855,6 +1881,7 @@ var _ = ginkgo.Describe("Actions", func() {
 
 					// Verify proper isolation of error reporting
 					gomega.Expect(metrics).To(gomega.HaveLen(2))
+
 					totalScanned := 0
 					totalFailed := 0
 					totalUpdated := 0

--- a/internal/actions/cleanup_test.go
+++ b/internal/actions/cleanup_test.go
@@ -41,6 +41,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 				Return([]types.Container{mockContainer}, nil)
 
 			var cleanupImageInfo []types.RemovedImageInfo
+
 			cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 				mockClient,
 				false,
@@ -91,6 +92,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 					Return(nil)
 
 				var cleanupImageIDs []types.RemovedImageInfo
+
 				cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 					mockClient,
 					true,
@@ -130,6 +132,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 				Return([]types.Container{scopedOldContainer}, nil)
 
 			var cleanupImageIDs []types.RemovedImageInfo
+
 			cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 				mockClient,
 				true,
@@ -180,6 +183,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 				Return(nil)
 
 			var cleanupImageIDs []types.RemovedImageInfo
+
 			cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 				mockClient,
 				true,
@@ -216,6 +220,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 				Return([]types.Container{scopedContainer}, nil)
 
 			var cleanupImageIDs []types.RemovedImageInfo
+
 			cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 				mockClient,
 				false,
@@ -263,6 +268,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 			mockClient.EXPECT().StopAndRemoveContainer(oldContainer, 10*time.Minute).Return(nil)
 
 			var cleanupImageIDs []types.RemovedImageInfo
+
 			cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 				mockClient,
 				false,
@@ -284,6 +290,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 			mockClient.EXPECT().ListContainers(mock.Anything).Return([]types.Container{}, nil)
 
 			var cleanupImageIDs []types.RemovedImageInfo
+
 			cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 				mockClient,
 				false,
@@ -331,6 +338,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 				Return(errors.New("stop container failed"))
 
 			var cleanupImageIDs []types.RemovedImageInfo
+
 			cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 				mockClient,
 				false,
@@ -392,6 +400,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 			mockClient.EXPECT().StopAndRemoveContainer(old2Container, 10*time.Minute).Return(nil)
 
 			var cleanupImageIDs []types.RemovedImageInfo
+
 			cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 				mockClient,
 				true,
@@ -458,6 +467,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 					Return(nil)
 
 				var cleanupImageIDs []types.RemovedImageInfo
+
 				cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 					mockClient,
 					true,
@@ -525,6 +535,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 					Return(nil)
 
 				var cleanupImageIDs []types.RemovedImageInfo
+
 				cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 					mockClient,
 					true,
@@ -577,6 +588,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 				mockClient.EXPECT().StopAndRemoveContainer(oldContainer, 10*time.Minute).Return(nil)
 
 				var cleanupImageIDs []types.RemovedImageInfo
+
 				cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 					mockClient,
 					true,
@@ -623,6 +635,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 			mockClient.EXPECT().StopAndRemoveContainer(oldContainer, 10*time.Minute).Return(nil)
 
 			var cleanupImageIDs []types.RemovedImageInfo
+
 			cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 				mockClient,
 				false,
@@ -679,6 +692,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 				Times(1)
 
 			var cleanupImageInfos []types.RemovedImageInfo
+
 			cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 				mockClient,
 				true,
@@ -736,6 +750,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 			// Should not clean up different scope container
 
 			var cleanupImageInfos []types.RemovedImageInfo
+
 			cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 				mockClient,
 				true,
@@ -796,6 +811,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 			// Even though it's in the chain, scope isolation does not prevent cleanup when no scope filter
 
 			var cleanupImageInfos []types.RemovedImageInfo
+
 			cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 				mockClient,
 				true,
@@ -856,6 +872,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 			// Test cleanup without scope filter - should clean chained container only
 			// Note: unscoped filter excludes containers with scopes, so only chained container is cleaned
 			var cleanupImageInfos []types.RemovedImageInfo
+
 			cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 				mockClient,
 				true,
@@ -918,6 +935,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 
 				// Cleanup should clean the referenced container as it's a chained parent container
 				var cleanupImageInfos []types.RemovedImageInfo
+
 				cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 					mockClient,
 					true,
@@ -992,6 +1010,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 					Return(errors.New("container stop failed"))
 
 				var cleanupImageInfos []types.RemovedImageInfo
+
 				cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 					mockClient,
 					true,
@@ -1067,6 +1086,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 					Return(errors.New("stop failed"))
 
 				var cleanupImageInfos []types.RemovedImageInfo
+
 				cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 					mockClient,
 					false, // No image cleanup to focus on container removal
@@ -1140,6 +1160,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 					Return(errors.New("interruption error"))
 
 				var cleanupImageInfos []types.RemovedImageInfo
+
 				cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 					mockClient,
 					true,
@@ -1195,6 +1216,7 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 				Return(errors.New("scope-a failure"))
 
 			var cleanupImageInfos []types.RemovedImageInfo
+
 			cleanupOccurred, err := RemoveExcessWatchtowerInstances(
 				mockClient,
 				false,

--- a/internal/actions/doc.go
+++ b/internal/actions/doc.go
@@ -39,5 +39,6 @@
 //	}
 //	metric := actions.RunUpdatesWithNotifications(params)
 //
-// The package integrates with the container package for Docker operations, session package for update reporting, sorter package for container ordering, and lifecycle package for pre/post-update hooks, using logrus for logging operations and errors.
+// The package integrates with the container package for Docker operations, session package for update reporting, sorter package for container ordering, and lifecycle package for pre/post-update
+// hooks, using logrus for logging operations and errors.
 package actions

--- a/internal/actions/update_dependencies_test.go
+++ b/internal/actions/update_dependencies_test.go
@@ -2098,7 +2098,6 @@ var _ = ginkgo.Describe("the update action", func() {
 				// Create containers with replica-style names (e.g., myproject-db-1)
 				// and depends-on labels referencing service names without replica numbers
 				// This reproduces the bug where exact matching fails for transitive dependencies
-
 				dbContainer := mockActions.CreateMockContainerWithConfig(
 					"myproject-db-1",
 					"/myproject-db-1",

--- a/internal/actions/update_image_test.go
+++ b/internal/actions/update_image_test.go
@@ -16,8 +16,10 @@ import (
 var _ = ginkgo.Describe("the update action", func() {
 	// Tests for image reference handling to cover isPinned functionality
 	ginkgo.When("handling different image reference formats", func() {
-		var client *mockActions.MockClient
-		var config types.UpdateParams
+		var (
+			client *mockActions.MockClient
+			config types.UpdateParams
+		)
 
 		ginkgo.BeforeEach(func() {
 			config = types.UpdateParams{

--- a/internal/actions/update_restart_test.go
+++ b/internal/actions/update_restart_test.go
@@ -149,6 +149,7 @@ var _ = ginkgo.Describe("the update action", func() {
 				// Verify categorization
 				updated := report.Updated()
 				restarted := report.Restarted()
+
 				gomega.Expect(updated[0].Name()).To(gomega.Equal("stale-container"))
 				gomega.Expect(restarted[0].Name()).To(gomega.Equal("restart-container-1"))
 				gomega.Expect(restarted[1].Name()).To(gomega.Equal("restart-container-2"))
@@ -1104,6 +1105,7 @@ var _ = ginkgo.Describe("the update action", func() {
 					if client.TestData.Staleness == nil {
 						client.TestData.Staleness = make(map[string]bool)
 					}
+
 					for i := range containers {
 						name := fmt.Sprintf("perf-container-%d", i)
 						client.TestData.Staleness[name] = true

--- a/internal/actions/update_watchtower_test.go
+++ b/internal/actions/update_watchtower_test.go
@@ -199,7 +199,9 @@ var _ = ginkgo.Describe("Watchtower container handling", func() {
 				false,
 				false,
 			)
+
 			var cleanupImageInfos []types.RemovedImageInfo
+
 			cleanupOccurred, err := actions.RemoveExcessWatchtowerInstances(
 				client,
 				true, // cleanup=true
@@ -246,7 +248,9 @@ var _ = ginkgo.Describe("Watchtower container handling", func() {
 				false,
 				false,
 			)
+
 			var cleanupImageInfos []types.RemovedImageInfo
+
 			cleanupOccurred, err := actions.RemoveExcessWatchtowerInstances(
 				client,
 				true,

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -89,6 +89,7 @@ var _ = ginkgo.Describe("SetupAndStartAPI", func() {
 			mockServer := mockAPI.NewMockHTTPServer(ginkgo.GinkgoT())
 			mockServer.EXPECT().ListenAndServe().RunAndReturn(func() error {
 				done <- true
+
 				<-ctx.Done()
 
 				return nil
@@ -162,6 +163,7 @@ var _ = ginkgo.Describe("SetupAndStartAPI", func() {
 			mockServer := mockAPI.NewMockHTTPServer(ginkgo.GinkgoT())
 			mockServer.EXPECT().ListenAndServe().RunAndReturn(func() error {
 				done <- true
+
 				<-ctx.Done()
 
 				return nil
@@ -258,6 +260,7 @@ var _ = ginkgo.Describe("SetupAndStartAPI", func() {
 				ctx := context.Background()
 
 				var capturedParams types.UpdateParams
+
 				runUpdatesWithNotifications := func(_ context.Context, _ types.Filter, params types.UpdateParams) *metrics.Metric {
 					capturedParams = params
 

--- a/internal/logging/startup_test.go
+++ b/internal/logging/startup_test.go
@@ -123,6 +123,7 @@ var _ = ginkgo.Describe("WriteStartupMessage", func() {
 
 	ginkgo.It("should warn about trace logging", func() {
 		originalLevel := logrus.GetLevel()
+
 		logrus.SetLevel(logrus.TraceLevel)
 		defer logrus.SetLevel(originalLevel)
 
@@ -215,6 +216,7 @@ var _ = ginkgo.Describe("LogScheduleInfo", func() {
 
 	ginkgo.It("should log one-time update", func() {
 		cmd.PersistentFlags().Bool("run-once", true, "")
+
 		logger := logrus.NewEntry(logrus.StandardLogger())
 
 		logging.LogScheduleInfo(logger, cmd, time.Time{}, nil)
@@ -226,6 +228,7 @@ var _ = ginkgo.Describe("LogScheduleInfo", func() {
 	ginkgo.It("should log flag conflict when both run-once and update-on-start are set", func() {
 		cmd.PersistentFlags().Bool("run-once", true, "")
 		cmd.PersistentFlags().Bool("update-on-start", true, "")
+
 		logger := logrus.NewEntry(logrus.StandardLogger())
 
 		logging.LogScheduleInfo(logger, cmd, time.Time{}, nil)
@@ -237,6 +240,7 @@ var _ = ginkgo.Describe("LogScheduleInfo", func() {
 
 	ginkgo.It("should log update on start", func() {
 		cmd.PersistentFlags().Bool("update-on-start", true, "")
+
 		logger := logrus.NewEntry(logrus.StandardLogger())
 
 		logging.LogScheduleInfo(logger, cmd, time.Time{}, nil)
@@ -248,6 +252,7 @@ var _ = ginkgo.Describe("LogScheduleInfo", func() {
 	ginkgo.It("should log HTTP API without periodic polls", func() {
 		cmd.PersistentFlags().Bool("http-api-update", true, "")
 		cmd.PersistentFlags().Bool("http-api-periodic-polls", false, "")
+
 		logger := logrus.NewEntry(logrus.StandardLogger())
 
 		logging.LogScheduleInfo(logger, cmd, time.Time{}, nil)
@@ -260,6 +265,7 @@ var _ = ginkgo.Describe("LogScheduleInfo", func() {
 	ginkgo.It("should log HTTP API with periodic polls", func() {
 		cmd.PersistentFlags().Bool("http-api-update", true, "")
 		cmd.PersistentFlags().Bool("http-api-periodic-polls", true, "")
+
 		logger := logrus.NewEntry(logrus.StandardLogger())
 
 		logging.LogScheduleInfo(logger, cmd, time.Time{}, nil)

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -503,8 +503,10 @@ func TestAPI_StartServerAsyncLogErrorOnFailure(t *testing.T) {
 
 var _ = ginkgo.Describe("API", func() {
 	ginkgo.Describe("RequireToken middleware", func() {
-		var apiInstance *api.API
-		var server *ghttp.Server
+		var (
+			apiInstance *api.API
+			server      *ghttp.Server
+		)
 
 		ginkgo.BeforeEach(func() {
 			apiInstance = api.New(testToken, ":8080")
@@ -577,7 +579,9 @@ var _ = ginkgo.Describe("API", func() {
 		ginkgo.It("should fail with a fatal log when token is empty", func() {
 			emptyTokenAPI := api.New("", ":8080")
 			emptyTokenAPI.RegisterFunc("/test", http.HandlerFunc(testHandler))
+
 			var logOutput string
+
 			logrus.SetOutput(&testLogWriter{
 				buffer: []byte{},
 				writeFunc: func(b []byte) (int, error) {
@@ -587,9 +591,12 @@ var _ = ginkgo.Describe("API", func() {
 				},
 			})
 			defer logrus.SetOutput(nil)
+
 			originalExit := logrus.StandardLogger().ExitFunc
 			logrus.StandardLogger().ExitFunc = func(int) { panic("fatal exit") }
+
 			defer func() { logrus.StandardLogger().ExitFunc = originalExit }()
+
 			gomega.Expect(func() { _ = emptyTokenAPI.Start(context.Background(), true, false) }).
 				To(gomega.Panic())
 			gomega.Expect(logOutput).

--- a/pkg/api/metrics/metrics_test.go
+++ b/pkg/api/metrics/metrics_test.go
@@ -58,10 +58,12 @@ func getWithToken(baseURL string) (map[string]string, error) {
 }
 
 var _ = ginkgo.Describe("the metrics API", func() {
-	var server *ghttp.Server
-	var httpAPI *api.API
-	var m *metricsAPI.Handler
-	var handleReq http.HandlerFunc
+	var (
+		server    *ghttp.Server
+		httpAPI   *api.API
+		m         *metricsAPI.Handler
+		handleReq http.HandlerFunc
+	)
 
 	ginkgo.BeforeEach(func() {
 		httpAPI = api.New(token, ":8080")
@@ -136,6 +138,7 @@ var _ = ginkgo.Describe("the metrics API", func() {
 		for range 3 {
 			metrics.Default().RegisterScan(nil)
 		}
+
 		gomega.Eventually(metrics.Default().QueueIsEmpty).Should(gomega.BeTrue())
 
 		gomega.Eventually(tryGetMetrics).Should(gomega.SatisfyAll(

--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -37,10 +37,13 @@ const (
 )
 
 var _ = ginkgo.Describe("the client", func() {
-	var docker *dockerClient.Client
-	var mockServer *ghttp.Server
+	var (
+		docker     *dockerClient.Client
+		mockServer *ghttp.Server
+	)
 
 	// Set up a mock Docker server before each test.
+
 	ginkgo.BeforeEach(func() {
 		mockServer = ghttp.NewServer()
 		docker, _ = dockerClient.NewClientWithOpts(
@@ -318,6 +321,7 @@ var _ = ginkgo.Describe("the client", func() {
 						&mockContainer.Watchtower,
 						&mockContainer.Running,
 					)...)
+
 				client := client{
 					api:           docker,
 					ClientOptions: ClientOptions{},
@@ -338,6 +342,7 @@ var _ = ginkgo.Describe("the client", func() {
 						&mockContainer.Watchtower,
 						&mockContainer.Running,
 					)...)
+
 				filter := filters.FilterByNames([]string{"lollercoaster"}, filters.NoFilter)
 				client := client{
 					api:           docker,
@@ -359,6 +364,7 @@ var _ = ginkgo.Describe("the client", func() {
 						&mockContainer.Watchtower,
 						&mockContainer.Running,
 					)...)
+
 				client := client{
 					api:           docker,
 					ClientOptions: ClientOptions{},
@@ -383,6 +389,7 @@ var _ = ginkgo.Describe("the client", func() {
 						&mockContainer.Watchtower,
 						&mockContainer.Running,
 					)...)
+
 				client := client{
 					api:           docker,
 					ClientOptions: ClientOptions{IncludeStopped: true},
@@ -406,6 +413,7 @@ var _ = ginkgo.Describe("the client", func() {
 						&mockContainer.Running,
 						&mockContainer.Restarting,
 					)...)
+
 				client := client{
 					api:           docker,
 					ClientOptions: ClientOptions{IncludeRestarting: true},
@@ -426,6 +434,7 @@ var _ = ginkgo.Describe("the client", func() {
 						&mockContainer.Watchtower,
 						&mockContainer.Running,
 					)...)
+
 				client := client{
 					api:           docker,
 					ClientOptions: ClientOptions{IncludeRestarting: false},
@@ -446,6 +455,7 @@ var _ = ginkgo.Describe("the client", func() {
 						&mockContainer.Watchtower,
 						&mockContainer.Running,
 					)...)
+
 				client := client{
 					api:           docker,
 					ClientOptions: ClientOptions{},
@@ -467,6 +477,7 @@ var _ = ginkgo.Describe("the client", func() {
 						&mockContainer.Watchtower,
 						&mockContainer.Running,
 					)...)
+
 				client := client{
 					api:           docker,
 					ClientOptions: ClientOptions{},
@@ -491,6 +502,7 @@ var _ = ginkgo.Describe("the client", func() {
 					consumerContainerRef := mockContainer.NetConsumerOK
 					mockServer.AppendHandlers(
 						mockContainer.GetContainerHandlers(&consumerContainerRef)...)
+
 					client := client{
 						api:           docker,
 						ClientOptions: ClientOptions{},
@@ -498,6 +510,7 @@ var _ = ginkgo.Describe("the client", func() {
 					// Execute GetContainer and verify network mode resolution.
 					container, err := client.GetContainer(consumerContainerRef.ContainerID())
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 					networkMode := container.ContainerInfo().HostConfig.NetworkMode
 					gomega.Expect(networkMode.ConnectedContainer()).
 						To(gomega.Equal(mockContainer.NetSupplierContainerName))
@@ -510,6 +523,7 @@ var _ = ginkgo.Describe("the client", func() {
 					consumerContainerRef := mockContainer.NetConsumerInvalidSupplier
 					mockServer.AppendHandlers(
 						mockContainer.GetContainerHandlers(&consumerContainerRef)...)
+
 					client := client{
 						api:           docker,
 						ClientOptions: ClientOptions{},
@@ -517,6 +531,7 @@ var _ = ginkgo.Describe("the client", func() {
 					// Execute GetContainer and verify fallback to container ID.
 					container, err := client.GetContainer(consumerContainerRef.ContainerID())
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 					networkMode := container.ContainerInfo().HostConfig.NetworkMode
 					gomega.Expect(networkMode.ConnectedContainer()).
 						To(gomega.Equal(mockContainer.NetSupplierNotFoundID))
@@ -550,6 +565,7 @@ var _ = ginkgo.Describe("the client", func() {
 								),
 							),
 						)
+
 						client := client{api: docker}
 						err := client.WaitForContainerHealthy(types.ContainerID(cid), 5*time.Second)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -572,6 +588,7 @@ var _ = ginkgo.Describe("the client", func() {
 								),
 								func(w http.ResponseWriter, _ *http.Request) {
 									callCount++
+
 									var response dockerContainer.InspectResponse
 									if callCount <= 2 { // First two calls return starting
 										response = dockerContainer.InspectResponse{
@@ -600,6 +617,7 @@ var _ = ginkgo.Describe("the client", func() {
 											Config: &dockerContainer.Config{},
 										}
 									}
+
 									w.Header().Set("Content-Type", "application/json")
 									w.WriteHeader(http.StatusOK)
 									json.NewEncoder(w).Encode(response)
@@ -614,6 +632,7 @@ var _ = ginkgo.Describe("the client", func() {
 								),
 								func(w http.ResponseWriter, _ *http.Request) {
 									callCount++
+
 									var response dockerContainer.InspectResponse
 									if callCount <= 2 { // First two calls return starting
 										response = dockerContainer.InspectResponse{
@@ -642,6 +661,7 @@ var _ = ginkgo.Describe("the client", func() {
 											Config: &dockerContainer.Config{},
 										}
 									}
+
 									w.Header().Set("Content-Type", "application/json")
 									w.WriteHeader(http.StatusOK)
 									json.NewEncoder(w).Encode(response)
@@ -656,6 +676,7 @@ var _ = ginkgo.Describe("the client", func() {
 								),
 								func(w http.ResponseWriter, _ *http.Request) {
 									callCount++
+
 									var response dockerContainer.InspectResponse
 									if callCount <= 2 { // First two calls return starting
 										response = dockerContainer.InspectResponse{
@@ -684,12 +705,14 @@ var _ = ginkgo.Describe("the client", func() {
 											Config: &dockerContainer.Config{},
 										}
 									}
+
 									w.Header().Set("Content-Type", "application/json")
 									w.WriteHeader(http.StatusOK)
 									json.NewEncoder(w).Encode(response)
 								},
 							),
 						)
+
 						client := client{api: docker}
 						err := client.WaitForContainerHealthy(types.ContainerID(cid), 5*time.Second)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -726,6 +749,7 @@ var _ = ginkgo.Describe("the client", func() {
 								),
 							),
 						)
+
 						client := client{api: docker}
 						err := client.WaitForContainerHealthy(types.ContainerID(cid), 5*time.Second)
 						gomega.Expect(err).To(gomega.HaveOccurred())
@@ -754,8 +778,10 @@ var _ = ginkgo.Describe("the client", func() {
 
 				ginkgo.It("should detect Podman via CONTAINER environment variable", func() {
 					memFs := afero.NewMemMapFs()
+
 					restore := withEnvVars(map[string]string{"CONTAINER": "podman"})
 					defer restore()
+
 					testClient := client{
 						api: docker,
 						ClientOptions: ClientOptions{
@@ -769,6 +795,7 @@ var _ = ginkgo.Describe("the client", func() {
 
 				ginkgo.It("should detect Podman via API Name field", func() {
 					memFs := afero.NewMemMapFs()
+
 					mockServer.AppendHandlers(
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", gomega.MatchRegexp(`^/v[0-9.]+/info$`)),
@@ -777,6 +804,7 @@ var _ = ginkgo.Describe("the client", func() {
 							}),
 						),
 					)
+
 					testClient := client{
 						api: docker,
 						ClientOptions: ClientOptions{
@@ -790,6 +818,7 @@ var _ = ginkgo.Describe("the client", func() {
 
 				ginkgo.It("should detect Podman via API ServerVersion field", func() {
 					memFs := afero.NewMemMapFs()
+
 					mockServer.AppendHandlers(
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", gomega.MatchRegexp(`^/v[0-9.]+/info$`)),
@@ -798,6 +827,7 @@ var _ = ginkgo.Describe("the client", func() {
 							}),
 						),
 					)
+
 					testClient := client{
 						api: docker,
 						ClientOptions: ClientOptions{
@@ -820,6 +850,7 @@ var _ = ginkgo.Describe("the client", func() {
 							}),
 						),
 					)
+
 					testClient := client{
 						api: docker,
 						ClientOptions: ClientOptions{
@@ -833,14 +864,17 @@ var _ = ginkgo.Describe("the client", func() {
 
 				ginkgo.It("should fall back to Docker when detection fails", func() {
 					memFs := afero.NewMemMapFs()
+
 					mockServer.AppendHandlers(
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", gomega.MatchRegexp(`^/v[0-9.]+/info$`)),
 							ghttp.RespondWith(http.StatusInternalServerError, "server error"),
 						),
 					)
+
 					resetLogrus, logbuf := captureLogrus(logrus.DebugLevel)
 					defer resetLogrus()
+
 					testClient := client{
 						api: docker,
 						ClientOptions: ClientOptions{
@@ -885,6 +919,7 @@ var _ = ginkgo.Describe("the client", func() {
 				// Capture logrus output in buffer.
 				resetLogrus, logbuf := captureLogrus(logrus.DebugLevel)
 				defer resetLogrus()
+
 				user := ""
 				containerID := types.ContainerID("ex-cont-id")
 				execID := "ex-exec-id"
@@ -1007,6 +1042,7 @@ var _ = ginkgo.Describe("the client", func() {
 				// Capture logrus output in buffer.
 				resetLogrus, logbuf := captureLogrus(logrus.DebugLevel)
 				defer resetLogrus()
+
 				user := ""
 				containerID := types.ContainerID("ex-cont-id")
 				execID := "ex-exec-id"
@@ -1138,6 +1174,7 @@ var _ = ginkgo.Describe("the client", func() {
 			client := client{api: docker}
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
+
 			_, err := client.captureExecOutput(ctx, "exec-id")
 			gomega.Expect(err).To(gomega.HaveOccurred())
 		})
@@ -1341,6 +1378,7 @@ var _ = ginkgo.Describe("the client", func() {
 				// Execute ListContainers
 				resetLogrus, logbuf := captureLogrus(logrus.DebugLevel)
 				defer resetLogrus()
+
 				client := client{api: docker, ClientOptions: ClientOptions{}}
 				containers, err := client.ListContainers()
 
@@ -1353,6 +1391,7 @@ var _ = ginkgo.Describe("the client", func() {
 				for i, c := range containers {
 					containerIDs[i] = string(c.ID())
 				}
+
 				gomega.Expect(containerIDs).To(gomega.ContainElement(validContainer1ID))
 				gomega.Expect(containerIDs).To(gomega.ContainElement(validContainer2ID))
 				gomega.Expect(containerIDs).NotTo(gomega.ContainElement(ghostContainerID))
@@ -1362,8 +1401,10 @@ var _ = ginkgo.Describe("the client", func() {
 	})
 
 	ginkgo.Describe("TLS client methods", func() {
-		var tlsServer *ghttp.Server
-		var testClient Client
+		var (
+			tlsServer  *ghttp.Server
+			testClient Client
+		)
 
 		ginkgo.BeforeEach(func() {
 			tlsServer = ghttp.NewTLSServer()
@@ -1396,6 +1437,7 @@ var _ = ginkgo.Describe("the client", func() {
 					}),
 				),
 			)
+
 			info, err := testClient.GetInfo()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(info).NotTo(gomega.BeNil())
@@ -1406,6 +1448,7 @@ var _ = ginkgo.Describe("the client", func() {
 			// Create a non-TLS server to simulate TLS failure
 			httpServer := ghttp.NewServer()
 			defer httpServer.Close()
+
 			httpServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.RespondWith(http.StatusOK, "OK"),
@@ -1448,6 +1491,7 @@ var _ = ginkgo.Describe("the client", func() {
 					}),
 				),
 			)
+
 			info, err := testClient.GetInfo()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(info).To(gomega.HaveKeyWithValue("Name", "test-docker"))
@@ -1464,6 +1508,7 @@ var _ = ginkgo.Describe("the client", func() {
 			func() {
 				tlsServer := ghttp.NewTLSServer()
 				defer tlsServer.Close()
+
 				tlsServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/_ping"),
@@ -1477,11 +1522,13 @@ var _ = ginkgo.Describe("the client", func() {
 						}),
 					),
 				)
+
 				restore := withEnvVars(map[string]string{
 					"DOCKER_TLS_VERIFY": "1",
 					"DOCKER_HOST":       tlsServer.URL(),
 				})
 				defer restore()
+
 				client := NewClient(ClientOptions{})
 				gomega.Expect(client).NotTo(gomega.BeNil())
 			},
@@ -1490,6 +1537,7 @@ var _ = ginkgo.Describe("the client", func() {
 		ginkgo.It("should fail when TLS is required but server is HTTP-only", func() {
 			httpServer := ghttp.NewServer()
 			defer httpServer.Close()
+
 			httpServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.RespondWith(http.StatusOK, "OK"),
@@ -1498,17 +1546,20 @@ var _ = ginkgo.Describe("the client", func() {
 					ghttp.RespondWith(http.StatusInternalServerError, "TLS connection failed"),
 				),
 			)
+
 			restore := withEnvVars(map[string]string{
 				"DOCKER_TLS_VERIFY": "1",
 				"DOCKER_HOST":       httpServer.URL(),
 			})
 			defer restore()
+
 			gomega.Expect(func() { NewClient(ClientOptions{}) }).ToNot(gomega.Panic())
 		})
 
 		ginkgo.It("should negotiate API version with TLS", func() {
 			tlsServer := ghttp.NewTLSServer()
 			defer tlsServer.Close()
+
 			tlsServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", gomega.MatchRegexp(`^/v[0-9.]+/version$`)),
@@ -1518,11 +1569,13 @@ var _ = ginkgo.Describe("the client", func() {
 					}),
 				),
 			)
+
 			restore := withEnvVars(map[string]string{
 				"DOCKER_TLS_VERIFY": "1",
 				"DOCKER_HOST":       tlsServer.URL(),
 			})
 			defer restore()
+
 			client := NewClient(ClientOptions{})
 			gomega.Expect(client).NotTo(gomega.BeNil())
 		})
@@ -1530,6 +1583,7 @@ var _ = ginkgo.Describe("the client", func() {
 		ginkgo.It("should use forced API version with TLS", func() {
 			tlsServer := ghttp.NewTLSServer()
 			defer tlsServer.Close()
+
 			tlsServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/_ping"),
@@ -1543,12 +1597,14 @@ var _ = ginkgo.Describe("the client", func() {
 					}),
 				),
 			)
+
 			restore := withEnvVars(map[string]string{
 				"DOCKER_TLS_VERIFY":  "1",
 				"DOCKER_HOST":        tlsServer.URL(),
 				"DOCKER_API_VERSION": "1.40",
 			})
 			defer restore()
+
 			client := NewClient(ClientOptions{})
 			gomega.Expect(client).NotTo(gomega.BeNil())
 		})
@@ -1558,6 +1614,7 @@ var _ = ginkgo.Describe("the client", func() {
 			func() {
 				tlsServer := ghttp.NewTLSServer()
 				defer tlsServer.Close()
+
 				tlsServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/_ping"),
@@ -1571,12 +1628,14 @@ var _ = ginkgo.Describe("the client", func() {
 						}),
 					),
 				)
+
 				restore := withEnvVars(map[string]string{
 					"DOCKER_TLS_VERIFY":  "1",
 					"DOCKER_HOST":        tlsServer.URL(),
 					"DOCKER_API_VERSION": "1.99",
 				})
 				defer restore()
+
 				client := NewClient(ClientOptions{})
 				gomega.Expect(client).NotTo(gomega.BeNil())
 			},

--- a/pkg/container/container_id_test.go
+++ b/pkg/container/container_id_test.go
@@ -310,6 +310,7 @@ var _ = ginkgo.Describe("GetContainerIDFromHostname", func() {
 			if wantErr {
 				gomega.Expect(err).To(gomega.HaveOccurred())
 				gomega.Expect(got).To(gomega.BeEmpty())
+
 				if errorSubstring != "" {
 					gomega.Expect(err.Error()).To(gomega.ContainSubstring(errorSubstring))
 				}
@@ -482,6 +483,7 @@ var _ = ginkgo.Describe("GetCurrentContainerID", func() {
 			if expectError {
 				gomega.Expect(err).To(gomega.HaveOccurred())
 				gomega.Expect(id).To(gomega.BeEmpty())
+
 				if errorSubstring != "" {
 					gomega.Expect(err.Error()).To(gomega.ContainSubstring(errorSubstring))
 				}

--- a/pkg/container/container_source_test.go
+++ b/pkg/container/container_source_test.go
@@ -28,12 +28,16 @@ const (
 )
 
 var _ = ginkgo.Describe("ListSourceContainers", func() {
-	var docker *dockerClient.Client
-	var mockServer *ghttp.Server
+	var (
+		docker     *dockerClient.Client
+		mockServer *ghttp.Server
+	)
 
 	ginkgo.BeforeEach(func() {
 		mockServer = ghttp.NewServer()
+
 		var err error
+
 		docker, err = dockerClient.NewClientWithOpts(
 			dockerClient.WithHost(mockServer.URL()),
 			dockerClient.WithHTTPClient(mockServer.HTTPTestServer.Client()))
@@ -50,7 +54,9 @@ var _ = ginkgo.Describe("ListSourceContainers", func() {
 			ghttp.VerifyRequest("GET", gomega.MatchRegexp("^/v[0-9.]+/containers/json$")),
 			func(w http.ResponseWriter, r *http.Request) {
 				filtersParam := r.URL.Query().Get("filters")
+
 				var filters map[string]map[string]bool
+
 				err := json.Unmarshal([]byte(filtersParam), &filters)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -59,10 +65,12 @@ var _ = ginkgo.Describe("ListSourceContainers", func() {
 					gomega.Expect(exists).To(gomega.BeFalse())
 				} else {
 					gomega.Expect(exists).To(gomega.BeTrue())
+
 					actualStatuses := make([]string, 0, len(statusMap))
 					for status := range statusMap {
 						actualStatuses = append(actualStatuses, status)
 					}
+
 					gomega.Expect(actualStatuses).To(gomega.ConsistOf(expectedStatuses))
 				}
 
@@ -256,12 +264,16 @@ var _ = ginkgo.Describe("buildListFilterArgs", func() {
 })
 
 var _ = ginkgo.Describe("GetSourceContainer", func() {
-	var docker *dockerClient.Client
-	var mockServer *ghttp.Server
+	var (
+		docker     *dockerClient.Client
+		mockServer *ghttp.Server
+	)
 
 	ginkgo.BeforeEach(func() {
 		mockServer = ghttp.NewServer()
+
 		var err error
+
 		docker, err = dockerClient.NewClientWithOpts(
 			dockerClient.WithHost(mockServer.URL()),
 			dockerClient.WithHTTPClient(mockServer.HTTPTestServer.Client()))
@@ -495,12 +507,16 @@ var _ = ginkgo.Describe("GetSourceContainer", func() {
 })
 
 var _ = ginkgo.Describe("StopAndRemoveSourceContainer", func() {
-	var docker *dockerClient.Client
-	var mockServer *ghttp.Server
+	var (
+		docker     *dockerClient.Client
+		mockServer *ghttp.Server
+	)
 
 	ginkgo.BeforeEach(func() {
 		mockServer = ghttp.NewServer()
+
 		var err error
+
 		docker, err = dockerClient.NewClientWithOpts(
 			dockerClient.WithHost(mockServer.URL()),
 			dockerClient.WithHTTPClient(mockServer.HTTPTestServer.Client()))
@@ -714,6 +730,7 @@ var _ = ginkgo.Describe("StopAndRemoveSourceContainer", func() {
 						query := r.URL.Query()
 						signal := query.Get("signal")
 						timeoutStr := query.Get("t")
+
 						gomega.Expect(signal).To(gomega.Equal("SIGTERM"))
 						gomega.Expect(timeoutStr).To(gomega.Equal("30"))
 						w.WriteHeader(http.StatusNoContent)
@@ -1644,7 +1661,9 @@ var _ = ginkgo.Describe("filterAliases", func() {
 
 	ginkgo.It("handles nil alias list", func() {
 		shortID := testShortID
+
 		var aliases []string
+
 		result := filterAliases(aliases, shortID)
 		gomega.Expect(result).To(gomega.BeEmpty())
 	})
@@ -1686,12 +1705,16 @@ var _ = ginkgo.Describe("filterAliases", func() {
 })
 
 var _ = ginkgo.Describe("StopSourceContainer", func() {
-	var docker *dockerClient.Client
-	var mockServer *ghttp.Server
+	var (
+		docker     *dockerClient.Client
+		mockServer *ghttp.Server
+	)
 
 	ginkgo.BeforeEach(func() {
 		mockServer = ghttp.NewServer()
+
 		var err error
+
 		docker, err = dockerClient.NewClientWithOpts(
 			dockerClient.WithHost(mockServer.URL()),
 			dockerClient.WithHTTPClient(mockServer.HTTPTestServer.Client()))
@@ -1791,6 +1814,7 @@ var _ = ginkgo.Describe("StopSourceContainer", func() {
 						query := r.URL.Query()
 						signal := query.Get("signal")
 						timeoutStr := query.Get("t")
+
 						gomega.Expect(signal).To(gomega.Equal("SIGTERM"))
 						gomega.Expect(timeoutStr).To(gomega.Equal("30"))
 						w.WriteHeader(http.StatusNoContent)

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -574,6 +574,7 @@ var _ = ginkgo.Describe("Container", func() {
 					for i := 1; i <= 100; i++ {
 						deps = append(deps, fmt.Sprintf("dep%d", i))
 					}
+
 					label := strings.Join(deps, ",")
 					container = MockContainer(WithLabels(map[string]string{
 						"com.centurylinklabs.watchtower.depends-on": label,
@@ -603,12 +604,15 @@ var _ = ginkgo.Describe("Container", func() {
 				logOutput := &bytes.Buffer{}
 				originalOutput := logrus.StandardLogger().Out
 				originalLevel := logrus.GetLevel()
+
 				logrus.SetOutput(logOutput)
 				logrus.SetLevel(logrus.WarnLevel)
+
 				defer func() {
 					logrus.SetOutput(originalOutput)
 					logrus.SetLevel(originalLevel)
 				}()
+
 				container = MockContainer(WithLinks([]string{"invalidlink"}))
 				links := container.Links()
 				gomega.Expect(links).To(gomega.BeEmpty())
@@ -620,12 +624,15 @@ var _ = ginkgo.Describe("Container", func() {
 				logOutput := &bytes.Buffer{}
 				originalOutput := logrus.StandardLogger().Out
 				originalLevel := logrus.GetLevel()
+
 				logrus.SetOutput(logOutput)
 				logrus.SetLevel(logrus.WarnLevel)
+
 				defer func() {
 					logrus.SetOutput(originalOutput)
 					logrus.SetLevel(originalLevel)
 				}()
+
 				container = MockContainer(WithLinks([]string{":alias"}))
 				links := container.Links()
 				gomega.Expect(links).To(gomega.BeEmpty())
@@ -1030,6 +1037,7 @@ var _ = ginkgo.Describe("Container", func() {
 				if c.HostConfig == nil {
 					c.HostConfig = &dockerContainer.HostConfig{}
 				}
+
 				c.HostConfig.MemorySwappiness = &swappiness
 			}
 		}
@@ -1038,6 +1046,7 @@ var _ = ginkgo.Describe("Container", func() {
 			logOutput = &bytes.Buffer{}
 			logrus.SetOutput(logOutput)
 			logrus.SetLevel(logrus.DebugLevel)
+
 			mockContainer = MockContainer(WithMemorySwappiness(defaultMemorySwappiness))
 			inspectResponse := dockerContainer.InspectResponse{
 				ContainerJSONBase: &dockerContainer.ContainerJSONBase{
@@ -1061,6 +1070,7 @@ var _ = ginkgo.Describe("Container", func() {
 
 			if disableMemorySwappiness {
 				hostConfig.MemorySwappiness = nil
+
 				clog.Debug("Disabled memory swappiness for Podman compatibility")
 			}
 
@@ -1080,6 +1090,7 @@ var _ = ginkgo.Describe("Container", func() {
 
 			if disableMemorySwappiness {
 				hostConfig.MemorySwappiness = nil
+
 				clog.Debug("Disabled memory swappiness for Podman compatibility")
 			}
 
@@ -1108,6 +1119,7 @@ var _ = ginkgo.Describe("Container", func() {
 					if c.HostConfig == nil {
 						c.HostConfig = &dockerContainer.HostConfig{}
 					}
+
 					c.HostConfig.NanoCPUs = nanoCPUs
 					c.HostConfig.CPUShares = cpuShares
 					c.HostConfig.CPUQuota = cpuQuota
@@ -1121,6 +1133,7 @@ var _ = ginkgo.Describe("Container", func() {
 				logOutput = &bytes.Buffer{}
 				logrus.SetOutput(logOutput)
 				logrus.SetLevel(logrus.DebugLevel)
+
 				mockContainer = MockContainer(
 					WithCPUSettings(
 						defaultNanoCPUs,
@@ -1317,6 +1330,7 @@ var _ = ginkgo.Describe("Container", func() {
 					if c.HostConfig == nil {
 						c.HostConfig = &dockerContainer.HostConfig{}
 					}
+
 					c.HostConfig.MemorySwappiness = &defaultMemorySwappiness
 				},
 			)

--- a/pkg/container/image_test.go
+++ b/pkg/container/image_test.go
@@ -22,8 +22,11 @@ import (
 )
 
 var _ = ginkgo.Describe("the client", func() {
-	var docker *dockerClient.Client
-	var mockServer *ghttp.Server
+	var (
+		docker     *dockerClient.Client
+		mockServer *ghttp.Server
+	)
+
 	ginkgo.BeforeEach(func() {
 		mockServer = ghttp.NewServer()
 		docker, _ = dockerClient.NewClientWithOpts(
@@ -36,8 +39,10 @@ var _ = ginkgo.Describe("the client", func() {
 	ginkgo.Describe("WarnOnHeadPullFailed", func() {
 		containerUnknown := MockContainer(WithImageName("unknown.repo/prefix/imagename:latest"))
 		containerKnown := MockContainer(WithImageName("docker.io/prefix/imagename:latest"))
+
 		ginkgo.When(`warn on head failure is set to "always"`, func() {
 			c := client{ClientOptions: ClientOptions{WarnOnHeadFailed: WarnAlways}}
+
 			ginkgo.It("should always return true", func() {
 				gomega.Expect(c.WarnOnHeadPullFailed(containerUnknown)).To(gomega.BeTrue())
 				gomega.Expect(c.WarnOnHeadPullFailed(containerKnown)).To(gomega.BeTrue())
@@ -45,6 +50,7 @@ var _ = ginkgo.Describe("the client", func() {
 		})
 		ginkgo.When(`warn on head failure is set to "auto"`, func() {
 			c := client{ClientOptions: ClientOptions{WarnOnHeadFailed: WarnAuto}}
+
 			ginkgo.It("should return false for unknown repos", func() {
 				gomega.Expect(c.WarnOnHeadPullFailed(containerUnknown)).To(gomega.BeFalse())
 			})
@@ -54,6 +60,7 @@ var _ = ginkgo.Describe("the client", func() {
 		})
 		ginkgo.When(`warn on head failure is set to "never"`, func() {
 			c := client{ClientOptions: ClientOptions{WarnOnHeadFailed: WarnNever}}
+
 			ginkgo.It("should never return true", func() {
 				gomega.Expect(c.WarnOnHeadPullFailed(containerUnknown)).To(gomega.BeFalse())
 				gomega.Expect(c.WarnOnHeadPullFailed(containerKnown)).To(gomega.BeFalse())
@@ -82,9 +89,12 @@ var _ = ginkgo.Describe("the client", func() {
 				imageAParent := util.GenerateRandomSHA256()
 				images := map[string][]string{imageA: {imageAParent}}
 				mockServer.AppendHandlers(mockContainer.RemoveImageHandler(images))
+
 				c := client{api: docker}
+
 				resetLogrus, logbuf := captureLogrus(logrus.DebugLevel)
 				defer resetLogrus()
+
 				gomega.Expect(c.RemoveImageByID(types.ImageID(imageA), "test-image")).
 					To(gomega.Succeed())
 				shortA := types.ImageID(imageA).ShortID()
@@ -99,7 +109,9 @@ var _ = ginkgo.Describe("the client", func() {
 		ginkgo.When("image is not found", func() {
 			ginkgo.It("should return an error", func() {
 				image := util.GenerateRandomSHA256()
+
 				mockServer.AppendHandlers(mockContainer.RemoveImageHandler(nil))
+
 				c := client{api: docker}
 				err := c.RemoveImageByID(types.ImageID(image), "test-image")
 				gomega.Expect(cerrdefs.IsNotFound(err)).To(gomega.BeTrue())
@@ -117,6 +129,7 @@ var _ = ginkgo.Describe("the client", func() {
 						image.ID = currentImageID
 					},
 				)
+
 				mockServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest(
@@ -128,9 +141,12 @@ var _ = ginkgo.Describe("the client", func() {
 						}),
 					),
 				)
+
 				c := client{api: docker}
+
 				resetLogrus, logbuf := captureLogrus(logrus.DebugLevel)
 				defer resetLogrus()
+
 				stale, latestID, err := c.IsContainerStale(
 					container,
 					types.UpdateParams{NoPull: true},
@@ -154,6 +170,7 @@ var _ = ginkgo.Describe("the client", func() {
 						image.ID = currentImageID
 					},
 				)
+
 				mockServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest(
@@ -165,9 +182,12 @@ var _ = ginkgo.Describe("the client", func() {
 						}),
 					),
 				)
+
 				c := client{api: docker}
+
 				resetLogrus, logbuf := captureLogrus(logrus.DebugLevel)
 				defer resetLogrus()
+
 				stale, latestID, err := c.IsContainerStale(
 					container,
 					types.UpdateParams{NoPull: true},
@@ -190,6 +210,7 @@ var _ = ginkgo.Describe("the client", func() {
 						image.ID = currentImageID
 					},
 				)
+
 				mockServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest(
@@ -202,9 +223,12 @@ var _ = ginkgo.Describe("the client", func() {
 						),
 					),
 				)
+
 				c := client{api: docker}
+
 				resetLogrus, logbuf := captureLogrus(logrus.DebugLevel)
 				defer resetLogrus()
+
 				stale, latestID, err := c.IsContainerStale(
 					container,
 					types.UpdateParams{NoPull: true},

--- a/pkg/notifications/notifier_test.go
+++ b/pkg/notifications/notifier_test.go
@@ -27,6 +27,7 @@ var _ = ginkgo.Describe("notifications", func() {
 				"shoutrrr",
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			notifier := notifications.NewNotifier(command)
 
 			gomega.Expect(notifier.GetNames()).To(gomega.BeEmpty())
@@ -41,6 +42,7 @@ var _ = ginkgo.Describe("notifications", func() {
 					"test.host",
 				})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				data := notifications.GetTemplateData(command)
 				title := data.Title
 				gomega.Expect(title).To(gomega.Equal("Watchtower updates on test.host"))
@@ -112,6 +114,7 @@ var _ = ginkgo.Describe("notifications", func() {
 					"5",
 				})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				delay := notifications.GetDelay(command, time.Duration(0))
 				gomega.Expect(delay).To(gomega.Equal(5 * time.Second))
 			})
@@ -136,6 +139,7 @@ var _ = ginkgo.Describe("notifications", func() {
 						"0",
 					})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 					delay := notifications.GetDelay(command, 7*time.Second)
 					gomega.Expect(delay).To(gomega.Equal(7 * time.Second))
 				},
@@ -146,6 +150,7 @@ var _ = ginkgo.Describe("notifications", func() {
 				content := "{{.Data.Host}} updated"
 				tmpFile, err := os.CreateTemp("", "template")
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				defer os.Remove(tmpFile.Name())
 
 				_, err = tmpFile.WriteString(content)
@@ -171,7 +176,6 @@ var _ = ginkgo.Describe("notifications", func() {
 	})
 	ginkgo.Describe("the slack notifier", func() {
 		// builderFn := notifications.NewSlackNotifier
-
 		ginkgo.When("passing a discord url to the slack notifier", func() {
 			command := cmd.NewRootCommand()
 			flags.RegisterNotificationFlags(command)
@@ -257,6 +261,7 @@ var _ = ginkgo.Describe("notifications", func() {
 		ginkgo.When("converting a slack service config into a shoutrrr url", func() {
 			command := cmd.NewRootCommand()
 			flags.RegisterNotificationFlags(command)
+
 			username := "containrrrbot"
 			tokenA := "AAAAAAAAA"
 			tokenB := "BBBBBBBBB"
@@ -384,6 +389,7 @@ var _ = ginkgo.Describe("notifications", func() {
 				notifier := notifications.NewNotifier(command)
 				names := notifier.GetNames()
 				gomega.Expect(names).To(gomega.ContainElement("gotify"))
+
 				urls := notifier.GetURLs()
 				gomega.Expect(urls).
 					To(gomega.ContainElement(gomega.ContainSubstring("gotify://gotify.example.com/test-token")))
@@ -404,12 +410,14 @@ var _ = ginkgo.Describe("notifications", func() {
 				gomega.Expect(command.ParseFlags(args)).To(gomega.Succeed())
 
 				logrus.SetLevel(logrus.TraceLevel)
+
 				logrus.SetOutput(io.Discard)
 				defer logrus.SetOutput(os.Stderr)
 
 				notifier := notifications.NewNotifier(command)
 				names := notifier.GetNames()
 				gomega.Expect(names).To(gomega.ContainElement("gotify"))
+
 				urls := notifier.GetURLs()
 				gomega.Expect(urls).
 					To(gomega.ContainElement(gomega.ContainSubstring("gotify://gotify.example.com/test-token")))

--- a/pkg/notifications/shoutrrr_test.go
+++ b/pkg/notifications/shoutrrr_test.go
@@ -111,6 +111,7 @@ updt1 (mock/updt1:latest): Updated
 					time.Second,
 				)
 				shoutrrr.AddLogHook()
+
 				hooksAfter := len(logrus.StandardLogger().Hooks[level])
 				gomega.Expect(hooksAfter).To(gomega.BeNumerically(">", hooksBefore))
 			})
@@ -128,8 +129,11 @@ updt1 (mock/updt1:latest): Updated
 					time.Second,
 				)
 				shoutrrr.AddLogHook()
+
 				hooksBefore := len(logrus.StandardLogger().Hooks[level])
+
 				shoutrrr.AddLogHook()
+
 				hooksAfter := len(logrus.StandardLogger().Hooks[level])
 				gomega.Expect(hooksAfter).To(gomega.Equal(hooksBefore))
 			})
@@ -658,9 +662,11 @@ Turns out everything is on fire
 
 				// Start multiple goroutines calling Close concurrently
 				done := make(chan bool, 10)
+
 				for range 10 {
 					go func() {
 						shoutrrr.Close()
+
 						done <- true
 					}()
 				}

--- a/pkg/registry/auth/auth_test.go
+++ b/pkg/registry/auth/auth_test.go
@@ -373,6 +373,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 	runBasicAuthTest := func(challengeHeader, creds, expectedToken, expectedErr string) {
 		// Create a TLS test server to simulate the registry.
 		server := ghttp.NewTLSServer()
+
 		server.AppendHandlers(
 			ghttp.CombineHandlers(
 				ghttp.VerifyRequest("GET", "/v2/"),
@@ -407,12 +408,15 @@ var _ = ginkgo.Describe("the auth module", func() {
 
 		// Temporarily disable WATCHTOWER_REGISTRY_TLS_SKIP to ensure HTTPS scheme.
 		originalTLSSkip := viper.GetBool("WATCHTOWER_REGISTRY_TLS_SKIP")
+
 		viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 		defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", originalTLSSkip)
 
 		// Execute GetToken and verify the result.
 		token, _, _, err := auth.GetToken(context.Background(), containerInstance, creds, client)
+
 		gomega.Expect(server.ReceivedRequests()).To(gomega.HaveLen(1))
+
 		if expectedErr != "" {
 			gomega.Expect(err).
 				To(gomega.HaveOccurred(), fmt.Sprintf("Expected an error for challenge '%s'", challengeHeader))
@@ -432,6 +436,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 	runBearerHeaderTest := func(creds, expectedToken string, expectAuthFailure bool) {
 		// Create a TLS test server to simulate the registry.
 		server := ghttp.NewTLSServer()
+
 		server.AppendHandlers(
 			ghttp.CombineHandlers(
 				ghttp.VerifyRequest("GET", "/"),
@@ -444,6 +449,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 							return
 						}
 					}
+
 					w.Header().Set("Content-Type", "application/json")
 					fmt.Fprintf(w, `{"token": "%s"}`, expectedToken)
 				},
@@ -469,6 +475,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 
 		// Execute GetBearerHeader and verify the result.
 		token, err := auth.GetBearerHeader(context.Background(), challenge, ref, creds, client)
+
 		gomega.Expect(server.ReceivedRequests()).To(gomega.HaveLen(1))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(token).To(gomega.Equal("Bearer " + expectedToken))
@@ -498,6 +505,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 		ginkgo.It("should return basic auth token when challenged with basic", func() {
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			runBasicAuthTest("Basic realm=\"test\"", "user:pass", "Basic user:pass", "")
 		})
 
@@ -506,6 +514,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 		ginkgo.It("should fail with no credentials for basic auth", func() {
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			runBasicAuthTest("Basic realm=\"test\"", "", "", "no credentials available")
 		})
 
@@ -514,6 +523,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 		ginkgo.It("should fail with unsupported challenge type", func() {
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			runBasicAuthTest(
 				"Digest realm=\"test\"",
 				"user:pass",
@@ -552,6 +562,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 			func() {
 				// Create an HTTP test server to simulate the registry.
 				server := ghttp.NewServer()
+
 				server.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/v2/"),
@@ -588,6 +599,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 					"",
 					client,
 				)
+
 				gomega.Expect(server.ReceivedRequests()).To(gomega.HaveLen(1))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(token).To(gomega.Equal(""))
@@ -599,6 +611,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 		ginkgo.It("should fail for HTTPS to HTTP registry without TLS skip", func() {
 			// Create an HTTP test server to simulate the registry.
 			server := ghttp.NewServer()
+
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/v2/"),
@@ -624,6 +637,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 
 			// Execute GetToken and verify the expected failure.
 			token, _, _, err := auth.GetToken(context.Background(), containerInstance, "", client)
+
 			gomega.Expect(server.ReceivedRequests()).To(gomega.BeEmpty())
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).
@@ -636,6 +650,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 		ginkgo.It("should handle empty WWW-Authenticate header with 401 status", func() {
 			// Create a TLS test server to simulate the registry.
 			server := ghttp.NewTLSServer()
+
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/v2/"),
@@ -678,6 +693,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 		ginkgo.It("should handle HTTPS registry with 200 OK without TLS skip", func() {
 			// Create a TLS test server to simulate a secure registry.
 			server := ghttp.NewTLSServer()
+
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/v2/"),
@@ -710,6 +726,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 
 			// Execute GetToken and verify the result.
 			token, _, _, err := auth.GetToken(context.Background(), containerInstance, "", client)
+
 			gomega.Expect(server.ReceivedRequests()).To(gomega.HaveLen(1))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(token).To(gomega.Equal(""))
@@ -720,6 +737,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 		ginkgo.It("should handle invalid TLS min version", func() {
 			// Create a TLS test server to simulate a secure registry.
 			server := ghttp.NewTLSServer()
+
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/v2/"),
@@ -754,6 +772,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 
 			// Execute GetToken and verify the result.
 			token, _, _, err := auth.GetToken(context.Background(), containerInstance, "", client)
+
 			gomega.Expect(server.ReceivedRequests()).To(gomega.HaveLen(1))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(token).To(gomega.Equal(""))
@@ -764,6 +783,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 		ginkgo.It("should fail with TLS version mismatch", func() {
 			// Create a TLS test server to simulate a secure registry.
 			server := ghttp.NewTLSServer()
+
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/v2/"),
@@ -797,7 +817,9 @@ var _ = ginkgo.Describe("the auth module", func() {
 
 		ginkgo.It("should extract the challenge host for bearer token", func() {
 			defer ginkgo.GinkgoRecover()
+
 			redirectServer := ghttp.NewTLSServer()
+
 			redirectServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/token"),
@@ -807,6 +829,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 			defer redirectServer.Close()
 
 			server := ghttp.NewTLSServer()
+
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/v2/"),
@@ -861,6 +884,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 		// Test case: Verifies that GetToken returns redirect=false when the challenge request is not redirected.
 		ginkgo.It("should return redirect=false when challenge request is not redirected", func() {
 			defer ginkgo.GinkgoRecover()
+
 			server := ghttp.NewTLSServer()
 			server.RouteToHandler("GET", "/v2/", ghttp.CombineHandlers(
 				ghttp.VerifyRequest("GET", "/v2/"),
@@ -877,6 +901,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 					},
 				),
 			))
+
 			server.RouteToHandler("GET", "/token", ghttp.CombineHandlers(
 				ghttp.VerifyRequest("GET", "/token"),
 				ghttp.RespondWith(http.StatusOK, `{"token": "mock-token"}`),
@@ -917,6 +942,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 		// Test case: Verifies that GetToken returns redirect=true when the challenge request is redirected.
 		ginkgo.It("should return redirect=true when challenge request is redirected", func() {
 			defer ginkgo.GinkgoRecover()
+
 			redirectServer := ghttp.NewTLSServer()
 			redirectServer.RouteToHandler("GET", "/v2/", ghttp.CombineHandlers(
 				ghttp.VerifyRequest("GET", "/v2/"),
@@ -933,6 +959,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 					},
 				),
 			))
+
 			redirectServer.RouteToHandler("GET", "/token", ghttp.CombineHandlers(
 				ghttp.VerifyRequest("GET", "/token"),
 				ghttp.RespondWith(http.StatusOK, `{"token": "mock-token"}`),
@@ -940,6 +967,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 			defer redirectServer.Close()
 
 			server := ghttp.NewTLSServer()
+
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/v2/"),
@@ -994,11 +1022,13 @@ var _ = ginkgo.Describe("the auth module", func() {
 		ginkgo.It("should fail when exceeding maximum redirects", func() {
 			// Create a chain of test servers to simulate multiple redirects
 			redirectCount := auth.DefaultMaxRedirects + 1 // Exceed limit (3 + 1 = 4 redirects)
+
 			servers := make([]*ghttp.Server, redirectCount)
 			for i := range redirectCount {
 				servers[i] = ghttp.NewServer()
 				defer servers[i].Close()
 			}
+
 			for i := range redirectCount {
 				if i < redirectCount-1 {
 					servers[i].AppendHandlers(
@@ -1108,6 +1138,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 		ginkgo.It("should fetch a bearer token successfully", func() {
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			runBearerHeaderTest("", "test-token", false)
 		})
 
@@ -1116,6 +1147,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 		ginkgo.It("should fetch a bearer token with credentials", func() {
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			runBearerHeaderTest("user:pass", "auth-token", true)
 		})
 
@@ -1138,6 +1170,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 		ginkgo.It("should fail on invalid JSON response", func() {
 			// Create a TLS test server to simulate the registry.
 			server := ghttp.NewTLSServer()
+
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/"),
@@ -1167,6 +1200,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 
 			// Execute GetBearerHeader and verify the failure.
 			token, err := auth.GetBearerHeader(context.Background(), challenge, ref, "", client)
+
 			gomega.Expect(server.ReceivedRequests()).To(gomega.HaveLen(1))
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(token).To(gomega.Equal(""))
@@ -1190,6 +1224,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 					},
 				),
 			))
+
 			server.RouteToHandler("GET", "/token", ghttp.CombineHandlers(
 				ghttp.VerifyRequest("GET", "/token"),
 				ghttp.RespondWith(
@@ -1226,6 +1261,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 
 			// Call GetBearerHeader directly to test processChallenge
 			token, err := auth.GetBearerHeader(context.Background(), challenge, ref, "", client)
+
 			gomega.Expect(server.ReceivedRequests()).To(gomega.HaveLen(1))
 			gomega.Expect(err).
 				NotTo(gomega.HaveOccurred(), "Expected no error from GetBearerHeader")
@@ -1243,6 +1279,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 				challenge := `bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:user/image:pull"`
 				imageRef, err := reference.ParseNormalizedNamed("nicholas-fedor/watchtower")
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				expected := &url.URL{
 					Host:     "ghcr.io",
 					Scheme:   "https",
@@ -1475,13 +1512,17 @@ var _ = ginkgo.Describe("the auth module", func() {
 		// and return the same client instance without race conditions.
 		ginkgo.It("should handle concurrent access safely", func() {
 			const numGoroutines = 100
+
 			clients := make([]auth.Client, numGoroutines)
+
 			var wg sync.WaitGroup
 
 			for i := range numGoroutines {
 				wg.Add(1)
+
 				go func(idx int) {
 					defer wg.Done()
+
 					clients[idx] = auth.NewAuthClient()
 				}(i)
 			}
@@ -1499,6 +1540,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 		ginkgo.It("should return a functional client", func() {
 			// Create a mock HTTP server to simulate a registry response.
 			server := ghttp.NewServer()
+
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/get"),

--- a/pkg/registry/digest/digest_test.go
+++ b/pkg/registry/digest/digest_test.go
@@ -138,6 +138,7 @@ var _ = ginkgo.Describe("Digests", func() {
 				resp.Header.Get("Www-Authenticate"),
 			)
 		}
+
 		digestHeader := resp.Header.Get(digest.ContentDigestHeader)
 		if digestHeader == "" {
 			return "", fmt.Errorf(
@@ -226,10 +227,12 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			resp, err := client.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			defer resp.Body.Close()
 
 			remoteDigest, err := extractHeadDigest(resp)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			matches := digest.DigestsMatch(
 				mockContainerEmptyDigests.ImageInfo().RepoDigests,
 				remoteDigest,
@@ -297,10 +300,12 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			resp, err := client.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			defer resp.Body.Close()
 
 			remoteDigest, err := extractHeadDigest(resp)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			matches := digest.DigestsMatch(
 				mockContainerWithServer.ImageInfo().RepoDigests,
 				remoteDigest,
@@ -381,6 +386,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should return an error if HEAD request fails", func() {
 			defer ginkgo.GinkgoRecover()
+
 			server := ghttp.NewTLSServer()
 			defer server.Close()
 
@@ -414,12 +420,14 @@ var _ = ginkgo.Describe("Digests", func() {
 					ghttp.VerifyRequest("HEAD", "/v2/test/image/manifests/latest"),
 					func(w http.ResponseWriter, _ *http.Request) {
 						logrus.Debug("Simulating network failure for HEAD request")
+
 						conn, _, err := w.(http.Hijacker).Hijack()
 						if err != nil {
 							logrus.WithError(err).Error("Failed to hijack connection")
 
 							return
 						}
+
 						conn.Close()
 					},
 				),
@@ -509,6 +517,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			resp, err := client.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			defer resp.Body.Close()
 
 			_, err = extractHeadDigest(resp)
@@ -582,10 +591,12 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			resp, err := client.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			defer resp.Body.Close()
 
 			remoteDigest, err := extractHeadDigest(resp)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			matches := digest.DigestsMatch(
 				mockContainerWithInvalidDigest.ImageInfo().RepoDigests,
 				remoteDigest,
@@ -598,6 +609,7 @@ var _ = ginkgo.Describe("Digests", func() {
 		// a 401 status and a malformed WWW-Authenticate header, simulating a misconfigured registry.
 		ginkgo.It("should handle malformed WWW-Authenticate header", func() {
 			defer ginkgo.GinkgoRecover()
+
 			server := ghttp.NewServer()
 			defer server.Close()
 
@@ -631,8 +643,10 @@ var _ = ginkgo.Describe("Digests", func() {
 			}
 
 			ctx := context.Background()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			registryAuth := auth.TransformAuth("token")
 			_, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
 			gomega.Expect(err).To(gomega.HaveOccurred())
@@ -655,6 +669,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should not fall back to GET when HEAD returns 404", func() {
 			defer ginkgo.GinkgoRecover()
+
 			server := ghttp.NewServer()
 			defer server.Close()
 
@@ -697,8 +712,10 @@ var _ = ginkgo.Describe("Digests", func() {
 			)
 
 			ctx := context.Background()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			registryAuth := auth.TransformAuth("token")
 
 			// Test that CompareDigest does not fall back to GET for 404 and returns error
@@ -716,6 +733,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should return error when both HEAD and GET fail", func() {
 			defer ginkgo.GinkgoRecover()
+
 			server := ghttp.NewServer()
 			defer server.Close()
 
@@ -756,8 +774,10 @@ var _ = ginkgo.Describe("Digests", func() {
 			)
 
 			ctx := context.Background()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			registryAuth := auth.TransformAuth("token")
 
 			// Test that CompareDigest fails when HEAD returns 500 (non-404 error)
@@ -770,6 +790,7 @@ var _ = ginkgo.Describe("Digests", func() {
 		})
 		ginkgo.It("should return true when HEAD request succeeds with matching digest", func() {
 			defer ginkgo.GinkgoRecover()
+
 			server := ghttp.NewServer()
 			defer server.Close()
 
@@ -808,8 +829,10 @@ var _ = ginkgo.Describe("Digests", func() {
 			)
 
 			ctx := context.Background()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			registryAuth := auth.TransformAuth("token")
 			inspector := newMockImageInspector([]string{mockDigest})
 			matches, err := digest.CompareDigest(ctx, inspector, mockContainer, registryAuth)
@@ -837,16 +860,19 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.BeforeEach(func() {
 			defer ginkgo.GinkgoRecover()
+
 			server = ghttp.NewTLSServer()
 		})
 
 		ginkgo.AfterEach(func() {
 			defer ginkgo.GinkgoRecover()
+
 			server.Close()
 		})
 
 		ginkgo.It("should use a custom user-agent", func() {
 			defer ginkgo.GinkgoRecover()
+
 			serverAddr := server.Addr()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -859,6 +885,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			origUserAgent := digest.UserAgent
 			digest.UserAgent = "Watchtower/v0.0.0-unknown"
+
 			defer func() { digest.UserAgent = origUserAgent }()
 
 			server.AppendHandlers(
@@ -909,10 +936,12 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			resp, err := client.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			defer resp.Body.Close()
 
 			remoteDigest, err := extractHeadDigest(resp)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			matches := digest.DigestsMatch(
 				mockContainerWithServer.ImageInfo().RepoDigests,
 				remoteDigest,
@@ -923,6 +952,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should handle HEAD request with non-200 status", func() {
 			defer ginkgo.GinkgoRecover()
+
 			serverAddr := server.Addr()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -978,6 +1008,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			resp, err := client.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			defer resp.Body.Close()
 
 			// Test extractHeadDigest directly with non-200 status
@@ -990,6 +1021,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should handle extractHeadDigest with missing digest header", func() {
 			defer ginkgo.GinkgoRecover()
+
 			serverAddr := server.Addr()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -1046,6 +1078,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			resp, err := client.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			defer resp.Body.Close()
 
 			// Test extractHeadDigest directly with missing digest header
@@ -1058,6 +1091,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should handle extractHeadDigest with valid digest header", func() {
 			defer ginkgo.GinkgoRecover()
+
 			serverAddr := server.Addr()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -1113,6 +1147,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			resp, err := client.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			defer resp.Body.Close()
 
 			// Test extractHeadDigest directly with valid digest header
@@ -1163,6 +1198,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should handle nil local digests slice", func() {
 			var localDigests []string
+
 			remoteDigest := mockDigestHash
 			result := digest.DigestsMatch(localDigests, remoteDigest)
 			gomega.Expect(result).To(gomega.BeFalse())
@@ -1334,7 +1370,9 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.BeforeEach(func() {
 			defer ginkgo.GinkgoRecover()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+
 			server = ghttp.NewServer()
 			logrus.WithField("server_addr", server.Addr()).
 				Debug("Starting test server")
@@ -1342,6 +1380,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.AfterEach(func() {
 			defer ginkgo.GinkgoRecover()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 			logrus.Debug("Closing test server")
 			server.Close()
@@ -1349,12 +1388,15 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should fetch a digest successfully", func() {
 			defer ginkgo.GinkgoRecover()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			scheme := "https"
 			if viper.GetBool("WATCHTOWER_REGISTRY_TLS_SKIP") {
 				scheme = "http"
 			}
+
 			serverAddr := server.Addr()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -1400,8 +1442,10 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should return an error if GET request fails after token", func() {
 			defer ginkgo.GinkgoRecover()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			server := ghttp.NewServer()
 			defer server.Close()
 
@@ -1449,6 +1493,7 @@ var _ = ginkgo.Describe("Digests", func() {
 		// Test case: Verifies that GetToken returns an error when the registry is unreachable.
 		ginkgo.It("should return an error if GetToken fails", func() {
 			defer ginkgo.GinkgoRecover()
+
 			mockImageRef := "unreachable.local/test/image:latest"
 			mockContainerUnreachable := mockActions.CreateMockContainerWithDigest(
 				mockID,
@@ -1488,6 +1533,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should return an error if GET request creation fails", func() {
 			defer ginkgo.GinkgoRecover()
+
 			serverAddr := server.Addr()
 			mockImageRef := serverAddr + "/test/image:latest\x00invalid"
 			mockContainerInvalidURL := mockActions.CreateMockContainerWithDigest(
@@ -1526,8 +1572,10 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should return an error if response decoding fails", func() {
 			defer ginkgo.GinkgoRecover()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			serverAddr := server.Addr()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -1581,6 +1629,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			resp, err := client.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			defer resp.Body.Close()
 
 			_, err = digest.ExtractGetDigest(resp)
@@ -1591,8 +1640,10 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should fall back to header when JSON decoding fails", func() {
 			defer ginkgo.GinkgoRecover()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			serverAddr := server.Addr()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -1648,6 +1699,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			resp, err := client.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			defer resp.Body.Close()
 
 			result, err := digest.ExtractGetDigest(resp)
@@ -1657,8 +1709,10 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should parse JSON manifest for digest extraction", func() {
 			defer ginkgo.GinkgoRecover()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			serverAddr := server.Addr()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -1712,6 +1766,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			resp, err := client.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			defer resp.Body.Close()
 
 			result, err := digest.ExtractGetDigest(resp)
@@ -1721,8 +1776,10 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should handle empty body error", func() {
 			defer ginkgo.GinkgoRecover()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			serverAddr := server.Addr()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -1776,6 +1833,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			resp, err := client.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			defer resp.Body.Close()
 
 			_, err = digest.ExtractGetDigest(resp)
@@ -1786,8 +1844,10 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should handle malformed JSON manifest", func() {
 			defer ginkgo.GinkgoRecover()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			serverAddr := server.Addr()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -1841,6 +1901,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			resp, err := client.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			defer resp.Body.Close()
 
 			_, err = digest.ExtractGetDigest(resp)
@@ -1853,6 +1914,7 @@ var _ = ginkgo.Describe("Digests", func() {
 		// with WATCHTOWER_REGISTRY_TLS_SKIP enabled, handling empty tokens as errors for unauthenticated registries.
 		ginkgo.It("should fetch digest from HTTP registry with TLS skip", func() {
 			defer ginkgo.GinkgoRecover()
+
 			server := ghttp.NewServer()
 			defer server.Close()
 
@@ -1886,8 +1948,10 @@ var _ = ginkgo.Describe("Digests", func() {
 			)
 
 			ctx := context.Background()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			registryAuth := auth.TransformAuth("token")
 			inspector := newMockImageInspector([]string{"ghcr.io/k6io/operator@" + mockDigestHash})
 			result, err := digest.CompareDigest(
@@ -1903,8 +1967,10 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should parse valid JSON manifest with digest field", func() {
 			defer ginkgo.GinkgoRecover()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			serverAddr := server.Addr()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -1964,6 +2030,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			resp, err := client.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			defer resp.Body.Close()
 
 			result, err := digest.ExtractGetDigest(resp)
@@ -1973,8 +2040,10 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should handle JSON manifest with empty digest field", func() {
 			defer ginkgo.GinkgoRecover()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			serverAddr := server.Addr()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -2030,6 +2099,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			resp, err := client.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			defer resp.Body.Close()
 
 			_, err = digest.ExtractGetDigest(resp)
@@ -2040,8 +2110,10 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should handle JSON manifest without digest field", func() {
 			defer ginkgo.GinkgoRecover()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			serverAddr := server.Addr()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -2097,6 +2169,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			resp, err := client.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			defer resp.Body.Close()
 
 			_, err = digest.ExtractGetDigest(resp)
@@ -2107,8 +2180,10 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should handle invalid plain text digest format", func() {
 			defer ginkgo.GinkgoRecover()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			serverAddr := server.Addr()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -2162,6 +2237,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			resp, err := client.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			defer resp.Body.Close()
 
 			_, err = digest.ExtractGetDigest(resp)
@@ -2172,8 +2248,10 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should handle short plain text digest", func() {
 			defer ginkgo.GinkgoRecover()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			serverAddr := server.Addr()
 			mockImageRef := serverAddr + "/test/image:latest"
 			mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -2227,6 +2305,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			resp, err := client.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			defer resp.Body.Close()
 
 			_, err = digest.ExtractGetDigest(resp)
@@ -2258,8 +2337,10 @@ var _ = ginkgo.Describe("Digests", func() {
 	ginkgo.When("fetching a digest with a redirecting registry", func() {
 		ginkgo.It("should update the manifest URL host based on challenge response", func() {
 			defer ginkgo.GinkgoRecover()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			server := ghttp.NewServer()
 			defer server.Close()
 
@@ -2330,8 +2411,10 @@ var _ = ginkgo.Describe("Digests", func() {
 		})
 		ginkgo.It("should conditionally update manifest URL host only when redirected", func() {
 			defer ginkgo.GinkgoRecover()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			server := ghttp.NewServer()
 			defer server.Close()
 
@@ -2403,8 +2486,10 @@ var _ = ginkgo.Describe("Digests", func() {
 
 		ginkgo.It("should not update manifest URL host when not redirected", func() {
 			defer ginkgo.GinkgoRecover()
+
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 			server := ghttp.NewServer()
 			defer server.Close()
 
@@ -2456,11 +2541,13 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			ginkgo.BeforeEach(func() {
 				defer ginkgo.GinkgoRecover()
+
 				server = ghttp.NewServer()
 			})
 
 			ginkgo.AfterEach(func() {
 				defer ginkgo.GinkgoRecover()
+
 				server.Close()
 			})
 
@@ -2495,8 +2582,10 @@ var _ = ginkgo.Describe("Digests", func() {
 
 				inspector := newMockImageInspector([]string{mockDigest})
 				ctx := context.Background()
+
 				viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 				defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 				registryAuth := auth.TransformAuth("")
 				result, err := digest.FetchDigest(
 					ctx,
@@ -2531,6 +2620,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			ginkgo.It("should handle URL parsing failure", func() {
 				defer ginkgo.GinkgoRecover()
+
 				mockContainerInvalidURL := mockActions.CreateMockContainerWithDigest(
 					mockID,
 					mockName,
@@ -2550,8 +2640,10 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			ginkgo.It("should handle plain text 404 responses (non-JSON body)", func() {
 				defer ginkgo.GinkgoRecover()
+
 				viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 				defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 				serverAddr := server.Addr()
 				mockImageRef := serverAddr + "/test/image:latest"
 				mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -2595,8 +2687,10 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			ginkgo.It("should handle OCI image index responses with proper Content-Type", func() {
 				defer ginkgo.GinkgoRecover()
+
 				viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 				defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 				serverAddr := server.Addr()
 				mockImageRef := serverAddr + "/test/image:latest"
 				mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -2661,6 +2755,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 				resp, err := client.Do(req)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				defer resp.Body.Close()
 
 				result, err := digest.ExtractGetDigest(resp)
@@ -2671,8 +2766,10 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			ginkgo.It("should handle invalid Content-Type headers", func() {
 				defer ginkgo.GinkgoRecover()
+
 				viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 				defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 				serverAddr := server.Addr()
 				mockImageRef := serverAddr + "/test/image:latest"
 				mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -2737,6 +2834,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 				resp, err := client.Do(req)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				defer resp.Body.Close()
 
 				_, err = digest.ExtractGetDigest(resp)
@@ -2747,8 +2845,10 @@ var _ = ginkgo.Describe("Digests", func() {
 
 			ginkgo.It("should handle missing or malformed Content-Type headers", func() {
 				defer ginkgo.GinkgoRecover()
+
 				viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 				defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 				serverAddr := server.Addr()
 				mockImageRef := serverAddr + "/test/image:latest"
 				mockContainerWithServer := mockActions.CreateMockContainerWithDigest(
@@ -2810,6 +2910,7 @@ var _ = ginkgo.Describe("Digests", func() {
 
 				resp, err := client.Do(req)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				defer resp.Body.Close()
 
 				_, err = digest.ExtractGetDigest(resp)
@@ -2822,6 +2923,7 @@ var _ = ginkgo.Describe("Digests", func() {
 				"should successfully use HEAD requests for lscr.io images when redirected",
 				func() {
 					defer ginkgo.GinkgoRecover()
+
 					server := ghttp.NewServer()
 					defer server.Close()
 
@@ -2881,8 +2983,10 @@ var _ = ginkgo.Describe("Digests", func() {
 
 					inspector := newMockImageInspector([]string{mockDigest})
 					ctx := context.Background()
+
 					viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 					defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
 					registryAuth := auth.TransformAuth("token")
 					result, err := digest.CompareDigest(
 						ctx,

--- a/pkg/registry/trust_test.go
+++ b/pkg/registry/trust_test.go
@@ -11,6 +11,7 @@ var _ = ginkgo.Describe("Registry credential helpers", func() {
 	ginkgo.Describe("EncodedAuth", func() {
 		ginkgo.It("should return repo credentials from env when set", func() {
 			var err error
+
 			expected := "eyJ1c2VybmFtZSI6IndhdGNodG93ZXItdXNlciIsInBhc3N3b3JkIjoid2F0Y2h0b3dlci1wYXNzIn0="
 
 			err = os.Setenv("REPO_USER", "watchtower-user")

--- a/pkg/sorter/dependency_test.go
+++ b/pkg/sorter/dependency_test.go
@@ -25,6 +25,7 @@ var _ = ginkgo.Describe("DependencySorter", func() {
 			c1.EXPECT().
 				ContainerInfo().
 				Return(&dockerContainer.InspectResponse{ContainerJSONBase: &dockerContainer.ContainerJSONBase{Name: "/c1"}, Config: &dockerContainer.Config{Labels: map[string]string{}}})
+
 			c2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c2.EXPECT().Name().Return("c2")
 			c2.EXPECT().ID().Return(types.ContainerID("id-c2"))
@@ -33,6 +34,7 @@ var _ = ginkgo.Describe("DependencySorter", func() {
 			c2.EXPECT().
 				ContainerInfo().
 				Return(&dockerContainer.InspectResponse{ContainerJSONBase: &dockerContainer.ContainerJSONBase{Name: "/c2"}, Config: &dockerContainer.Config{Labels: map[string]string{}}})
+
 			c3 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c3.EXPECT().Name().Return("c3")
 			c3.EXPECT().ID().Return(types.ContainerID("id-c3"))
@@ -58,6 +60,7 @@ var _ = ginkgo.Describe("DependencySorter", func() {
 			c1.EXPECT().
 				ContainerInfo().
 				Return(&dockerContainer.InspectResponse{ContainerJSONBase: &dockerContainer.ContainerJSONBase{Name: "/c1"}, Config: &dockerContainer.Config{Labels: map[string]string{}}})
+
 			c2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c2.EXPECT().Name().Return("c2")
 			c2.EXPECT().ID().Return(types.ContainerID("id-c2"))
@@ -84,6 +87,7 @@ var _ = ginkgo.Describe("DependencySorter", func() {
 			c1.EXPECT().
 				ContainerInfo().
 				Return(&dockerContainer.InspectResponse{ContainerJSONBase: &dockerContainer.ContainerJSONBase{Name: "/c1"}, Config: &dockerContainer.Config{Labels: map[string]string{}}})
+
 			c2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c2.EXPECT().Name().Return("c2")
 			c2.EXPECT().ID().Return(types.ContainerID("id-c2"))
@@ -92,6 +96,7 @@ var _ = ginkgo.Describe("DependencySorter", func() {
 			c2.EXPECT().
 				ContainerInfo().
 				Return(&dockerContainer.InspectResponse{ContainerJSONBase: &dockerContainer.ContainerJSONBase{Name: "/c2"}, Config: &dockerContainer.Config{Labels: map[string]string{}}})
+
 			c3 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c3.EXPECT().Name().Return("c3")
 			c3.EXPECT().ID().Return(types.ContainerID("id-c3"))
@@ -119,6 +124,7 @@ var _ = ginkgo.Describe("DependencySorter", func() {
 			c1.EXPECT().
 				ContainerInfo().
 				Return(&dockerContainer.InspectResponse{ContainerJSONBase: &dockerContainer.ContainerJSONBase{Name: "/c1"}, Config: &dockerContainer.Config{Labels: map[string]string{}}})
+
 			c2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c2.EXPECT().Name().Return("c2")
 			c2.EXPECT().Links().Return([]string{"c1"})
@@ -138,6 +144,7 @@ var _ = ginkgo.Describe("DependencySorter", func() {
 			watchtower := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			watchtower.EXPECT().Name().Return("watchtower")
 			watchtower.EXPECT().IsWatchtower().Return(true)
+
 			c1 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c1.EXPECT().Name().Return("c1")
 			c1.EXPECT().ID().Return(types.ContainerID("id-c1"))
@@ -146,6 +153,7 @@ var _ = ginkgo.Describe("DependencySorter", func() {
 			c1.EXPECT().
 				ContainerInfo().
 				Return(&dockerContainer.InspectResponse{ContainerJSONBase: &dockerContainer.ContainerJSONBase{Name: "/c1"}, Config: &dockerContainer.Config{Labels: map[string]string{}}})
+
 			c2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c2.EXPECT().Name().Return("c2")
 			c2.EXPECT().ID().Return(types.ContainerID("id-c2"))
@@ -199,6 +207,7 @@ var _ = ginkgo.Describe("DependencySorter", func() {
 			c1.EXPECT().
 				ContainerInfo().
 				Return(&dockerContainer.InspectResponse{ContainerJSONBase: &dockerContainer.ContainerJSONBase{Name: "/c1"}, Config: &dockerContainer.Config{Labels: map[string]string{}}})
+
 			c2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c2.EXPECT().Name().Return("c2")
 			c2.EXPECT().ID().Return(types.ContainerID("id-c2"))
@@ -220,6 +229,7 @@ var _ = ginkgo.Describe("DependencySorter", func() {
 			c1.EXPECT().
 				ContainerInfo().
 				Return(&dockerContainer.InspectResponse{ContainerJSONBase: &dockerContainer.ContainerJSONBase{Name: "/c1"}, Config: &dockerContainer.Config{Labels: map[string]string{}}})
+
 			c2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c2.EXPECT().Name().Return("c2")
 			c2.EXPECT().ID().Return(types.ContainerID("id-c2"))
@@ -243,6 +253,7 @@ var _ = ginkgo.Describe("DependencySorter", func() {
 			a.EXPECT().
 				ContainerInfo().
 				Return(&dockerContainer.InspectResponse{ContainerJSONBase: &dockerContainer.ContainerJSONBase{Name: "/a"}, Config: &dockerContainer.Config{Labels: map[string]string{}}})
+
 			b := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			b.EXPECT().Name().Return("b")
 			b.EXPECT().ID().Return(types.ContainerID("id-b"))
@@ -250,6 +261,7 @@ var _ = ginkgo.Describe("DependencySorter", func() {
 			b.EXPECT().
 				ContainerInfo().
 				Return(&dockerContainer.InspectResponse{ContainerJSONBase: &dockerContainer.ContainerJSONBase{Name: "/b"}, Config: &dockerContainer.Config{Labels: map[string]string{}}})
+
 			c := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c.EXPECT().Name().Return("c")
 			c.EXPECT().ID().Return(types.ContainerID("id-c"))
@@ -274,6 +286,7 @@ var _ = ginkgo.Describe("DependencySorter", func() {
 			c1.EXPECT().
 				ContainerInfo().
 				Return(&dockerContainer.InspectResponse{ContainerJSONBase: &dockerContainer.ContainerJSONBase{Name: "/c1"}, Config: &dockerContainer.Config{Labels: map[string]string{}}})
+
 			c2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c2.EXPECT().Name().Return("c2")
 			c2.EXPECT().Links().Return([]string{"c1"})
@@ -318,6 +331,7 @@ var _ = ginkgo.Describe("DependencySorter", func() {
 			a.EXPECT().
 				ContainerInfo().
 				Return(&dockerContainer.InspectResponse{ContainerJSONBase: &dockerContainer.ContainerJSONBase{Name: "/a"}, Config: &dockerContainer.Config{Labels: map[string]string{}}})
+
 			b := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			b.EXPECT().Name().Return("b")
 			b.EXPECT().ID().Return(types.ContainerID("id-b"))
@@ -334,6 +348,7 @@ var _ = ginkgo.Describe("DependencySorter", func() {
 			c.EXPECT().
 				ContainerInfo().
 				Return(&dockerContainer.InspectResponse{ContainerJSONBase: &dockerContainer.ContainerJSONBase{Name: "/c"}, Config: &dockerContainer.Config{Labels: map[string]string{}}})
+
 			d := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			d.EXPECT().Name().Return("d")
 			d.EXPECT().ID().Return(types.ContainerID("id-d"))
@@ -826,6 +841,7 @@ var _ = ginkgo.Describe("DependencySorter", func() {
 		ginkgo.It("should handle large number of containers with no dependencies", func() {
 			// Test performance and correctness with many containers
 			containers := make([]types.Container, 100)
+
 			for i := range 100 {
 				c := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 				c.EXPECT().Name().Return(fmt.Sprintf("container%d", i)).Maybe()
@@ -1212,6 +1228,7 @@ var _ = ginkgo.Describe("Identifier Collision Issues", func() {
 				// Containers from different projects should have different identifiers
 				ident1 := container.ResolveContainerIdentifier(c1)
 				ident2 := container.ResolveContainerIdentifier(c2)
+
 				gomega.Expect(ident1).To(gomega.Equal("app1-web"))
 				gomega.Expect(ident2).To(gomega.Equal("app2-web"))
 
@@ -1355,10 +1372,12 @@ var _ = ginkgo.Describe("Identifier Collision Issues", func() {
 				_, _, _, _, err := buildDependencyGraph(containers)
 
 				gomega.Expect(err).To(gomega.HaveOccurred())
+
 				var collisionErr IdentifierCollisionError
 				gomega.Expect(err).To(gomega.BeAssignableToTypeOf(collisionErr))
 				gomega.Expect(func() IdentifierCollisionError {
 					var target IdentifierCollisionError
+
 					_ = errors.As(err, &target)
 
 					return target
@@ -1366,6 +1385,7 @@ var _ = ginkgo.Describe("Identifier Collision Issues", func() {
 					To(gomega.Equal("c1"))
 				gomega.Expect(func() IdentifierCollisionError {
 					var target IdentifierCollisionError
+
 					_ = errors.As(err, &target)
 
 					return target
@@ -1430,6 +1450,7 @@ var _ = ginkgo.Describe("Identifier Collision Issues", func() {
 			_, err := sortByDependencies(containers)
 
 			gomega.Expect(err).To(gomega.HaveOccurred())
+
 			var collisionErr IdentifierCollisionError
 			gomega.Expect(err).To(gomega.BeAssignableToTypeOf(collisionErr))
 		})

--- a/pkg/sorter/sorter_test.go
+++ b/pkg/sorter/sorter_test.go
@@ -28,6 +28,7 @@ var _ = ginkgo.Describe("Container Sorting", func() {
 					},
 				})
 				c3.EXPECT().Name().Return("c3")
+
 				c1 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 				c1.EXPECT().ContainerInfo().Return(&dockerContainer.InspectResponse{
 					ContainerJSONBase: &dockerContainer.ContainerJSONBase{
@@ -38,6 +39,7 @@ var _ = ginkgo.Describe("Container Sorting", func() {
 					},
 				})
 				c1.EXPECT().Name().Return("c1")
+
 				c2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 				c2.EXPECT().ContainerInfo().Return(&dockerContainer.InspectResponse{
 					ContainerJSONBase: &dockerContainer.ContainerJSONBase{
@@ -69,6 +71,7 @@ var _ = ginkgo.Describe("Container Sorting", func() {
 				})
 				c1.EXPECT().Name().Return("c1").Maybe()
 				c1.EXPECT().ID().Return(types.ContainerID("id-c1")).Maybe()
+
 				c2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 				c2.EXPECT().ContainerInfo().Return(&dockerContainer.InspectResponse{
 					ContainerJSONBase: &dockerContainer.ContainerJSONBase{
@@ -110,6 +113,7 @@ var _ = ginkgo.Describe("Container Sorting", func() {
 						Labels: map[string]string{},
 					},
 				})
+
 				c2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 				c2.EXPECT().Name().Return("c2")
 				c2.EXPECT().ID().Return(types.ContainerID("id-c2"))
@@ -139,6 +143,7 @@ var _ = ginkgo.Describe("Container Sorting", func() {
 						Labels: map[string]string{},
 					},
 				})
+
 				c2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 				c2.EXPECT().Name().Return("c2")
 				c2.EXPECT().ID().Return(types.ContainerID("id-c2"))
@@ -149,6 +154,7 @@ var _ = ginkgo.Describe("Container Sorting", func() {
 						Labels: map[string]string{},
 					},
 				})
+
 				c3 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 				c3.EXPECT().Name().Return("c3")
 				c3.EXPECT().ID().Return(types.ContainerID("id-c3"))
@@ -179,6 +185,7 @@ var _ = ginkgo.Describe("Container Sorting", func() {
 						Labels: map[string]string{},
 					},
 				})
+
 				c2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 				c2.EXPECT().Name().Return("c2")
 				c2.EXPECT().ID().Return(types.ContainerID("id-c2")).Maybe()
@@ -208,6 +215,7 @@ var _ = ginkgo.Describe("Container Sorting", func() {
 						Labels: map[string]string{},
 					},
 				})
+
 				c3 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 				c3.EXPECT().Name().Return("c3")
 				c3.EXPECT().ID().Return(types.ContainerID("id-c3"))
@@ -237,6 +245,7 @@ var _ = ginkgo.Describe("Container Sorting", func() {
 				watchtower := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 				watchtower.EXPECT().Name().Return("watchtower")
 				watchtower.EXPECT().IsWatchtower().Return(true)
+
 				c1 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 				c1.EXPECT().Name().Return("c1")
 				c1.EXPECT().ID().Return(types.ContainerID("id-c1"))
@@ -247,6 +256,7 @@ var _ = ginkgo.Describe("Container Sorting", func() {
 						Labels: map[string]string{},
 					},
 				})
+
 				c2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 				c2.EXPECT().Name().Return("c2")
 				c2.EXPECT().ID().Return(types.ContainerID("id-c2"))
@@ -272,6 +282,7 @@ var _ = ginkgo.Describe("Container Sorting", func() {
 				watchtower1 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 				watchtower1.EXPECT().Name().Return("watchtower1")
 				watchtower1.EXPECT().IsWatchtower().Return(true)
+
 				c1 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 				c1.EXPECT().Name().Return("c1")
 				c1.EXPECT().ID().Return(types.ContainerID("id-c1"))
@@ -282,9 +293,11 @@ var _ = ginkgo.Describe("Container Sorting", func() {
 						Labels: map[string]string{},
 					},
 				})
+
 				watchtower2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 				watchtower2.EXPECT().Name().Return("watchtower2")
 				watchtower2.EXPECT().IsWatchtower().Return(true)
+
 				c2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 				c2.EXPECT().Name().Return("c2")
 				c2.EXPECT().ID().Return(types.ContainerID("id-c2"))

--- a/pkg/sorter/time_test.go
+++ b/pkg/sorter/time_test.go
@@ -186,8 +186,10 @@ var _ = ginkgo.Describe("byCreated", func() {
 		ginkgo.It("should swap elements at different indices", func() {
 			c1 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c1.EXPECT().Name().Return("c1")
+
 			c2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c2.EXPECT().Name().Return("c2")
+
 			c3 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c3.EXPECT().Name().Return("c3")
 
@@ -204,6 +206,7 @@ var _ = ginkgo.Describe("byCreated", func() {
 		ginkgo.It("should swap adjacent elements", func() {
 			c1 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c1.EXPECT().Name().Return("c1")
+
 			c2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c2.EXPECT().Name().Return("c2")
 


### PR DESCRIPTION
This change enhances the project's linting setup by adding golines formatter configuration for consistent line length and formatting, and configures revive linter rules for better code quality checks. It also applies consistent blank line spacing across test files to improve readability.

## Problem

The golangci-lint configuration was missing modern formatter settings and specific linter rules, leading to inconsistent code formatting and potential quality issues. Test files had inconsistent spacing that made them harder to read and maintain.

## Solution

Added golines formatter with a 200-character line limit and appropriate settings for Go code formatting. Configured revive linter with var-naming and package-comments rules to enforce better naming conventions. Ran formatting on all test files to apply consistent blank line spacing.

## Changes

- Add golines formatter configuration to golangci-lint.yaml with max-len: 200, tab-len: 4, and other settings
- Configure revive linter rules for var-naming and package-comments with appropriate exclusions
- Format 28 test files across internal/actions/, internal/api/, internal/logging/, pkg/api/, pkg/container/, pkg/notifications/, pkg/registry/, and pkg/sorter/ packages with consistent blank line spacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage across core functionality including update operations, container management, API handlers, and dependency resolution.
  * Added concurrency testing to validate thread-safe behavior in parallel operations.
  * Enhanced error handling and edge-case validation across multiple test suites.

* **Chores**
  * Updated linter configuration and formatting rules.
  * Improved code organization and test scaffolding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->