### PR TITLE
fix: replace fragile string-based error checking with typed errors

### DIFF
--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -341,7 +341,7 @@ func NewClient(opts ClientOptions) Client {
 		case err == nil:
 			// Ping succeeded: use the forced version client
 			cli = pingCli
-		case strings.Contains(err.Error(), "page not found"):
+		case cerrdefs.IsNotFound(err):
 			logrus.WithFields(logrus.Fields{
 				"version":  version,
 				"error":    err,

--- a/pkg/container/container_source.go
+++ b/pkg/container/container_source.go
@@ -81,8 +81,8 @@ func ListSourceContainers(
 			"list_options": fmt.Sprintf("%+v", listOptions),
 		}).Debug("ContainerList API call failed")
 
-		// Handle 404 responses from Docker API
-		if strings.Contains(err.Error(), "page not found") {
+		// Check for 404 responses and return an empty container list instead of failing.
+		if cerrdefs.IsNotFound(err) {
 			clog.WithFields(logrus.Fields{
 				"error":       err,
 				"endpoint":    "/containers/json",

--- a/pkg/container/container_source_test.go
+++ b/pkg/container/container_source_test.go
@@ -181,6 +181,21 @@ var _ = ginkgo.Describe("ListSourceContainers", func() {
 			gomega.Expect(containers).To(gomega.HaveLen(1))
 		})
 	})
+
+	ginkgo.When("Docker API returns 404 NotFound for container list", func() {
+		ginkgo.It("should return empty container list without error", func() {
+			mockServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", gomega.MatchRegexp("^/v[0-9.]+/containers/json$")),
+					ghttp.RespondWith(http.StatusNotFound, `{"message":"page not found"}`),
+				),
+			)
+
+			containers, err := ListSourceContainers(context.Background(), docker, ClientOptions{}, nil)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(containers).To(gomega.BeEmpty())
+		})
+	})
 })
 
 var _ = ginkgo.Describe("buildListFilterArgs", func() {


### PR DESCRIPTION
This PR addresses further instances of string-based error checking, where typed errors would be more appropriate.

## Problem

Two locations in the container package use `strings.Contains(err.Error(), "page not found")` to detect 404 responses from the Docker API. This pattern is fragile because:
- Error message format may change across Docker SDK versions
- Substring matching can produce false positives on unrelated errors containing "page not found"
- The Docker SDK already converts HTTP 404 to `cerrdefs.ErrNotFound`, which is the idiomatic check

## Solution

Replace both string-based checks with `cerrdefs.IsNotFound(err)`, which is the correct typed error check provided by the `containerd/errdefs` package.

## Changes

- Replace `strings.Contains(err.Error(), "page not found")` with `cerrdefs.IsNotFound(err)` in `pkg/container/container_source.go` (`ListSourceContainers`)
- Replace `strings.Contains(err.Error(), "page not found")` with `cerrdefs.IsNotFound(err)` in `pkg/container/client.go` (API version ping fallback)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error detection for Docker API communication to properly handle specific error responses instead of relying on message matching.

* **Tests**
  * Added test coverage to verify proper handling of Docker API 404 responses during container operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->