### PR TITLE
fix(goreleaser): add missing watchtower label to Docker images

### DIFF
--- a/build/goreleaser/nightly.yaml
+++ b/build/goreleaser/nightly.yaml
@@ -110,6 +110,7 @@ dockers_v2:
       org.opencontainers.image.licenses: "Apache-2.0"
       org.opencontainers.image.url: "https://github.com/nicholas-fedor/watchtower"
       org.opencontainers.image.documentation: "https://watchtower.nickfedor.com"
+      com.centurylinklabs.watchtower: "true"
 
   ##############################################################################
   # Platform-specific images - platform-prefixed nightly tags only
@@ -134,6 +135,7 @@ dockers_v2:
       org.opencontainers.image.licenses: "Apache-2.0"
       org.opencontainers.image.url: "https://github.com/nicholas-fedor/watchtower"
       org.opencontainers.image.documentation: "https://watchtower.nickfedor.com"
+      com.centurylinklabs.watchtower: "true"
 
   - id: "watchtower-i386-nightly"
     ids: ["watchtower-binary"]
@@ -155,6 +157,7 @@ dockers_v2:
       org.opencontainers.image.licenses: "Apache-2.0"
       org.opencontainers.image.url: "https://github.com/nicholas-fedor/watchtower"
       org.opencontainers.image.documentation: "https://watchtower.nickfedor.com"
+      com.centurylinklabs.watchtower: "true"
 
   - id: "watchtower-armhf-nightly"
     ids: ["watchtower-binary"]
@@ -176,6 +179,7 @@ dockers_v2:
       org.opencontainers.image.licenses: "Apache-2.0"
       org.opencontainers.image.url: "https://github.com/nicholas-fedor/watchtower"
       org.opencontainers.image.documentation: "https://watchtower.nickfedor.com"
+      com.centurylinklabs.watchtower: "true"
 
   - id: "watchtower-arm64v8-nightly"
     ids: ["watchtower-binary"]
@@ -197,6 +201,7 @@ dockers_v2:
       org.opencontainers.image.licenses: "Apache-2.0"
       org.opencontainers.image.url: "https://github.com/nicholas-fedor/watchtower"
       org.opencontainers.image.documentation: "https://watchtower.nickfedor.com"
+      com.centurylinklabs.watchtower: "true"
 
   - id: "watchtower-riscv64-nightly"
     ids: ["watchtower-binary"]
@@ -218,6 +223,7 @@ dockers_v2:
       org.opencontainers.image.licenses: "Apache-2.0"
       org.opencontainers.image.url: "https://github.com/nicholas-fedor/watchtower"
       org.opencontainers.image.documentation: "https://watchtower.nickfedor.com"
+      com.centurylinklabs.watchtower: "true"
 
 ################################################################################
 # Docker Image Signing (Cosign)

--- a/build/goreleaser/stable.yaml
+++ b/build/goreleaser/stable.yaml
@@ -154,6 +154,7 @@ dockers_v2:
       org.opencontainers.image.licenses: "Apache-2.0"
       org.opencontainers.image.url: "https://github.com/nicholas-fedor/watchtower"
       org.opencontainers.image.documentation: "https://watchtower.nickfedor.com"
+      com.centurylinklabs.watchtower: "true"
 
   ##############################################################################
   # Platform-specific images - platform-prefixed tags only
@@ -181,6 +182,7 @@ dockers_v2:
       org.opencontainers.image.licenses: "Apache-2.0"
       org.opencontainers.image.url: "https://github.com/nicholas-fedor/watchtower"
       org.opencontainers.image.documentation: "https://watchtower.nickfedor.com"
+      com.centurylinklabs.watchtower: "true"
 
   - id: "watchtower-i386"
     ids: ["watchtower-binary"]
@@ -205,6 +207,7 @@ dockers_v2:
       org.opencontainers.image.licenses: "Apache-2.0"
       org.opencontainers.image.url: "https://github.com/nicholas-fedor/watchtower"
       org.opencontainers.image.documentation: "https://watchtower.nickfedor.com"
+      com.centurylinklabs.watchtower: "true"
 
   - id: "watchtower-armhf"
     ids: ["watchtower-binary"]
@@ -229,6 +232,7 @@ dockers_v2:
       org.opencontainers.image.licenses: "Apache-2.0"
       org.opencontainers.image.url: "https://github.com/nicholas-fedor/watchtower"
       org.opencontainers.image.documentation: "https://watchtower.nickfedor.com"
+      com.centurylinklabs.watchtower: "true"
 
   - id: "watchtower-arm64v8"
     ids: ["watchtower-binary"]
@@ -253,6 +257,7 @@ dockers_v2:
       org.opencontainers.image.licenses: "Apache-2.0"
       org.opencontainers.image.url: "https://github.com/nicholas-fedor/watchtower"
       org.opencontainers.image.documentation: "https://watchtower.nickfedor.com"
+      com.centurylinklabs.watchtower: "true"
 
   - id: "watchtower-riscv64"
     ids: ["watchtower-binary"]
@@ -277,6 +282,7 @@ dockers_v2:
       org.opencontainers.image.licenses: "Apache-2.0"
       org.opencontainers.image.url: "https://github.com/nicholas-fedor/watchtower"
       org.opencontainers.image.documentation: "https://watchtower.nickfedor.com"
+      com.centurylinklabs.watchtower: "true"
 
 ################################################################################
 # Software Bill of Materials (SBOM) Configuration


### PR DESCRIPTION
This PR add a missing Docker label for Watchtower container images that was mistakenly omitted in the GoReleaser modernization (https://github.com/nicholas-fedor/watchtower/pull/1607). 

## Problem

Watchtower's self-update process currently fails to identify and recreate the Watchtower container. This leaves the old Watchtower container in a stopped state and fails to create the new container.

## Solution

Watchtower relies upon a `com.centurylinklabs.watchtower="true"` container label to self-identify itself for critical functions, such as self-updates. Labels were originally declared in the Dockerfile; however, migrated to the GoReleaser configurations in the latest update. The required label was not migrated to the GoReleaser configurations in that update.

Adding the label to the GoReleaser configurations corrects this problem.

## Changes

- Added `com.centurylinklabs.watchtower: "true"` labels to the GoReleaser stable and nightly dockers_v2 configurations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image builds (both stable and nightly versions) to support automatic updates via Watchtower for all platform variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/watchtower/pull/1620)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->