### PR TITLE
Apply changes from Go's `modernize` tool

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -854,7 +854,7 @@ func TestUpdateOnStartMultiInstanceScenario(t *testing.T) {
 		// Track update calls from both instances
 		updateCallCount := int32(0)
 
-		var completed int32
+		var completed atomic.Int32
 
 		instance1Called := make(chan bool, 1)
 		instance2Called := make(chan bool, 1)
@@ -898,7 +898,7 @@ func TestUpdateOnStartMultiInstanceScenario(t *testing.T) {
 				nil,
 			)
 			assert.NoError(t, err)
-			atomic.AddInt32(&completed, 1)
+			completed.Add(1)
 			close(instance1Called)
 		}()
 
@@ -929,7 +929,7 @@ func TestUpdateOnStartMultiInstanceScenario(t *testing.T) {
 				nil,
 			)
 			assert.NoError(t, err)
-			atomic.AddInt32(&completed, 1)
+			completed.Add(1)
 			close(instance2Called)
 		}()
 
@@ -941,7 +941,7 @@ func TestUpdateOnStartMultiInstanceScenario(t *testing.T) {
 		assert.Equal(
 			t,
 			int32(2),
-			atomic.LoadInt32(&completed),
+			completed.Load(),
 			"Both instances should have shut down properly",
 		)
 

--- a/internal/scheduling/scheduling.go
+++ b/internal/scheduling/scheduling.go
@@ -183,11 +183,11 @@ func RunUpgradesOnSchedule(
 	// If Watchtower has performed a self-cleanup, then prevent Watchtower
 	// from self-updating during the first update cycle.
 	if skipFirstRun {
-		var firstRun uint32 // atomic flag to track if this is the first run
+		var firstRun atomic.Uint32 // atomic flag to track if this is the first run
 
 		scheduledUpdateFunc = func() {
 			// Atomically check and set firstRun to ensure only the first execution skips self-update
-			skipWatchtowerSelfUpdate := atomic.CompareAndSwapUint32(&firstRun, 0, 1)
+			skipWatchtowerSelfUpdate := firstRun.CompareAndSwap(0, 1)
 			if skipWatchtowerSelfUpdate {
 				logrus.Debug(
 					"Skipping Watchtower self-update on first scheduled run due to cleanup",


### PR DESCRIPTION
This PR applies automated changes from Go's [modernize](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize) tool.

## Changes

- Migrate from sync/atomic functions to atomic.Uint32 and atomic.Int32 types in scheduling.go
- Update cmd/root_test.go to use atomic.Int32 with its Add and Load methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced concurrency handling and atomic operations in test infrastructure for improved reliability.

* **Refactor**
  * Improved thread-safety in internal scheduling operations through updated synchronization mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->