### PR TITLE
fix: restore revive-stopped configuration handling

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -615,7 +615,7 @@ func runMain(cfg types.RunConfig) int {
 			Filter:                       filter,                       // Container filter determining which containers are targeted
 			Cleanup:                      params.Cleanup,               // Remove old images after container updates
 			NoRestart:                    noRestart,                    // Prevent containers from being restarted after updates
-			ReviveStopped:                reviveStopped,                // Start stopped containers after update if true
+			ReviveStopped:                params.ReviveStopped,         // Start stopped containers after update if true
 			MonitorOnly:                  params.MonitorOnly,           // Monitor containers without performing updates
 			LifecycleHooks:               lifecycleHooks,               // Enable pre- and post-update lifecycle hook commands
 			RollingRestart:               rollingRestart,               // Update containers sequentially rather than all at once

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,12 @@ var (
 	// useful when users prefer manual restart control or want to minimize downtime during updates.
 	noRestart bool
 
+	// reviveStopped is a boolean flag that starts stopped containers after an update.
+	//
+	// It is set in preRun via the --revive-stopped flag or the WATCHTOWER_REVIVE_STOPPED environment variable,
+	// allowing users to have Watchtower start containers that were originally stopped before the update.
+	reviveStopped bool
+
 	// noPull is a boolean flag that skips pulling new images from the registry during updates.
 	//
 	// It is enabled in preRun via the --no-pull flag or the WATCHTOWER_NO_PULL environment variable,
@@ -203,6 +209,18 @@ var (
 	rootCmd = NewRootCommand()
 )
 
+// init registers command-line flags for the root command during package initialization.
+//
+// It invokes functions from the flags package to set default values and register flags for Docker configuration
+// (e.g., --host), system behavior (e.g., --interval), and notifications (e.g., --notifications), establishing
+// the CLI’s configurable parameters before execution begins.
+func init() {
+	flags.SetDefaults()
+	flags.RegisterDockerFlags(rootCmd)
+	flags.RegisterSystemFlags(rootCmd)
+	flags.RegisterNotificationFlags(rootCmd)
+}
+
 // NewRootCommand creates and configures the root command for the Watchtower CLI.
 //
 // It establishes the base usage string ("watchtower"), a short description summarizing its purpose,
@@ -221,18 +239,6 @@ func NewRootCommand() *cobra.Command {
 		PreRun: preRun,
 		Args:   cobra.ArbitraryArgs, // Permits any number of positional arguments, processed as container names later.
 	}
-}
-
-// init registers command-line flags for the root command during package initialization.
-//
-// It invokes functions from the flags package to set default values and register flags for Docker configuration
-// (e.g., --host), system behavior (e.g., --interval), and notifications (e.g., --notifications), establishing
-// the CLI’s configurable parameters before execution begins.
-func init() {
-	flags.SetDefaults()
-	flags.RegisterDockerFlags(rootCmd)
-	flags.RegisterSystemFlags(rootCmd)
-	flags.RegisterNotificationFlags(rootCmd)
 }
 
 // Execute runs the root command and manages any errors encountered during its execution.
@@ -350,7 +356,7 @@ func preRun(cmd *cobra.Command, _ []string) {
 	noPull, _ = flagsSet.GetBool("no-pull")
 	includeStopped, _ := flagsSet.GetBool("include-stopped")
 	includeRestarting, _ := flagsSet.GetBool("include-restarting")
-	reviveStopped, _ := flagsSet.GetBool("revive-stopped")
+	reviveStopped, _ = flagsSet.GetBool("revive-stopped")
 	removeVolumes, _ := flagsSet.GetBool("remove-volumes")
 	warnOnHeadPullFailed, _ := flagsSet.GetString("warn-on-head-failure")
 	disableMemorySwappiness, _ := flagsSet.GetBool("disable-memory-swappiness")
@@ -609,6 +615,7 @@ func runMain(cfg types.RunConfig) int {
 			Filter:                       filter,                       // Container filter determining which containers are targeted
 			Cleanup:                      params.Cleanup,               // Remove old images after container updates
 			NoRestart:                    noRestart,                    // Prevent containers from being restarted after updates
+			ReviveStopped:                reviveStopped,                // Start stopped containers after update if true
 			MonitorOnly:                  params.MonitorOnly,           // Monitor containers without performing updates
 			LifecycleHooks:               lifecycleHooks,               // Enable pre- and post-update lifecycle hook commands
 			RollingRestart:               rollingRestart,               // Update containers sequentially rather than all at once
@@ -673,6 +680,7 @@ func runMain(cfg types.RunConfig) int {
 			UseComposeDependsOn: useComposeDependsOn,
 			SkipSelfUpdate:      false, // SkipSelfUpdate is dynamically set in RunUpgradesOnSchedule based on skipFirstRun
 			CooldownDelay:       cooldownDelay,
+			ReviveStopped:       reviveStopped,
 		}
 		metric := runUpdatesWithNotifications(ctx, cfg.Filter, params)
 		metrics.Default().RegisterScan(metric)

--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -43,6 +43,7 @@ type RunUpdatesWithNotificationsParams struct {
 	Filter                       types.Filter      // Container filter determining which containers are targeted
 	Cleanup                      bool              // Remove old images after container updates
 	NoRestart                    bool              // Prevent containers from being restarted after updates
+	ReviveStopped                bool              // Start stopped containers after update if true.
 	MonitorOnly                  bool              // Monitor containers without performing updates
 	LifecycleHooks               bool              // Enable pre- and post-update lifecycle hook commands
 	RollingRestart               bool              // Update containers sequentially rather than all at once
@@ -102,6 +103,7 @@ func RunUpdatesWithNotifications(
 		SkipSelfUpdate:      params.SkipSelfUpdate,      // Skip Watchtower self-update
 		EphemeralSelfUpdate: params.EphemeralSelfUpdate, // Use ephemeral container for self-update if true
 		CooldownDelay:       params.CooldownDelay,       // Minimum time since image creation before allowing updates
+		ReviveStopped:       params.ReviveStopped,       // Start stopped containers after update if true
 	}
 
 	// Execute the container update operation

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -1791,9 +1791,10 @@ func restartStaleContainer(
 			)
 	}
 
-	// Start the new container unless restarts are disabled.
-	// Watchtower containers are always started.
-	if !config.NoRestart || sourceContainer.IsWatchtower() {
+	// Start the new container based on restart settings:
+	// - Watchtower containers bypass the NoRestart check
+	// - All containers (including Watchtower) start only if they were running or ReviveStopped is enabled
+	if (!config.NoRestart || sourceContainer.IsWatchtower()) && (sourceContainer.IsRunning() || config.ReviveStopped) {
 		logrus.WithFields(fields).
 			Debug("Starting container with updated configuration")
 

--- a/internal/actions/update_watchtower_test.go
+++ b/internal/actions/update_watchtower_test.go
@@ -162,6 +162,95 @@ var _ = ginkgo.Describe("Watchtower container handling", func() {
 				To(gomega.Equal(int32(0)), "Container should not be started with no-restart")
 		})
 
+		ginkgo.It("should not start a stopped container after update without revive-stopped", func() {
+			client := mockActions.CreateMockClient(
+				&mockActions.TestData{
+					Containers: []types.Container{
+						mockActions.CreateMockContainerWithConfig(
+							"stopped-nginx",
+							"/stopped-nginx",
+							"nginx:latest",
+							false,
+							false,
+							time.Now(),
+							&dockerContainer.Config{
+								Labels: map[string]string{},
+							}),
+					},
+					Staleness: map[string]bool{
+						"stopped-nginx": true,
+					},
+				},
+				false,
+				false,
+			)
+			report, cleanupImageInfos, err := actions.Update(
+				context.Background(),
+				client,
+				types.UpdateParams{
+					Cleanup:     true,
+					Filter:      filters.NoFilter,
+					CPUCopyMode: "auto",
+				},
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(report.Updated()).
+				To(gomega.HaveLen(1), "Stopped container should be updated")
+			gomega.Expect(cleanupImageInfos).
+				To(gomega.HaveLen(1), "Cleanup info should be collected for updated container")
+			gomega.Expect(client.TestData.StopContainerCount.Load()).
+				To(gomega.Equal(int32(1)), "Container should be stopped")
+			gomega.Expect(client.TestData.CreateContainerCount.Load()).
+				To(gomega.Equal(int32(1)), "Container should be created")
+			gomega.Expect(client.TestData.StartContainerCount.Load()).
+				To(gomega.Equal(int32(0)), "Stopped container should not be started without revive-stopped")
+		})
+
+		ginkgo.It("should start a stopped container after update with revive-stopped", func() {
+			client := mockActions.CreateMockClient(
+				&mockActions.TestData{
+					Containers: []types.Container{
+						mockActions.CreateMockContainerWithConfig(
+							"stopped-nginx",
+							"/stopped-nginx",
+							"nginx:latest",
+							false,
+							false,
+							time.Now(),
+							&dockerContainer.Config{
+								Labels: map[string]string{},
+							}),
+					},
+					Staleness: map[string]bool{
+						"stopped-nginx": true,
+					},
+				},
+				false,
+				false,
+			)
+			report, cleanupImageInfos, err := actions.Update(
+				context.Background(),
+				client,
+				types.UpdateParams{
+					Cleanup:       true,
+					Filter:        filters.NoFilter,
+					CPUCopyMode:   "auto",
+					ReviveStopped: true,
+				},
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(report.Updated()).
+				To(gomega.HaveLen(1), "Stopped container should be updated with revive-stopped")
+			gomega.Expect(cleanupImageInfos).
+				To(gomega.HaveLen(1), "Cleanup info should be collected for updated container")
+			gomega.Expect(client.TestData.StopContainerCount.Load()).
+				To(gomega.Equal(int32(1)), "Container should be stopped")
+			gomega.Expect(client.TestData.CreateContainerCount.Load()).
+				To(gomega.Equal(int32(1)), "Container should be created")
+			gomega.Expect(client.TestData.StartContainerCount.Load()).
+				To(gomega.Equal(int32(1)), "Stopped container should be started with revive-stopped")
+		})
+
 		ginkgo.It("should not rename Watchtower container in run-once mode", func() {
 			client := mockActions.CreateMockClient(
 				&mockActions.TestData{

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -743,9 +743,9 @@ func (c *client) StartContainer(ctx context.Context, container types.Container) 
 //
 // Unlike StartContainer, this does not create a new container from a source
 // configuration. It directly starts an existing, already-created container
-// using the Docker API's ContainerStart method. This bypasses the reviveStopped
-// check that prevents StartContainer from starting new containers when the
-// source container is stopped.
+// using the Docker API's ContainerStart method. Callers are responsible for
+// checking whether the container should be started (e.g., the reviveStopped
+// and noRestart checks in restartStaleContainer).
 //
 // This method is used by the ephemeral orchestrator to start the new container
 // after the old one has been stopped during the self-update sequence.

--- a/pkg/types/update_params.go
+++ b/pkg/types/update_params.go
@@ -9,6 +9,7 @@ type UpdateParams struct {
 	Filter              Filter        // Container filter.
 	Cleanup             bool          // Remove old images if true.
 	NoRestart           bool          // Skip restarts if true.
+	ReviveStopped       bool          // Start stopped containers after update if true.
 	Timeout             time.Duration // Update timeout.
 	MonitorOnly         bool          // Monitor without updating if true.
 	NoPull              bool          // Skip image pulls if true.


### PR DESCRIPTION
This PR corrects a regression in the handling of the `revive-stopped` configuration option.

## Problem

https://github.com/nicholas-fedor/watchtower/pull/1626 extracted `CreateContainer` from `StartTargetContainer` to fix the `--no-restart` flag behavior, but inadvertently omitted the `reviveStopped` check. This caused all containers (including originally stopped ones) to be started after update, ignoring the `IsRunning()` state check.

## Solution

Moved the `reviveStopped` check to `restartStaleContainer` where it gates the `StartContainerByID` call. The check now ensures:
- Stopped containers remain stopped unless `--revive-stopped` is enabled
- Running containers continue to restart normally
- Watchtower containers are always started (existing behavior preserved)

## Changes

- Add `ReviveStopped` field to `UpdateParams`, `RunConfig`, and `RunUpdatesWithNotificationsParams`
- Wire `revive-stopped` flag through all execution paths in `cmd/root.go`
- Fix start condition in `restartStaleContainer` to include `sourceContainer.IsRunning() || config.ReviveStopped`
- Update `StartContainerByID` comment to clarify caller responsibility
- Add unit tests verifying stopped container behavior with and without `revive-stopped`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --revive-stopped option (WATCHTOWER_REVIVE_STOPPED) to optionally restart containers that were stopped before an update; when enabled, stopped containers will be started as part of updates.

* **Tests**
  * Added test cases verifying update behavior with revive-stopped both enabled and disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/watchtower/pull/1657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->