### PR TITLE
Document regex pattern matching support

### DIFF
--- a/docs/configuration/arguments/index.md
+++ b/docs/configuration/arguments/index.md
@@ -26,6 +26,9 @@ docker run --rm \
 
 This command triggers an update attempt for "nginx" and "redis" containers, displays debug output, and removes the Watchtower container upon completion. Without arguments, Watchtower monitors all running containers.
 
+!!! Note
+    Regex patterns are supported. See [Regex Pattern Matching](../container-selection/index.md#regex_pattern_matching) for details.
+
 ## Secrets/Files
 
 Certain flags support referencing a file, using its contents as the value, to securely handle sensitive data like passwords or tokens, avoiding exposure in configuration files or command lines.
@@ -406,6 +409,9 @@ Environment Variable: WATCHTOWER_DISABLE_CONTAINERS
                 Type: Comma- or space-separated string list
              Default: None
 ```
+
+!!! Note
+    Regex patterns are supported. See [Regex Pattern Matching](../container-selection/index.md#regex-pattern-matching) for details.
 
 ### Scope Filter
 

--- a/docs/configuration/container-selection/index.md
+++ b/docs/configuration/container-selection/index.md
@@ -85,3 +85,38 @@ docker run -d --label=com.centurylinklabs.watchtower.monitor-only=true someimage
 ```
 
 When the label is specified on a container, Watchtower treats that container exactly as if [`WATCHTOWER_MONITOR_ONLY`](../arguments/index.md#monitor_only) was set, but the effect is limited to the individual container.
+
+## Regex Pattern Matching
+
+Both container inclusion (positional arguments) and exclusion  ([`--disable-containers`/`WATCHTOWER_DISABLE_CONTAINERS`](../arguments/index.md#disable_specific_containers)) support regular expression patterns for matching container names.
+
+!!! Note "Patterns are anchored to match the **full container name**"
+    Use `.*` (period + asterisk) for wildcards instead of just an `*` (asterisk)
+
+### Syntax
+
+- Patterns use [Go regex syntax](https://pkg.go.dev/regexp/syntax)
+- Patterns are anchored to match the **entire** container name
+- Invalid regex patterns fall back to literal string matching
+
+### Examples
+
+| Pattern | Matches |
+|---------|---------|
+| `container.*` | "container1", "container-abc", "mycontainer" |
+| `.*-dev` | "web-dev", "api-dev", "db-dev" |
+| `.*` | Any container name |
+| `nginx|redis` | Either "nginx" or "redis" |
+| `^web-.*$` | All containers starting with "web-" |
+
+- Exclude all containers starting with a specific prefix:
+
+```bash
+docker run -d -e WATCHTOWER_DISABLE_CONTAINERS="web-.*" nickfedor/watchtower
+```
+
+- Include only containers matching a pattern:
+
+```bash
+watchtower "db-.*" "cache-.*"
+```


### PR DESCRIPTION
This PR adds documentation for Watchtower's previously undocumented regex pattern matching support for container selection.

## Problem

GitHub issue #1403 requested wildcard support for `WATCHTOWER_DISABLE_CONTAINERS`, but the feature was already implemented in the codebase without being documented. Users had no way of knowing they could use regex patterns like `mailcowdockerized-.*` to match multiple containers.

## Solution

Add comprehensive documentation for the existing regex pattern matching feature, including:
- A new "Regex Pattern Matching" section in container-selection documentation
- Admonition notes in arguments/index.md linking to the new section
- Basic examples showing Go regex syntax and usage patterns

## Changes

- Add "Regex Pattern Matching" section to `docs/configuration/container-selection/index.md`
- Add admonition note for positional container arguments in `docs/configuration/arguments/index.md`
- Add admonition note for `--disable-containers`/`WATCHTOWER_DISABLE_CONTAINERS` in `docs/configuration/arguments/index.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive regex pattern matching documentation explaining how to use regular expressions for container selection in configuration, with practical examples and syntax guidelines for both inclusion and exclusion rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->