### PR TITLE
fix: use shared identifier matching for implicit restart logic

### DIFF
--- a/internal/actions/actions_internal_test.go
+++ b/internal/actions/actions_internal_test.go
@@ -925,6 +925,37 @@ var _ = ginkgo.Describe("linkedIdentifierMarkedForRestart project-service format
 			gomega.Expect(result).To(gomega.Equal("production-api-gateway"))
 		},
 	)
+
+	ginkgo.It("should accept replica match for qualified hyphenated link via hasExactOrReplica", func() {
+		// Exercises the refined guard: link contains '-', not present as exact key in
+		// restartByIdent, but FindMatchingIdentifiers returns replica match so
+		// hasExactOrReplica becomes true and the match is accepted.
+		restartByIdent := map[string]bool{
+			"myapp-db-1": true,
+		}
+		links := []string{"myapp-db"}
+		dependent := mockActions.CreateMockContainerWithConfig(
+			"dependent",
+			"myapp-web",
+			"web:latest",
+			true,
+			false,
+			time.Now(),
+			&dockerContainer.Config{},
+		)
+		restarting := mockActions.CreateMockContainerWithConfig(
+			"myapp-db-1",
+			"myapp-db-1",
+			"db:latest",
+			true,
+			false,
+			time.Now(),
+			&dockerContainer.Config{},
+		)
+		allContainers := []types.Container{dependent, restarting}
+		result := linkedIdentifierMarkedForRestart(links, restartByIdent, dependent, allContainers)
+		gomega.Expect(result).To(gomega.Equal("myapp-db-1"))
+	})
 })
 
 var _ = ginkgo.Describe("linkedIdentifierMarkedForRestart cross-project fallback", func() {
@@ -1013,6 +1044,37 @@ var _ = ginkgo.Describe("linkedIdentifierMarkedForRestart cross-project fallback
 		allContainers := []types.Container{dependent, restarting}
 		result := linkedIdentifierMarkedForRestart(links, restartByIdent, dependent, allContainers)
 		gomega.Expect(result).To(gomega.Equal("otherproject-db"))
+	})
+
+	ginkgo.It("should resolve bare hyphenated service name via service-only fallback", func() {
+		// The link is a bare service name (exactly as declared in another compose
+		// file) that contains hyphens. It must resolve via the service-only path
+		// even though the actual identifier in the restart map is project-qualified.
+		restartByIdent := map[string]bool{
+			"database1-watchtower-test-database-1": true,
+		}
+		links := []string{"watchtower-test-database"}
+		dependent := mockActions.CreateMockContainerWithConfig(
+			"app1-foo-1",
+			"app1-foo-1",
+			"foo:latest",
+			true,
+			false,
+			time.Now(),
+			&dockerContainer.Config{},
+		)
+		db := mockActions.CreateMockContainerWithConfig(
+			"database1-watchtower-test-database-1",
+			"database1-watchtower-test-database-1",
+			"db:latest",
+			true,
+			false,
+			time.Now(),
+			&dockerContainer.Config{},
+		)
+		allContainers := []types.Container{dependent, db}
+		result := linkedIdentifierMarkedForRestart(links, restartByIdent, dependent, allContainers)
+		gomega.Expect(result).To(gomega.Equal("database1-watchtower-test-database-1"))
 	})
 })
 

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -28,9 +29,6 @@ const defaultPullFailureDelay = 5 * time.Minute
 
 // defaultHealthCheckTimeout defines the default timeout for waiting for container health checks.
 const defaultHealthCheckTimeout = 5 * time.Minute
-
-// projectServiceParts defines the expected number of parts in a project-service link format.
-const projectServiceParts = 2
 
 // Update scans and updates containers based on parameters.
 //
