### PR TITLE
fix(container): default empty device CgroupPermissions to 'rwm' for Podman compatibility

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -421,6 +421,14 @@ func (c *Container) GetCreateHostConfig() *dockerContainer.HostConfig {
 	hostConfigCopy := *c.containerInfo.HostConfig
 	hostConfig := &hostConfigCopy
 
+	// Deep copy slices that will be mutated to avoid modifying the original
+	// under a read lock.
+	if len(hostConfig.Devices) > 0 {
+		devicesCopy := make([]dockerContainer.DeviceMapping, len(hostConfig.Devices))
+		copy(devicesCopy, hostConfig.Devices)
+		hostConfig.Devices = devicesCopy
+	}
+
 	// Adjust link format for each entry (and drop invalid ones).
 	adjusted := make([]string, 0, len(hostConfig.Links))
 	for _, link := range hostConfig.Links {

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -447,6 +447,20 @@ func (c *Container) GetCreateHostConfig() *dockerContainer.HostConfig {
 
 	hostConfig.Links = adjusted
 
+	// Normalize device CgroupPermissions for Podman compatibility.
+	//
+	// Podman leaves CgroupPermissions empty in Docker API inspect responses.
+	// Both Docker and Podman treat bare device specifications (without explicit
+	// permissions) as "rwm". Defaulting here prevents "empty device mode"
+	// errors when recreating containers.
+	for i := range hostConfig.Devices {
+		if hostConfig.Devices[i].CgroupPermissions == "" {
+			hostConfig.Devices[i].CgroupPermissions = "rwm"
+			clog.WithField("device", hostConfig.Devices[i].PathOnHost).
+				Debug("Defaulted empty device CgroupPermissions to 'rwm'")
+		}
+	}
+
 	return hostConfig
 }
 

--- a/pkg/container/container_mock_test.go
+++ b/pkg/container/container_mock_test.go
@@ -374,6 +374,26 @@ func WithBinds(binds []string) MockContainerUpdate {
 	}
 }
 
+// WithDevices sets device mappings on the mock container's HostConfig.
+//
+// This is primarily used to test device permission normalization (empty
+// CgroupPermissions defaulting to "rwm") for Podman compatibility.
+//
+// Parameters:
+//   - devices: Slice of DeviceMapping structs.
+//
+// Returns:
+//   - MockContainerUpdate: Function to set devices in container HostConfig.
+func WithDevices(devices []dockerContainer.DeviceMapping) MockContainerUpdate {
+	return func(c *dockerContainer.InspectResponse, _ *dockerImage.InspectResponse) {
+		if c.HostConfig == nil {
+			c.HostConfig = &dockerContainer.HostConfig{}
+		}
+
+		c.HostConfig.Devices = devices
+	}
+}
+
 // MockClient is a mock implementation of the Operations interface for testing container operations.
 type MockClient struct {
 	createFunc        func(context.Context, *dockerContainer.Config, *dockerContainer.HostConfig, *dockerNetwork.NetworkingConfig, *ocispec.Platform, string) (dockerClient.ContainerCreateResult, error)

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -1118,5 +1118,35 @@ var _ = ginkgo.Describe("Container", func() {
 			gomega.Expect(mount.VolumeOptions.Subpath).
 				To(gomega.Equal("ha/nest"), "Subpath should be preserved")
 		})
+
+		ginkgo.It("defaults empty device CgroupPermissions to 'rwm' for Podman compatibility", func() {
+			devices := []dockerContainer.DeviceMapping{
+				{
+					PathOnHost:        "/dev/net/tun",
+					PathInContainer:   "/dev/net/tun",
+					CgroupPermissions: "", // empty, as returned by Podman inspect
+				},
+				{
+					PathOnHost:        "/dev/dri/renderD128",
+					PathInContainer:   "/dev/dri/renderD128",
+					CgroupPermissions: "rw", // explicit value should be preserved
+				},
+			}
+
+			container := MockContainer(WithDevices(devices))
+			hostConfig := container.GetCreateHostConfig()
+
+			gomega.Expect(hostConfig.Devices).To(gomega.HaveLen(2))
+
+			// Empty permissions must be defaulted (this fixes the Podman "empty device mode" error)
+			gomega.Expect(hostConfig.Devices[0].PathOnHost).To(gomega.Equal("/dev/net/tun"))
+			gomega.Expect(hostConfig.Devices[0].CgroupPermissions).
+				To(gomega.Equal("rwm"), "empty CgroupPermissions should default to 'rwm'")
+
+			// Explicit permissions must be left untouched
+			gomega.Expect(hostConfig.Devices[1].PathOnHost).To(gomega.Equal("/dev/dri/renderD128"))
+			gomega.Expect(hostConfig.Devices[1].CgroupPermissions).
+				To(gomega.Equal("rw"), "explicit CgroupPermissions must be preserved")
+		})
 	})
 })


### PR DESCRIPTION
This PR addresses Podman containers that report empty device CgroupPermissions, which causes "empty device mode" errors during container recreation.

## Problem

Podman leaves CgroupPermissions empty in Docker API inspect responses for device mappings like `/dev/dri/renderD128:/dev/dri/renderD128`. When Watchtower attempts to recreate the container, Podman rejects the empty permissions with "empty device mode in device specification", breaking container updates.

## Solution

Default empty CgroupPermissions to `"rwm"` (read, write, mknod) in `GetCreateHostConfig()`. Both Docker and Podman treat bare device specifications without explicit permissions as `"rwm"`, so this default matches the expected behavior.

## Changes

- Add device permission normalization loop in container.go
- Add WithDevices mock helper for testing
- Add unit test verifying empty permissions are defaulted and explicit permissions are preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented container recreation failures by normalizing empty device cgroup permissions to sensible defaults, improving compatibility with Podman-like runtimes and ensuring stable device handling.

* **Tests**
  * Added a unit test and mock helper to verify device permission normalization behavior and cover Podman compatibility scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/watchtower/pull/1673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->