### PR TITLE
fix(scheduling): strip quotes from cron schedule spec before parsing

### DIFF
--- a/internal/scheduling/scheduling.go
+++ b/internal/scheduling/scheduling.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -223,6 +224,8 @@ func RunUpgradesOnSchedule(
 
 	// Add the update function to the cron schedule, handling concurrency and metrics.
 	if scheduleSpec != "" {
+		scheduleSpec = strings.Trim(scheduleSpec, `"'`)
+
 		_, err := scheduler.AddFunc(
 			scheduleSpec,
 			scheduledUpdateFunc)

--- a/internal/scheduling/scheduling_test.go
+++ b/internal/scheduling/scheduling_test.go
@@ -308,6 +308,95 @@ func TestRunUpgradesOnSchedule_InvalidCronSpec(t *testing.T) {
 	}
 }
 
+func TestRunUpgradesOnSchedule_QuotedScheduleSpec(t *testing.T) {
+	tests := []struct {
+		name         string
+		scheduleSpec string
+		expectError  bool
+	}{
+		{
+			name:         "double-quoted cron spec from Docker Compose",
+			scheduleSpec: `"0 0 2 * * *"`,
+			expectError:  false,
+		},
+		{
+			name:         "single-quoted cron spec",
+			scheduleSpec: `'0 0 2 * * *'`,
+			expectError:  false,
+		},
+		{
+			name:         "double-quoted descriptor",
+			scheduleSpec: `"@hourly"`,
+			expectError:  false,
+		},
+		{
+			name:         "unquoted cron spec",
+			scheduleSpec: `0 0 2 * * *`,
+			expectError:  false,
+		},
+		{
+			name:         "unquoted descriptor",
+			scheduleSpec: `@hourly`,
+			expectError:  false,
+		},
+		{
+			name:         "double-quoted invalid spec still errors",
+			scheduleSpec: `"invalid cron spec"`,
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
+
+			ctx := t.Context()
+
+			runUpdatesWithNotifications := func(_ context.Context, _ types.Filter, _ types.UpdateParams) *metrics.Metric {
+				return &metrics.Metric{Scanned: 0, Updated: 0, Failed: 0}
+			}
+
+			writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {}
+
+			timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
+			defer timeoutCancel()
+
+			err := scheduling.RunUpgradesOnSchedule(
+				timeoutCtx,
+				cmd,
+				filters.NoFilter,
+				"test filter",
+				nil,
+				false,
+				tt.scheduleSpec,
+				writeStartupMessage,
+				runUpdatesWithNotifications,
+				client,
+				"",
+				nil,
+				"v1.0.0",
+				false, // monitorOnly
+				false, // updateOnStart
+				false, // skipFirstRun
+				nil,   // currentWatchtowerContainer
+				false, // startupMessageSent
+				false, // ephemeralSelfUpdate
+			)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got %v", err)
+				}
+			}
+		})
+	}
+}
+
 func TestRunUpgradesOnSchedule_ContextCancellation(t *testing.T) {
 	cmd := &cobra.Command{}
 	client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)


### PR DESCRIPTION
This PR implements input validation for values wrapped with quotations to Watchtower's schedule configuration option.

## Problem

When users configure `WATCHTOWER_SCHEDULE` in Docker Compose with quotes (e.g., `WATCHTOWER_SCHEDULE="0 0 2 * * *"`), Docker Compose passes the literal quote characters as part of the environment variable value. The cron parser (`robfig/cron/v3`) then fails with `strconv.Atoi: parsing "\"0": invalid syntax` because it tries to parse `"0` as an integer. This is a common Docker Compose pattern and was not handled by Watchtower.

## Solution

Strip single and double quotes from the schedule specification string before passing it to the cron parser, following the same pattern already used for `DOCKER_API_VERSION` in the flags package. The fix is applied at the point of consumption in the scheduling code, protecting against quotes from any source (env var or CLI flag).

## Changes

- `internal/scheduling/scheduling.go` -- Added `strings.Trim(scheduleSpec, `"'`)` to strip wrapping quotes from the schedule spec before cron parsing, and added `"strings"` import
- `internal/scheduling/scheduling_test.go` -- Added `TestRunUpgradesOnSchedule_QuotedScheduleSpec` with 6 test cases covering double-quoted cron, single-quoted cron, double-quoted descriptor, unquoted variants, and double-quoted invalid specs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Schedule specifications now properly handle quoted cron expressions, accepting both single and double-quoted inputs alongside unquoted formats (e.g., `"0 0 2 * * *"`, `'0 0 2 * * *'`, or `@hourly`).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/watchtower/pull/1686?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->