### PR TITLE
Resolve gosec SARIF validation error

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -33,6 +33,13 @@ jobs:
         uses: securego/gosec@bb17e422fc34bf4c0a2e5cab9d07dc45a68c040c # v2.24.7
         with:
           args: "-no-fail -fmt sarif -out results.sarif ./..."
+      # Gosec generates SARIF output where some rules (e.g., G704) are missing
+      # the 'relationships' field, causing GitHub CodeQL upload validation to fail.
+      # This step adds empty relationships arrays to rules that lack them.
+      - name: Fix gosec SARIF output
+        run: |
+          jq '(.runs[0].tool.driver.rules // []) |= map(if has("relationships") then . else . + {"relationships": []} end)' results.sarif > results-fixed.sarif
+          mv results-fixed.sarif results.sarif
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@c793b717bc78562f491db7b0e93a3a178b099162 # v4
         with:


### PR DESCRIPTION
This PR fixes the GitHub Actions workflow failure where gosec SARIF results fail to upload to GitHub CodeQL due to missing `relationships` fields in certain rules.

## Problem

The security workflow was failing with validation error:

```
instance.runs[0].tool.driver.rules[3].relationships[0] is not of a type(s) object
```

Gosec generates SARIF output where rule G704 (SSRF via taint analysis) is missing the `relationships` field, causing inconsistent schema that violates SARIF validation requirements.

## Solution

Add a post-processing step to the workflow that uses `jq` to add empty `relationships` arrays to any rules lacking this field before uploading to GitHub CodeQL.

## Changes

- Added "Fix gosec SARIF output" step in `.github/workflows/security.yaml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security scanning validation in CI/CD pipeline to ensure proper handling of security scan results during automated checks. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->