### PR TITLE
fix: handle container removed between check and stop

### DIFF
--- a/pkg/container/container_source.go
+++ b/pkg/container/container_source.go
@@ -279,6 +279,15 @@ func StopSourceContainer(
 		Timeout: &timeoutSeconds,
 	})
 	if err != nil {
+		// Check if the container was already removed by another process before
+		// the stop call completed, treating it as already stopped.
+		if cerrdefs.IsNotFound(err) {
+			clog.WithField("elapsed", time.Since(startTime)).
+				Debug("Container not found during stop, treating as already stopped")
+
+			return nil
+		}
+
 		// Log the failure with elapsed time and error details for debugging.
 		clog.WithError(err).
 			WithField("elapsed", time.Since(startTime)).

--- a/pkg/container/container_source_test.go
+++ b/pkg/container/container_source_test.go
@@ -1841,6 +1841,28 @@ var _ = ginkgo.Describe("StopSourceContainer", func() {
 			gomega.Expect(mockServer.ReceivedRequests()).To(gomega.BeEmpty())
 		})
 	})
+
+	ginkgo.When("stopping a container that was removed between check and stop", func() {
+		ginkgo.It("should return nil when Docker returns 404 NotFound", func() {
+			container := MockContainer(
+				WithContainerState(dockerContainer.State{Running: true}),
+			)
+			cid := container.ContainerInfo().ID
+
+			mockServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(
+						"POST",
+						gomega.HaveSuffix(fmt.Sprintf("containers/%s/stop", cid)),
+					),
+					ghttp.RespondWith(http.StatusNotFound, `{"message":"No such container"}`),
+				),
+			)
+
+			err := StopSourceContainer(context.Background(), docker, container, 10*time.Second)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		})
+	})
 })
 
 var _ = ginkgo.Describe("debugLogMacAddress", func() {


### PR DESCRIPTION
This PR addresses a TOCTOU race condition that exists in `StopSourceContainer`. 

## Problem

After `IsRunning()` returns true but before `ContainerStop` executes, another process can remove the container. The Docker SDK returns `cerrdefs.ErrNotFound` (HTTP 404) in this case, but Watchtower wraps it as a generic `errStopContainerFailed`, preventing callers from distinguishing an already-stopped container from an actual failure.

## Solution

Add a `cerrdefs.IsNotFound(err)` check in `StopSourceContainer` immediately after the `ContainerStop` call fails. When the container is not found, return nil (treating it as already stopped) with a debug log instead of propagating an error.

## Changes

- Check `cerrdefs.IsNotFound(err)` before wrapping as `errStopContainerFailed` in `StopSourceContainer`
- Add test case verifying container removed between running check and stop is treated as already stopped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when stopping containers that are no longer available, treating "not found" scenarios as successful operations with debug logging instead of reporting failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->