### PR TITLE
ci(build): enable host network for buildkit container

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,6 +70,7 @@ jobs:
           driver: docker-container
           platforms: linux/amd64,linux/386,linux/arm/v6,linux/arm64/v8,linux/riscv64
           use: true
+          driver-opts: network=host
 
       - name: Install Syft for SBOM generation # Install Syft for GoReleaser SBOM generation
         if: ${{ inputs.build-type == 'prod' }}


### PR DESCRIPTION
This PR explicitly sets the BuildKit container to use host DNS to resolve the DNS resolution failure for resolve image config for docker-image://docker.io/docker/buildkit-syft-scanner:stable-1: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline network configuration to improve multi-platform Docker image build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->