### PR TITLE
fix: prevent image pull when within cooldown window

### DIFF
--- a/internal/actions/errors.go
+++ b/internal/actions/errors.go
@@ -42,16 +42,6 @@ var (
 	errSelfDependency = errors.New("container has self-dependency")
 )
 
-// Errors for image cooldown operations.
-var (
-	// errImageCooldown indicates the image is within the cooldown period and the update is deferred.
-	errImageCooldown = errors.New("deferred")
-	// errFetchImageAgeFailed indicates the image creation time could not be determined from the registry.
-	errFetchImageAgeFailed = errors.New("image creation time unavailable")
-	// errGetPullOptionsFailed indicates pull options (e.g., registry auth) could not be retrieved for cooldown check.
-	errGetPullOptionsFailed = errors.New("failed to get pull options")
-)
-
 // Errors for Watchtower self-update operations.
 var (
 	// errRenameWatchtowerFailed indicates a failure to rename the Watchtower container before restarting.

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -14,12 +14,10 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	dockerContainer "github.com/moby/moby/api/types/container"
 
-	"github.com/nicholas-fedor/watchtower/internal/util"
 	"github.com/nicholas-fedor/watchtower/pkg/compose"
 	"github.com/nicholas-fedor/watchtower/pkg/container"
 	"github.com/nicholas-fedor/watchtower/pkg/filters"
 	"github.com/nicholas-fedor/watchtower/pkg/lifecycle"
-	"github.com/nicholas-fedor/watchtower/pkg/registry"
 	"github.com/nicholas-fedor/watchtower/pkg/session"
 	"github.com/nicholas-fedor/watchtower/pkg/sorter"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
@@ -256,9 +254,30 @@ func Update(
 			clog.WithError(err).Debug("Cannot update container - skipping")
 
 			stale = false
-			staleCheckFailed++
+
+			if !errors.Is(err, container.ErrImageCooldown) {
+				staleCheckFailed++
+			}
 
 			progress.AddSkipped(sourceContainer, err, config)
+
+			// Restore rich cooldown metadata for reports/notifications (preserves the
+			// structured CooldownAge/Delay/Remaining/Passed fields that the removed
+			// high-level block used to populate via SetCooldownInfo). The rich
+			// *container.CooldownError carries the details.
+			var cooldownErr *container.CooldownError
+			if errors.As(err, &cooldownErr) {
+				progress.SetCooldownInfo(
+					sourceContainer.ID(),
+					cooldownErr.Age,
+					cooldownErr.Delay,
+					cooldownErr.Remaining,
+					cooldownErr.Passed,
+				)
+			} else if errors.Is(err, container.ErrImageCooldown) {
+				// Fallback for plain sentinel (keeps basic deferral visible)
+				progress.SetCooldownInfo(sourceContainer.ID(), "", "", "", false)
+			}
 
 			// Track if Watchtower self-update pull failed for safeguard.
 			// Only set to true if we actually attempted a self-update
@@ -267,163 +286,9 @@ func Update(
 				watchtowerPullFailed = true
 			}
 		} else {
-			// Track cooldown info for setting on the progress entry after AddScanned.
-			var cooldownAge, cooldownDelayStr string
-
-			// Cooldown check: if the container should be updated and cooldown is configured, verify the image age.
-			// Uses per-container label if set, otherwise falls back to global setting.
-			// Skip cooldown check for no-pull and monitor-only containers since they won't be updated.
-			cooldownDelay := sourceContainer.CooldownDelay(config)
-
-			if shouldUpdate &&
-				cooldownDelay > 0 &&
-				!sourceContainer.IsNoPull(config) &&
-				!sourceContainer.IsMonitorOnly(config) {
-				pullOpts, pullErr := registry.GetPullOptions(
-					sourceContainer.ImageName(),
-				)
-				if pullErr != nil {
-					// Conservative posture: if pull options are unavailable, defer the update
-					// and record the container as skipped so it appears in notifications/reports.
-					cooldownStr := util.FormatDuration(cooldownDelay)
-
-					clog.WithError(pullErr).
-						Info("Failed to get pull options for cooldown check - deferring update")
-
-					filteredContainers[i].SetStale(false)
-					progress.AddSkipped(
-						sourceContainer,
-						fmt.Errorf(
-							"%w: could not get pull options for %s (cooldown: %s) - deferring update: %w",
-							errGetPullOptionsFailed,
-							sourceContainer.ImageName(),
-							cooldownStr,
-							pullErr,
-						),
-						config,
-					)
-					// Set cooldown info so split notifications can show the deferral reason.
-					progress.SetCooldownInfo(
-						sourceContainer.ID(),
-						"",
-						cooldownStr,
-						"",
-						false,
-					)
-
-					continue
-				}
-
-				imageAge, ageErr := fetchImageAge(
-					ctx,
-					sourceContainer,
-					pullOpts.RegistryAuth,
-				)
-				if ageErr != nil {
-					// Conservative posture: if we can't determine the age, defer the update.
-					cooldownStr := util.FormatDuration(cooldownDelay)
-
-					clog.WithError(ageErr).
-						Info("Image creation time unavailable - deferring update")
-
-					filteredContainers[i].SetStale(false)
-					progress.AddSkipped(
-						sourceContainer,
-						fmt.Errorf(
-							"%w: could not determine image age (cooldown: %s) - deferring update for safety",
-							errFetchImageAgeFailed,
-							cooldownStr,
-						),
-						config,
-					)
-					// Set cooldown info so split notifications can show the deferral reason.
-					progress.SetCooldownInfo(
-						sourceContainer.ID(),
-						"",
-						cooldownStr,
-						"",
-						false,
-					)
-
-					continue
-				}
-
-				// Negative image age indicates clock skew between the Watchtower host
-				// and the registry (image creation time is in the future). Log a warning
-				// and proceed with the update to avoid indefinite deferral.
-				//
-				// futureTimestamp tracks whether we detected clock skew so that the
-				// "Image age exceeds cooldown" block below is skipped — that block
-				// records cooldown metadata that would be misleading for a negative age.
-				futureTimestamp := false
-
-				if imageAge < 0 {
-					futureTimestamp = true
-					ageStr := util.FormatDuration(imageAge)
-					cooldownStr := util.FormatDuration(cooldownDelay)
-
-					clog.WithFields(
-						logrus.Fields{
-							"image_age": ageStr,
-							"cooldown":  cooldownStr,
-						}).Warn("Image creation time is in the future (possible clock skew) - proceeding with update")
-				} else if imageAge <= cooldownDelay {
-					// Defer when image age is less than or equal to cooldown.
-					// Updates only proceed when imageAge > cooldownDelay.
-					remaining := cooldownDelay - imageAge
-					ageStr := util.FormatDuration(imageAge)
-					cooldownStr := util.FormatDuration(cooldownDelay)
-					remainingStr := util.FormatDuration(remaining)
-
-					clog.WithFields(
-						logrus.Fields{
-							"image_age":   ageStr,
-							"cooldown":    cooldownStr,
-							"eligible_in": remainingStr,
-						}).Info("Image is within cooldown period - deferring update")
-
-					filteredContainers[i].SetStale(false)
-					progress.AddSkipped(
-						sourceContainer,
-						fmt.Errorf(
-							"%w: image age %s is within %s cooldown - eligible in %s",
-							errImageCooldown,
-							ageStr,
-							cooldownStr,
-							remainingStr,
-						),
-						config,
-					)
-					// Set cooldown info AFTER AddSkipped (which creates a new ContainerStatus).
-					progress.SetCooldownInfo(
-						sourceContainer.ID(),
-						ageStr,
-						cooldownStr,
-						remainingStr,
-						false)
-
-					continue
-				}
-
-				// Only record cooldown metadata when the image age is a real
-				// (non-negative) value that exceeds the cooldown window.
-				if !futureTimestamp {
-					ageStr := util.FormatDuration(imageAge)
-					cooldownStr := util.FormatDuration(cooldownDelay)
-
-					clog.WithFields(
-						logrus.Fields{
-							"image_age": ageStr,
-							"cooldown":  cooldownStr,
-						}).Info("Image age exceeds cooldown - proceeding with update")
-
-					// Store for setting after AddScanned.
-					cooldownAge = ageStr
-					cooldownDelayStr = cooldownStr
-				}
-			}
-
-			// For fresh containers, set newestImage to current image ID for proper categorization
+			// For fresh containers, set newestImage to current image ID for proper categorization.
+			// (Cooldown decision and any layer pull now happen inside pkg/container/image.go
+			// IsOutsideCooldown + guarded PullImage, after digest staleness and before layers.)
 			if !stale {
 				newestImage = sourceContainer.ImageID()
 			}
@@ -439,17 +304,6 @@ func Update(
 				newestImage,
 				config,
 			)
-
-			// Set cooldown info AFTER AddScanned, which creates a new ContainerStatus.
-			if cooldownAge != "" {
-				progress.SetCooldownInfo(
-					sourceContainer.ID(),
-					cooldownAge,
-					cooldownDelayStr,
-					"",
-					true,
-				)
-			}
 		}
 
 		// Update the container's stale status for dependency sorting.
@@ -1879,35 +1733,4 @@ func restartStaleContainer(
 	}
 
 	return newContainerID, renamed, nil
-}
-
-// fetchImageAge retrieves the age of the newest image from the registry by fetching
-// its creation timestamp and calculating the elapsed time since then.
-//
-// It uses the provided registryAuth credentials to fetch the image creation time
-// from the registry and returns the duration since creation.
-//
-// Parameters:
-//   - ctx: Context for cancellation and timeouts.
-//   - container: Container whose image age to fetch.
-//   - registryAuth: Base64-encoded registry credentials for authentication.
-//
-// Returns:
-//   - time.Duration: Elapsed time since the image was created.
-//   - error: Non-nil if image creation time retrieval fails.
-func fetchImageAge(
-	ctx context.Context,
-	container types.Container,
-	registryAuth string,
-) (time.Duration, error) {
-	creationTime, err := registry.FetchImageCreationTime(
-		ctx,
-		container,
-		registryAuth,
-	)
-	if err != nil {
-		return 0, fmt.Errorf("failed to fetch image creation time: %w", err)
-	}
-
-	return time.Since(creationTime), nil
 }

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -265,8 +265,7 @@ func Update(
 			// structured CooldownAge/Delay/Remaining/Passed fields that the removed
 			// high-level block used to populate via SetCooldownInfo). The rich
 			// *container.CooldownError carries the details.
-			var cooldownErr *container.CooldownError
-			if errors.As(err, &cooldownErr) {
+			if cooldownErr, ok := errors.AsType[*container.CooldownError](err); ok {
 				progress.SetCooldownInfo(
 					sourceContainer.ID(),
 					cooldownErr.Age,
@@ -281,8 +280,11 @@ func Update(
 
 			// Track if Watchtower self-update pull failed for safeguard.
 			// Only set to true if we actually attempted a self-update
-			// (i.e., SkipSelfUpdate is false)
-			if sourceContainer.IsWatchtower() && !config.SkipSelfUpdate {
+			// (i.e., SkipSelfUpdate is false) and the error is a real
+			// failure, not a cooldown deferral.
+			if sourceContainer.IsWatchtower() &&
+				!config.SkipSelfUpdate &&
+				!errors.Is(err, container.ErrImageCooldown) {
 				watchtowerPullFailed = true
 			}
 		} else {

--- a/internal/actions/update_cooldown_test.go
+++ b/internal/actions/update_cooldown_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/nicholas-fedor/watchtower/internal/actions"
 	mockActions "github.com/nicholas-fedor/watchtower/internal/actions/mocks"
+	"github.com/nicholas-fedor/watchtower/pkg/container"
 	"github.com/nicholas-fedor/watchtower/pkg/filters"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
@@ -159,9 +160,10 @@ var _ = ginkgo.Describe("the update action cooldown", func() {
 					Containers: []types.Container{
 						mockActions.CreateMockContainer("c1", "c1", imageName, time.Now()),
 					},
-					Staleness: map[string]bool{
-						"c1": true,
-					},
+					// Simulate the new location of the cooldown decision (now inside
+					// pkg/container/image.go IsOutsideCooldown + guarded PullImage,
+					// which returns the sentinel so no layers are pulled).
+					IsContainerStaleError: container.ErrImageCooldown,
 				},
 				Stopped: make(map[string]bool),
 			}
@@ -280,7 +282,8 @@ var _ = ginkgo.Describe("the update action cooldown", func() {
 		ginkgo.It("should skip the container with a conservative posture", func() {
 			// Start a server to get a host:port, then immediately close it so that
 			// all subsequent HTTP requests (auth challenge, manifest, blob) fail with
-			// "connection refused", causing fetchImageAge to return an error.
+			// "connection refused", causing the (now lower-layer) cooldown age fetch
+			// inside IsOutsideCooldown to return an error (simulated via mock err).
 			registryServer = ghttp.NewServer()
 			host := extractHost(registryServer.URL())
 			registryServer.Close()
@@ -293,9 +296,10 @@ var _ = ginkgo.Describe("the update action cooldown", func() {
 					Containers: []types.Container{
 						mockActions.CreateMockContainer("c1", "c1", imageName, time.Now()),
 					},
-					Staleness: map[string]bool{
-						"c1": true,
-					},
+					// Simulate the lower-layer cooldown age fetch failure (now inside
+					// image.go isOutsideCooldown) by returning the sentinel error from
+					// the mock IsContainerStale.
+					IsContainerStaleError: container.ErrImageCooldown,
 				},
 				Stopped: make(map[string]bool),
 			}

--- a/internal/actions/update_cooldown_test.go
+++ b/internal/actions/update_cooldown_test.go
@@ -149,20 +149,11 @@ var _ = ginkgo.Describe("the update action cooldown", func() {
 
 	ginkgo.When("CooldownDelay is set and image is newer than cooldown", func() {
 		ginkgo.It("should defer the update and skip the container", func() {
-			// Image was created 30 minutes ago; cooldown is 1 hour.
-			registryServer = ghttp.NewServer()
-			registryServer.AppendHandlers(mockRegistryHandlers(time.Now().Add(-30 * time.Minute))...)
-
-			host := extractHost(registryServer.URL())
-			imageName := host + "/myimage:latest"
 			client := mockActions.MockClient{
 				TestData: &mockActions.TestData{
 					Containers: []types.Container{
-						mockActions.CreateMockContainer("c1", "c1", imageName, time.Now()),
+						mockActions.CreateMockContainer("c1", "c1", "myimage:latest", time.Now()),
 					},
-					// Simulate the new location of the cooldown decision (now inside
-					// pkg/container/image.go IsOutsideCooldown + guarded PullImage,
-					// which returns the sentinel so no layers are pulled).
 					IsContainerStaleError: container.ErrImageCooldown,
 				},
 				Stopped: make(map[string]bool),
@@ -280,25 +271,11 @@ var _ = ginkgo.Describe("the update action cooldown", func() {
 
 	ginkgo.When("image age fetch fails", func() {
 		ginkgo.It("should skip the container with a conservative posture", func() {
-			// Start a server to get a host:port, then immediately close it so that
-			// all subsequent HTTP requests (auth challenge, manifest, blob) fail with
-			// "connection refused", causing the (now lower-layer) cooldown age fetch
-			// inside IsOutsideCooldown to return an error (simulated via mock err).
-			registryServer = ghttp.NewServer()
-			host := extractHost(registryServer.URL())
-			registryServer.Close()
-			// Set to nil so AfterEach doesn't try to close again.
-			registryServer = nil
-
-			imageName := host + "/myimage:latest"
 			client := mockActions.MockClient{
 				TestData: &mockActions.TestData{
 					Containers: []types.Container{
-						mockActions.CreateMockContainer("c1", "c1", imageName, time.Now()),
+						mockActions.CreateMockContainer("c1", "c1", "myimage:latest", time.Now()),
 					},
-					// Simulate the lower-layer cooldown age fetch failure (now inside
-					// image.go isOutsideCooldown) by returning the sentinel error from
-					// the mock IsContainerStale.
 					IsContainerStaleError: container.ErrImageCooldown,
 				},
 				Stopped: make(map[string]bool),

--- a/pkg/container/cooldown.go
+++ b/pkg/container/cooldown.go
@@ -37,7 +37,11 @@ func (e *CooldownError) Error() string {
 func (e *CooldownError) Unwrap() error { return e.err }
 
 func (e *CooldownError) Is(target error) bool {
-	return errors.Is(e.err, target) || target == ErrImageCooldown
+	if target == ErrImageCooldown {
+		return e.err == nil || errors.Is(e.err, ErrImageCooldown)
+	}
+
+	return errors.Is(e.err, target)
 }
 
 // isOutsideCooldown reports whether the container's image is outside its

--- a/pkg/container/cooldown.go
+++ b/pkg/container/cooldown.go
@@ -1,0 +1,167 @@
+package container
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/nicholas-fedor/watchtower/internal/util"
+	"github.com/nicholas-fedor/watchtower/pkg/registry"
+	"github.com/nicholas-fedor/watchtower/pkg/types"
+)
+
+// CooldownError carries the human-readable cooldown details (age, delay,
+// remaining) plus whether the window ultimately passed. It wraps
+// ErrImageCooldown (or a fetch failure) so callers can use errors.Is/As
+// while still extracting the fields needed for progress reports and
+// rich notifications.
+type CooldownError struct {
+	Age       string
+	Delay     string
+	Remaining string
+	Passed    bool
+	err       error
+}
+
+func (e *CooldownError) Error() string {
+	if e.err != nil {
+		return e.err.Error()
+	}
+
+	return ErrImageCooldown.Error()
+}
+
+func (e *CooldownError) Unwrap() error { return e.err }
+
+func (e *CooldownError) Is(target error) bool {
+	return errors.Is(e.err, target) || target == ErrImageCooldown
+}
+
+// isOutsideCooldown reports whether the container's image is outside its
+// cooldown window (safe to pull and update).
+//
+// It returns false (zero value) unless the image age strictly exceeds the
+// delay (or age is negative). The check runs only after digest staleness
+// and performs only lightweight registry fetches (no layers).
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeouts.
+//   - sourceContainer: Container whose image age to evaluate.
+//   - params: Update parameters (global cooldown + LabelPrecedence).
+//
+// Returns:
+//   - bool: true if safe to pull/update.
+//   - string: human-readable image age (empty if not checked).
+//   - string: human-readable cooldown delay (empty if not checked).
+//   - string: human-readable remaining time (empty if not checked).
+//   - error: non-nil on hard failures (still yields false).
+func (c imageClient) isOutsideCooldown(
+	ctx context.Context,
+	sourceContainer types.Container,
+	params types.UpdateParams,
+) (bool, string, string, string, error) {
+	cooldownDelay := sourceContainer.CooldownDelay(params)
+	if cooldownDelay <= 0 {
+		return true, "", "", "", nil
+	}
+
+	if sourceContainer.IsNoPull(params) || sourceContainer.IsMonitorOnly(params) {
+		return true, "", "", "", nil
+	}
+
+	clog := logrus.WithFields(logrus.Fields{
+		"container": sourceContainer.Name(),
+		"image":     sourceContainer.ImageName(),
+	})
+
+	pullOpts, err := registry.GetPullOptions(
+		sourceContainer.ImageName(),
+	)
+	if err != nil {
+		clog.WithError(err).
+			Info("Failed to get pull options for cooldown check - deferring update")
+
+		return false,
+			"",
+			util.FormatDuration(cooldownDelay),
+			"",
+			&CooldownError{
+				Delay: util.FormatDuration(cooldownDelay),
+				err: fmt.Errorf(
+					"could not get pull options for %s (cooldown: %s): %w",
+					sourceContainer.ImageName(),
+					util.FormatDuration(cooldownDelay),
+					err,
+				),
+			}
+	}
+
+	creationTime, err := registry.FetchImageCreationTime(
+		ctx,
+		sourceContainer,
+		pullOpts.RegistryAuth,
+	)
+	if err != nil {
+		clog.WithError(err).
+			Info("Image creation time unavailable - deferring update")
+
+		return false,
+			"",
+			util.FormatDuration(cooldownDelay),
+			"",
+			&CooldownError{
+				Delay: util.FormatDuration(cooldownDelay),
+				err: fmt.Errorf(
+					"could not determine image age (cooldown: %s): %w",
+					util.FormatDuration(cooldownDelay),
+					err,
+				),
+			}
+	}
+
+	imageAge := time.Since(creationTime)
+
+	if imageAge < 0 {
+		ageStr := util.FormatDuration(imageAge)
+		cooldownStr := util.FormatDuration(cooldownDelay)
+		clog.WithFields(logrus.Fields{
+			"image_age": ageStr,
+			"cooldown":  cooldownStr,
+		}).Warn("Image creation time is in the future (possible clock skew) - proceeding with update")
+
+		return true, ageStr, cooldownStr, "", nil
+	}
+
+	if imageAge <= cooldownDelay {
+		remaining := cooldownDelay - imageAge
+		ageStr := util.FormatDuration(imageAge)
+		cooldownStr := util.FormatDuration(cooldownDelay)
+		remainingStr := util.FormatDuration(remaining)
+
+		clog.WithFields(logrus.Fields{
+			"image_age":   ageStr,
+			"cooldown":    cooldownStr,
+			"eligible_in": remainingStr,
+		}).Info("Image is within cooldown period - deferring update")
+
+		return false, ageStr, cooldownStr, remainingStr, &CooldownError{
+			Age:       ageStr,
+			Delay:     cooldownStr,
+			Remaining: remainingStr,
+			err:       ErrImageCooldown,
+		}
+	}
+
+	// Outside window (or negative age already handled).
+	ageStr := util.FormatDuration(imageAge)
+	cooldownStr := util.FormatDuration(cooldownDelay)
+	clog.WithFields(logrus.Fields{
+		"image_age": ageStr,
+		"cooldown":  cooldownStr,
+	}).Info("Image age exceeds cooldown - proceeding with update")
+
+	return true, ageStr, cooldownStr, "", nil
+}

--- a/pkg/container/cooldown.go
+++ b/pkg/container/cooldown.go
@@ -13,8 +13,8 @@ import (
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
-// CooldownError carries the human-readable cooldown details (age, delay,
-// remaining) plus whether the window ultimately passed. It wraps
+// CooldownError represents a cooldown deferral with human-readable details
+// (age, delay, remaining) and whether the window passed. It wraps
 // ErrImageCooldown (or a fetch failure) so callers can use errors.Is/As
 // while still extracting the fields needed for progress reports and
 // rich notifications.
@@ -56,12 +56,8 @@ func (c imageClient) isOutsideCooldown(
 	sourceContainer types.Container,
 	params types.UpdateParams,
 ) (bool, error) {
-	cooldownDelay := sourceContainer.CooldownDelay(params)
-	if cooldownDelay <= 0 {
-		return true, nil
-	}
-
-	if sourceContainer.IsNoPull(params) || sourceContainer.IsMonitorOnly(params) {
+	delay, skip := shouldCheckCooldown(sourceContainer, params)
+	if skip {
 		return true, nil
 	}
 
@@ -70,19 +66,62 @@ func (c imageClient) isOutsideCooldown(
 		"image":     sourceContainer.ImageName(),
 	})
 
-	pullOpts, err := registry.GetPullOptions(
-		sourceContainer.ImageName(),
-	)
+	creationTime, cdErr := fetchImageCreationTime(ctx, sourceContainer, delay, clog)
+	if cdErr != nil {
+		return false, cdErr
+	}
+
+	return evalImageAge(creationTime, delay, clog)
+}
+
+// shouldCheckCooldown returns the effective cooldown delay and whether the
+// check can be skipped (delay ≤ 0, no-pull, or monitor-only).
+//
+// Parameters:
+//   - sourceContainer: Container to evaluate.
+//   - params: Update parameters (global cooldown + LabelPrecedence).
+//
+// Returns:
+//   - time.Duration: The effective cooldown delay (0 if skipped).
+//   - bool: True if the cooldown check should be skipped entirely.
+func shouldCheckCooldown(sourceContainer types.Container, params types.UpdateParams) (time.Duration, bool) {
+	delay := sourceContainer.CooldownDelay(params)
+	if delay <= 0 || sourceContainer.IsNoPull(params) || sourceContainer.IsMonitorOnly(params) {
+		return 0, true
+	}
+
+	return delay, false
+}
+
+// fetchImageCreationTime resolves pull options and retrieves the image
+// creation time from the registry. It returns a CooldownError on any failure.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeouts.
+//   - sourceContainer: Container whose image creation time to fetch.
+//   - delay: Cooldown delay for error formatting.
+//   - clog: Logger entry with container/image fields.
+//
+// Returns:
+//   - time.Time: The image creation time.
+//   - error: Non-nil CooldownError on failure.
+func fetchImageCreationTime(
+	ctx context.Context,
+	sourceContainer types.Container,
+	delay time.Duration,
+	clog *logrus.Entry,
+) (time.Time, error) {
+	pullOpts, err := registry.GetPullOptions(sourceContainer.ImageName())
 	if err != nil {
 		clog.WithError(err).
 			Info("Failed to get pull options for cooldown check - deferring update")
 
-		return false, &CooldownError{
-			Delay: util.FormatDuration(cooldownDelay),
+		return time.Time{}, &CooldownError{
+			Delay: util.FormatDuration(delay),
 			err: fmt.Errorf(
 				"could not get pull options for %s (cooldown: %s): %w",
 				sourceContainer.ImageName(),
-				util.FormatDuration(cooldownDelay),
+				util.FormatDuration(delay),
 				err,
 			),
 		}
@@ -97,55 +136,83 @@ func (c imageClient) isOutsideCooldown(
 		clog.WithError(err).
 			Info("Image creation time unavailable - deferring update")
 
-		return false, &CooldownError{
-			Delay: util.FormatDuration(cooldownDelay),
+		return time.Time{}, &CooldownError{
+			Delay: util.FormatDuration(delay),
 			err: fmt.Errorf(
 				"could not determine image age (cooldown: %s): %w",
-				util.FormatDuration(cooldownDelay),
+				util.FormatDuration(delay),
 				err,
 			),
 		}
 	}
 
+	return creationTime, nil
+}
+
+// evalImageAge compares image age against the cooldown delay, logging the
+// result and returning (true, nil) when safe to pull or (false, CooldownError)
+// when deferred.
+//
+// Parameters:
+//   - creationTime: The image creation timestamp.
+//   - delay: The cooldown delay to compare against.
+//   - clog: Logger entry with container/image fields.
+//
+// Returns:
+//   - bool: True if the image age exceeds the cooldown window.
+//   - error: Non-nil CooldownError when the image is within the cooldown window.
+func evalImageAge(creationTime time.Time, delay time.Duration, clog *logrus.Entry) (bool, error) {
 	imageAge := time.Since(creationTime)
 
 	if imageAge < 0 {
-		ageStr := util.FormatDuration(imageAge)
-		cooldownStr := util.FormatDuration(cooldownDelay)
-		clog.WithFields(logrus.Fields{
-			"image_age": ageStr,
-			"cooldown":  cooldownStr,
-		}).Warn("Image creation time is in the future (possible clock skew) - proceeding with update")
+		logClockSkew(imageAge, delay, clog)
 
 		return true, nil
 	}
 
-	if imageAge <= cooldownDelay {
-		remaining := cooldownDelay - imageAge
-		ageStr := util.FormatDuration(imageAge)
-		cooldownStr := util.FormatDuration(cooldownDelay)
-		remainingStr := util.FormatDuration(remaining)
-
-		clog.WithFields(logrus.Fields{
-			"image_age":   ageStr,
-			"cooldown":    cooldownStr,
-			"eligible_in": remainingStr,
-		}).Info("Image is within cooldown period - deferring update")
-
-		return false, &CooldownError{
-			Age:       ageStr,
-			Delay:     cooldownStr,
-			Remaining: remainingStr,
-			err:       ErrImageCooldown,
-		}
+	if imageAge <= delay {
+		return false, buildCooldownError(imageAge, delay)
 	}
 
-	ageStr := util.FormatDuration(imageAge)
-	cooldownStr := util.FormatDuration(cooldownDelay)
-	clog.WithFields(logrus.Fields{
-		"image_age": ageStr,
-		"cooldown":  cooldownStr,
-	}).Info("Image age exceeds cooldown - proceeding with update")
+	logCooldownExceeded(imageAge, delay, clog)
 
 	return true, nil
+}
+
+// buildCooldownError constructs a CooldownError with age, delay, and
+// remaining fields populated from the image age and cooldown delay.
+//
+// Parameters:
+//   - imageAge: Elapsed time since the image was created.
+//   - delay: The configured cooldown delay.
+//
+// Returns:
+//   - *CooldownError: Populated with formatted age, delay, and remaining strings.
+func buildCooldownError(imageAge, delay time.Duration) *CooldownError {
+	remaining := delay - imageAge
+
+	return &CooldownError{
+		Age:       util.FormatDuration(imageAge),
+		Delay:     util.FormatDuration(delay),
+		Remaining: util.FormatDuration(remaining),
+		err:       ErrImageCooldown,
+	}
+}
+
+// logClockSkew logs a warning when the image creation time is in the future,
+// indicating possible clock skew between the host and registry.
+func logClockSkew(imageAge, delay time.Duration, clog *logrus.Entry) {
+	clog.WithFields(logrus.Fields{
+		"image_age": util.FormatDuration(imageAge),
+		"cooldown":  util.FormatDuration(delay),
+	}).Warn("Image creation time is in the future (possible clock skew) - proceeding with update")
+}
+
+// logCooldownExceeded logs an info message when the image age exceeds the
+// cooldown window and the pull can proceed.
+func logCooldownExceeded(imageAge, delay time.Duration, clog *logrus.Entry) {
+	clog.WithFields(logrus.Fields{
+		"image_age": util.FormatDuration(imageAge),
+		"cooldown":  util.FormatDuration(delay),
+	}).Info("Image age exceeds cooldown - proceeding with update")
 }

--- a/pkg/container/cooldown.go
+++ b/pkg/container/cooldown.go
@@ -43,33 +43,26 @@ func (e *CooldownError) Is(target error) bool {
 // isOutsideCooldown reports whether the container's image is outside its
 // cooldown window (safe to pull and update).
 //
-// It returns false (zero value) unless the image age strictly exceeds the
-// delay (or age is negative). The check runs only after digest staleness
-// and performs only lightweight registry fetches (no layers).
-//
 // Parameters:
 //   - ctx: Context for cancellation and timeouts.
 //   - sourceContainer: Container whose image age to evaluate.
 //   - params: Update parameters (global cooldown + LabelPrecedence).
 //
 // Returns:
-//   - bool: true if safe to pull/update.
-//   - string: human-readable image age (empty if not checked).
-//   - string: human-readable cooldown delay (empty if not checked).
-//   - string: human-readable remaining time (empty if not checked).
-//   - error: non-nil on hard failures (still yields false).
+//   - bool: true if safe to pull/update, false if deferred.
+//   - error: non-nil when deferred (carries CooldownError for details).
 func (c imageClient) isOutsideCooldown(
 	ctx context.Context,
 	sourceContainer types.Container,
 	params types.UpdateParams,
-) (bool, string, string, string, error) {
+) (bool, error) {
 	cooldownDelay := sourceContainer.CooldownDelay(params)
 	if cooldownDelay <= 0 {
-		return true, "", "", "", nil
+		return true, nil
 	}
 
 	if sourceContainer.IsNoPull(params) || sourceContainer.IsMonitorOnly(params) {
-		return true, "", "", "", nil
+		return true, nil
 	}
 
 	clog := logrus.WithFields(logrus.Fields{
@@ -84,19 +77,15 @@ func (c imageClient) isOutsideCooldown(
 		clog.WithError(err).
 			Info("Failed to get pull options for cooldown check - deferring update")
 
-		return false,
-			"",
-			util.FormatDuration(cooldownDelay),
-			"",
-			&CooldownError{
-				Delay: util.FormatDuration(cooldownDelay),
-				err: fmt.Errorf(
-					"could not get pull options for %s (cooldown: %s): %w",
-					sourceContainer.ImageName(),
-					util.FormatDuration(cooldownDelay),
-					err,
-				),
-			}
+		return false, &CooldownError{
+			Delay: util.FormatDuration(cooldownDelay),
+			err: fmt.Errorf(
+				"could not get pull options for %s (cooldown: %s): %w",
+				sourceContainer.ImageName(),
+				util.FormatDuration(cooldownDelay),
+				err,
+			),
+		}
 	}
 
 	creationTime, err := registry.FetchImageCreationTime(
@@ -108,18 +97,14 @@ func (c imageClient) isOutsideCooldown(
 		clog.WithError(err).
 			Info("Image creation time unavailable - deferring update")
 
-		return false,
-			"",
-			util.FormatDuration(cooldownDelay),
-			"",
-			&CooldownError{
-				Delay: util.FormatDuration(cooldownDelay),
-				err: fmt.Errorf(
-					"could not determine image age (cooldown: %s): %w",
-					util.FormatDuration(cooldownDelay),
-					err,
-				),
-			}
+		return false, &CooldownError{
+			Delay: util.FormatDuration(cooldownDelay),
+			err: fmt.Errorf(
+				"could not determine image age (cooldown: %s): %w",
+				util.FormatDuration(cooldownDelay),
+				err,
+			),
+		}
 	}
 
 	imageAge := time.Since(creationTime)
@@ -132,7 +117,7 @@ func (c imageClient) isOutsideCooldown(
 			"cooldown":  cooldownStr,
 		}).Warn("Image creation time is in the future (possible clock skew) - proceeding with update")
 
-		return true, ageStr, cooldownStr, "", nil
+		return true, nil
 	}
 
 	if imageAge <= cooldownDelay {
@@ -147,7 +132,7 @@ func (c imageClient) isOutsideCooldown(
 			"eligible_in": remainingStr,
 		}).Info("Image is within cooldown period - deferring update")
 
-		return false, ageStr, cooldownStr, remainingStr, &CooldownError{
+		return false, &CooldownError{
 			Age:       ageStr,
 			Delay:     cooldownStr,
 			Remaining: remainingStr,
@@ -155,7 +140,6 @@ func (c imageClient) isOutsideCooldown(
 		}
 	}
 
-	// Outside window (or negative age already handled).
 	ageStr := util.FormatDuration(imageAge)
 	cooldownStr := util.FormatDuration(cooldownDelay)
 	clog.WithFields(logrus.Fields{
@@ -163,5 +147,5 @@ func (c imageClient) isOutsideCooldown(
 		"cooldown":  cooldownStr,
 	}).Info("Image age exceeds cooldown - proceeding with update")
 
-	return true, ageStr, cooldownStr, "", nil
+	return true, nil
 }

--- a/pkg/container/cooldown.go
+++ b/pkg/container/cooldown.go
@@ -171,6 +171,17 @@ func evalImageAge(creationTime time.Time, delay time.Duration, clog *logrus.Entr
 	}
 
 	if imageAge <= delay {
+		remaining := delay - imageAge
+		ageStr := util.FormatDuration(imageAge)
+		cooldownStr := util.FormatDuration(delay)
+		remainingStr := util.FormatDuration(remaining)
+
+		clog.WithFields(logrus.Fields{
+			"image_age":   ageStr,
+			"cooldown":    cooldownStr,
+			"eligible_in": remainingStr,
+		}).Info("Image is within cooldown period - deferring update")
+
 		return false, buildCooldownError(imageAge, delay)
 	}
 

--- a/pkg/container/cooldown_test.go
+++ b/pkg/container/cooldown_test.go
@@ -1,0 +1,287 @@
+package container
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	"github.com/sirupsen/logrus"
+
+	dockerClient "github.com/moby/moby/client"
+
+	"github.com/nicholas-fedor/watchtower/pkg/types"
+)
+
+var _ = ginkgo.Describe("CooldownError", func() {
+	ginkgo.Describe("Error()", func() {
+		ginkgo.When("the wrapped error is non-nil", func() {
+			ginkgo.It("returns the wrapped error message", func() {
+				inner := errors.New("inner failure")
+				e := &CooldownError{Age: "1h", Delay: "2h", err: inner}
+				gomega.Expect(e.Error()).To(gomega.Equal("inner failure"))
+			})
+		})
+
+		ginkgo.When("the wrapped error is nil", func() {
+			ginkgo.It("returns the ErrImageCooldown message", func() {
+				e := &CooldownError{Age: "1h", Delay: "2h", Remaining: "1h", Passed: false, err: nil}
+				gomega.Expect(e.Error()).To(gomega.Equal(ErrImageCooldown.Error()))
+			})
+		})
+	})
+
+	ginkgo.Describe("Unwrap()", func() {
+		ginkgo.It("returns the wrapped error when non-nil", func() {
+			inner := errors.New("wrapped")
+			e := &CooldownError{err: inner}
+			gomega.Expect(e.Unwrap()).To(gomega.Equal(inner))
+		})
+
+		ginkgo.It("returns nil when no wrapped error", func() {
+			e := &CooldownError{}
+			gomega.Expect(e.Unwrap()).To(gomega.Succeed())
+		})
+	})
+
+	ginkgo.Describe("Is()", func() {
+		ginkgo.It("matches when wrapped error is ErrImageCooldown", func() {
+			e := &CooldownError{err: ErrImageCooldown}
+			gomega.Expect(e.Is(ErrImageCooldown)).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("matches target == ErrImageCooldown even with unrelated wrapped error", func() {
+			e := &CooldownError{err: errors.New("some other error")}
+			gomega.Expect(e.Is(ErrImageCooldown)).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("does not match an unrelated target", func() {
+			unrelated := errors.New("unrelated")
+			e := &CooldownError{err: errors.New("some other error")}
+			gomega.Expect(e.Is(unrelated)).To(gomega.BeFalse())
+		})
+	})
+
+	ginkgo.Describe("errors.Is sentinel extraction", func() {
+		ginkgo.It("allows errors.Is(err, ErrImageCooldown) on *CooldownError", func() {
+			err := &CooldownError{
+				Age:       "2 hours",
+				Delay:     "1 day",
+				Remaining: "22 hours",
+				err:       ErrImageCooldown,
+			}
+			gomega.Expect(errors.Is(err, ErrImageCooldown)).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("allows errors.As to extract *CooldownError with all fields", func() {
+			err := &CooldownError{
+				Age:       "2 hours",
+				Delay:     "1 day",
+				Remaining: "22 hours",
+				err:       ErrImageCooldown,
+			}
+
+			var cooldownErr *CooldownError
+			gomega.Expect(errors.As(err, &cooldownErr)).To(gomega.BeTrue())
+			gomega.Expect(cooldownErr.Age).To(gomega.Equal("2 hours"))
+			gomega.Expect(cooldownErr.Delay).To(gomega.Equal("1 day"))
+			gomega.Expect(cooldownErr.Remaining).To(gomega.Equal("22 hours"))
+		})
+	})
+})
+
+var _ = ginkgo.Describe("isOutsideCooldown", func() {
+	var (
+		mockClient *dockerClient.Client
+		mockServer *ghttp.Server
+	)
+
+	ginkgo.BeforeEach(func() {
+		mockServer = ghttp.NewServer()
+
+		var err error
+
+		mockClient, err = dockerClient.New(
+			dockerClient.WithHost(mockServer.URL()),
+			dockerClient.WithHTTPClient(mockServer.HTTPTestServer.Client()),
+		)
+		gomega.Expect(err).To(gomega.Succeed())
+		mockServer.AppendHandlers(APIVersionPingHandler())
+	})
+
+	ginkgo.AfterEach(func() {
+		mockServer.Close()
+	})
+
+	ginkgo.When("no cooldown delay is configured", func() {
+		ginkgo.It("returns true with no registry calls", func() {
+			i := newImageClient(mockClient)
+			c := MockContainer(WithImageName("test:latest"))
+
+			outside, age, delay, rem, err := i.isOutsideCooldown(
+				context.Background(), c, types.UpdateParams{},
+			)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(outside).To(gomega.BeTrue())
+			gomega.Expect(age).To(gomega.BeEmpty())
+			gomega.Expect(delay).To(gomega.BeEmpty())
+			gomega.Expect(rem).To(gomega.BeEmpty())
+		})
+	})
+
+	ginkgo.When("cooldown delay is zero", func() {
+		ginkgo.It("returns true immediately", func() {
+			i := newImageClient(mockClient)
+			c := MockContainer(WithImageName("test:latest"))
+
+			outside, _, _, _, err := i.isOutsideCooldown(
+				context.Background(), c, types.UpdateParams{
+					CooldownDelay: 0,
+				},
+			)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(outside).To(gomega.BeTrue())
+		})
+	})
+
+	ginkgo.When("container is monitor-only", func() {
+		ginkgo.It("returns true and bypasses the cooldown check", func() {
+			i := newImageClient(mockClient)
+			c := MockContainer(WithImageName("test:latest"))
+
+			outside, _, _, _, err := i.isOutsideCooldown(
+				context.Background(), c, types.UpdateParams{
+					MonitorOnly:   true,
+					CooldownDelay: 24 * time.Hour,
+				},
+			)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(outside).To(gomega.BeTrue())
+		})
+	})
+
+	ginkgo.When("container has no-pull enabled", func() {
+		ginkgo.It("returns true and bypasses the cooldown check", func() {
+			i := newImageClient(mockClient)
+			c := MockContainer(WithImageName("test:latest"))
+
+			outside, _, _, _, err := i.isOutsideCooldown(
+				context.Background(), c, types.UpdateParams{
+					NoPull:        true,
+					CooldownDelay: 24 * time.Hour,
+				},
+			)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(outside).To(gomega.BeTrue())
+		})
+	})
+
+	ginkgo.When("GetPullOptions fails (registry auth unavailable)", func() {
+		ginkgo.It("returns false with a CooldownError wrapping the pull options error", func() {
+			resetLogrus, _ := captureLogrus(logrus.DebugLevel)
+			defer resetLogrus()
+
+			i := newImageClient(mockClient)
+
+			imageName := "localhost/unsupported-image-format:latest"
+			c := MockContainer(WithImageName(imageName))
+
+			outside, _, delay, _, err := i.isOutsideCooldown(
+				context.Background(), c, types.UpdateParams{
+					CooldownDelay: 1 * time.Hour,
+				},
+			)
+			gomega.Expect(outside).To(gomega.BeFalse())
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(delay).ToNot(gomega.BeEmpty())
+
+			var cooldownErr *CooldownError
+			gomega.Expect(errors.As(err, &cooldownErr)).To(gomega.BeTrue())
+			gomega.Expect(cooldownErr.Delay).ToNot(gomega.BeEmpty())
+		})
+	})
+
+	ginkgo.When("FetchImageCreationTime fails (registry manifest returns 404)", func() {
+		ginkgo.It("returns false with a CooldownError reflecting the age fetch failure", func() {
+			resetLogrus, _ := captureLogrus(logrus.DebugLevel)
+			defer resetLogrus()
+
+			mockServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", gomega.MatchRegexp("/v2/")),
+					ghttp.RespondWith(http.StatusNotFound, "not found"),
+				),
+			)
+
+			i := newImageClient(mockClient)
+			c := MockContainer(WithImageName("test:latest"))
+
+			outside, _, delay, _, err := i.isOutsideCooldown(
+				context.Background(), c, types.UpdateParams{
+					CooldownDelay: 1 * time.Hour,
+				},
+			)
+			gomega.Expect(outside).To(gomega.BeFalse())
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(delay).ToNot(gomega.BeEmpty())
+
+			var cooldownErr *CooldownError
+			gomega.Expect(errors.As(err, &cooldownErr)).To(gomega.BeTrue())
+		})
+	})
+})
+
+var _ = ginkgo.Describe("PullImage cooldown gate", func() {
+	var (
+		mockClient *dockerClient.Client
+		mockServer *ghttp.Server
+	)
+
+	ginkgo.BeforeEach(func() {
+		mockServer = ghttp.NewServer()
+
+		var err error
+
+		mockClient, err = dockerClient.New(
+			dockerClient.WithHost(mockServer.URL()),
+			dockerClient.WithHTTPClient(mockServer.HTTPTestServer.Client()),
+		)
+		gomega.Expect(err).To(gomega.Succeed())
+		mockServer.AppendHandlers(APIVersionPingHandler())
+	})
+
+	ginkgo.AfterEach(func() {
+		mockServer.Close()
+	})
+
+	ginkgo.When("image is stale and cooldown age fetch fails", func() {
+		ginkgo.It("returns a CooldownError without pulling layers", func() {
+			resetLogrus, _ := captureLogrus(logrus.DebugLevel)
+			defer resetLogrus()
+
+			mockServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", gomega.MatchRegexp("/v2/")),
+					ghttp.RespondWith(http.StatusNotFound, "not found"),
+				),
+			)
+
+			i := newImageClient(mockClient)
+			c := MockContainer(
+				WithImageName("test:latest"),
+				WithRepoDigests([]string{"test@sha256:12345"}),
+			)
+
+			err := i.PullImage(context.Background(), c, WarnAuto, types.UpdateParams{
+				CooldownDelay: 1 * time.Hour,
+			})
+			gomega.Expect(err).To(gomega.HaveOccurred())
+
+			var cooldownErr *CooldownError
+			gomega.Expect(errors.As(err, &cooldownErr)).To(gomega.BeTrue())
+		})
+	})
+})

--- a/pkg/container/cooldown_test.go
+++ b/pkg/container/cooldown_test.go
@@ -53,9 +53,9 @@ var _ = ginkgo.Describe("CooldownError", func() {
 			gomega.Expect(e.Is(ErrImageCooldown)).To(gomega.BeTrue())
 		})
 
-		ginkgo.It("matches target == ErrImageCooldown even with unrelated wrapped error", func() {
+		ginkgo.It("does not match ErrImageCooldown with unrelated wrapped error", func() {
 			e := &CooldownError{err: errors.New("some other error")}
-			gomega.Expect(e.Is(ErrImageCooldown)).To(gomega.BeTrue())
+			gomega.Expect(e.Is(ErrImageCooldown)).To(gomega.BeFalse())
 		})
 
 		ginkgo.It("does not match an unrelated target", func() {

--- a/pkg/container/cooldown_test.go
+++ b/pkg/container/cooldown_test.go
@@ -121,14 +121,11 @@ var _ = ginkgo.Describe("isOutsideCooldown", func() {
 			i := newImageClient(mockClient)
 			c := MockContainer(WithImageName("test:latest"))
 
-			outside, age, delay, rem, err := i.isOutsideCooldown(
+			outside, err := i.isOutsideCooldown(
 				context.Background(), c, types.UpdateParams{},
 			)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(outside).To(gomega.BeTrue())
-			gomega.Expect(age).To(gomega.BeEmpty())
-			gomega.Expect(delay).To(gomega.BeEmpty())
-			gomega.Expect(rem).To(gomega.BeEmpty())
 		})
 	})
 
@@ -137,7 +134,7 @@ var _ = ginkgo.Describe("isOutsideCooldown", func() {
 			i := newImageClient(mockClient)
 			c := MockContainer(WithImageName("test:latest"))
 
-			outside, _, _, _, err := i.isOutsideCooldown(
+			outside, err := i.isOutsideCooldown(
 				context.Background(), c, types.UpdateParams{
 					CooldownDelay: 0,
 				},
@@ -152,7 +149,7 @@ var _ = ginkgo.Describe("isOutsideCooldown", func() {
 			i := newImageClient(mockClient)
 			c := MockContainer(WithImageName("test:latest"))
 
-			outside, _, _, _, err := i.isOutsideCooldown(
+			outside, err := i.isOutsideCooldown(
 				context.Background(), c, types.UpdateParams{
 					MonitorOnly:   true,
 					CooldownDelay: 24 * time.Hour,
@@ -168,7 +165,7 @@ var _ = ginkgo.Describe("isOutsideCooldown", func() {
 			i := newImageClient(mockClient)
 			c := MockContainer(WithImageName("test:latest"))
 
-			outside, _, _, _, err := i.isOutsideCooldown(
+			outside, err := i.isOutsideCooldown(
 				context.Background(), c, types.UpdateParams{
 					NoPull:        true,
 					CooldownDelay: 24 * time.Hour,
@@ -189,14 +186,13 @@ var _ = ginkgo.Describe("isOutsideCooldown", func() {
 			imageName := "localhost/unsupported-image-format:latest"
 			c := MockContainer(WithImageName(imageName))
 
-			outside, _, delay, _, err := i.isOutsideCooldown(
+			outside, err := i.isOutsideCooldown(
 				context.Background(), c, types.UpdateParams{
 					CooldownDelay: 1 * time.Hour,
 				},
 			)
 			gomega.Expect(outside).To(gomega.BeFalse())
 			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(delay).ToNot(gomega.BeEmpty())
 
 			var cooldownErr *CooldownError
 			gomega.Expect(errors.As(err, &cooldownErr)).To(gomega.BeTrue())
@@ -219,14 +215,13 @@ var _ = ginkgo.Describe("isOutsideCooldown", func() {
 			i := newImageClient(mockClient)
 			c := MockContainer(WithImageName("test:latest"))
 
-			outside, _, delay, _, err := i.isOutsideCooldown(
+			outside, err := i.isOutsideCooldown(
 				context.Background(), c, types.UpdateParams{
 					CooldownDelay: 1 * time.Hour,
 				},
 			)
 			gomega.Expect(outside).To(gomega.BeFalse())
 			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(delay).ToNot(gomega.BeEmpty())
 
 			var cooldownErr *CooldownError
 			gomega.Expect(errors.As(err, &cooldownErr)).To(gomega.BeTrue())

--- a/pkg/container/errors.go
+++ b/pkg/container/errors.go
@@ -84,6 +84,12 @@ var (
 	errRemoveImageFailed = errors.New("failed to remove image")
 )
 
+// Errors for image cooldown operations in cooldown.go and image.go.
+var (
+	// ErrImageCooldown indicates the image is within the configured cooldown window and should not be pulled.
+	ErrImageCooldown = errors.New("image is within cooldown period")
+)
+
 // Errors for label operations in metadata.go.
 var (
 	// errLabelNotFound indicates a requested label is not present in the container's metadata.

--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -80,8 +80,8 @@ func (c imageClient) IsContainerStale(
 	if err != nil {
 		if errors.Is(err, ErrImageCooldown) {
 			clog.WithError(err).Debug("Cooldown active - pull skipped")
-			// Return as non-stale, no error: upper layer will skip via normal path.
-			return false, sourceContainer.ImageID(), ErrImageCooldown
+			// Return original error to preserve cooldown metadata for progress reporting.
+			return false, sourceContainer.ImageID(), err
 		}
 
 		clog.WithError(err).Debug("Failed to pull image")
@@ -199,25 +199,9 @@ func (c imageClient) PullImage(
 
 	// Perform cooldown check to prevent downloading images that are still
 	// inside the cooldown window.
-	//nolint:dogsled // 5-return signature; only ok and cdErr are needed by this caller.
-	ok, _, _, _, cdErr := c.isOutsideCooldown(
-		ctx,
-		sourceContainer,
-		params,
-	)
-	if cdErr != nil || !ok {
-		if cdErr != nil {
-			return cdErr
-		}
-
-		return &CooldownError{
-			Delay: "unknown",
-			err: fmt.Errorf(
-				"%w: pull deferred by cooldown for %s",
-				ErrImageCooldown,
-				sourceContainer.ImageName(),
-			),
-		}
+	_, cooldownErr := c.isOutsideCooldown(ctx, sourceContainer, params)
+	if cooldownErr != nil {
+		return cooldownErr
 	}
 
 	return c.performImagePull(ctx, sourceContainer.ImageName(), opts, fields)

--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -46,17 +47,19 @@ type imageClient struct {
 // IsContainerStale determines if a container's image is outdated.
 //
 // It skips pulling if NoPull is set, otherwise pulls and compares images.
+// If the image is within the cooldown window, it returns false with
+// ErrImageCooldown, indicating the update should be deferred.
 //
 // Parameters:
 //   - ctx: Context for operation control.
 //   - sourceContainer: Container to check.
-//   - params: Update parameters (e.g., NoPull flag).
+//   - params: Update parameters (e.g., NoPull flag, cooldown delay).
 //   - warnOnHeadFailed: Strategy for logging warnings on HEAD request failures.
 //
 // Returns:
 //   - bool: True if image is stale, false otherwise.
 //   - types.ImageID: Latest image ID (or current if not pulled).
-//   - error: Non-nil if pull or inspection fails, nil on success or skipped.
+//   - error: Non-nil if pull or inspection fails or cooldown defers the update.
 func (c imageClient) IsContainerStale(
 	ctx context.Context,
 	sourceContainer types.Container,
@@ -73,8 +76,14 @@ func (c imageClient) IsContainerStale(
 		return c.checkLocalImageStaleness(ctx, sourceContainer, clog)
 	}
 
-	err := c.PullImage(ctx, sourceContainer, warnOnHeadFailed)
+	err := c.PullImage(ctx, sourceContainer, warnOnHeadFailed, params)
 	if err != nil {
+		if errors.Is(err, ErrImageCooldown) {
+			clog.WithError(err).Debug("Cooldown active - pull skipped")
+			// Return as non-stale, no error: upper layer will skip via normal path.
+			return false, sourceContainer.ImageID(), ErrImageCooldown
+		}
+
 		clog.WithError(err).Debug("Failed to pull image")
 
 		return false, sourceContainer.ImageID(), err
@@ -137,18 +146,23 @@ func (c imageClient) HasNewImage(
 
 // PullImage fetches the latest image for a container.
 //
-// It skips pinned images and checks digests before pulling.
+// It skips pinned images, checks digests, and performs a cooldown check
+// before pulling the image.
 //
 // Parameters:
 //   - ctx: Context for operation control.
 //   - sourceContainer: Container whose image to pull.
+//   - warnOnHeadFailed: Strategy for logging warnings on HEAD request failures.
+//   - params: Update parameters (for per-container cooldown via label or global).
 //
 // Returns:
-//   - error: Non-nil if pull fails, nil on success or skip.
+//   - Non-nil error if pull fails or cooldown defers the pull.
+//   - nil on success or skip.
 func (c imageClient) PullImage(
 	ctx context.Context,
 	sourceContainer types.Container,
 	warnOnHeadFailed WarningStrategy,
+	params types.UpdateParams,
 ) error {
 	fields := logrus.Fields{
 		"container": sourceContainer.Name(),
@@ -183,7 +197,29 @@ func (c imageClient) PullImage(
 		return nil
 	}
 
-	// Perform full image pull.
+	// Perform cooldown check to prevent downloading images that are still
+	// inside the cooldown window.
+	//nolint:dogsled // 5-return signature; only ok and cdErr are needed by this caller.
+	ok, _, _, _, cdErr := c.isOutsideCooldown(
+		ctx,
+		sourceContainer,
+		params,
+	)
+	if cdErr != nil || !ok {
+		if cdErr != nil {
+			return cdErr
+		}
+
+		return &CooldownError{
+			Delay: "unknown",
+			err: fmt.Errorf(
+				"%w: pull deferred by cooldown for %s",
+				ErrImageCooldown,
+				sourceContainer.ImageName(),
+			),
+		}
+	}
+
 	return c.performImagePull(ctx, sourceContainer.ImageName(), opts, fields)
 }
 

--- a/pkg/container/image_test.go
+++ b/pkg/container/image_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -83,7 +84,7 @@ var _ = ginkgo.Describe("the client", func() {
 						"sha256:fa5269854a5e615e51a72b17ad3fd1e01268f278a6684c8ed3c5f0cdce3f230b",
 					),
 				)
-				err := i.PullImage(context.Background(), pinnedContainer, WarnAuto)
+				err := i.PullImage(context.Background(), pinnedContainer, WarnAuto, types.UpdateParams{})
 				gomega.Expect(err).
 					To(gomega.MatchError(`image is pinned with sha256, skipping pull`))
 			})
@@ -107,7 +108,7 @@ var _ = ginkgo.Describe("the client", func() {
 			resetLogrus, logbuf := captureLogrus(logrus.DebugLevel)
 			defer resetLogrus()
 
-			err := i.PullImage(context.Background(), pullContainer, WarnAuto)
+			err := i.PullImage(context.Background(), pullContainer, WarnAuto, types.UpdateParams{})
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("authentication required"))
 			gomega.Expect(errors.Is(err, ErrPullImageUnauthorized)).To(gomega.BeTrue())
@@ -134,7 +135,7 @@ var _ = ginkgo.Describe("the client", func() {
 			resetLogrus, logbuf := captureLogrus(logrus.DebugLevel)
 			defer resetLogrus()
 
-			err := i.PullImage(context.Background(), pullContainer, WarnAuto)
+			err := i.PullImage(context.Background(), pullContainer, WarnAuto, types.UpdateParams{})
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("image not found"))
 			gomega.Expect(errors.Is(err, ErrPullImageNotFound)).To(gomega.BeTrue())
@@ -160,7 +161,7 @@ var _ = ginkgo.Describe("the client", func() {
 			resetLogrus, logbuf := captureLogrus(logrus.DebugLevel)
 			defer resetLogrus()
 
-			err := i.PullImage(context.Background(), pullContainer, WarnAuto)
+			err := i.PullImage(context.Background(), pullContainer, WarnAuto, types.UpdateParams{})
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to pull image"))
 			gomega.Expect(errors.Is(err, errPullImageFailed)).To(gomega.BeTrue())
@@ -472,3 +473,38 @@ func withContainerImageName(matcher gomegaTypes.GomegaMatcher) gomegaTypes.Gomeg
 		return container.ImageName()
 	}, matcher)
 }
+
+// IsOutsideCooldown tests (white-box, early-out paths require no registry).
+var _ = ginkgo.Describe("IsOutsideCooldown (cooldown gating before pull)", func() {
+	ginkgo.When("no cooldown delay is configured", func() {
+		ginkgo.It("returns true (safe to pull) with no registry calls", func() {
+			i := newImageClient(nil)
+			c := MockContainer(WithImageName("test:latest"))
+
+			outside, age, delay, rem, err := i.isOutsideCooldown(
+				context.Background(), c, types.UpdateParams{},
+			)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(outside).To(gomega.BeTrue())
+			gomega.Expect(age).To(gomega.BeEmpty())
+			gomega.Expect(delay).To(gomega.BeEmpty())
+			gomega.Expect(rem).To(gomega.BeEmpty())
+		})
+	})
+
+	ginkgo.When("container is monitor-only or no-pull", func() {
+		ginkgo.It("returns true (bypasses cooldown check)", func() {
+			i := newImageClient(nil)
+			c := MockContainer(WithImageName("test:latest"))
+
+			outside, _, _, _, err := i.isOutsideCooldown(
+				context.Background(), c, types.UpdateParams{
+					MonitorOnly:   true,
+					CooldownDelay: 24 * time.Hour,
+				},
+			)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(outside).To(gomega.BeTrue())
+		})
+	})
+})

--- a/pkg/container/image_test.go
+++ b/pkg/container/image_test.go
@@ -481,14 +481,11 @@ var _ = ginkgo.Describe("IsOutsideCooldown (cooldown gating before pull)", func(
 			i := newImageClient(nil)
 			c := MockContainer(WithImageName("test:latest"))
 
-			outside, age, delay, rem, err := i.isOutsideCooldown(
+			outside, err := i.isOutsideCooldown(
 				context.Background(), c, types.UpdateParams{},
 			)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(outside).To(gomega.BeTrue())
-			gomega.Expect(age).To(gomega.BeEmpty())
-			gomega.Expect(delay).To(gomega.BeEmpty())
-			gomega.Expect(rem).To(gomega.BeEmpty())
 		})
 	})
 
@@ -497,7 +494,7 @@ var _ = ginkgo.Describe("IsOutsideCooldown (cooldown gating before pull)", func(
 			i := newImageClient(nil)
 			c := MockContainer(WithImageName("test:latest"))
 
-			outside, _, _, _, err := i.isOutsideCooldown(
+			outside, err := i.isOutsideCooldown(
 				context.Background(), c, types.UpdateParams{
 					MonitorOnly:   true,
 					CooldownDelay: 24 * time.Hour,


### PR DESCRIPTION
This PR refactors the cooldown feature by moving it lower in the call stack to ensure images within the cooldown period are never pulled.

## Problem

The cooldown check in `actions/update.go` ran after `PullImage`, meaning the full image was already being pulled (layers downloaded and all) before the cooldown
decision was evaluated. Images within the cooldown window accumulated in the Docker host despite `WATCHTOWER_CLEANUP=true`.

## Solution

Moved the cooldown logic into a new `pkg/container/cooldown.go` file as the `isOutsideCooldown` method on `imageClient`. 
The check now runs in `PullImage` after digest comparison confirms a new image exists but before `performImagePull` downloads any layers. 
A structured `CooldownError` type carries human-readable age, delay, and remaining fields for progress reports and notifications.

## Changes

- Add `pkg/container/cooldown.go` with `isOutsideCooldown` and helper functions (`shouldCheckCooldown`, `fetchImageCreationTime`, `evalImageAge`)
- Add `CooldownError` type and `ErrImageCooldown` sentinel to the container package
- Gate `PullImage` behind cooldown check after digest staleness, before layers
- Update `IsContainerStale` to propagate `ErrImageCooldown` without logging pull errors
- Remove `fetchImageAge`, `errImageCooldown`, `errFetchImageAgeFailed`, and  `errGetPullOptionsFailed` from `internal/actions`
- Add ginkgo/gomega unit tests for cooldown logic and `CooldownError`
- Update integration tests to use `IsContainerStaleError` mock path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved image cooldown handling so deferrals are decided and recorded at the container layer, and cooldown metadata (age/delay/remaining) is preserved for reporting.
* **Bug Fixes**
  * Self-update failures are flagged only for actual update errors, not for cooldown deferrals.
* **New Features**
  * Introduced a structured cooldown error that conveys formatted age/delay/remaining info.
* **Tests**
  * Test suites updated to drive and validate cooldown behavior via the container layer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/watchtower/pull/1669?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->