### PR TITLE
Enable Renovate support for transitive Go dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,12 @@
       "semanticCommitType": "chore"
     },
     {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "semanticCommitType": "chore",
+      "enabled": true
+    },
+    {
       "description": "Automerge non-major updates",
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true


### PR DESCRIPTION
This PR enables Renovate to automatically update indirect/transitive Go dependencies.

## Changes

- Added explicit configuration entry to enforce Renovate updates for indirect/transitive Go dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated dependency updates for indirect Go module dependencies, streamlining maintenance workflows and improving overall project dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->