### PR TITLE
test(cmd): increase sleep duration to fix timer resolution race

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1217,13 +1217,14 @@ func TestValidateRollingRestartDependenciesAcceptsCancelableContext(t *testing.T
 		mockClient.AssertExpectations(t)
 	})
 
-	// Test with timeout context
+ 	// Test with timeout context
 	t.Run("timeout context is propagated to client", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
 		defer cancel()
 
-		// Wait for context to timeout
-		time.Sleep(time.Millisecond)
+		// Wait for context to timeout; use a duration that reliably exceeds
+		// the nanosecond deadline regardless of OS timer resolution.
+		time.Sleep(time.Millisecond * 10)
 
 		// Verify context has expired before proceeding
 		require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)


### PR DESCRIPTION
This PR increases the sleep timer from 1ms to 10ms to provide more time and avoid a timer resolution race condition during unit testing in GitHub Action runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced reliability of timeout-propagation test by adjusting timing parameters to ensure context expiration consistently occurs and is properly verified before mocked operations and error assertions execute. This improves test stability for cancellable context scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/watchtower/pull/1614)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->