### PR TITLE
style: replace curly apostrophes with straight apostrophes

### DIFF
--- a/build/mockery/mockery.yaml
+++ b/build/mockery/mockery.yaml
@@ -111,7 +111,7 @@ recursive: true
 # exclude: []
 
 # Include auto-generated files in package discovery when true.
-# When false, skips files matching Go’s generated file convention (e.g., "// Code generated").
+# When false, skips files matching Go's generated file convention (e.g., "// Code generated").
 # Default: true
 # include-auto-generated: false
 
@@ -145,7 +145,7 @@ recursive: true
 # with-expecter: true
 
 # Specify build tags for the generated mock files.
-# Matches Go’s build constraint syntax (e.g., "// +build tag1,tag2").
+# Matches Go's build constraint syntax (e.g., "// +build tag1,tag2").
 # https://pkg.go.dev/cmd/go#hdr-Build_constraints
 # Default: ""
 # mock-build-tags: ""
@@ -179,7 +179,7 @@ pkgname: "mocks"
 # inpackage: true
 
 # Define the output directory for mocks using a Go template.
-# "{{.InterfaceDir}}/mocks" places mocks in a subdirectory of the interface’s source dir.
+# "{{.InterfaceDir}}/mocks" places mocks in a subdirectory of the interface's source dir.
 # Default: "mocks/{{.PackagePath}}"
 dir: "{{.InterfaceDir}}/mocks"
 

--- a/cmd/notify-upgrade.go
+++ b/cmd/notify-upgrade.go
@@ -31,7 +31,7 @@ var (
 )
 
 // init registers the notify-upgrade command with the root command.
