### PR TITLE
fix: add timeout input validation and improve docs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -281,9 +281,16 @@ func preRun(cmd *cobra.Command, _ []string) {
 	flags.GetSecretsFromFiles(cmd)
 	cleanup, noRestart, monitorOnly, timeout = flags.ReadFlags(cmd)
 
-	// Validate the timeout value to ensure it’s non-negative, preventing invalid stop durations.
+	// Validate the timeout value to ensure it's non-negative, preventing invalid stop durations.
 	if timeout < 0 {
 		logrus.Fatal("Please specify a positive value for timeout value.")
+	}
+
+	// Warn if timeout is unreasonably small, which likely indicates a configuration
+	// error (such as passing a raw value without a time duration unit).
+	if timeout > 0 && timeout < time.Second {
+		logrus.WithField("timeout", timeout).
+			Warn("WATCHTOWER_TIMEOUT is less than 1 second")
 	}
 
 	// Set additional configuration flags that control update behavior and scope.

--- a/docs/configuration/arguments/index.md
+++ b/docs/configuration/arguments/index.md
@@ -932,7 +932,7 @@ Sets the timeout (e.g., `30s`) before forcibly stopping a container during updat
 ```text
             Argument: --stop-timeout
 Environment Variable: WATCHTOWER_TIMEOUT
-                Type: Duration
+                Type: Duration (e.g., 30s, 1m, 5m)
               Default: 30s
 ```
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -92,7 +92,7 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		"stop-timeout",
 		"t",
 		envDuration("WATCHTOWER_TIMEOUT"),
-		"Timeout before a container is forcefully stopped")
+		"Timeout before a container is forcefully stopped (e.g., 30s, 1m, 5m)")
 
 	flags.StringP(
 		"cooldown-delay",


### PR DESCRIPTION
This PR adds input validation for the `WATCHTOWER_TIMEOUT` configuration option.

## Problem

Users may forget to use the proper Go time duration syntax when configuring the timeout, which is interpreted as nanoseconds when no units are provided.

## Solution

Add a simple conditional check that warns users when the timeout is configured as less than a second.
The documentation is also slightly improved to provide examples of the expected syntax.

## Changes

- Add warning log when WATCHTOWER_TIMEOUT is less than 1 second to catch likely misconfigurations
- Update flag description and docs to clarify duration format with examples (e.g., 30s, 1m, 5m)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a warning notification when stop-timeout is configured to a value less than 1 second to alert users of potentially problematic configurations

* **Documentation**
  * Clarified stop-timeout configuration format with duration examples
  * Enhanced help text with practical timeout examples for improved user guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/watchtower/pull/1665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->