### PR TITLE
fix(actions): restore no-restart flag to only skip container start

### DIFF
--- a/docs/configuration/arguments/index.md
+++ b/docs/configuration/arguments/index.md
@@ -277,7 +277,7 @@ Environment Variable: WATCHTOWER_INCLUDE_RESTARTING
 
 ### Disable Container Restart
 
-Prevents restarting containers after updating.
+Stops and removes the old containers and creates new ones with the updated image, but does not start the new containers.
 This is useful when an external system (e.g., systemd) manages the container lifecycle.
 
 ```text

--- a/internal/actions/actions_internal_test.go
+++ b/internal/actions/actions_internal_test.go
@@ -519,6 +519,48 @@ var _ = ginkgo.Describe("shouldUpdateContainer", func() {
 		result := shouldUpdateContainer(container, true, params)
 		gomega.Expect(result).To(gomega.BeFalse())
 	})
+
+	ginkgo.It("should allow update of non-Watchtower containers when NoRestart is true", func() {
+		container := mockActions.CreateMockContainerWithConfig(
+			"non-watchtower-id",
+			"nginx",
+			"nginx:latest",
+			true,
+			false,
+			time.Now(),
+			&dockerContainer.Config{
+				Labels: map[string]string{},
+			},
+		)
+		params := types.UpdateParams{
+			NoRestart: true,
+		}
+		result := shouldUpdateContainer(container, true, params)
+		gomega.Expect(result).To(gomega.BeTrue())
+	})
+
+	ginkgo.It("should allow update of Watchtower containers when NoRestart is true", func() {
+		currentID := currentWatchtowerID
+		container := mockActions.CreateMockContainerWithConfig(
+			currentID,
+			"watchtower-current",
+			"watchtower:latest",
+			true,
+			false,
+			time.Now(),
+			&dockerContainer.Config{
+				Labels: map[string]string{
+					"com.centurylinklabs.watchtower": "true",
+				},
+			},
+		)
+		params := types.UpdateParams{
+			NoRestart:          true,
+			CurrentContainerID: types.ContainerID(currentID),
+		}
+		result := shouldUpdateContainer(container, true, params)
+		gomega.Expect(result).To(gomega.BeTrue())
+	})
 })
 
 var _ = ginkgo.Describe("linkedIdentifierMarkedForRestart", func() {

--- a/internal/actions/actions_internal_test.go
+++ b/internal/actions/actions_internal_test.go
@@ -2436,8 +2436,9 @@ var _ = ginkgo.Describe("performRollingRestart", func() {
 						"container-1": true,
 						"container-2": true,
 					},
-					StopOrder:  []string{},
-					StartOrder: []string{},
+					StopOrder:   []string{},
+					CreateOrder: []string{},
+					StartOrder:  []string{},
 				},
 				false,
 				false,
@@ -2455,11 +2456,11 @@ var _ = ginkgo.Describe("performRollingRestart", func() {
 				nil,
 			)
 
-			// Verify start order is forward (container-0, container-1, container-2).
-			gomega.Expect(client.TestData.StartOrder).To(gomega.HaveLen(3))
-			gomega.Expect(client.TestData.StartOrder[0]).To(gomega.Equal("container-0"))
-			gomega.Expect(client.TestData.StartOrder[1]).To(gomega.Equal("container-1"))
-			gomega.Expect(client.TestData.StartOrder[2]).To(gomega.Equal("container-2"))
+			// Verify create order is forward (container-0, container-1, container-2).
+			gomega.Expect(client.TestData.CreateOrder).To(gomega.HaveLen(3))
+			gomega.Expect(client.TestData.CreateOrder[0]).To(gomega.Equal("container-0"))
+			gomega.Expect(client.TestData.CreateOrder[1]).To(gomega.Equal("container-1"))
+			gomega.Expect(client.TestData.CreateOrder[2]).To(gomega.Equal("container-2"))
 		})
 	})
 

--- a/internal/actions/actions_test.go
+++ b/internal/actions/actions_test.go
@@ -261,10 +261,10 @@ var _ = ginkgo.Describe("Actions", func() {
 
 					gomega.Expect(metric).NotTo(gomega.BeNil())
 					// Only container1 should be updated, container2 should be skipped due to CurrentContainerID
-					gomega.Expect(client.TestData.StartOrder).To(gomega.HaveLen(1))
-					gomega.Expect(client.TestData.StartOrder).
+					gomega.Expect(client.TestData.CreateOrder).To(gomega.HaveLen(1))
+					gomega.Expect(client.TestData.CreateOrder).
 						To(gomega.ContainElement("watchtower-1"))
-					gomega.Expect(client.TestData.StartOrder).
+					gomega.Expect(client.TestData.CreateOrder).
 						To(gomega.Not(gomega.ContainElement("watchtower-2")))
 				},
 			)
@@ -1163,16 +1163,16 @@ var _ = ginkgo.Describe("Actions", func() {
 				wg.Wait()
 
 				// Verify scope isolation through separate TestData tracking
-				// client1 should only start scope1-watchtower
-				gomega.Expect(client1.TestData.StartOrder).
+				// client1 should only create scope1-watchtower
+				gomega.Expect(client1.TestData.CreateOrder).
 					To(gomega.ContainElement("scope1-watchtower"))
-				gomega.Expect(client1.TestData.StartOrder).
+				gomega.Expect(client1.TestData.CreateOrder).
 					NotTo(gomega.ContainElement("scope2-watchtower"))
 
-				// client2 should only start scope2-watchtower
-				gomega.Expect(client2.TestData.StartOrder).
+				// client2 should only create scope2-watchtower
+				gomega.Expect(client2.TestData.CreateOrder).
 					To(gomega.ContainElement("scope2-watchtower"))
-				gomega.Expect(client2.TestData.StartOrder).
+				gomega.Expect(client2.TestData.CreateOrder).
 					NotTo(gomega.ContainElement("scope1-watchtower"))
 			},
 		)

--- a/internal/actions/errors.go
+++ b/internal/actions/errors.go
@@ -30,6 +30,8 @@ var (
 	errStopContainerFailed = errors.New("failed to stop container")
 	// errStartContainerFailed indicates a failure to start a container after an update.
 	errStartContainerFailed = errors.New("failed to start container")
+	// errCreateContainerFailed indicates a failure to create a container during the update process.
+	errCreateContainerFailed = errors.New("failed to create container")
 	// errParseImageReference indicates a failure to parse a container’s image reference.
 	errParseImageReference = errors.New("failed to parse image reference")
 	// errInvalidImageReference indicates an invalid image reference that cannot be processed.

--- a/internal/actions/mocks/client.go
+++ b/internal/actions/mocks/client.go
@@ -32,6 +32,7 @@ type TestData struct {
 	RenameContainerCount         atomic.Int32                          // Number of times RenameContainer was called.
 	StopContainerCount           atomic.Int32                          // Number of times StopContainer was called.
 	StartContainerCount          atomic.Int32                          // Number of times StartContainer was called.
+	CreateContainerCount         atomic.Int32                          // Number of times CreateContainer was called.
 	UpdateContainerCount         atomic.Int32                          // Number of times UpdateContainer was called.
 	IsContainerStaleCount        atomic.Int32                          // Number of times IsContainerStale was called.
 	WaitForContainerHealthyCount atomic.Int32                          // Number of times WaitForContainerHealthy was called.
@@ -45,6 +46,7 @@ type TestData struct {
 	ListContainersFailCount      int                                   // Number of times ListContainers should fail before succeeding.
 	StopContainerError           error                                 // Error to return from StopContainer (for testing).
 	StartContainerError          error                                 // Error to return from StartContainer (for testing).
+	CreateContainerError         error                                 // Error to return from CreateContainer (for testing).
 	UpdateContainerError         error                                 // Error to return from UpdateContainer (for testing).
 	StopContainerFailCount       int                                   // Number of times StopContainer should fail before succeeding.
 	RemoveImageError             error                                 // Error to return from RemoveImageByID (for testing).
@@ -196,6 +198,26 @@ func (client MockClient) IsContainerRunning(c types.Container) bool {
 	return !client.Stopped[string(c.ID())]
 }
 
+// CreateContainer simulates creating a new container from a source container's
+// configuration without starting it.
+// It provides a minimal implementation for testing purposes.
+// Returns the configured CreateContainerError if set.
+func (client MockClient) CreateContainer(ctx context.Context, c types.Container) (types.ContainerID, error) {
+	client.TestData.CreateContainerCount.Add(1)
+
+	if err := client.checkContextCancellation(ctx); err != nil {
+		return "", err
+	}
+
+	if client.TestData.CreateContainerError != nil {
+		return "", client.TestData.CreateContainerError
+	}
+
+	client.TestData.StartOrder = append(client.TestData.StartOrder, c.Name())
+
+	return c.ID(), nil
+}
+
 // StartContainer simulates starting a container, returning the container's ID.
 // It provides a minimal implementation for testing purposes.
 // Returns the configured StartContainerError if set.
@@ -228,9 +250,6 @@ func (client MockClient) StartContainerByID(ctx context.Context, containerID typ
 	if client.TestData.StartContainerError != nil {
 		return client.TestData.StartContainerError
 	}
-
-	client.TestData.StartOrder = append(client.TestData.StartOrder, string(containerID))
-	client.Stopped[string(containerID)] = false
 
 	return nil
 }

--- a/internal/actions/mocks/client.go
+++ b/internal/actions/mocks/client.go
@@ -52,6 +52,7 @@ type TestData struct {
 	RemoveImageError             error                                 // Error to return from RemoveImageByID (for testing).
 	FailedImageIDs               []types.ImageID                       // List of image IDs that should fail removal.
 	StopOrder                    []string                              // Order in which containers were stopped.
+	CreateOrder                  []string                              // Order in which containers were created.
 	StartOrder                   []string                              // Order in which containers were started.
 	SimulatedLatency             time.Duration                         // Simulated latency for operations (default 0 for fast tests, set for context cancellation tests).
 	LastContainerChain           string                                // Last container chain passed to CreateEphemeralOrchestrator.
@@ -213,7 +214,7 @@ func (client MockClient) CreateContainer(ctx context.Context, c types.Container)
 		return "", client.TestData.CreateContainerError
 	}
 
-	client.TestData.StartOrder = append(client.TestData.StartOrder, c.Name())
+	client.TestData.CreateOrder = append(client.TestData.CreateOrder, c.Name())
 
 	return c.ID(), nil
 }

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -747,7 +747,6 @@ func UpdateImplicitRestart(
 // It checks multiple conditions:
 // - The container must be stale (outdated image)
 // - The container must not be monitor-only
-// - Updates are allowed unless NoRestart is true and it's not a Watchtower container
 // - Watchtower containers are skipped in run-once mode
 // - Watchtower self-updates are skipped if SkipSelfUpdate is true
 //
@@ -770,12 +769,6 @@ func shouldUpdateContainer(
 
 	// Skip monitor-only containers
 	if container.IsMonitorOnly(config) {
-		return false
-	}
-
-	// Allow update if NoRestart is false, or if it's a Watchtower container
-	// (which can update even with NoRestart)
-	if config.NoRestart && !container.IsWatchtower() {
 		return false
 	}
 
@@ -1689,8 +1682,7 @@ func restartStaleContainer(
 		"image":     sourceContainer.ImageName(),
 	}
 
-	renamed := false
-	newContainerID := sourceContainer.ID() // Default to original ID
+	var renamed bool
 
 	// Rename Watchtower containers regardless of NoRestart flag,
 	// but skip in run-once mode as there's no need to avoid conflicts
@@ -1782,16 +1774,29 @@ func restartStaleContainer(
 		}
 	}
 
+	// Create the new container with updated configuration.
+	newContainerID, err := client.CreateContainer(ctx, sourceContainer)
+	if err != nil {
+		logrus.WithFields(fields).
+			WithError(err).
+			Debug("Failed to create container")
+
+		return "",
+			renamed,
+			fmt.Errorf(
+				"%w: %w",
+				errStartContainerFailed,
+				err,
+			)
+	}
+
 	// Start the new container unless restarts are disabled.
 	// Watchtower containers are always started.
 	if !config.NoRestart || sourceContainer.IsWatchtower() {
 		logrus.WithFields(fields).
 			Debug("Starting container with updated configuration")
 
-		var err error
-
-		// Start the new container.
-		newContainerID, err = client.StartContainer(ctx, sourceContainer)
+		err = client.StartContainerByID(ctx, newContainerID)
 		if err != nil {
 			logrus.WithFields(fields).
 				WithError(err).

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -1785,7 +1785,7 @@ func restartStaleContainer(
 			renamed,
 			fmt.Errorf(
 				"%w: %w",
-				errStartContainerFailed,
+				errCreateContainerFailed,
 				err,
 			)
 	}

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -1775,7 +1775,8 @@ func restartStaleContainer(
 	}
 
 	// Create the new container with updated configuration.
-	newContainerID, err := client.CreateContainer(ctx, sourceContainer)
+	//nolint:contextcheck // Using detached context intentionally to survive parent cancellation
+	newContainerID, err := client.CreateContainer(detachedCtx, sourceContainer)
 	if err != nil {
 		logrus.WithFields(fields).
 			WithError(err).
@@ -1796,7 +1797,8 @@ func restartStaleContainer(
 		logrus.WithFields(fields).
 			Debug("Starting container with updated configuration")
 
-		err = client.StartContainerByID(ctx, newContainerID)
+		//nolint:contextcheck // Using detached context intentionally to survive parent cancellation
+		err = client.StartContainerByID(detachedCtx, newContainerID)
 		if err != nil {
 			logrus.WithFields(fields).
 				WithError(err).

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -1830,6 +1830,10 @@ func restartStaleContainer(
 				)
 		}
 
+		logrus.WithFields(fields).
+			WithField("new_id", newContainerID.ShortID()).
+			Info("Started new container")
+
 		// Run post-update lifecycle hooks for restarting containers if enabled.
 		if sourceContainer.ToRestart() && config.LifecycleHooks {
 			logrus.WithFields(fields).

--- a/internal/actions/update_dependencies_test.go
+++ b/internal/actions/update_dependencies_test.go
@@ -415,8 +415,9 @@ var _ = ginkgo.Describe("the update action", func() {
 						"container-b": true,
 						"container-c": true,
 					},
-					StopOrder:  []string{},
-					StartOrder: []string{},
+					StopOrder:   []string{},
+					CreateOrder: []string{},
+					StartOrder:  []string{},
 				},
 				false,
 				false,
@@ -432,8 +433,8 @@ var _ = ginkgo.Describe("the update action", func() {
 			// Verify stop order: dependents first (reverse dependency order)
 			gomega.Expect(client.TestData.StopOrder).
 				To(gomega.Equal([]string{"container-a", "container-b", "container-c"}))
-			// Verify start order: dependencies first
-			gomega.Expect(client.TestData.StartOrder).
+			// Verify create order: dependencies first
+			gomega.Expect(client.TestData.CreateOrder).
 				To(gomega.Equal([]string{"container-c", "container-b", "container-a"}))
 		})
 	})
@@ -1297,8 +1298,9 @@ var _ = ginkgo.Describe("the update action", func() {
 						"app-2": false,
 						"app-3": false,
 					},
-					StopOrder:  []string{},
-					StartOrder: []string{},
+					StopOrder:   []string{},
+					CreateOrder: []string{},
+					StartOrder:  []string{},
 				},
 				false,
 				false,
@@ -1330,13 +1332,13 @@ var _ = ginkgo.Describe("the update action", func() {
 			// db should be last in stop order
 			gomega.Expect(stopOrder[len(stopOrder)-1]).To(gomega.Equal("db"))
 
-			// Verify start order: db first, then dependents
-			startOrder := client.TestData.StartOrder
-			gomega.Expect(startOrder).To(gomega.HaveLen(4))
-			gomega.Expect(startOrder[0]).To(gomega.Equal("db"))
-			gomega.Expect(startOrder).To(gomega.ContainElement("app-1"))
-			gomega.Expect(startOrder).To(gomega.ContainElement("app-2"))
-			gomega.Expect(startOrder).To(gomega.ContainElement("app-3"))
+			// Verify create order: db first, then dependents
+			createOrder := client.TestData.CreateOrder
+			gomega.Expect(createOrder).To(gomega.HaveLen(4))
+			gomega.Expect(createOrder[0]).To(gomega.Equal("db"))
+			gomega.Expect(createOrder).To(gomega.ContainElement("app-1"))
+			gomega.Expect(createOrder).To(gomega.ContainElement("app-2"))
+			gomega.Expect(createOrder).To(gomega.ContainElement("app-3"))
 		})
 	})
 
@@ -1743,8 +1745,9 @@ var _ = ginkgo.Describe("the update action", func() {
 						"c-service2": true,
 						"d-service3": true,
 					},
-					StopOrder:  []string{},
-					StartOrder: []string{},
+					StopOrder:   []string{},
+					CreateOrder: []string{},
+					StartOrder:  []string{},
 				},
 				false,
 				false,
@@ -1765,8 +1768,8 @@ var _ = ginkgo.Describe("the update action", func() {
 			gomega.Expect(client.TestData.StopOrder).
 				To(gomega.Equal([]string{"c-service2", "b-service1", "d-service3"}))
 
-			// Verify start order: dependency order
-			gomega.Expect(client.TestData.StartOrder).
+			// Verify create order: dependency order
+			gomega.Expect(client.TestData.CreateOrder).
 				To(gomega.Equal([]string{"d-service3", "b-service1", "c-service2"}))
 
 			// Verify cleanup for updated containers

--- a/internal/actions/update_restart_test.go
+++ b/internal/actions/update_restart_test.go
@@ -1299,8 +1299,9 @@ var _ = ginkgo.Describe("the update action", func() {
 							"priority-b": false,
 							"priority-a": false,
 						},
-						StopOrder:  []string{},
-						StartOrder: []string{},
+						StopOrder:   []string{},
+						CreateOrder: []string{},
+						StartOrder:  []string{},
 					},
 					false,
 					false,
@@ -1321,10 +1322,10 @@ var _ = ginkgo.Describe("the update action", func() {
 				gomega.Expect(report.Updated()).To(gomega.HaveLen(1))
 				gomega.Expect(report.Restarted()).To(gomega.HaveLen(2))
 
-				// Verify start order respects dependencies (dependencies first)
-				gomega.Expect(client.TestData.StartOrder).To(gomega.ContainElement("priority-c"))
-				gomega.Expect(client.TestData.StartOrder).To(gomega.ContainElement("priority-b"))
-				gomega.Expect(client.TestData.StartOrder).To(gomega.ContainElement("priority-a"))
+				// Verify create order respects dependencies (dependencies first)
+				gomega.Expect(client.TestData.CreateOrder).To(gomega.ContainElement("priority-c"))
+				gomega.Expect(client.TestData.CreateOrder).To(gomega.ContainElement("priority-b"))
+				gomega.Expect(client.TestData.CreateOrder).To(gomega.ContainElement("priority-a"))
 			})
 
 			ginkgo.It("should handle mixed update types in restart sequences", func() {

--- a/internal/actions/update_watchtower_test.go
+++ b/internal/actions/update_watchtower_test.go
@@ -117,6 +117,51 @@ var _ = ginkgo.Describe("Watchtower container handling", func() {
 				To(gomega.Equal(int32(0)), "RenameContainer should not be called with no-restart")
 		})
 
+		ginkgo.It("should stop and recreate non-Watchtower containers with no-restart", func() {
+			client := mockActions.CreateMockClient(
+				&mockActions.TestData{
+					Containers: []types.Container{
+						mockActions.CreateMockContainerWithConfig(
+							"nginx",
+							"/nginx",
+							"nginx:latest",
+							true,
+							false,
+							time.Now(),
+							&dockerContainer.Config{
+								Labels: map[string]string{},
+							}),
+					},
+					Staleness: map[string]bool{
+						"nginx": true,
+					},
+				},
+				false,
+				false,
+			)
+			report, cleanupImageInfos, err := actions.Update(
+				context.Background(),
+				client,
+				types.UpdateParams{
+					Cleanup:     true,
+					NoRestart:   true,
+					Filter:      filters.NoFilter,
+					CPUCopyMode: "auto",
+				},
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(report.Updated()).
+				To(gomega.HaveLen(1), "Non-Watchtower container should be updated with no-restart")
+			gomega.Expect(cleanupImageInfos).
+				To(gomega.HaveLen(1), "Cleanup info should be collected for updated container")
+			gomega.Expect(client.TestData.StopContainerCount.Load()).
+				To(gomega.Equal(int32(1)), "Container should be stopped")
+			gomega.Expect(client.TestData.CreateContainerCount.Load()).
+				To(gomega.Equal(int32(1)), "Container should be created with no-restart")
+			gomega.Expect(client.TestData.StartContainerCount.Load()).
+				To(gomega.Equal(int32(0)), "Container should not be started with no-restart")
+		})
+
 		ginkgo.It("should not rename Watchtower container in run-once mode", func() {
 			client := mockActions.CreateMockClient(
 				&mockActions.TestData{

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -133,6 +133,18 @@ type Client interface {
 	//   - error: Non-nil if stop/removal fails, nil on success.
 	StopAndRemoveContainer(ctx context.Context, container types.Container, timeout time.Duration) error
 
+	// CreateContainer creates a new container based on the provided
+	// container's configuration, but does not start it.
+	//
+	// Parameters:
+	//   - ctx: Context for cancellation and timeout control.
+	//   - container: Source container to replicate.
+	//
+	// Returns:
+	//   - types.ContainerID: ID of the new container.
+	//   - error: Non-nil if creation fails, nil on success.
+	CreateContainer(ctx context.Context, container types.Container) (types.ContainerID, error)
+
 	// StartContainer creates and starts a new container based on the provided
 	// container's configuration.
 	//
@@ -619,6 +631,59 @@ func (c *client) StopAndRemoveContainer(ctx context.Context, container types.Con
 	return nil
 }
 
+// CreateContainer creates a new container based on the provided
+// container's configuration, but does not start it.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeout control.
+//   - container: Source container to replicate.
+//
+// Returns:
+//   - types.ContainerID: ID of the new container.
+//   - error: Non-nil if creation fails, nil on success.
+func (c *client) CreateContainer(ctx context.Context, container types.Container) (types.ContainerID, error) {
+	fields := logrus.Fields{
+		"container": container.Name(),
+		"image":     container.ImageName(),
+	}
+	// Determine if the container runtime is Podman to handle runtime-specific differences.
+	//
+	//nolint:contextcheck // getRuntime uses context.Background() internally for cached detection
+	isPodman := c.getRuntime()
+
+	clientVersion := c.GetVersion()
+
+	logrus.WithFields(fields).WithField("client_version", clientVersion).
+		Debug("Obtaining source container network configuration")
+
+	// Get unified network config.
+	networkConfig := getNetworkConfig(container, clientVersion)
+
+	// Create new container with selected config.
+	newID, err := CreateTargetContainer(
+		ctx,
+		c.api,
+		container,
+		networkConfig,
+		clientVersion,
+		flags.DockerAPIMinVersion, // Docker API Version 1.24
+		c.DisableMemorySwappiness,
+		c.CPUCopyMode,
+		isPodman,
+	)
+	if err != nil {
+		logrus.WithFields(fields).WithError(err).Debug("Failed to create new container")
+
+		return "", err
+	}
+
+	logrus.WithFields(fields).
+		WithField("new_id", newID.ShortID()).
+		Debug("Created new container")
+
+	return newID, nil
+}
+
 // StartContainer creates and starts a new container based on an
 // existing container's configuration.
 //
@@ -634,6 +699,7 @@ func (c *client) StartContainer(ctx context.Context, container types.Container) 
 		"container": container.Name(),
 		"image":     container.ImageName(),
 	}
+
 	// Determine if the container runtime is Podman to handle runtime-specific differences.
 	//
 	//nolint:contextcheck // getRuntime uses context.Background() internally for cached detection

--- a/pkg/container/container_target.go
+++ b/pkg/container/container_target.go
@@ -21,7 +21,7 @@ const (
 	cleanupTimeout = 10 * time.Second
 )
 
-// StartTargetContainer creates and starts a new container based on the source container’s configuration.
+// StartTargetContainer creates and starts a new container based on the source container's configuration.
 //
 // It applies the provided network configuration and respects the reviveStopped option.
 // For legacy Docker API versions (< 1.44) with multiple networks, it creates the container with a single
@@ -49,6 +49,91 @@ func StartTargetContainer(
 	sourceContainer types.Container,
 	networkConfig *dockerNetwork.NetworkingConfig,
 	reviveStopped bool,
+	clientVersion string,
+	minSupportedVersion string,
+	disableMemorySwappiness bool,
+	cpuCopyMode string,
+	isPodman bool,
+) (types.ContainerID, error) {
+	createdContainerID, err := CreateTargetContainer(
+		ctx,
+		api,
+		sourceContainer,
+		networkConfig,
+		clientVersion,
+		minSupportedVersion,
+		disableMemorySwappiness,
+		cpuCopyMode,
+		isPodman,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	clog := logrus.WithFields(logrus.Fields{
+		"container": sourceContainer.Name(),
+		"id":        sourceContainer.ID().ShortID(),
+	})
+
+	// Skip starting if source isn't running and revive isn't enabled.
+	if !sourceContainer.IsRunning() && !reviveStopped {
+		clog.WithField("new_id", createdContainerID).
+			Debug("Created container, not starting due to stopped state")
+
+		return createdContainerID, nil
+	}
+
+	// Start the newly created container.
+	clog.WithField("new_id", createdContainerID).
+		Debug("Starting new container")
+
+	_, err = api.ContainerStart(
+		ctx,
+		string(createdContainerID),
+		dockerClient.ContainerStartOptions{},
+	)
+	if err != nil {
+		clog.WithError(err).
+			WithField("new_id", createdContainerID).
+			Debug("Failed to start new container")
+
+		return createdContainerID, fmt.Errorf("%w: %w", errStartContainerFailed, err)
+	}
+
+	// Log detailed start message
+	message := "Started new container"
+	if sourceContainer.IsLinkedToRestarting() {
+		message = "Started linked container"
+	}
+
+	clog.WithField("new_id", createdContainerID.ShortID()).Info(message)
+
+	return createdContainerID, nil
+}
+
+// CreateTargetContainer creates a new container based on the source container's
+// configuration but does not start it. It applies the provided network configuration,
+// renames the container, and attaches additional networks for legacy API versions.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeout control.
+//   - api: Interface for container operations (Operations).
+//   - sourceContainer: Source container to replicate.
+//   - networkConfig: Network configuration to apply to the new container.
+//   - clientVersion: Docker API version used by the client.
+//   - minSupportedVersion: Minimum Docker API version required for full network features.
+//   - disableMemorySwappiness: If true, disables memory swappiness for Podman compatibility.
+//   - cpuCopyMode: CPU copy mode for container recreation, used for compatibility with Podman.
+//   - isPodman: If true, indicates Podman is being used for CPU compatibility.
+//
+// Returns:
+//   - types.ContainerID: ID of the new container.
+//   - error: Non-nil if creation fails, nil on success.
+func CreateTargetContainer(
+	ctx context.Context,
+	api Operations,
+	sourceContainer types.Container,
+	networkConfig *dockerNetwork.NetworkingConfig,
 	clientVersion string,
 	minSupportedVersion string,
 	disableMemorySwappiness bool,
@@ -191,39 +276,6 @@ func StartTargetContainer(
 			return "", err
 		}
 	}
-
-	// Skip starting if source isn’t running and revive isn’t enabled.
-	if !sourceContainer.IsRunning() && !reviveStopped {
-		clog.WithField("new_id", createdContainerID).
-			Debug("Created container, not starting due to stopped state")
-
-		return createdContainerID, nil
-	}
-
-	// Start the newly created container.
-	clog.WithField("new_id", createdContainerID).
-		Debug("Starting new container")
-
-	_, err = api.ContainerStart(
-		ctx,
-		createdContainer.ID,
-		dockerClient.ContainerStartOptions{},
-	)
-	if err != nil {
-		clog.WithError(err).
-			WithField("new_id", createdContainerID).
-			Debug("Failed to start new container")
-
-		return createdContainerID, fmt.Errorf("%w: %w", errStartContainerFailed, err)
-	}
-
-	// Log detailed start message
-	message := "Started new container"
-	if sourceContainer.IsLinkedToRestarting() {
-		message = "Started linked container"
-	}
-
-	clog.WithField("new_id", createdContainerID.ShortID()).Info(message)
 
 	return createdContainerID, nil
 }

--- a/pkg/container/mocks/Client.go
+++ b/pkg/container/mocks/Client.go
@@ -40,6 +40,72 @@ func (_m *MockClient) EXPECT() *MockClient_Expecter {
 	return &MockClient_Expecter{mock: &_m.Mock}
 }
 
+// CreateContainer provides a mock function for the type MockClient
+func (_mock *MockClient) CreateContainer(ctx context.Context, container types.Container) (types.ContainerID, error) {
+	ret := _mock.Called(ctx, container)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateContainer")
+	}
+
+	var r0 types.ContainerID
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, types.Container) (types.ContainerID, error)); ok {
+		return returnFunc(ctx, container)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, types.Container) types.ContainerID); ok {
+		r0 = returnFunc(ctx, container)
+	} else {
+		r0 = ret.Get(0).(types.ContainerID)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, types.Container) error); ok {
+		r1 = returnFunc(ctx, container)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockClient_CreateContainer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateContainer'
+type MockClient_CreateContainer_Call struct {
+	*mock.Call
+}
+
+// CreateContainer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - container types.Container
+func (_e *MockClient_Expecter) CreateContainer(ctx interface{}, container interface{}) *MockClient_CreateContainer_Call {
+	return &MockClient_CreateContainer_Call{Call: _e.mock.On("CreateContainer", ctx, container)}
+}
+
+func (_c *MockClient_CreateContainer_Call) Run(run func(ctx context.Context, container types.Container)) *MockClient_CreateContainer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 types.Container
+		if args[1] != nil {
+			arg1 = args[1].(types.Container)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_CreateContainer_Call) Return(containerID types.ContainerID, err error) *MockClient_CreateContainer_Call {
+	_c.Call.Return(containerID, err)
+	return _c
+}
+
+func (_c *MockClient_CreateContainer_Call) RunAndReturn(run func(ctx context.Context, container types.Container) (types.ContainerID, error)) *MockClient_CreateContainer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateEphemeralOrchestrator provides a mock function for the type MockClient
 func (_mock *MockClient) CreateEphemeralOrchestrator(ctx context.Context, sourceContainer types.Container, newImage string, containerChain string) (types.ContainerID, error) {
 	ret := _mock.Called(ctx, sourceContainer, newImage, containerChain)


### PR DESCRIPTION
## Problem

The `--no-restart` flag was silently skipping all container updates instead of only skipping the container start step. When enabled, stale containers were never stopped, never recreated, and never restarted — resulting in `updated=0` every cycle despite new images being available. This was a long-standing bug originally reported as containrrr/watchtower#1441 and subsequently reported in https://github.com/nicholas-fedor/watchtower/issues/1554 .

## Solution

Separated container creation from container starting in the update pipeline. The `NoRestart` check was removed from `shouldUpdateContainer()` and the `restartStaleContainer` function was updated to always create the new container, then conditionally start it only when `NoRestart` is false (or the container is Watchtower). This restores the original intended behavior from the initial `--no-restart` implementation in containrrr/watchtower#9: stop old containers, create new ones with the updated image, but leave them stopped for orchestration tools to handle.

## Changes

- **`internal/actions/update.go`**: Removed `NoRestart` check from `shouldUpdateContainer()`; refactored `restartStaleContainer` to call `CreateContainer` always, then conditionally start via `StartContainerByID`
- **`pkg/container/client.go`**: Added `CreateContainer` method to the `Client` interface and implemented it as create-only (no start); refactored `StartContainer` to delegate to `CreateTargetContainer` + `ContainerStart`
- **`pkg/container/container_target.go`**: Extracted `CreateTargetContainer` from `StartTargetContainer`; `StartTargetContainer` now delegates to `CreateTargetContainer` + conditional `ContainerStart` (preserving `reviveStopped` behavior)
- **`internal/actions/errors.go`**: Added `errCreateContainerFailed` constant so callers can distinguish creation vs start failures
- **`internal/actions/actions_internal_test.go`**: Added unit tests for `shouldUpdateContainer` with `NoRestart=true`
- **`internal/actions/update_watchtower_test.go`**: Added integration test verifying containers are stopped and created but not started with `NoRestart`
- **`internal/actions/mocks/client.go`**: Added `CreateContainer` mock method with `CreateContainerCount` and `CreateContainerError` fields
- **`pkg/container/mocks/Client.go`**: Regenerated to include `CreateContainer`
- **`docs/configuration/arguments/index.md`**: Updated `--no-restart` description to reflect correct behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the `--no-restart` flag: Watchtower stops and removes old containers, creates new ones with the updated image, but does not start the new containers automatically.

* **Bug Fixes**
  * Ensure no-restart flow recreates containers without starting them and allows updates for non-Watchtower containers as intended.

* **Tests**
  * Updated test coverage and order assertions to verify creation ordering and no-restart behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/watchtower/pull/1626)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->