-// It follows Cobra’s best practice of adding subcommands in an init function,
+// It follows Cobra's best practice of adding subcommands in an init function,
 // avoiding global variables and ensuring proper command hierarchy setup.
 func init() {
 	rootCmd.AddCommand(&cobra.Command{
@@ -59,7 +59,7 @@ func runNotifyUpgrade(cmd *cobra.Command, args []string) {
 //   - cmd: The *cobra.Command instance representing the `notify-upgrade` subcommand, providing access to parsed flags
 //     such as notification types (e.g., --notifications) and other settings that influence notifier behavior.
 //   - _: A slice of strings representing positional arguments, unused here as the command accepts no arguments (enforced
-//     by cobra.NoArgs), included for compatibility with Cobra’s RunE signature.
+//     by cobra.NoArgs), included for compatibility with Cobra's RunE signature.
 //
 // Returns:
 //   - error: An error value if a critical operation fails (e.g., creating or writing to the temporary file), wrapped with
@@ -107,7 +107,7 @@ func runNotifyUpgradeE(cmd *cobra.Command, _ []string) error {
 		urlBuilder.WriteString(u)
 	}
 
-	// Write the constructed string to the temporary file. This is a critical step, as the file’s purpose is to store this data.
+	// Write the constructed string to the temporary file. This is a critical step, as the file's purpose is to store this data.
 	_, err = fmt.Fprint(outFile, urlBuilder.String())
 	if err != nil {
 		logrus.WithError(err).
@@ -127,7 +127,7 @@ func runNotifyUpgradeE(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("%w: %w", errSyncTempFile, err)
 	}
 
-	// Attempt to retrieve the running container’s ID to provide precise instructions for copying the file from the container.
+	// Attempt to retrieve the running container's ID to provide precise instructions for copying the file from the container.
 	// Use a placeholder ("<CONTAINER>") if this fails, ensuring the user still gets actionable guidance.
 	containerID := "<CONTAINER>"
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -213,7 +213,7 @@ var (
 //
 // It invokes functions from the flags package to set default values and register flags for Docker configuration
 // (e.g., --host), system behavior (e.g., --interval), and notifications (e.g., --notifications), establishing
-// the CLI’s configurable parameters before execution begins.
+// the CLI's configurable parameters before execution begins.
 func init() {
 	flags.SetDefaults()
 	flags.RegisterDockerFlags(rootCmd)
@@ -457,7 +457,7 @@ func preRun(cmd *cobra.Command, _ []string) {
 // builds the container filter, and delegates to runMain for core execution,
 // exiting with a status code based on the outcome (0 for success, non-zero for failure).
 //
-// This function bridges flag parsing and the application’s primary workflow.
+// This function bridges flag parsing and the application's primary workflow.
 //
 // Parameters:
 //   - command: The cobra.Command instance being executed, providing access to parsed flags.

--- a/internal/actions/doc.go
+++ b/internal/actions/doc.go
@@ -1,4 +1,4 @@
-// Package actions provides core logic for Watchtower’s container update operations.
+// Package actions provides core logic for Watchtower's container update operations.
 // It handles container staleness checks, updates, and lifecycle management.
 //
 // Key components:

--- a/internal/actions/errors.go
+++ b/internal/actions/errors.go
@@ -32,7 +32,7 @@ var (
 	errStartContainerFailed = errors.New("failed to start container")
 	// errCreateContainerFailed indicates a failure to create a container during the update process.
 	errCreateContainerFailed = errors.New("failed to create container")
-	// errParseImageReference indicates a failure to parse a container’s image reference.
+	// errParseImageReference indicates a failure to parse a container's image reference.
 	errParseImageReference = errors.New("failed to parse image reference")
 	// errInvalidImageReference indicates an invalid image reference that cannot be processed.
 	errInvalidImageReference = errors.New("invalid image reference")

--- a/internal/actions/mocks/progress.go
+++ b/internal/actions/mocks/progress.go
@@ -58,7 +58,7 @@ func CreateMockProgressReport(states ...session.State) types.Report {
 			progress.AddScanned(c, c.ImageID(), types.UpdateParams{})
 			progress.MarkRestarted(c.ID())
 		case session.UnknownState, session.ScannedState, session.StaleState:
-			// These states are not explicitly handled in this mock as they’re intermediate or unused here.
+			// These states are not explicitly handled in this mock as they're intermediate or unused here.
 			continue
 		}
 

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -234,7 +234,7 @@ func Update(
 			}
 		}
 
-		// Verify the container’s configuration if it’s slated for update to
+		// Verify the container's configuration if it's slated for update to
 		// ensure recreation is possible.
 		if err == nil && shouldUpdate {
 			err = sourceContainer.VerifyConfiguration()
@@ -452,7 +452,7 @@ func Update(
 			}
 		}
 
-		// Update the container’s stale status for dependency sorting.
+		// Update the container's stale status for dependency sorting.
 		// Only mark as stale if the container should actually be updated.
 		filteredContainers[i].SetStale(stale && shouldUpdate)
 
@@ -1023,7 +1023,7 @@ func parseReference(
 	return normalizedRef, nil
 }
 
-// isPinned checks if a container’s image is pinned by a digest reference.
+// isPinned checks if a container's image is pinned by a digest reference.
 //
 // It selects a valid image name from ImageName(), Config.Image,
 // or a fallback (imageInfo.ID or container name),

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -43,9 +43,9 @@ var (
 	errOpenFileFailed = errors.New("failed to open secret file")
 	// errReplaceSliceFailed indicates a failure to replace a slice value in a flag.
 	errReplaceSliceFailed = errors.New("failed to replace slice value in flag")
-	// errReadFileFailed indicates a failure to read a file’s contents for secrets.
+	// errReadFileFailed indicates a failure to read a file's contents for secrets.
 	errReadFileFailed = errors.New("failed to read secret file")
-	// errSetFlagFailed indicates a failure to set a flag’s value during configuration.
+	// errSetFlagFailed indicates a failure to set a flag's value during configuration.
 	errSetFlagFailed = errors.New("failed to set flag value")
 	// errInvalidFlagName indicates an invalid flag name was provided for modification.
 	errInvalidFlagName = errors.New("invalid flag name provided")
@@ -1070,7 +1070,7 @@ func getSecretFromFile(flags *pflag.FlagSet, secret string) error {
 func isFilePath(path string) bool {
 	firstColon := strings.IndexRune(path, ':')
 	if firstColon != 1 && firstColon != -1 {
-		// If ':' exists but isn’t the second character, it’s likely not a file path (e.g., URLs).
+		// If ':' exists but isn't the second character, it's likely not a file path (e.g., URLs).
 		return false
 	}
 
@@ -1323,7 +1323,7 @@ func appendFlagValue(flags *pflag.FlagSet, name string, values ...string) error 
 	return nil
 }
 
-// setFlagIfDefault sets a flag’s default value if unchanged.
+// setFlagIfDefault sets a flag's default value if unchanged.
 //
 // Parameters:
 //   - flags: Flag set.

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -787,7 +787,7 @@ func TestReadFlags_Errors(t *testing.T) {
 	cmd := new(cobra.Command)
 
 	SetDefaults()
-	// Don’t register flags to force errors
+	// Don't register flags to force errors
 	assert.PanicsWithValue(t, "FATAL", func() {
 		ReadFlags(cmd)
 	})

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -907,7 +907,7 @@ func (c *client) WarnOnHeadPullFailed(container types.Container) bool {
 	return registry.WarnOnAPIConsumption(container)
 }
 
-// IsContainerStale checks if a container’s image is outdated.
+// IsContainerStale checks if a container's image is outdated.
 //
 // Parameters:
 //   - container: Container to check.
@@ -1136,7 +1136,7 @@ func (c *client) RemoveImageByID(
 	return nil
 }
 
-// GetVersion returns the client’s API version.
+// GetVersion returns the client's API version.
 //
 // Returns:
 //   - string: Docker API version (e.g., "1.44").

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -123,7 +123,7 @@ func (c *Container) SetLinkedToRestarting(value bool) {
 	c.LinkedToRestarting = value
 }
 
-// IsStale returns whether the container’s image is outdated.
+// IsStale returns whether the container's image is outdated.
 //
 // Returns:
 //   - bool: True if stale, false otherwise.
@@ -222,7 +222,7 @@ func (c *Container) Name() string {
 	return c.normalizedName
 }
 
-// ImageID returns the ID of the container’s image.
+// ImageID returns the ID of the container's image.
 //
 // Returns:
 //   - types.ImageID: Image ID or empty string if imageInfo is nil.
@@ -234,7 +234,7 @@ func (c *Container) ImageID() types.ImageID {
 	return types.ImageID(c.imageInfo.ID)
 }
 
-// ImageName returns the name of the container’s image.
+// ImageName returns the name of the container's image.
 //
 // It uses the Zodiac label if present, otherwise Config.Image, appending ":latest" if untagged.
 //
@@ -450,7 +450,7 @@ func (c *Container) GetCreateHostConfig() *dockerContainer.HostConfig {
 	return hostConfig
 }
 
-// VerifyConfiguration validates the container’s metadata for recreation.
+// VerifyConfiguration validates the container's metadata for recreation.
 //
 // Returns:
 //   - error: Non-nil if metadata is missing or invalid, nil on success.

--- a/pkg/container/container_source.go
+++ b/pkg/container/container_source.go
@@ -653,12 +653,12 @@ func validateMacAddresses(
 		}
 	}
 
-	// Retrieve container state to determine if it’s running, which affects MAC address expectations.
+	// Retrieve container state to determine if it's running, which affects MAC address expectations.
 	// Non-running containers (e.g., created, exited) typically lack MAC addresses due to inactive network interfaces.
 	containerInfo := sourceContainer.ContainerInfo()
 	isRunning := sourceContainer.IsRunning()
 
-	// Extract the container’s state (e.g., "running", "created", "exited") for logging context.
+	// Extract the container's state (e.g., "running", "created", "exited") for logging context.
 	// Use "unknown" as a fallback if container metadata is incomplete to ensure safe logging.
 	containerState := "unknown"
 	if containerInfo != nil && containerInfo.State != nil {
@@ -680,7 +680,7 @@ func validateMacAddresses(
 		return nil
 	}
 
-	// Handle host network mode, where the container uses the host’s network stack and should not have its own MAC addresses.
+	// Handle host network mode, where the container uses the host's network stack and should not have its own MAC addresses.
 	if isHostNetwork {
 		if foundMac {
 			// MAC addresses in host mode are unexpected and indicate a misconfiguration; log a warning and return an error.
@@ -720,7 +720,7 @@ func validateMacAddresses(
 	return nil
 }
 
-// filterAliases removes the container’s short ID from the list of aliases.
+// filterAliases removes the container's short ID from the list of aliases.
 //
 // Parameters:
 //   - aliases: List of aliases to filter.
@@ -740,7 +740,7 @@ func filterAliases(aliases []string, shortID string) []string {
 	return result
 }
 
-// debugLogMacAddress logs MAC address info for a container’s network config.
+// debugLogMacAddress logs MAC address info for a container's network config.
 //
 // Parameters:
 //   - networkConfig: Network configuration to check.

--- a/pkg/container/doc.go
+++ b/pkg/container/doc.go
@@ -20,6 +20,6 @@
 //	    }
 //	}
 //
-// The package integrates with Docker’s API via docker/docker client libraries and supports
-// Watchtower’s update workflows, including authentication, scope filtering, and custom lifecycle hooks.
+// The package integrates with Docker's API via docker/docker client libraries and supports
+// Watchtower's update workflows, including authentication, scope filtering, and custom lifecycle hooks.
 package container

--- a/pkg/container/errors.go
+++ b/pkg/container/errors.go
@@ -14,7 +14,7 @@ var (
 	errAttachExecFailed = errors.New("failed to attach to exec instance")
 	// errReadExecOutputFailed indicates a failure to read output from an exec instance.
 	errReadExecOutputFailed = errors.New("failed to read exec output")
-	// errInspectExecFailed indicates a failure to inspect an exec instance’s status.
+	// errInspectExecFailed indicates a failure to inspect an exec instance's status.
 	errInspectExecFailed = errors.New("failed to inspect exec instance")
 	// errCommandFailed indicates a command executed in a container failed with a non-zero exit code.
 	errCommandFailed = errors.New("command execution failed")
@@ -24,7 +24,7 @@ var (
 var (
 	// errListContainersFailed indicates a failure to list containers from the Docker host.
 	errListContainersFailed = errors.New("failed to list containers")
-	// errInspectContainerFailed indicates a failure to inspect a container’s details.
+	// errInspectContainerFailed indicates a failure to inspect a container's details.
 	errInspectContainerFailed = errors.New("failed to inspect container")
 	// errStopContainerFailed indicates a failure to stop a container with a signal.
 	errStopContainerFailed = errors.New("failed to stop container")
@@ -56,7 +56,7 @@ var (
 	errNoImageInfo = errors.New("no image info available")
 	// errNoContainerInfo indicates the container lacks metadata required for recreation.
 	errNoContainerInfo = errors.New("no container info available")
-	// errInvalidConfig indicates the container’s configuration is invalid for recreation.
+	// errInvalidConfig indicates the container's configuration is invalid for recreation.
 	errInvalidConfig = errors.New("invalid container configuration")
 	// ErrUnexpectedContainerType indicates an unexpected container type was encountered.
 	ErrUnexpectedContainerType = errors.New("unexpected container type")
@@ -86,7 +86,7 @@ var (
 
 // Errors for label operations in metadata.go.
 var (
-	// errLabelNotFound indicates a requested label is not present in the container’s metadata.
+	// errLabelNotFound indicates a requested label is not present in the container's metadata.
 	errLabelNotFound = errors.New("label not found")
 )
 

--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -43,7 +43,7 @@ type imageClient struct {
 	api dockerClient.APIClient
 }
 
-// IsContainerStale determines if a container’s image is outdated.
+// IsContainerStale determines if a container's image is outdated.
 //
 // It skips pulling if NoPull is set, otherwise pulls and compares images.
 //

--- a/pkg/container/mocks/ApiServer.go
+++ b/pkg/container/mocks/ApiServer.go
@@ -26,7 +26,7 @@ const (
 	assertionOffset      = 2 // Call stack offset for Gomega assertions in nested calls
 )
 
-// Returns the file contents or an error if the file isn’t found.
+// Returns the file contents or an error if the file isn't found.
 func getMockJSONFile(relPath string) ([]byte, error) {
 	absPath, _ := filepath.Abs(relPath)
 
@@ -50,7 +50,7 @@ func RespondWithJSONFile(
 	return handler
 }
 
-// Returns the handler and an error if the file can’t be read.
+// Returns the handler and an error if the file can't be read.
 func respondWithJSONFile(
 	relPath string,
 	statusCode int,
@@ -73,7 +73,7 @@ func GetContainerHandlers(containerRefs ...*ContainerRef) []http.HandlerFunc {
 		for _, ref := range containerRef.references {
 			handlers = append(handlers, getContainerFileHandler(ref))
 		}
-		// Append image handler for each container’s image
+		// Append image handler for each container's image
 		handlers = append(handlers, getImageHandler(containerRef.image.id,
 			RespondWithJSONFile(containerRef.image.getFileName(), http.StatusOK),
 		))
@@ -178,7 +178,7 @@ const (
 	NetSupplierContainerName = "/wt-contnet-producer-1"
 )
 
-// Fails the test if the file can’t be retrieved; returns a 404 handler if the container is missing.
+// Fails the test if the file can't be retrieved; returns a 404 handler if the container is missing.
 func getContainerFileHandler(container *ContainerRef) http.HandlerFunc {
 	if container.isMissing {
 		return containerNotFoundResponse(string(container.id))

--- a/pkg/container/mocks/container_ref.go
+++ b/pkg/container/mocks/container_ref.go
@@ -29,7 +29,7 @@ type ContainerRef struct {
 	isMissing  bool
 }
 
-// Uses the explicit file if set, otherwise falls back to the container name; returns an error if the file doesn’t exist.
+// Uses the explicit file if set, otherwise falls back to the container name; returns an error if the file doesn't exist.
 func (cr *ContainerRef) getContainerFile() (string, error) {
 	file := cr.file
 	if file == "" {
@@ -50,7 +50,7 @@ func (cr *ContainerRef) getContainerFile() (string, error) {
 	return containerFile, nil
 }
 
-// ContainerID returns the mock container’s ID.
+// ContainerID returns the mock container's ID.
 func (cr *ContainerRef) ContainerID() types.ContainerID {
 	return cr.id
 }

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -185,7 +185,7 @@ func ExecutePreUpdateCommand(
 		"timeout":   timeout,
 	})
 
-	// Skip if no command or container isn’t running.
+	// Skip if no command or container isn't running.
 	if len(command) == 0 {
 		clog.Debug("No pre-update command supplied. Skipping")
 

--- a/pkg/notifications/email.go
+++ b/pkg/notifications/email.go
@@ -86,7 +86,7 @@ func newEmailNotifier(c *cobra.Command) types.ConvertibleNotifier {
 	}
 }
 
-// GetURL generates the SMTP URL from the notifier’s configuration.
+// GetURL generates the SMTP URL from the notifier's configuration.
 //
 // Parameters:
 //   - c: Cobra command (unused here).

--- a/pkg/notifications/gotify.go
+++ b/pkg/notifications/gotify.go
@@ -117,7 +117,7 @@ func getGotifyURL(flags *pflag.FlagSet) string {
 	return gotifyURL
 }
 
-// GetURL generates the Gotify service URL from the notifier’s configuration.
+// GetURL generates the Gotify service URL from the notifier's configuration.
 //
 // Parameters:
 //   - c: Cobra command (unused here).

--- a/pkg/notifications/msteams.go
+++ b/pkg/notifications/msteams.go
@@ -61,7 +61,7 @@ func newMsTeamsNotifier(cmd *cobra.Command) types.ConvertibleNotifier {
 	}
 }
 
-// GetURL generates the Teams service URL from the notifier’s webhook.
+// GetURL generates the Teams service URL from the notifier's webhook.
 //
 // Parameters:
 //   - c: Cobra command (unused here).

--- a/pkg/notifications/shoutrrr.go
+++ b/pkg/notifications/shoutrrr.go
@@ -42,7 +42,7 @@ const shutdownGracePeriod = 50 * time.Millisecond
 
 // LocalLog is a logrus logger that does not send entries as notifications.
 //
-// It’s used for internal logging to avoid notification loops.
+// It's used for internal logging to avoid notification loops.
 var LocalLog = logrus.WithField("notify", "no")
 
 // router defines the interface for sending Shoutrrr notifications.

--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -565,7 +565,7 @@ func GetChallengeRequest(ctx context.Context, url url.URL) (*http.Request, error
 //
 // Parameters:
 //   - ctx: Context for request lifecycle control, enabling cancellation or timeouts.
-//   - challenge: Challenge string from the registry’s WWW-Authenticate header.
+//   - challenge: Challenge string from the registry's WWW-Authenticate header.
 //   - imageRef: Normalized image reference for scoping the token request.
 //   - registryAuth: Base64-encoded auth string (e.g., "username:password").
 //   - client: Client instance for executing HTTP requests.
@@ -754,7 +754,7 @@ func GetAuthURL(challenge string, imageRef reference.Named) (*url.URL, error) {
 
 // GetRegistryAddress extracts the registry address from an image reference.
 //
-// It returns the domain part of the reference, mapping Docker Hub’s default domain to its canonical host if needed.
+// It returns the domain part of the reference, mapping Docker Hub's default domain to its canonical host if needed.
 //
 // Parameters:
 //   - imageRef: Image reference string (e.g., "docker.io/library/alpine").
@@ -776,7 +776,7 @@ func GetRegistryAddress(imageRef string) (string, error) {
 	// Extract the domain from the normalized reference.
 	address := reference.Domain(normalizedRef)
 
-	// Map Docker Hub’s default domain to its canonical host for registry requests.
+	// Map Docker Hub's default domain to its canonical host for registry requests.
 	if address == DockerRegistryDomain {
 		logrus.WithFields(logrus.Fields{
 			"image_ref": imageRef,

--- a/pkg/registry/auth/auth_test.go
+++ b/pkg/registry/auth/auth_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 // TestAuth executes the registry authentication test suite using the Ginkgo
-// testing framework. It registers Gomega’s fail handler to report test failures
+// testing framework. It registers Gomega's fail handler to report test failures
 // and runs the full set of specifications defined in this file.
 func TestAuth(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
@@ -67,21 +67,21 @@ type mockContainer struct {
 	imageName string // Image name used by the container
 }
 
-// ID returns the container’s unique identifier as a types.ContainerID. This method
+// ID returns the container's unique identifier as a types.ContainerID. This method
 // satisfies part of the types.Container interface, allowing the mock to be used
 // in authentication functions requiring an ID.
 func (m mockContainer) ID() types.ContainerID {
 	return types.ContainerID(m.id)
 }
 
-// Name returns the container’s name as a string. This method provides a readable
+// Name returns the container's name as a string. This method provides a readable
 // identifier for the container, fulfilling another requirement of the types.Container
-// interface, though it’s not directly used in these tests.
+// interface, though it's not directly used in these tests.
 func (m mockContainer) Name() string {
 	return m.name
 }
 
-// ImageName returns the container’s image name, such as "ghcr.io/test/image". This
+// ImageName returns the container's image name, such as "ghcr.io/test/image". This
 // method is critical for authentication tests, as it provides the image reference
 // that the auth package processes to fetch tokens or construct URLs.
 func (m mockContainer) ImageName() string {
@@ -104,14 +104,14 @@ func (m mockContainer) ContainerInfo() *dockerContainer.InspectResponse {
 }
 
 // GetCreateConfig returns a pointer to a containertypes.Config, representing the
-// container’s creation configuration. This method satisfies the types.Container interface,
+// container's creation configuration. This method satisfies the types.Container interface,
 // returning nil as a minimal stub since the auth package does not use this data in these tests.
 func (m mockContainer) GetCreateConfig() *dockerContainer.Config {
 	return nil // Minimal stub, not used in these tests
 }
 
 // GetCreateHostConfig returns a pointer to a containertypes.HostConfig, representing the
-// container’s host-specific creation configuration (e.g., port bindings, network settings).
+// container's host-specific creation configuration (e.g., port bindings, network settings).
 // This method satisfies the types.Container interface, returning nil as a minimal stub since
 // the auth package does not use this data in these authentication-focused tests.
 func (m mockContainer) GetCreateHostConfig() *dockerContainer.HostConfig {
@@ -362,12 +362,12 @@ var _ = ginkgo.BeforeSuite(func() {
 })
 
 var _ = ginkgo.Describe("the auth module", func() {
-	// mockID is a constant identifier used across test cases to represent a container’s
+	// mockID is a constant identifier used across test cases to represent a container's
 	// unique ID. It ensures consistency in mock container creation.
 	const mockID = "mock-id"
 
 	// mockName is a constant name used for mock containers in tests. It provides a
-	// human-readable identifier, though it’s not critical for auth functionality.
+	// human-readable identifier, though it's not critical for auth functionality.
 	const mockName = "mock-container"
 
 	// mockImage is the default image name for the initial mock container, representing
@@ -401,7 +401,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 		)
 		defer server.Close()
 
-		// Configure the container with the test server’s address.
+		// Configure the container with the test server's address.
 		serverURL, _ := url.Parse(server.URL())
 		containerInstance := mockContainer{
 			id:        mockID,
@@ -552,7 +552,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 			)
 		})
 
-		// Test case: Tests GetToken’s behavior when an HTTP request fails (e.g., due to an
+		// Test case: Tests GetToken's behavior when an HTTP request fails (e.g., due to an
 		// unreachable host). Uses a non-existent URL to trigger a network error, ensuring
 		// the function handles such failures gracefully.
 		ginkgo.It("should handle HTTP request failure", func() {
@@ -591,7 +591,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 				)
 				defer server.Close()
 
-				// Parse the server URL to extract the host for the container’s image name.
+				// Parse the server URL to extract the host for the container's image name.
 				serverURL, _ := url.Parse(server.URL())
 				containerInstance := mockContainer{
 					id:        mockID,
@@ -640,7 +640,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 			)
 			defer server.Close()
 
-			// Parse the server URL to extract the host for the container’s image name.
+			// Parse the server URL to extract the host for the container's image name.
 			serverURL, _ := url.Parse(server.URL())
 			containerInstance := mockContainer{
 				id:        mockID,
@@ -684,7 +684,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 			)
 			defer server.Close()
 
-			// Parse the server URL to extract the host for the container’s image name.
+			// Parse the server URL to extract the host for the container's image name.
 			serverURL, _ := url.Parse(server.URL())
 			containerInstance := mockContainer{
 				id:        mockID,
@@ -732,7 +732,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 			)
 			defer server.Close()
 
-			// Parse the server URL to extract the host for the container’s image name.
+			// Parse the server URL to extract the host for the container's image name.
 			serverURL, _ := url.Parse(server.URL())
 			containerInstance := mockContainer{
 				id:        mockID,
@@ -776,7 +776,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 			)
 			defer server.Close()
 
-			// Parse the server URL to extract the host for the container’s image name.
+			// Parse the server URL to extract the host for the container's image name.
 			serverURL, _ := url.Parse(server.URL())
 			containerInstance := mockContainer{
 				id:        mockID,
@@ -827,7 +827,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 			)
 			defer server.Close()
 
-			// Parse the server URL to extract the host for the container’s image name.
+			// Parse the server URL to extract the host for the container's image name.
 			serverURL, _ := url.Parse(server.URL())
 			containerInstance := mockContainer{
 				id:        mockID,
@@ -835,7 +835,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 				imageName: serverURL.Host + "/test/image:latest",
 			}
 
-			// Simulate TLS 1.3, which is incompatible with the test server’s TLS version.
+			// Simulate TLS 1.3, which is incompatible with the test server's TLS version.
 			viper.Set("WATCHTOWER_REGISTRY_TLS_MIN_VERSION", "TLS1.3")
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_MIN_VERSION", "")
 
@@ -1098,7 +1098,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 				}
 			}
 
-			// Configure container with the first server’s address
+			// Configure container with the first server's address
 			serverURL, _ := url.Parse(servers[0].URL())
 			containerInstance := mockContainer{
 				id:        mockID,
@@ -1199,7 +1199,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 			runBearerHeaderTest("user:pass", "auth-token", true)
 		})
 
-		// Test case: Tests GetBearerHeader’s error handling when the HTTP request fails
+		// Test case: Tests GetBearerHeader's error handling when the HTTP request fails
 		// (e.g., due to an unreachable host). Ensures proper error propagation.
 		ginkgo.It("should fail on HTTP request error", func() {
 			client := &testAuthClient{
@@ -1614,7 +1614,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 	})
 })
 
-// getScopeFromImageAuthURL extracts and returns the repository path from an auth URL’s
+// getScopeFromImageAuthURL extracts and returns the repository path from an auth URL's
 // scope parameter for a given image name. It constructs a mock challenge header, builds
 // the auth URL, and strips the "repository:" prefix and ":pull" suffix, providing the
 // clean path used in registry authentication.

--- a/pkg/registry/manifest/manifest.go
+++ b/pkg/registry/manifest/manifest.go
@@ -19,11 +19,11 @@ import (
 var (
 	// errMissingTag indicates the parsed image reference lacks a tag.
 	errMissingTag = errors.New("parsed container image reference has no tag")
-	// errFailedParseImageName indicates a failure to parse the container’s image name.
+	// errFailedParseImageName indicates a failure to parse the container's image name.
 	errFailedParseImageName = errors.New("failed to parse image name")
 )
 
-// BuildManifestURL constructs a URL for accessing a container’s image manifest from its registry.
+// BuildManifestURL constructs a URL for accessing a container's image manifest from its registry.
 //
 // It parses the image name into a normalized reference, extracts the registry host, and builds a URL with path and tag,
 // using the provided scheme.

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -88,7 +88,7 @@ func DefaultAuthHandler(_ context.Context) (string, error) {
 	return "", nil
 }
 
-// WarnOnAPIConsumption determines whether to warn about API consumption for a container’s registry.
+// WarnOnAPIConsumption determines whether to warn about API consumption for a container's registry.
 //
 // It returns true for registries supporting HEAD requests (e.g., Docker Hub, GHCR) or if parsing fails.
 //

--- a/pkg/registry/trust.go
+++ b/pkg/registry/trust.go
@@ -151,7 +151,7 @@ func EncodedConfigCredentials(imageRef string) (string, error) {
 		return "", fmt.Errorf("%w: %w", errFailedLoadDockerConfig, err)
 	}
 
-	// Retrieve credentials from the config’s store.
+	// Retrieve credentials from the config's store.
 	credStore := CredentialsStore(*configFile)
 	credentials, _ := credStore.Get(server)
 

--- a/pkg/session/container_status.go
+++ b/pkg/session/container_status.go
@@ -31,7 +31,7 @@ const (
 	RestartedStateString = "Restarted"
 )
 
-// ContainerStatus holds a container’s state during a session.
+// ContainerStatus holds a container's state during a session.
 //
 //nolint:errname // ContainerStatus is not an error type, it contains an error field.
 type ContainerStatus struct {
@@ -53,7 +53,7 @@ type ContainerStatus struct {
 // ID returns the container ID.
 //
 // Returns:
-//   - types.ContainerID: Container’s unique identifier.
+//   - types.ContainerID: Container's unique identifier.
 func (u *ContainerStatus) ID() types.ContainerID {
 	return u.containerID
 }
@@ -61,7 +61,7 @@ func (u *ContainerStatus) ID() types.ContainerID {
 // Name returns the container name.
 //
 // Returns:
-//   - string: Container’s name.
+//   - string: Container's name.
 func (u *ContainerStatus) Name() string {
 	return u.containerName
 }

--- a/pkg/session/progress.go
+++ b/pkg/session/progress.go
@@ -116,7 +116,7 @@ func (m Progress) Add(update *ContainerStatus) {
 	}).Debug("Added container status to progress map")
 }
 
-// MarkForUpdate sets a container’s state to updated.
+// MarkForUpdate sets a container's state to updated.
 //
 // Parameters:
 //   - containerID: ID of container to mark.
@@ -136,7 +136,7 @@ func (m Progress) MarkForUpdate(containerID types.ContainerID) {
 	}).Debug("Marked container for update")
 }
 
-// MarkRestarted sets a container’s state to restarted.
+// MarkRestarted sets a container's state to restarted.
 //
 // Parameters:
 //   - containerID: ID of container to mark.

--- a/pkg/session/report.go
+++ b/pkg/session/report.go
@@ -264,7 +264,7 @@ func (s SortableContainers) Len() int {
 //   - i, j: Indices to compare.
 //
 // Returns:
-//   - bool: True if i’s ID is less than j’s.
+//   - bool: True if i's ID is less than j's.
 func (s SortableContainers) Less(i, j int) bool {
 	return s[i].ID() < s[j].ID()
 }

--- a/pkg/types/container.go
+++ b/pkg/types/container.go
@@ -8,7 +8,7 @@ import (
 	dockerImage "github.com/moby/moby/api/types/image"
 )
 
-// Container defines a docker container’s interface in Watchtower.
+// Container defines a docker container's interface in Watchtower.
 type Container interface {
 	ContainerInfo() *dockerContainer.InspectResponse  // Container metadata.
 	ID() ContainerID                                  // Container ID.

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -12,7 +12,7 @@ type Report interface {
 	All() []ContainerReport       // All unique containers.
 }
 
-// ContainerReport defines a container’s session status.
+// ContainerReport defines a container's session status.
 type ContainerReport interface {
 	ID() ContainerID             // Container ID.
 	Name() string                // Container name.


### PR DESCRIPTION
This PR standarizes the apostrophe character used throughout the codebase.

## Change

- Replace all instances of Unicode right single quotation mark (') with ASCII apostrophe (')

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style & Documentation**
  * Updated documentation and comments throughout the codebase for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/watchtower/pull/1667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->