### PR TITLE
ci(build): move containerd image store setup before buildx setup

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,17 +59,17 @@ jobs:
         with:
           platforms: linux/amd64,linux/386,linux/arm/v6,linux/arm64/v8,linux/riscv64
 
+      - name: Enable containerd snapshotter # Enable containerd for multi-platform builds
+        run: |
+          sudo bash -c 'echo "{\"features\": {\"containerd-snapshotter\": true}}" > /etc/docker/daemon.json'
+          sudo systemctl restart docker
+
       - name: Set up Docker Buildx # Configure multi-platform builds.
         uses: docker/setup-buildx-action@21162887f0d6e25b4e8eafb0cf44cf9bf7f6acd3
         with:
           driver: docker-container
           platforms: linux/amd64,linux/386,linux/arm/v6,linux/arm64/v8,linux/riscv64
           use: true
-
-      - name: Enable containerd snapshotter # Enable containerd for multi-platform builds
-        run: |
-          sudo bash -c 'echo "{\"features\": {\"containerd-snapshotter\": true}}" > /etc/docker/daemon.json'
-          sudo systemctl restart docker
 
       - name: Install Syft for SBOM generation # Install Syft for GoReleaser SBOM generation
         if: ${{ inputs.build-type == 'prod' }}


### PR DESCRIPTION
Build jobs are currently failing when GoReleaser is building container images.
This PR hopes to alleviate any potential race conditions caused by Docker restarting after the Buildx container has been setup.

## Changes

- Move `Enable containerd snapshotter` step before `Set up Docker Buildx` step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the build workflow step execution order for improved container image building efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->