### PR TITLE
fix(container): set Detach true in ExecStart to prevent blocking on command execution

### DIFF
--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -1022,7 +1022,7 @@ func (c *client) ExecuteCommand(
 	// Start the exec instance.
 	clog.WithField("exec_id", exec.ID).Debug("Starting exec instance")
 
-	execStartCheck := dockerClient.ExecStartOptions{TTY: true}
+	execStartCheck := dockerClient.ExecStartOptions{Detach: true, TTY: true}
 
 	_, err = c.api.ExecStart(ctx, exec.ID, execStartCheck)
 	if err != nil {

--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -1184,6 +1184,37 @@ var _ = ginkgo.Describe("the client", func() {
 				gomega.Expect(skipUpdate).To(gomega.BeFalse())
 			})
 		})
+		ginkgo.When("ExecStart is called", func() {
+			ginkgo.It("should use Detach true to prevent blocking on command execution", func() {
+				client := &client{
+					api:           docker,
+					ClientOptions: ClientOptions{},
+				}
+
+				containerID := types.ContainerID("detach-test-cont-id")
+				execID := "detach-test-exec-id"
+				cmd := "detach-test-cmd"
+
+				// Set up standard handlers
+				setupExecMockHandlers(mockServer, string(containerID), execID, cmd, -1, -1, 0, false, false)
+
+				container, err := client.GetContainer(context.Background(), containerID)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				skipUpdate, err := client.ExecuteCommand(context.Background(), container, cmd, 1, 0, 0)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(skipUpdate).To(gomega.BeFalse())
+
+				// Verify the ExecStart request contained Detach: true
+				// by inspecting the last request body received by the mock server.
+				// The setupExecMockHandlers already verifies this via VerifyJSONRepresenting,
+				// but we add this test to explicitly document the requirement:
+				// ExecStart must use Detach: true so that the daemon does not block
+				// until the command finishes. Without Detach: true, ExecStart blocks,
+				// and a subsequent ExecAttach receives "exec command is already running"
+				// which causes exit code 126 and aborts the update.
+			})
+		})
 	})
 
 	// Test suite for captureExecOutput.
@@ -2075,7 +2106,8 @@ func setupExecMockHandlers(
 				gomega.MatchRegexp(fmt.Sprintf("^/v[0-9.]+/exec/%s/start$", execID)),
 			),
 			ghttp.VerifyJSONRepresenting(dockerContainer.ExecStartRequest{
-				Tty: true,
+				Detach: true,
+				Tty:    true,
 			}),
 			ghttp.RespondWith(http.StatusOK, nil),
 		),


### PR DESCRIPTION
This PR fixes ExecStart blocking lifecycle hooks by setting Detach: true and preventing false exit code 126 on Docker Engine v29+.

## Problem

Under Docker Engine v29 (moby/moby v29+), `ExecStart` with `Detach=false` (the default) blocks synchronously until the command finishes. When watchtower subsequently calls `ExecAttach` to capture output, the exec instance is already complete, and the daemon responds with "exec command is already running". This error text gets captured as the command output, and `ExecInspect` reports exit code 126, causing the lifecycle hook to be marked as failed despite the command having actually succeeded. Every container with a pre-update lifecycle hook fails its update.

## Solution

Set `Detach: true` in `ExecStartOptions` so that `ExecStart` returns immediately after launching the command in the background. The subsequent `ExecAttach` can then properly stream output while the command runs, and `waitForExecOrTimeout` correctly retrieves the exit code via `ExecInspect`. This matches the standard Docker API pattern for non-blocking exec with output capture.

## Changes

- `pkg/container/client.go:1025` — Added `Detach: true` to `ExecStartOptions` so ExecStart does not block until command completion
- `pkg/container/client_test.go` — Added test verifying `ExecStart` sends `Detach: true` and updated mock to expect it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed command execution in containers to eliminate blocking behavior and prevent subsequent attachment failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/watchtower/pull/1683?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->