@@ -527,9 +525,11 @@ func hasSelfDependency(c types.Container) bool {
 // continuing until no more containers are marked for restart.
 //
 // Parameters:
-//   - allContainers: List of all containers.
-//   - containers: List of containers to update.
-//   - useComposeDependsOn: Boolean value of use-compose-depends-on configuration
+//   - allContainers: Full list of containers being managed.
+//   - containers: Slice of containers to evaluate and potentially mark for restart.
+//   - useComposeDependsOn: Whether to consider Docker Compose depends_on labels.
+//
+// This function mutates the ToRestart / LinkedToRestarting state on containers in place.
 func UpdateImplicitRestart(
 	allContainers,
 	containers []types.Container,
@@ -539,10 +539,47 @@ func UpdateImplicitRestart(
 
 	byID := make(map[types.ContainerID]types.Container, len(allContainers))
 
-	restartByName := make(map[string]bool, len(allContainers))
+	// Key restart tracking by the canonical identifier (ResolveContainerIdentifier)
+	// so that links produced by c.Links() can be matched directly. We also record
+	// the bare .Name() as an alias to improve exact-match resilience across
+	// different naming conventions (explicit container_name vs. Compose defaults,
+	// with or without replica suffixes).
+	restartByIdentifier := make(map[string]bool, len(allContainers)+len(allContainers))
+	resolvedToContainer := make(map[string]types.Container, len(allContainers)+len(allContainers))
+
 	for _, c := range allContainers {
 		byID[c.ID()] = c
-		restartByName[c.Name()] = c.ToRestart()
+
+		// Fall back through Name then ID to guarantee a non-empty key.
+		resolvedID := container.ResolveContainerIdentifier(c)
+		if resolvedID == "" {
+			resolvedID = c.Name()
+		}
+
+		if resolvedID == "" {
+			resolvedID = string(c.ID())
+		}
+
+		if resolvedID == "" {
+			logrus.WithField("container_id", c.ID()).Debug("Skipping container with empty identifier")
+
+			continue
+		}
+
+		restartByIdentifier[resolvedID] = c.ToRestart()
+		resolvedToContainer[resolvedID] = c
+
+		// Also index by bare name for better exact matching in mixed scenarios
+		bareName := c.Name()
+		if bareName != "" && bareName != resolvedID {
+			if _, exists := restartByIdentifier[bareName]; !exists {
+				restartByIdentifier[bareName] = c.ToRestart()
+			}
+
+			if _, exists := resolvedToContainer[bareName]; !exists {
+				resolvedToContainer[bareName] = c
+			}
+		}
 	}
 
 	markedContainers := []string{}
@@ -569,7 +606,7 @@ func UpdateImplicitRestart(
 
 			if link := linkedIdentifierMarkedForRestart(
 				links,
-				restartByName,
+				restartByIdentifier,
 				c,
 				allContainers,
 			); link != "" {
@@ -582,7 +619,8 @@ func UpdateImplicitRestart(
 
 				if ac, ok := byID[c.ID()]; ok {
 					ac.SetLinkedToRestarting(true)
-					restartByName[ac.Name()] = true
+					resolved := container.ResolveContainerIdentifier(ac)
+					restartByIdentifier[resolved] = true
 				}
 
 				markedContainers = append(markedContainers, c.Name())
@@ -647,38 +685,41 @@ func shouldUpdateContainer(
 	return true
 }
 
-// linkedIdentifierMarkedForRestart finds a restarting linked container by identifier.
+// linkedIdentifierMarkedForRestart returns the identifier of a container in the
+// links list that is marked for restart, or the empty string if none is found.
 //
-// It searches for a container identifier in the links list that is marked for restart,
-// returning its identifier. The matching follows this priority order:
-//
-//  1. Exact match: Direct identifier match in restartByIdentifier map.
-//
-//  2. Project-service format (exactly one dash): Matches containers where both the project
-//     and service name match the linked container's project and service.
-//
-//  3. Service-only format (no dash): Prioritizes same-project matches first, then falls back
-//     to cross-project matches. This ensures that dependencies within the same Docker Compose
-//     project are preferred over external dependencies, while still allowing cross-project
-//     dependencies when no same-project match exists.
+// The function attempts an exact match first. Otherwise it delegates to
+// FindMatchingIdentifiers and selects among the returned candidates using
+// project information from labels (via getProject). For links containing
+// hyphens, a match is only accepted if the link string itself exists in the
+// restart map or a candidate from the same project is available. Short
+// service-name links fall back to a service-only path with the same project
+// preference.
 //
 // Parameters:
-//   - links: List of linked container identifiers.
-//   - restartByIdentifier: Map of container identifiers to restart status.
-//   - dependentContainer: The container that has the dependency.
-//   - allContainers: List of all containers.
+//   - links: List of linked container identifiers (from Container.Links()).
+//   - restartByIdentifier: Map of container identifiers to their restart status.
+//   - dependentContainer: The container whose links are being evaluated.
+//   - allContainers: Full list of containers (used for project lookup and resolution).
 //
 // Returns:
-//   - string: Identifier of restarting linked container, or empty if none.
+//   - string: Identifier of a restarting linked container, or "" if none found.
 func linkedIdentifierMarkedForRestart(
 	links []string,
 	restartByIdentifier map[string]bool,
 	dependentContainer types.Container,
 	allContainers []types.Container,
 ) string {
-	nameToContainer := make(map[string]types.Container, len(allContainers))
+	// Build a lookup that supports both bare names and ResolveContainerIdentifier
+	// results, since the restart map may be populated with either.
+	idToContainer := make(map[string]types.Container, len(allContainers)+len(allContainers))
 	for _, c := range allContainers {
-		nameToContainer[c.Name()] = c
+		idToContainer[c.Name()] = c
+
+		resolved := container.ResolveContainerIdentifier(c)
+		if resolved != "" && resolved != c.Name() {
+			idToContainer[resolved] = c
+		}
 	}
 
 	dependentProject := getProject(dependentContainer)
@@ -690,13 +731,18 @@ func linkedIdentifierMarkedForRestart(
 			"dependentProject":    dependentProject,
 		}).Debug("Searching for restarting linked container")
 
+	// Overall strategy per link:
+	//   1. Exact match against the restart map.
+	//   2. Delegate to FindMatchingIdentifiers (exact / replica / service-only).
+	//   3. Among matches, prefer same-project (via labels).
+	//   4. For links that look qualified, apply an additional guard.
+	//   5. Bare service names have a final ExtractServiceName fallback path.
 	for _, link := range links {
 		logrus.WithField(
 			"checking_link",
 			link,
 		).Debug("Checking link for restarting match")
 
-		// Exact match
 		if restartByIdentifier[link] {
 			logrus.WithField(
 				"found_restarting_identifier",
@@ -706,112 +752,100 @@ func linkedIdentifierMarkedForRestart(
 			return link
 		}
 
-		if strings.Contains(link, "-") && strings.Count(link, "-") == 1 {
-			// project-service format (only if exactly one dash)
-			parts := strings.Split(link, "-")
-			if len(parts) != projectServiceParts {
-				continue
+		// Collect only the identifiers that are currently marked for restart.
+		// This list is passed to FindMatchingIdentifiers for exact/replica/service matching.
+		restartingNames := make([]string, 0, len(restartByIdentifier))
+		for name, restarting := range restartByIdentifier {
+			if restarting {
+				restartingNames = append(restartingNames, name)
 			}
+		}
 
-			linkProject := parts[0]
-			serviceName := parts[1]
+		matches := sorter.FindMatchingIdentifiers(link, restartingNames)
 
-			logrus.WithFields(
-				logrus.Fields{
-					"link":        link,
-					"linkProject": linkProject,
-					"serviceName": serviceName,
-				}).Debug("Checking project-service match")
+		if len(matches) > 0 {
+			dependentProject := getProject(dependentContainer)
 
-			for identifier, restarting := range restartByIdentifier {
-				if restarting && getProject(nameToContainer[identifier]) == linkProject &&
-					strings.Contains(identifier, serviceName) {
-					logrus.WithFields(
-						logrus.Fields{
-							"link":    link,
-							"matched": identifier,
-							"project": linkProject,
-							"service": serviceName,
-						}).Debug("Found restarting linked container via project-service match")
-
-					return identifier
-				}
-			}
-		} else {
-			// service name only, prioritize same project first, then cross-project dependencies
-			logrus.WithFields(
-				logrus.Fields{
-					"link":             link,
-					"dependentProject": dependentProject,
-				}).Debug("Checking service-only match")
-
-			// crossProjectMatch stores the first cross-project match found, used as fallback
-			// when no same-project match exists.
-			//
-			// NOTE: Go map iteration order is non-deterministic, so when multiple cross-project
-			// containers match the service name, the first one encountered during iteration is
-			// selected. This non-determinism is acceptable for fallback scenarios where no exact
-			// or same-project match exists, as it provides a "best effort" approach.
-			//
-			// The strings.Contains matching is intentional for service-only lookups, allowing
-			// service names like "db" to match container identifiers like "project1-db" or
-			// "myapp-db". This flexible matching enables shorthand references without requiring
-			// the full project-service format.
-			var crossProjectMatch string
-
-			// Collect and sort identifiers to ensure deterministic iteration order.
-			// This is critical for reproducible behavior: without sorting, the iteration
-			// order of restartByIdentifier map would be random, causing different
-			// cross-project matches to be selected on each run when multiple candidates
-			// exist. Sorting ensures that:
-			//   1. The same cross-project container is always selected as fallback
-			//   2. Restarts happen in a predictable, testable order
-			//   3. Multiple Watchtower runs produce consistent results
-			identifiers := make([]string, 0, len(restartByIdentifier))
-			for identifier := range restartByIdentifier {
-				identifiers = append(identifiers, identifier)
-			}
-			// Sort alphabetically for deterministic ordering across all identifiers
-			slices.Sort(identifiers)
-
-			for _, identifier := range identifiers {
-				restarting := restartByIdentifier[identifier]
-				if restarting && strings.Contains(identifier, link) {
-					matchProject := getProject(nameToContainer[identifier])
-					// Priority 1: Same-project match - return immediately
-					if matchProject == dependentProject {
-						logrus.WithFields(
-							logrus.Fields{
-								"link":    link,
-								"matched": identifier,
-								"project": matchProject,
-							}).Debug("Found restarting linked container via same-project service match")
-
-						return identifier
-					}
-					// Priority 2: Cross-project match - remember first match for fallback.
-					// We only store the first match to maintain deterministic behavior.
-					// Since identifiers are sorted alphabetically above, the first match
-					// in alphabetical order will be selected, ensuring consistent
-					// cross-project dependency resolution across multiple runs.
-					if crossProjectMatch == "" {
-						crossProjectMatch = identifier
-					}
-				}
-			}
-
-			// If no same-project match was found, return cross-project match as fallback.
-			// See note above about non-deterministic selection when multiple matches exist.
-			if crossProjectMatch != "" {
-				logrus.WithFields(
-					logrus.Fields{
+			// Prefer any candidate that shares the dependent's project (from labels).
+			for _, matchedID := range matches {
+				if getProject(idToContainer[matchedID]) == dependentProject && dependentProject != "" {
+					logrus.WithFields(logrus.Fields{
 						"link":    link,
-						"matched": crossProjectMatch,
-						"project": getProject(nameToContainer[crossProjectMatch]),
-					}).Debug("Found restarting linked container via cross-project service match")
+						"matched": matchedID,
+						"reason":  "same-project via FindMatchingIdentifiers",
+					}).Debug("Found restarting linked container")
 
-				return crossProjectMatch
+					return matchedID
+				}
 			}
+
+			// Guard for qualified links (those containing '-'):
+			// Only promote a match if the original link string is itself marked
+			// for restart (i.e. an explicit full identifier was used) or we
+			// already selected a same-project candidate.
+			if !strings.Contains(link, "-") || restartByIdentifier[link] {
+				chosen := matches[0]
+				logrus.WithFields(logrus.Fields{
+					"link":    link,
+					"matched": chosen,
+					"reason":  "first match via FindMatchingIdentifiers",
+				}).Debug("Found restarting linked container")
+
+				return chosen
+			}
+
+			logrus.WithFields(logrus.Fields{
+				"link": link,
+			}).Debug("Qualified link did not match any restarting candidate")
+		}
+
+		// Only bare service names (links without '-') reach the service-only fallback.
+		// Any link containing a hyphen was either matched earlier or deliberately
+		// skipped by the qualified-link guard above.
+		if strings.Contains(link, "-") {
+			continue
+		}
+
+		dependentProject := getProject(dependentContainer)
+		linkService := sorter.ExtractServiceName(link)
+
+		// Build the list of currently restarting containers that match on service name alone.
+		var serviceCandidates []string
+
+		for _, name := range restartingNames {
+			if sorter.ExtractServiceName(name) == linkService {
+				serviceCandidates = append(serviceCandidates, name)
+			}
+		}
+
+		if len(serviceCandidates) > 0 {
+			// Prefer a candidate from the same project as the dependent.
+			for _, cand := range serviceCandidates {
+				c := idToContainer[cand]
+				if c != nil &&
+					getProject(idToContainer[cand]) == dependentProject &&
+					dependentProject != "" {
+					logrus.WithFields(logrus.Fields{
+						"link":    link,
+						"matched": cand,
+						"reason":  "same-project service fallback",
+					}).Debug("Found restarting linked container")
+
+					return cand
+				}
+			}
+
+			// No same-project service match found; take the first candidate
+			// after sorting for deterministic behavior.
+			sort.Strings(serviceCandidates)
+			chosen := serviceCandidates[0]
+			logrus.WithFields(logrus.Fields{
+				"link":    link,
+				"matched": chosen,
+				"reason":  "first service fallback",
+			}).Debug("Found restarting linked container")
+
+			return chosen
 		}
 	}
 
@@ -821,6 +855,15 @@ func linkedIdentifierMarkedForRestart(
 }
 
 // getProject extracts the project name from a container's compose project label.
+//
+// Falls back to parsing the leading segment of the container name if no project
+// label is present.
+//
+// Parameters:
+//   - c: Container to inspect.
+//
+// Returns:
+//   - string: Project name, or "" if none can be determined.
 func getProject(c types.Container) string {
 	if monitoredContainer, ok := c.(*container.Container); ok {
 		if info := monitoredContainer.ContainerInfo(); info != nil && info.Config != nil {

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -545,7 +545,6 @@ func UpdateImplicitRestart(
 	// different naming conventions (explicit container_name vs. Compose defaults,
 	// with or without replica suffixes).
 	restartByIdentifier := make(map[string]bool, len(allContainers)+len(allContainers))
-	resolvedToContainer := make(map[string]types.Container, len(allContainers)+len(allContainers))
 
 	for _, c := range allContainers {
 		byID[c.ID()] = c
@@ -567,17 +566,12 @@ func UpdateImplicitRestart(
 		}
 
 		restartByIdentifier[resolvedID] = c.ToRestart()
-		resolvedToContainer[resolvedID] = c
 
 		// Also index by bare name for better exact matching in mixed scenarios
 		bareName := c.Name()
 		if bareName != "" && bareName != resolvedID {
 			if _, exists := restartByIdentifier[bareName]; !exists {
 				restartByIdentifier[bareName] = c.ToRestart()
-			}
-
-			if _, exists := resolvedToContainer[bareName]; !exists {
-				resolvedToContainer[bareName] = c
 			}
 		}
 	}
@@ -617,10 +611,17 @@ func UpdateImplicitRestart(
 					}).Debug("Marked container as linked to restarting")
 				containers[i].SetLinkedToRestarting(true)
 
-				if ac, ok := byID[c.ID()]; ok {
-					ac.SetLinkedToRestarting(true)
-					resolved := container.ResolveContainerIdentifier(ac)
+				if allContainer, ok := byID[c.ID()]; ok {
+					allContainer.SetLinkedToRestarting(true)
+					resolved := container.ResolveContainerIdentifier(allContainer)
 					restartByIdentifier[resolved] = true
+
+					bareName := allContainer.Name()
+					if bareName != "" && bareName != resolved {
+						restartByIdentifier[bareName] = true
+					}
+
+					restartByIdentifier[string(allContainer.ID())] = true
 				}
 
 				markedContainers = append(markedContainers, c.Name())
@@ -688,13 +689,12 @@ func shouldUpdateContainer(
 // linkedIdentifierMarkedForRestart returns the identifier of a container in the
 // links list that is marked for restart, or the empty string if none is found.
 //
-// The function attempts an exact match first. Otherwise it delegates to
-// FindMatchingIdentifiers and selects among the returned candidates using
-// project information from labels (via getProject). For links containing
-// hyphens, a match is only accepted if the link string itself exists in the
-// restart map or a candidate from the same project is available. Short
-// service-name links fall back to a service-only path with the same project
-// preference.
+// The function attempts an exact match first, then delegates to
+// FindMatchingIdentifiers (exact/replica/service-only strategies) with
+// same-project preference. A hyphenated link is only treated as an explicit
+// project-qualified reference (restricting pure service-only results) when
+// it begins with a known project prefix from the container set. Bare service
+// names, including hyphenated ones, reach the service-only fallback.
 //
 // Parameters:
 //   - links: List of linked container identifiers (from Container.Links()).
@@ -724,6 +724,17 @@ func linkedIdentifierMarkedForRestart(
 
 	dependentProject := getProject(dependentContainer)
 
+	// Collect known projects so we can distinguish bare service-name references
+	// (which may contain hyphens) from explicit project-qualified identifiers
+	// the caller wrote in a label.
+	knownProjects := map[string]bool{}
+
+	for _, c := range allContainers {
+		if p := getProject(c); p != "" {
+			knownProjects[p] = true
+		}
+	}
+
 	logrus.WithFields(
 		logrus.Fields{
 			"links":               links,
@@ -735,13 +746,31 @@ func linkedIdentifierMarkedForRestart(
 	//   1. Exact match against the restart map.
 	//   2. Delegate to FindMatchingIdentifiers (exact / replica / service-only).
 	//   3. Among matches, prefer same-project (via labels).
-	//   4. For links that look qualified, apply an additional guard.
-	//   5. Bare service names have a final ExtractServiceName fallback path.
+	//   4. Only treat a hyphenated link as an explicit project-qualified reference
+	//      (and therefore restrict pure service-only resolution) when the link
+	//      begins with a known project prefix. Bare service names are allowed to
+	//      use the service fallback even when they contain hyphens.
 	for _, link := range links {
 		logrus.WithField(
 			"checking_link",
 			link,
 		).Debug("Checking link for restarting match")
+
+		// Determine once per link whether it is written as an explicit
+		// project-qualified identifier (starts with a known project- prefix).
+		// Bare service names, even when they contain hyphens, must be allowed
+		// to reach the service-only fallback.
+		isExplicitProjectRef := false
+
+		if strings.Contains(link, "-") {
+			for p := range knownProjects {
+				if strings.HasPrefix(link, p+"-") {
+					isExplicitProjectRef = true
+
+					break
+				}
+			}
+		}
 
 		if restartByIdentifier[link] {
 			logrus.WithField(
@@ -784,11 +813,34 @@ func linkedIdentifierMarkedForRestart(
 				}
 			}
 
-			// Guard for qualified links (those containing '-'):
-			// Only promote a match if the original link string is itself marked
-			// for restart (i.e. an explicit full identifier was used) or we
-			// already selected a same-project candidate.
-			if !strings.Contains(link, "-") || restartByIdentifier[link] {
+			// Determine if any match from FindMatchingIdentifiers was an
+			// exact or replica match (vs pure service-only). We are more
+			// permissive with exact/replica results.
+			hasExactOrReplica := false
+
+			for _, matchID := range matches {
+				if matchID == link {
+					hasExactOrReplica = true
+
+					break
+				}
+
+				if strings.HasPrefix(matchID, link+"-") {
+					suffix := matchID[len(link)+1:]
+					if sorter.IsPositiveInteger(suffix) {
+						hasExactOrReplica = true
+
+						break
+					}
+				}
+			}
+
+			// Only treat the link as an explicit project-qualified reference (and
+			// therefore block a pure service-only result) when it starts with a
+			// known project prefix. Bare service names (even hyphenated ones such
+			// as "watchtower-test-database") are permitted to resolve via the
+			// service fallback.
+			if !isExplicitProjectRef || restartByIdentifier[link] || hasExactOrReplica {
 				chosen := matches[0]
 				logrus.WithFields(logrus.Fields{
 					"link":    link,
@@ -804,10 +856,9 @@ func linkedIdentifierMarkedForRestart(
 			}).Debug("Qualified link did not match any restarting candidate")
 		}
 
-		// Only bare service names (links without '-') reach the service-only fallback.
-		// Any link containing a hyphen was either matched earlier or deliberately
-		// skipped by the qualified-link guard above.
-		if strings.Contains(link, "-") {
+		// Skip the bare service-name fallback for links that are explicit
+		// project-qualified references.
+		if isExplicitProjectRef {
 			continue
 		}
 

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -768,7 +768,12 @@ func linkedIdentifierMarkedForRestart(
 
 			// Prefer any candidate that shares the dependent's project (from labels).
 			for _, matchedID := range matches {
-				if getProject(idToContainer[matchedID]) == dependentProject && dependentProject != "" {
+				matchedContainer, ok := idToContainer[matchedID]
+				if !ok || matchedContainer == nil {
+					continue
+				}
+
+				if getProject(matchedContainer) == dependentProject && dependentProject != "" {
 					logrus.WithFields(logrus.Fields{
 						"link":    link,
 						"matched": matchedID,
@@ -821,9 +826,12 @@ func linkedIdentifierMarkedForRestart(
 		if len(serviceCandidates) > 0 {
 			// Prefer a candidate from the same project as the dependent.
 			for _, cand := range serviceCandidates {
-				c := idToContainer[cand]
-				if c != nil &&
-					getProject(idToContainer[cand]) == dependentProject &&
+				c, ok := idToContainer[cand]
+				if !ok || c == nil {
+					continue
+				}
+
+				if getProject(c) == dependentProject &&
 					dependentProject != "" {
 					logrus.WithFields(logrus.Fields{
 						"link":    link,

--- a/internal/actions/update_dependencies_test.go
+++ b/internal/actions/update_dependencies_test.go
@@ -203,6 +203,46 @@ var _ = ginkgo.Describe("the update action", func() {
 		)
 
 		ginkgo.It(
+			"should propagate restart for hyphenated Compose project names with explicit container_name using real emitted labels",
+			func() {
+				testData := getComposeHyphenatedProjectTestData()
+				containers := testData.Containers
+
+				// base is stale
+				containers[0].SetStale(true)
+
+				gomega.Expect(containers[0].ToRestart()).To(gomega.BeTrue())  // base
+				gomega.Expect(containers[1].ToRestart()).To(gomega.BeFalse()) // dependent
+
+				actions.UpdateImplicitRestart(containers, containers, true)
+
+				gomega.Expect(containers[0].ToRestart()).To(gomega.BeTrue())
+				gomega.Expect(containers[1].ToRestart()).To(gomega.BeTrue())
+			},
+		)
+
+		ginkgo.It(
+			"should mark dependents for implicit restart with multi-hyphen Compose project names and explicit container_name",
+			func() {
+				testData := getHyphenatedProjectWithContainerNameTestData()
+				containers := testData.Containers
+
+				// base is stale
+				containers[0].SetStale(true)
+
+				gomega.Expect(containers[0].ToRestart()).To(gomega.BeTrue())  // base
+				gomega.Expect(containers[1].ToRestart()).To(gomega.BeFalse()) // dependent-simple
+				gomega.Expect(containers[2].ToRestart()).To(gomega.BeFalse()) // dependent-network
+
+				actions.UpdateImplicitRestart(containers, containers, true)
+
+				gomega.Expect(containers[0].ToRestart()).To(gomega.BeTrue())
+				gomega.Expect(containers[1].ToRestart()).To(gomega.BeTrue(), "dependent-simple should be marked via depends_on")
+				gomega.Expect(containers[2].ToRestart()).To(gomega.BeTrue(), "dependent-network should be marked via depends_on + network_mode")
+			},
+		)
+
+		ginkgo.It(
 			"should NOT propagate restart via compose depends_on when UseComposeDependsOn is false",
 			func() {
 				// Create containers with compose depends_on label
@@ -402,6 +442,210 @@ var _ = ginkgo.Describe("the update action", func() {
 			gomega.Expect(report.Updated()).To(gomega.HaveLen(1))
 			gomega.Expect(cleanupImageInfos).To(gomega.HaveLen(1))
 		})
+
+		ginkgo.It("should skip containers with no usable identifier without breaking restart propagation", func() {
+			// Container that will cause ResolveContainerIdentifier to return ""
+			// (no name, no ID, no useful labels).
+			badContainer := mockActions.CreateMockContainerWithConfig(
+				"", "",
+				"bad:latest",
+				true,
+				false,
+				time.Now(),
+				&dockerContainer.Config{
+					Labels:       map[string]string{},
+					ExposedPorts: dockerNetwork.PortSet{},
+				},
+			)
+
+			base := mockActions.CreateMockContainerWithConfig(
+				"base",
+				"/base",
+				"base:latest",
+				true,
+				false,
+				time.Now().AddDate(0, 0, -1),
+				&dockerContainer.Config{
+					Labels: map[string]string{
+						"com.docker.compose.project": "test-project",
+						"com.docker.compose.service": "base",
+					},
+					ExposedPorts: dockerNetwork.PortSet{},
+				},
+			)
+
+			dependent := mockActions.CreateMockContainerWithConfig(
+				"dependent",
+				"/dependent",
+				"dep:latest",
+				true,
+				false,
+				time.Now(),
+				&dockerContainer.Config{
+					Labels: map[string]string{
+						"com.docker.compose.project":    "test-project",
+						"com.docker.compose.service":    "dependent",
+						"com.docker.compose.depends_on": "base:service_started:false",
+					},
+					ExposedPorts: dockerNetwork.PortSet{},
+				},
+			)
+
+			containers := []types.Container{badContainer, base, dependent}
+			base.SetStale(true)
+
+			actions.UpdateImplicitRestart(containers, containers, true)
+
+			// The valid dependent should still be marked despite the bad container
+			gomega.Expect(dependent.ToRestart()).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should not promote cross-project replica matches for qualified links when dependent has no project label", func() {
+			// Dependent has no project label, uses a hyphenated link via compose depends_on.
+			// Base exists only as a replica form in the restart map.
+			base := mockActions.CreateMockContainerWithConfig(
+				"project-base-1",
+				"/project-base-1",
+				"base:latest",
+				true,
+				false,
+				time.Now().AddDate(0, 0, -1),
+				&dockerContainer.Config{
+					Labels: map[string]string{
+						"com.docker.compose.project":          "project",
+						"com.docker.compose.service":          "base",
+						"com.docker.compose.container-number": "1",
+					},
+					ExposedPorts: dockerNetwork.PortSet{},
+				},
+			)
+
+			// Dependent with no project label
+			dependent := mockActions.CreateMockContainerWithConfig(
+				"dependent",
+				"/dependent",
+				"dep:latest",
+				true,
+				false,
+				time.Now(),
+				&dockerContainer.Config{
+					Labels: map[string]string{
+						"com.docker.compose.service":    "dependent",
+						"com.docker.compose.depends_on": "project-base:service_started:false",
+					},
+					ExposedPorts: dockerNetwork.PortSet{},
+				},
+			)
+
+			containers := []types.Container{base, dependent}
+			base.SetStale(true)
+
+			actions.UpdateImplicitRestart(containers, containers, true)
+
+			// Because the link "project-base" contains hyphens and the exact link
+			// is not in the restart map (only "project-base-1" is), and the
+			// dependent has no project label for same-project preference,
+			// the guard should prevent incorrectly marking the dependent.
+			gomega.Expect(dependent.ToRestart()).To(gomega.BeFalse())
+		})
+
+		ginkgo.It("should handle the replica special case in ResolveContainerIdentifier for restart decisions", func() {
+			// This tests the early return in ResolveContainerIdentifier:
+			// if the container's runtime name matches the pattern "project-service-N",
+			// it returns the runtime name directly instead of the constructed form.
+			// This can happen with certain container_name configurations.
+
+			// Base container whose Name() will trigger the special case
+			base := mockActions.CreateMockContainerWithConfig(
+				"myproject-db-1", // runtime name matches project-service-N pattern
+				"/myproject-db-1",
+				"db:latest",
+				true,
+				false,
+				time.Now().AddDate(0, 0, -1),
+				&dockerContainer.Config{
+					Labels: map[string]string{
+						"com.docker.compose.project": "myproject",
+						"com.docker.compose.service": "db",
+					},
+					ExposedPorts: dockerNetwork.PortSet{},
+				},
+			)
+
+			dependent := mockActions.CreateMockContainerWithConfig(
+				"myproject-app-1",
+				"/myproject-app-1",
+				"app:latest",
+				true,
+				false,
+				time.Now(),
+				&dockerContainer.Config{
+					Labels: map[string]string{
+						"com.docker.compose.project":    "myproject",
+						"com.docker.compose.service":    "app",
+						"com.docker.compose.depends_on": "myproject-db:service_started:false",
+					},
+					ExposedPorts: dockerNetwork.PortSet{},
+				},
+			)
+
+			containers := []types.Container{base, dependent}
+			base.SetStale(true)
+
+			actions.UpdateImplicitRestart(containers, containers, true)
+
+			// The dependent should still be marked, even though the base resolved
+			// to its runtime name "myproject-db-1" due to the special case.
+			gomega.Expect(dependent.ToRestart()).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should resolve dependencies that come only from network_mode via host config", func() {
+			// This covers the case where a container has no com.docker.compose.depends_on
+			// label, so the link must come from getLinksFromHostConfig (network_mode: service:xxx).
+			base := mockActions.CreateMockContainerWithConfig(
+				"base",
+				"/base",
+				"base:latest",
+				true,
+				false,
+				time.Now().AddDate(0, 0, -1),
+				&dockerContainer.Config{
+					Labels: map[string]string{
+						"com.docker.compose.project": "test",
+						"com.docker.compose.service": "base",
+					},
+					ExposedPorts: dockerNetwork.PortSet{},
+				},
+			)
+
+			// Dependent that only declares the relationship via a watchtower depends-on label
+			// (no compose depends_on label). This simulates links coming from external
+			// sources such as network_mode / host config parsing.
+			dependent := mockActions.CreateMockContainerWithConfig(
+				"dependent",
+				"/dependent",
+				"dep:latest",
+				true,
+				false,
+				time.Now(),
+				&dockerContainer.Config{
+					Labels: map[string]string{
+						"com.docker.compose.project":                "test",
+						"com.docker.compose.service":                "dependent",
+						"com.centurylinklabs.watchtower.depends-on": "base",
+					},
+					ExposedPorts: dockerNetwork.PortSet{},
+				},
+			)
+
+			containers := []types.Container{base, dependent}
+			base.SetStale(true)
+
+			actions.UpdateImplicitRestart(containers, containers, true)
+
+			gomega.Expect(dependent.ToRestart()).To(gomega.BeTrue())
+		})
+
 		ginkgo.It("should ensure dependencies are stopped and started in correct order", func() {
 			// Create dependency chain: A depends on B, B depends on C
 			containers := createDependencyChain(
@@ -1813,6 +2057,50 @@ var _ = ginkgo.Describe("the update action", func() {
 					To(gomega.Equal("network-dependent"))
 					// dependent container
 				gomega.Expect(containers[1].ToRestart()).To(gomega.BeTrue())
+			},
+		)
+
+		ginkgo.It(
+			"should restart containers with both compose depends_on and network_mode dependency",
+			func() {
+				testData := getComposeDependsOnWithNetworkModeTestData()
+				client := mockActions.CreateMockClient(testData, false, false)
+
+				report, cleanupImageInfos, err := actions.Update(
+					context.Background(),
+					client,
+					types.UpdateParams{Cleanup: true, CPUCopyMode: "auto"},
+				)
+
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(report.Updated()).
+					To(gomega.HaveLen(1))
+				gomega.Expect(cleanupImageInfos).To(gomega.HaveLen(1))
+				gomega.Expect(cleanupImageInfos[0].ContainerName).
+					To(gomega.Equal("download-stack-vpn-1"))
+
+				containers := testData.Containers
+				gomega.Expect(containers[0].Name()).
+					To(gomega.Equal("download-stack-vpn-1"))
+				gomega.Expect(containers[1].Name()).
+					To(gomega.Equal("download-stack-web-1"))
+
+				// The dependent container should be marked for restart via compose depends_on
+				gomega.Expect(containers[1].ToRestart()).To(gomega.BeTrue())
+
+				// Verify stop order: dependent first, then dependency (reverse sorted order)
+				gomega.Expect(client.TestData.StopOrder).
+					To(gomega.Equal([]string{"download-stack-web-1", "download-stack-vpn-1"}))
+
+				// Verify create order: dependency first, then dependent
+				gomega.Expect(client.TestData.CreateOrder).
+					To(gomega.Equal([]string{"download-stack-vpn-1", "download-stack-web-1"}))
+
+				// Verify the dependent container preserves the network mode referencing the dependency
+				newDependent := containers[1]
+				networkMode := newDependent.ContainerInfo().HostConfig.NetworkMode
+				gomega.Expect(string(networkMode)).
+					To(gomega.Equal("container:download-stack-vpn-1"))
 			},
 		)
 	})

--- a/internal/actions/update_dependencies_test.go
+++ b/internal/actions/update_dependencies_test.go
@@ -500,9 +500,10 @@ var _ = ginkgo.Describe("the update action", func() {
 			gomega.Expect(dependent.ToRestart()).To(gomega.BeTrue())
 		})
 
-		ginkgo.It("should not promote cross-project replica matches for qualified links when dependent has no project label", func() {
-			// Dependent has no project label, uses a hyphenated link via compose depends_on.
-			// Base exists only as a replica form in the restart map.
+		ginkgo.It("should allow replica matches for qualified links via hasExactOrReplica even without project label on dependent", func() {
+			// Dependent has no project label and a hyphenated link from compose depends_on.
+			// The restarting candidate is a replica; FindMatchingIdentifiers hits replica
+			// strategy so hasExactOrReplica is true and the qualified-link guard permits it.
 			base := mockActions.CreateMockContainerWithConfig(
 				"project-base-1",
 				"/project-base-1",
@@ -542,11 +543,8 @@ var _ = ginkgo.Describe("the update action", func() {
 
 			actions.UpdateImplicitRestart(containers, containers, true)
 
-			// Because the link "project-base" contains hyphens and the exact link
-			// is not in the restart map (only "project-base-1" is), and the
-			// dependent has no project label for same-project preference,
-			// the guard should prevent incorrectly marking the dependent.
-			gomega.Expect(dependent.ToRestart()).To(gomega.BeFalse())
+			// Replica matches for qualified links are permitted by the refined guard.
+			gomega.Expect(dependent.ToRestart()).To(gomega.BeTrue())
 		})
 
 		ginkgo.It("should handle the replica special case in ResolveContainerIdentifier for restart decisions", func() {
@@ -601,7 +599,8 @@ var _ = ginkgo.Describe("the update action", func() {
 
 		ginkgo.It("should resolve dependencies that come only from network_mode via host config", func() {
 			// This covers the case where a container has no com.docker.compose.depends_on
-			// label, so the link must come from getLinksFromHostConfig (network_mode: service:xxx).
+			// label and no watchtower depends-on label, so the link must come from
+			// getLinksFromHostConfig (network_mode: container:xxx).
 			base := mockActions.CreateMockContainerWithConfig(
 				"base",
 				"/base",
@@ -618,9 +617,8 @@ var _ = ginkgo.Describe("the update action", func() {
 				},
 			)
 
-			// Dependent that only declares the relationship via a watchtower depends-on label
-			// (no compose depends_on label). This simulates links coming from external
-			// sources such as network_mode / host config parsing.
+			// Dependent that declares the relationship only via HostConfig.NetworkMode
+			// (no compose depends_on label, no watchtower depends-on label).
 			dependent := mockActions.CreateMockContainerWithConfig(
 				"dependent",
 				"/dependent",
@@ -630,13 +628,13 @@ var _ = ginkgo.Describe("the update action", func() {
 				time.Now(),
 				&dockerContainer.Config{
 					Labels: map[string]string{
-						"com.docker.compose.project":                "test",
-						"com.docker.compose.service":                "dependent",
-						"com.centurylinklabs.watchtower.depends-on": "base",
+						"com.docker.compose.project": "test",
+						"com.docker.compose.service": "dependent",
 					},
 					ExposedPorts: dockerNetwork.PortSet{},
 				},
 			)
+			dependent.ContainerInfo().HostConfig.NetworkMode = "container:base"
 
 			containers := []types.Container{base, dependent}
 			base.SetStale(true)

--- a/internal/actions/update_helpers_test.go
+++ b/internal/actions/update_helpers_test.go
@@ -343,6 +343,7 @@ func getHyphenatedProjectWithContainerNameTestData() *mockActions.TestData {
 			},
 			ExposedPorts: dockerNetwork.PortSet{},
 		})
+	dependentNetwork.ContainerInfo().HostConfig.NetworkMode = "container:base"
 
 	return &mockActions.TestData{
 		Staleness: map[string]bool{

--- a/internal/actions/update_helpers_test.go
+++ b/internal/actions/update_helpers_test.go
@@ -235,6 +235,125 @@ func getComposeMultiHopTestData() *mockActions.TestData {
 	}
 }
 
+// getComposeHyphenatedProjectTestData creates test data for a hyphenated Compose
+// project name with explicit container_name declarations and real Compose-emitted
+// depends_on label strings in "service:condition:bool" format.
+func getComposeHyphenatedProjectTestData() *mockActions.TestData {
+	// Base service with *explicit container_name* producing a bare runtime name.
+	// Project label present so Links() will emit the project-prefixed form ("download-torrent-base").
+	baseContainer := mockActions.CreateMockContainerWithConfig(
+		"base",
+		"/base",
+		"redis:alpine",
+		true,
+		false,
+		time.Now().AddDate(0, 0, -1),
+		&dockerContainer.Config{
+			Image: "redis:alpine",
+			Labels: map[string]string{
+				"com.docker.compose.project":          "download-torrent",
+				"com.docker.compose.service":          "base",
+				"com.docker.compose.container-number": "1",
+			},
+			ExposedPorts: dockerNetwork.PortSet{},
+		})
+
+	// Dependent with bare container_name + real Compose-emitted depends_on label format.
+	dependentContainer := mockActions.CreateMockContainerWithConfig(
+		"dependent",
+		"/dependent",
+		"app:latest",
+		true,
+		false,
+		time.Now(),
+		&dockerContainer.Config{
+			Image: "app:latest",
+			Labels: map[string]string{
+				"com.docker.compose.project":          "download-torrent",
+				"com.docker.compose.service":          "dependent",
+				"com.docker.compose.container-number": "1",
+				"com.docker.compose.depends_on":       "base:service_started:false",
+			},
+			ExposedPorts: dockerNetwork.PortSet{},
+		})
+
+	return &mockActions.TestData{
+		Staleness:  map[string]bool{baseContainer.Name(): true, dependentContainer.Name(): false},
+		Containers: []types.Container{baseContainer, dependentContainer},
+	}
+}
+
+// getHyphenatedProjectWithContainerNameTestData creates test data for a Compose
+// project name containing multiple hyphens, using explicit container_name on all
+// services and real Compose-emitted depends_on label strings.
+func getHyphenatedProjectWithContainerNameTestData() *mockActions.TestData {
+	// Uses a project name with multiple hyphens and explicit container_name values
+	// to exercise the restart marking logic with realistic Compose label output.
+	base := mockActions.CreateMockContainerWithConfig(
+		"base",
+		"/base",
+		"redis:alpine",
+		true,
+		false,
+		time.Now().AddDate(0, 0, -1),
+		&dockerContainer.Config{
+			Image: "redis:alpine",
+			// Set container-number so ResolveContainerIdentifier returns the
+			// replica form while compose depends_on links remain non-replica.
+			Labels: map[string]string{
+				"com.docker.compose.project":          "my-app-project",
+				"com.docker.compose.service":          "base",
+				"com.docker.compose.container-number": "1",
+			},
+			ExposedPorts: dockerNetwork.PortSet{},
+		})
+
+	dependentSimple := mockActions.CreateMockContainerWithConfig(
+		"dependent-simple",
+		"/dependent-simple",
+		"alpine:latest",
+		true,
+		false,
+		time.Now(),
+		&dockerContainer.Config{
+			Image: "alpine:latest",
+			Labels: map[string]string{
+				"com.docker.compose.project":          "my-app-project",
+				"com.docker.compose.service":          "dependent-simple",
+				"com.docker.compose.container-number": "1",
+				"com.docker.compose.depends_on":       "base:service_started:false",
+			},
+			ExposedPorts: dockerNetwork.PortSet{},
+		})
+
+	dependentNetwork := mockActions.CreateMockContainerWithConfig(
+		"dependent-network",
+		"/dependent-network",
+		"alpine:latest",
+		true,
+		false,
+		time.Now(),
+		&dockerContainer.Config{
+			Image: "alpine:latest",
+			Labels: map[string]string{
+				"com.docker.compose.project":          "my-app-project",
+				"com.docker.compose.service":          "dependent-network",
+				"com.docker.compose.container-number": "1",
+				"com.docker.compose.depends_on":       "base:service_started:false",
+			},
+			ExposedPorts: dockerNetwork.PortSet{},
+		})
+
+	return &mockActions.TestData{
+		Staleness: map[string]bool{
+			base.Name():             true,
+			dependentSimple.Name():  false,
+			dependentNetwork.Name(): false,
+		},
+		Containers: []types.Container{base, dependentSimple, dependentNetwork},
+	}
+}
+
 func createDependencyChain(names []string) []types.Container {
 	containers := make([]types.Container, len(names))
 	for i := range names {
@@ -266,4 +385,46 @@ func createDependencyChain(names []string) []types.Container {
 	}
 
 	return containers
+}
+
+func getComposeDependsOnWithNetworkModeTestData() *mockActions.TestData {
+	staleContainer := mockActions.CreateMockContainerWithConfig(
+		"download-stack-vpn-1",
+		"/download-stack-vpn-1",
+		"gluetun:latest",
+		true,
+		false,
+		time.Now().AddDate(0, 0, -1),
+		&dockerContainer.Config{
+			Image: "gluetun:latest",
+			Labels: map[string]string{
+				"com.docker.compose.project": "download-stack",
+				"com.docker.compose.service": "vpn",
+			},
+			ExposedPorts: dockerNetwork.PortSet{},
+		})
+
+	dependentContainer := mockActions.CreateMockContainerWithConfig(
+		"download-stack-web-1",
+		"/download-stack-web-1",
+		"nginx:latest",
+		true,
+		false,
+		time.Now(),
+		&dockerContainer.Config{
+			Image: "nginx:latest",
+			Labels: map[string]string{
+				"com.docker.compose.project":    "download-stack",
+				"com.docker.compose.service":    "web",
+				"com.docker.compose.depends_on": "vpn:service_started:false",
+			},
+			ExposedPorts: dockerNetwork.PortSet{},
+		})
+
+	dependentContainer.ContainerInfo().HostConfig.NetworkMode = "container:download-stack-vpn-1"
+
+	return &mockActions.TestData{
+		Staleness:  map[string]bool{staleContainer.Name(): true, dependentContainer.Name(): false},
+		Containers: []types.Container{staleContainer, dependentContainer},
+	}
 }

--- a/pkg/sorter/dependency.go
+++ b/pkg/sorter/dependency.go
@@ -288,7 +288,7 @@ func buildDependencyGraph(
 					// Only match if the suffix is a positive integer (replica number).
 					// This ensures we don't match "watchtower-test-database" when looking for "watchtower-test-database2",
 					// or create false dependencies between similarly named but distinct services.
-					if isPositiveInteger(suffix) {
+					if IsPositiveInteger(suffix) {
 						matchedKeys = append(matchedKeys, key)
 					}
 				}
@@ -336,7 +336,7 @@ func buildDependencyGraph(
 			var serviceMatchKeys []string
 
 			for key := range containerMap {
-				serviceName := extractServiceName(key)
+				serviceName := ExtractServiceName(key)
 				if serviceName == normalizedLink {
 					serviceMatchKeys = append(serviceMatchKeys, key)
 				}
@@ -359,7 +359,7 @@ func buildDependencyGraph(
 					"matched_key":       serviceMatchKey,
 					"dependent":         normalizedIdentifier,
 					"match_type":        "service_only",
-					"extracted_service": extractServiceName(serviceMatchKey),
+					"extracted_service": ExtractServiceName(serviceMatchKey),
 				}).Debug("Matched dependency via service name fallback")
 
 				// This container depends on the linked container, so increment its indegree
@@ -386,7 +386,7 @@ func buildDependencyGraph(
 	return containerMap, indegree, adjacency, normalizedMap, nil
 }
 
-// isPositiveInteger checks if a string represents a positive integer (1 or greater).
+// IsPositiveInteger checks if a string represents a positive integer (1 or greater).
 //
 // This validation is critical for distinguishing Docker Compose-style replica suffixes
 // (e.g., "db-1", "db-2") from other hyphenated container names (e.g., "db-backup",
@@ -399,13 +399,7 @@ func buildDependencyGraph(
 //
 // This prevents false dependency relationships between unrelated containers with
 // similar names, which could cause incorrect update ordering or circular dependencies.
-//
-// Parameters:
-//   - s: The string to check (typically the suffix after "-" in a container name).
-//
-// Returns:
-//   - bool: True if the string is a valid integer >= 1, false otherwise.
-func isPositiveInteger(s string) bool {
+func IsPositiveInteger(s string) bool {
 	if s == "" {
 		return false
 	}
@@ -415,7 +409,7 @@ func isPositiveInteger(s string) bool {
 	return err == nil && n > 0
 }
 
-// extractServiceName extracts the service name from a container identifier.
+// ExtractServiceName extracts the service name from a container identifier.
 //
 // Container identifiers from ResolveContainerIdentifier() follow the pattern:
 //   - "project-service" when both project and service labels exist
@@ -433,13 +427,7 @@ func isPositiveInteger(s string) bool {
 //   - "myapp" -> "myapp"
 //   - "my-app-service" -> "service" (last segment before any replica number)
 //   - "my-app-service-2" -> "service" (strips replica suffix)
-//
-// Parameters:
-//   - identifier: The full container identifier (e.g., "postgresql-postgres").
-//
-// Returns:
-//   - string: The extracted service name.
-func extractServiceName(identifier string) string {
+func ExtractServiceName(identifier string) string {
 	if identifier == "" {
 		return ""
 	}
@@ -453,13 +441,90 @@ func extractServiceName(identifier string) string {
 
 	// Check if the last part is a replica number (positive integer)
 	// If so, we need to skip it and take the second-to-last part as service name
-	if isPositiveInteger(parts[len(parts)-1]) {
+	if IsPositiveInteger(parts[len(parts)-1]) {
 		// Return the part before the replica number (e.g., "service" from "project-service-1")
 		return parts[len(parts)-2]
 	}
 
 	// No replica number, service name is the last part
 	return parts[len(parts)-1]
+}
+
+// FindMatchingIdentifiers returns the identifiers from the given list that match
+// the provided link. It applies the same three matching strategies used in
+// buildDependencyGraph:
+//
+//  1. Exact match.
+//  2. Replica prefix match: the identifier starts with "<link>-" and the suffix
+//     after the hyphen is a positive integer (Docker Compose replica numbering).
+//  3. Service-only match using ExtractServiceName. This strategy only succeeds
+//     when exactly one candidate matches; multiple matches (e.g. the same
+//     service name in different projects) are treated as ambiguous and return
+//     no results.
+//
+// Parameters:
+//   - link: Dependency link to resolve (typically from Container.Links()).
+//   - identifiers: List of known container identifiers to search within.
+//
+// Returns:
+//   - []string: Matching identifiers. Returns nil or an empty slice when there
+//     is no match or when the service-only strategy finds multiple candidates.
+func FindMatchingIdentifiers(link string, identifiers []string) []string {
+	if link == "" || len(identifiers) == 0 {
+		return nil
+	}
+
+	// Build a temporary lookup for efficiency
+	idSet := make(map[string]bool, len(identifiers))
+	for _, id := range identifiers {
+		idSet[id] = true
+	}
+
+	var matches []string
+
+	// 1. Exact match
+	if idSet[link] {
+		matches = append(matches, link)
+
+		return matches
+	}
+
+	// 2. Replica prefix match (only if suffix is positive integer)
+	var replicaMatches []string
+
+	for id := range idSet {
+		if strings.HasPrefix(id, link+"-") {
+			suffix := id[len(link)+1:]
+			if IsPositiveInteger(suffix) {
+				replicaMatches = append(replicaMatches, id)
+			}
+		}
+	}
+
+	if len(replicaMatches) > 0 {
+		sort.Strings(replicaMatches)
+		matches = append(matches, replicaMatches...)
+
+		return matches
+	}
+
+	// 3. Service-only match using ExtractServiceName.
+	// Only accepted when exactly one candidate matches the service name.
+	// Multiple matches are ambiguous (different projects) and are discarded.
+	var serviceMatches []string
+
+	normalizedLink := ExtractServiceName(link)
+	for id := range idSet {
+		if ExtractServiceName(id) == normalizedLink {
+			serviceMatches = append(serviceMatches, id)
+		}
+	}
+
+	if len(serviceMatches) == 1 {
+		matches = append(matches, serviceMatches[0])
+	}
+
+	return matches
 }
 
 // initializeQueue creates the initial processing queue for Kahn's algorithm.

--- a/pkg/sorter/dependency_test.go
+++ b/pkg/sorter/dependency_test.go
@@ -1489,7 +1489,7 @@ var _ = ginkgo.Describe("Identifier Collision Issues", func() {
 var _ = ginkgo.Describe("isPositiveInteger", func() {
 	ginkgo.DescribeTable("validates positive integers correctly",
 		func(input string, expected bool) {
-			result := isPositiveInteger(input)
+			result := IsPositiveInteger(input)
 			gomega.Expect(result).To(gomega.Equal(expected))
 		},
 		ginkgo.Entry("should return true for single digit positive integer", "1", true),
@@ -1508,7 +1508,7 @@ var _ = ginkgo.Describe("isPositiveInteger", func() {
 var _ = ginkgo.Describe("extractServiceName", func() {
 	ginkgo.DescribeTable("extracts service name from container identifier",
 		func(input, expected string) {
-			result := extractServiceName(input)
+			result := ExtractServiceName(input)
 			gomega.Expect(result).To(gomega.Equal(expected))
 		},
 		ginkgo.Entry(
@@ -1862,3 +1862,43 @@ func indexOf(names []string, target string) int {
 
 	return -1
 }
+
+var _ = ginkgo.Describe("FindMatchingIdentifiers", func() {
+	ginkgo.It("should return exact match when present", func() {
+		identifiers := []string{"project-db", "other-db"}
+		matches := FindMatchingIdentifiers("project-db", identifiers)
+		gomega.Expect(matches).To(gomega.Equal([]string{"project-db"}))
+	})
+
+	ginkgo.It("should match replica suffix when link has no replica", func() {
+		identifiers := []string{"project-db-1", "project-db-2", "other"}
+		matches := FindMatchingIdentifiers("project-db", identifiers)
+		gomega.Expect(matches).To(gomega.ConsistOf("project-db-1", "project-db-2"))
+	})
+
+	ginkgo.It("should not match replica when suffix is not a positive integer", func() {
+		identifiers := []string{"project-db-backup"}
+		matches := FindMatchingIdentifiers("project-db", identifiers)
+		gomega.Expect(matches).To(gomega.BeEmpty())
+	})
+
+	ginkgo.It("should return service-only match when exactly one candidate exists", func() {
+		identifiers := []string{"project1-db"}
+		matches := FindMatchingIdentifiers("db", identifiers)
+		gomega.Expect(matches).To(gomega.Equal([]string{"project1-db"}))
+	})
+
+	ginkgo.It("should return no matches for ambiguous service name across projects", func() {
+		identifiers := []string{"project1-db", "project2-db"}
+		matches := FindMatchingIdentifiers("db", identifiers)
+		gomega.Expect(matches).To(gomega.BeEmpty())
+	})
+
+	ginkgo.It("should return empty for empty input", func() {
+		matches := FindMatchingIdentifiers("", []string{"db"})
+		gomega.Expect(matches).To(gomega.BeEmpty())
+
+		matches = FindMatchingIdentifiers("db", []string{})
+		gomega.Expect(matches).To(gomega.BeEmpty())
+	})
+})


### PR DESCRIPTION
Implicit restart propagation failed for containers in Compose projects with hyphenated names or custom container_name, and for links where the resolved identifier differed from the depends_on label. The restart tracking map now uses canonical identifiers and a new FindMatchingIdentifiers function to correctly resolve links across exact, replica, and service-only match strategies.

## Problem

Watchtower's implicit restart logic used brittle string heuristics to match dependency links against container identifiers.
This caused dependents to be skipped during updates in certain situations, such as:

- Compose projects with hyphenated names (e.g., `download-torrent`, `my-app-project`)
- Containers using explicit `container_name` which produce a bare runtime name
- Containers whose resolved identifier (replica form like `project-service-1`) differs from the Compose depends_on link (`project-service`)
- Links containing hyphens where the dependent has no project label to disambiguate cross-project matches

As a result, dependents were often not stopped before their dependencies, leading to incorrect update ordering and/or missing restarts.

## Solution

The restart decision logic now reuses the existing, well-tested matching strategies from the dependency sorter. Restart tracking was also aligned to use `ResolveContainerIdentifier` keys (with bare name fallbacks) for consistency between link resolution and restart decisions. Additional defensive guards were added for qualified links and edge cases, such as empty identifiers.

## Changes

- `internal/actions/update.go`: Rewrote restart tracking map and `linkedIdentifierMarkedForRestart` to use `FindMatchingIdentifiers`, same-project preference, and the qualified-link guard
- `pkg/sorter/dependency.go`: Added `FindMatchingIdentifiers`; exported `IsPositiveInteger` and `ExtractServiceName` by renaming from unexported
- Added comprehensive tests for hyphenated project names, explicit container_name, replica special cases, empty identifiers, network_mode-only dependencies, and cross-project guards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved implicit container-restart propagation to correctly handle hyphenated project/service names, explicit container names, replica-style identifiers, and network_mode-based dependencies, with more deterministic same-project preference.
  * Fixed edge-case dependency resolution for containers with missing or ambiguous identifiers.

* **Tests**
  * Added extensive tests covering implicit restart propagation, replica/name matching, hyphenated links, and network_mode-derived dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/watchtower/pull/1677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->