### PR TITLE
Update DNS error pattern in digest test

### DIFF
--- a/pkg/registry/digest/digest_test.go
+++ b/pkg/registry/digest/digest_test.go
@@ -1508,7 +1508,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			registryAuth := auth.TransformAuth("token")
 			_, _, _, err := auth.GetToken(ctx, mockContainerUnreachable, registryAuth, client)
 			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).To(gomega.MatchRegexp("no such host|server misbehaving"))
+			gomega.Expect(err.Error()).To(gomega.MatchRegexp("Temporary failure in name resolution|no such host|server misbehaving"))
 		})
 
 		ginkgo.It("should return an error if manifest URL build fails", func() {


### PR DESCRIPTION
Fix failing test by updating the DNS error regex pattern to accommodate modern Go error messages.

## Problem

The test "should return an error if GetToken fails" in pkg/registry/digest/digest_test.go was failing because it expected a DNS error matching the pattern "no such host|server misbehaving", but modern Go versions produce "Temporary failure in name resolution" for DNS resolution failures.

## Solution

Updated the regex pattern on line 1511 to include both the legacy and modern error messages, ensuring the test passes across different Go versions while maintaining its original intent of verifying error handling when token retrieval fails.

## Changes

- Modified `pkg/registry/digest/digest_test.go:1511` regex pattern to include both old and new error messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated error message pattern validation to accommodate additional DNS-related error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->