### PR TITLE
fix: differentiate auth, not-found, and transient errors during image pull

### DIFF
--- a/pkg/container/errors.go
+++ b/pkg/container/errors.go
@@ -74,10 +74,10 @@ var (
 	errInspectImageFailed = errors.New("failed to inspect image")
 	// errPullImageFailed indicates a failure to pull an image from the registry.
 	errPullImageFailed = errors.New("failed to pull image")
-	// errPullImageUnauthorized indicates an authentication failure during image pull.
-	errPullImageUnauthorized = errors.New("failed to pull image: authentication required")
-	// errPullImageNotFound indicates the image was not found in the registry.
-	errPullImageNotFound = errors.New("failed to pull image: image not found")
+	// ErrPullImageUnauthorized indicates an authentication failure during image pull.
+	ErrPullImageUnauthorized = errors.New("failed to pull image: authentication required")
+	// ErrPullImageNotFound indicates the image was not found in the registry.
+	ErrPullImageNotFound = errors.New("failed to pull image: image not found")
 	// errReadPullResponseFailed indicates a failure to read the pull response stream.
 	errReadPullResponseFailed = errors.New("failed to read pull response")
 	// errRemoveImageFailed indicates a failure to remove an image from the Docker host.

--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -392,11 +392,11 @@ func (c imageClient) performImagePull(
 		case cerrdefs.IsUnauthorized(err):
 			clog.WithError(err).Warn("Image pull failed: authentication required")
 
-			return fmt.Errorf("%w: %s: %w", errPullImageUnauthorized, imageName, err)
+			return fmt.Errorf("%w: %s: %w", ErrPullImageUnauthorized, imageName, err)
 		case cerrdefs.IsNotFound(err):
 			clog.WithError(err).Debug("Image pull failed: image not found in registry")
 
-			return fmt.Errorf("%w: %s: %w", errPullImageNotFound, imageName, err)
+			return fmt.Errorf("%w: %s: %w", ErrPullImageNotFound, imageName, err)
 		default:
 			clog.WithError(err).Debug("Failed to initiate image pull")
 

--- a/pkg/container/image_test.go
+++ b/pkg/container/image_test.go
@@ -84,7 +84,7 @@ var _ = ginkgo.Describe("the client", func() {
 		})
 	})
 	ginkgo.When("pulling an image that requires authentication", func() {
-		ginkgo.It("should log at Warn level and return errPullImageUnauthorized for auth failures", func() {
+		ginkgo.It("should log at Warn level and return ErrPullImageUnauthorized for auth failures", func() {
 			mockServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", gomega.MatchRegexp("/images/")),
@@ -105,14 +105,14 @@ var _ = ginkgo.Describe("the client", func() {
 			err := i.PullImage(context.Background(), pullContainer, WarnAuto)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("authentication required"))
-			gomega.Expect(errors.Is(err, errPullImageUnauthorized)).To(gomega.BeTrue())
+			gomega.Expect(errors.Is(err, ErrPullImageUnauthorized)).To(gomega.BeTrue())
 			gomega.Expect(errors.Is(err, errPullImageFailed)).To(gomega.BeFalse())
 			gomega.Eventually(logbuf).Should(gbytes.Say(`level=warning`))
 			gomega.Eventually(logbuf).Should(gbytes.Say(`Image pull failed: authentication required`))
 		})
 	})
 	ginkgo.When("pulling an image that does not exist in registry", func() {
-		ginkgo.It("should log at Debug level and return errPullImageNotFound for not found errors", func() {
+		ginkgo.It("should log at Debug level and return ErrPullImageNotFound for not found errors", func() {
 			mockServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", gomega.MatchRegexp("/images/")),
@@ -133,7 +133,7 @@ var _ = ginkgo.Describe("the client", func() {
 			err := i.PullImage(context.Background(), pullContainer, WarnAuto)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("image not found"))
-			gomega.Expect(errors.Is(err, errPullImageNotFound)).To(gomega.BeTrue())
+			gomega.Expect(errors.Is(err, ErrPullImageNotFound)).To(gomega.BeTrue())
 			gomega.Expect(errors.Is(err, errPullImageFailed)).To(gomega.BeFalse())
 			gomega.Eventually(logbuf).Should(gbytes.Say(`Image pull failed: image not found in registry`))
 		})
@@ -161,8 +161,8 @@ var _ = ginkgo.Describe("the client", func() {
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to pull image"))
 			gomega.Expect(errors.Is(err, errPullImageFailed)).To(gomega.BeTrue())
-			gomega.Expect(errors.Is(err, errPullImageUnauthorized)).To(gomega.BeFalse())
-			gomega.Expect(errors.Is(err, errPullImageNotFound)).To(gomega.BeFalse())
+			gomega.Expect(errors.Is(err, ErrPullImageUnauthorized)).To(gomega.BeFalse())
+			gomega.Expect(errors.Is(err, ErrPullImageNotFound)).To(gomega.BeFalse())
 			gomega.Eventually(logbuf).Should(gbytes.Say(`Failed to initiate image pull`))
 		})
 	})


### PR DESCRIPTION
This PR implements more nuanced error handling when Watchtower is pulling container images, including providing users more appropriate feedback for auth-related issues.

## Problem

`performImagePull` wraps all errors identically as `errPullImageFailed`, making it impossible for callers to distinguish between:
- **Unauthorized** (HTTP 401) — permanent auth failure requiring credential fix
- **Not Found** (HTTP 404) — image doesn't exist at the specified tag
- **Transient** (DNS, timeout) — retryable network error

This prevents appropriate recovery strategies and leads to misleading error messages.

## Solution

Add two new sentinel errors (`errPullImageUnauthorized`, `errPullImageNotFound`) and check `cerrdefs.IsUnauthorized`/`cerrdefs.IsNotFound` before wrapping. Each error type gets an appropriate log level (Warn for auth, Debug for not-found).

## Changes

- Add `errPullImageUnauthorized` and `errPullImageNotFound` sentinel errors in `pkg/container/errors.go`
- Add type switch in `performImagePull` checking `cerrdefs.IsUnauthorized` and `cerrdefs.IsNotFound` before generic wrapping
- Add tests verifying each error path produces a distinguishable error via `errors.Is()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More specific error reporting for image pulls (distinct auth-required vs. image-not-found cases)
  * Adjusted logging levels for clearer diagnostics: warnings for auth failures, debug for missing images
  * Improved troubleshooting information for image pull failures

* **Tests**
  * Added tests verifying error types and corresponding log levels/messages for image-pull scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->