### PR TITLE
Update container startup failures to log at warning level

### DIFF
--- a/pkg/session/progress_test.go
+++ b/pkg/session/progress_test.go
@@ -554,6 +554,20 @@ func TestProgress_UpdateFailed(t *testing.T) {
 				"cont1": &ContainerStatus{state: ScannedState, containerID: "cont1"},
 			},
 		},
+		{
+			name: "failure container not in progress map",
+			m: Progress{
+				"cont1": &ContainerStatus{state: ScannedState, containerID: "cont1"},
+			},
+			args: args{
+				failures: map[types.ContainerID]error{
+					"cont2": errors.New("container not found"),
+				},
+			},
+			want: Progress{
+				"cont1": &ContainerStatus{state: ScannedState, containerID: "cont1"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This pull request updates the log level to ensure users are warned when containers with dependencies fail to start (e.g., due to network namespace issues).

## Problem

Debug-level logging made container startup failures invisible to users running Watchtower without debug logging enabled, as noted in issue #1299.

## Solution

- Changed the log level from `Debug` to `Warn` for the "Updated container state to failed" message so users can see these failures in standard logs without needing debug mode
- Added defensive nil pointer check to prevent panics when a container ID exists in the failures map but not in the progress map

## Changes

- `pkg/session/progress.go`: Change log level to Warn and add nil check
- `pkg/session/progress_test.go`: Add test case for container not found edge case


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when handling progress updates for unavailable containers. The system now gracefully skips missing entries and continues processing without failures.

* **Logging**
  * Enhanced error visibility with elevated logging levels for container update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->