### PR TITLE
Exclude unsupported architectures from GoReleaser builds

### DIFF
--- a/build/goreleaser/dev.yml
+++ b/build/goreleaser/dev.yml
@@ -99,6 +99,12 @@ builds:
     ignore:
       - goos: windows
         goarch: riscv64
+      - goos: windows
+        goarch: arm
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: arm
 
     # Set the modified timestamp on the output binary, typically
     # you would do this to ensure a build was reproducible.

--- a/build/goreleaser/prod.yml
+++ b/build/goreleaser/prod.yml
@@ -88,6 +88,12 @@ builds:
     ignore:
       - goos: windows
         goarch: riscv64
+      - goos: windows
+        goarch: arm
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: arm
 
     # Set the modified timestamp on the output binary, typically
     # you would do this to ensure a build was reproducible.


### PR DESCRIPTION
This PR updates the GoReleaser configuration to ignore unsupported OS/architecture combinations that cause build failures. The changes prevent attempts to build for windows/arm, darwin/386, and darwin/arm, which are not supported by the Go toolchain.

## Problem

The CI build fails with the error `go: unsupported GOOS/GOARCH pair windows/arm` when building for the `windows_arm_6` target (see logs). The same failure would occur for `darwin/386` and `darwin/arm`, as these combinations are not supported by the Go compiler.

## Solution

Add these OS/ARCH pairs to the `ignore` list in both `build/goreleaser/dev.yml` and `build/goreleaser/prod.yml`. This excludes them from the build matrix, preventing the build errors and allowing the CI pipeline to complete successfully.

## Changes

- **Modified** `build/goreleaser/dev.yml`: Added three ignore entries for `windows/arm`, `darwin/386`, and `darwin/arm`.
- **Modified** `build/goreleaser/prod.yml`: Added the same three ignore entries for consistency across build configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configurations to exclude specific platform and architecture combinations from the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->