### PR TITLE
Resolve type mismatch after a minor Shoutrrr API change

### DIFF
--- a/pkg/notifications/msteams.go
+++ b/pkg/notifications/msteams.go
@@ -84,7 +84,7 @@ func (n *msTeamsTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 	clog.Debug("Parsed Microsoft Teams webhook URL")
 
 	// Create Teams config from webhook.
-	config, err := teams.ConfigFromWebhookURL(*webhookURL)
+	config, err := teams.ConfigFromWebhookURL(webhookURL)
 	if err != nil {
 		clog.WithError(err).
 			Debug("Failed to create Microsoft Teams config from webhook URL")


### PR DESCRIPTION
This PR resolves a minor API update after an update to the latest version of Shoutrrr.

## Problem

The upstream shoutrrr library changed the `ConfigFromWebhookURL` function signature in commit `ddc98046` from accepting a `url.URL` value to a `*url.URL` pointer. This broke compilation in Watchtower, which was dereferencing the pointer from `url.Parse` before passing it to `ConfigFromWebhookURL`.

## Solution

Removed the pointer dereference operator from the `ConfigFromWebhookURL` call site. The `url.Parse` function already returns a `*url.URL`, and the updated shoutrrr API now expects a pointer directly rather than a copied struct value.

## Changes

- Update `pkg/notifications/msteams.go` to pass `webhookURL` pointer directly to `teams.ConfigFromWebhookURL` instead of dereferencing with `*webhookURL`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MS Teams webhook URL handling in notifications to ensure proper processing and delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->