### PR TITLE
feat: add Docker registry mirror support for digest comparison

### DIFF
--- a/build/mkdocs/mkdocs.yaml
+++ b/build/mkdocs/mkdocs.yaml
@@ -188,6 +188,7 @@ nav:
       - Lifecycle Hooks: advanced-features/lifecycle-hooks/index.md
       - Linked Containers: advanced-features/linked-containers/index.md
       - Metrics API: advanced-features/metrics-api/index.md
+      - Registry Mirrors: advanced-features/registry-mirrors/index.md
       - Remote Hosts: advanced-features/remote-hosts/index.md
       - Running Multiple Instances: advanced-features/running-multiple-instances/index.md
       - Stop Signals: advanced-features/stop-signals/index.md

--- a/docs/advanced-features/registry-mirrors/index.md
+++ b/docs/advanced-features/registry-mirrors/index.md
@@ -138,7 +138,7 @@ When using internal mirrors that may use self-signed certificates:
     "registry-mirrors": [
         "https://harbor.internal.company.com"
     ],
-  "insecure-registries": [
+    "insecure-registries": [
         "harbor.internal.company.com"
     ]
 }

--- a/docs/advanced-features/registry-mirrors/index.md
+++ b/docs/advanced-features/registry-mirrors/index.md
@@ -7,7 +7,7 @@ Registry mirrors provide alternative locations for pulling Docker images, useful
 When the Docker daemon is configured with registry mirrors, Watchtower automatically detects and uses them during its update checks. This means:
 
 - **Digest comparisons** — Watchtower fetches image manifests from mirrors before falling back to the canonical registry, so it can detect updates even when the primary registry is inaccessible.
-- **All registries supported** — Mirrors can be configured globally (for all registries) or per-registry (e.g., a dedicated mirror for Docker Hub and a separate one for a private registry).
+- **All registries supported** — Global mirrors apply to all image registries (Docker Hub, GHCR, private registries, etc.).
 
 !!! Note
     Mirror support in Watchtower covers **digest comparison only** — determining whether a newer image exists. The actual image pull is handled by the Docker daemon, which already uses configured mirrors natively.
@@ -28,7 +28,7 @@ After making changes, restart the daemon:
 sudo systemctl restart docker
 ```
 
-### Global Mirrors
+### Configuration Format
 
 Global mirrors apply to all image registries. Add them under the `registry-mirrors` key:
 
@@ -42,43 +42,20 @@ Global mirrors apply to all image registries. Add them under the `registry-mirro
 
 When multiple mirrors are listed, they are tried in order until one succeeds.
 
-### Per-Registry Mirrors
-
-For more granular control, configure mirrors for specific registries using the `registries` key. Each entry maps a registry name to its list of mirrors:
-
-```json title="/etc/docker/daemon.json"
-{
-    "registries": {
-        "docker.io": [
-            "https://docker-hub-mirror.example.com"
-        ],
-        "registry.example.com": [
-            "https://private-mirror.example.com"
-        ]
-    }
-}
-```
-
-This is useful when different registries have different mirrors — for example, a local Harbor instance for Docker Hub and a separate Artifactory for a private registry.
-
 ### Command-Line Configuration
 
-Global mirrors can also be set via the `dockerd` command line:
+Mirrors can also be set via the `dockerd` command line:
 
 ```bash
 dockerd --registry-mirror https://mirror.example.com
 ```
 
-!!! Note
-    Per-registry mirrors can only be configured in `daemon.json`, not via command-line flags.
-
-## How Watchtower Selects a Mirror
+## How Watchtower Uses Mirrors
 
 When checking if a container's image has been updated, Watchtower resolves the mirror to use in this order:
 
-1. **Per-registry mirrors** — If the image's registry (e.g., `docker.io`) has dedicated mirrors configured, those are tried first.
-2. **Global mirrors** — If no per-registry mirrors exist (or they all fail), the global mirror list is tried.
-3. **Canonical registry** — If all mirrors fail, Watchtower falls back to the original registry (e.g., `index.docker.io`).
+1. **Configured mirrors** — The global mirror list from the Docker daemon is tried first.
+2. **Canonical registry** — If all mirrors fail, Watchtower falls back to the original registry (e.g., `index.docker.io`).
 
 The first mirror to successfully respond with the image manifest wins. This means a fast, nearby mirror is preferred over a distant canonical registry.
 
@@ -106,26 +83,6 @@ Mirrors are tried in the order listed. If the first is unreachable, the next is 
         "https://primary-mirror.company.com",
         "https://backup-mirror.company.com"
     ]
-}
-```
-
-### Dedicated Mirrors per Registry
-
-Different registries use different mirrors. This is useful in corporate environments where each registry has its own local cache:
-
-```json title="/etc/docker/daemon.json"
-{
-    "registries": {
-        "docker.io": [
-            "https://docker-hub-mirror.company.com"
-        ],
-        "ghcr.io": [
-            "https://ghcr-mirror.company.com"
-        ],
-        "registry.internal.company.com": [
-            "https://harbor.internal.company.com"
-        ]
-    }
 }
 ```
 

--- a/docs/advanced-features/registry-mirrors/index.md
+++ b/docs/advanced-features/registry-mirrors/index.md
@@ -1,0 +1,185 @@
+# Registry Mirrors
+
+Registry mirrors provide alternative locations for pulling Docker images, useful when access to the default registry is slow, unreliable, or restricted by network policy. Watchtower uses these mirrors when checking whether containers need updates, ensuring it can detect new images even when the primary registry is unreachable.
+
+## Overview
+
+When the Docker daemon is configured with registry mirrors, Watchtower automatically detects and uses them during its update checks. This means:
+
+- **Digest comparisons** — Watchtower fetches image manifests from mirrors before falling back to the canonical registry, so it can detect updates even when the primary registry is inaccessible.
+- **All registries supported** — Mirrors can be configured globally (for all registries) or per-registry (e.g., a dedicated mirror for Docker Hub and a separate one for a private registry).
+
+!!! Note
+    Mirror support in Watchtower covers **digest comparison only** — determining whether a newer image exists. The actual image pull is handled by the Docker daemon, which already uses configured mirrors natively.
+
+## Configuring Registry Mirrors
+
+Registry mirrors are configured in the Docker daemon, not in Watchtower itself.
+
+### Configuration File
+
+- **Linux**: `/etc/docker/daemon.json`
+- **Windows**: `C:\ProgramData\docker\config\daemon.json`
+- **Rootless mode**: `~/.config/docker/daemon.json`
+
+After making changes, restart the daemon:
+
+```bash title="Linux with systemd"
+sudo systemctl restart docker
+```
+
+### Global Mirrors
+
+Global mirrors apply to all image registries. Add them under the `registry-mirrors` key:
+
+```json title="/etc/docker/daemon.json"
+{
+    "registry-mirrors": [
+        "https://mirror.example.com"
+    ]
+}
+```
+
+When multiple mirrors are listed, they are tried in order until one succeeds.
+
+### Per-Registry Mirrors
+
+For more granular control, configure mirrors for specific registries using the `registries` key. Each entry maps a registry name to its list of mirrors:
+
+```json title="/etc/docker/daemon.json"
+{
+    "registries": {
+        "docker.io": [
+            "https://docker-hub-mirror.example.com"
+        ],
+        "registry.example.com": [
+            "https://private-mirror.example.com"
+        ]
+    }
+}
+```
+
+This is useful when different registries have different mirrors — for example, a local Harbor instance for Docker Hub and a separate Artifactory for a private registry.
+
+### Command-Line Configuration
+
+Global mirrors can also be set via the `dockerd` command line:
+
+```bash
+dockerd --registry-mirror https://mirror.example.com
+```
+
+!!! Note
+    Per-registry mirrors can only be configured in `daemon.json`, not via command-line flags.
+
+## How Watchtower Selects a Mirror
+
+When checking if a container's image has been updated, Watchtower resolves the mirror to use in this order:
+
+1. **Per-registry mirrors** — If the image's registry (e.g., `docker.io`) has dedicated mirrors configured, those are tried first.
+2. **Global mirrors** — If no per-registry mirrors exist (or they all fail), the global mirror list is tried.
+3. **Canonical registry** — If all mirrors fail, Watchtower falls back to the original registry (e.g., `index.docker.io`).
+
+The first mirror to successfully respond with the image manifest wins. This means a fast, nearby mirror is preferred over a distant canonical registry.
+
+## Configuration Examples
+
+### Single Global Mirror
+
+A single mirror used for all registries:
+
+```json title="/etc/docker/daemon.json"
+{
+    "registry-mirrors": [
+        "https://docker-mirror.company.com"
+    ]
+}
+```
+
+### Multiple Mirrors with Redundancy
+
+Mirrors are tried in the order listed. If the first is unreachable, the next is used:
+
+```json title="/etc/docker/daemon.json"
+{
+    "registry-mirrors": [
+        "https://primary-mirror.company.com",
+        "https://backup-mirror.company.com"
+    ]
+}
+```
+
+### Dedicated Mirrors per Registry
+
+Different registries use different mirrors. This is useful in corporate environments where each registry has its own local cache:
+
+```json title="/etc/docker/daemon.json"
+{
+    "registries": {
+        "docker.io": [
+            "https://docker-hub-mirror.company.com"
+        ],
+        "ghcr.io": [
+            "https://ghcr-mirror.company.com"
+        ],
+        "registry.internal.company.com": [
+            "https://harbor.internal.company.com"
+        ]
+    }
+}
+```
+
+### Corporate Proxy Environment
+
+When using internal mirrors that may use self-signed certificates:
+
+```json title="/etc/docker/daemon.json"
+{
+    "registry-mirrors": [
+        "https://harbor.internal.company.com"
+    ],
+  "insecure-registries": [
+        "harbor.internal.company.com"
+    ]
+}
+```
+
+## Troubleshooting
+
+### Mirrors Not Being Used
+
+1. **Verify daemon configuration** — Confirm that `/etc/docker/daemon.json` contains valid JSON and the Docker daemon has been restarted since the last change.
+2. **Enable debug logging** — Run Watchtower with debug logging to see mirror resolution in action:
+
+    ```bash
+    docker run -d --name watchtower \
+    -e WATCHTOWER_DEBUG=true \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    nickfedor/watchtower
+    ```
+
+    Look for log output containing `Resolved registry mirror configuration`.
+3. **Check network access** — Ensure the host can reach the mirror URLs (e.g., `curl -I https://mirror.example.com/v2/`).
+4. **Verify mirror content** — Confirm the mirror is operational and has the required images.
+
+### Authentication Issues
+
+If a mirror requires authentication, configure credentials in the Docker daemon (e.g., `docker login`). Watchtower uses the same credentials for mirrors as for the canonical registry.
+
+### SSL/TLS Errors
+
+For mirrors using self-signed or internal CA certificates, add them to the `insecure-registries` list:
+
+```json
+{
+  "insecure-registries": ["internal-mirror.company.com"]
+}
+```
+
+!!! Warning
+    Insecure registries accept HTTPS with untrusted certificates. Only use this for internal mirrors under your control.
+
+## Related Features
+
+- [Private Registries](../../configuration/private-registries/index.md) — Authenticating with private image registries
+- [Secure Connections](../../configuration/secure-connections/index.md) — TLS and certificate configuration

--- a/pkg/container/cooldown_test.go
+++ b/pkg/container/cooldown_test.go
@@ -246,6 +246,12 @@ var _ = ginkgo.Describe("PullImage cooldown gate", func() {
 		)
 		gomega.Expect(err).To(gomega.Succeed())
 		mockServer.AppendHandlers(APIVersionPingHandler())
+		mockServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", gomega.MatchRegexp(`/info$`)),
+				ghttp.RespondWithJSONEncoded(http.StatusOK, map[string]any{}),
+			),
+		)
 	})
 
 	ginkgo.AfterEach(func() {

--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -351,8 +351,15 @@ func (c imageClient) shouldSkipPull(
 	clog.Debug("Checking if pull is needed")
 
 	warn := c.warnOnHeadFailed(sourceContainer, warnOnHeadFailed)
-	// Compare current and remote digests.
-	match, err := digest.CompareDigest(ctx, sourceContainer, registryAuth)
+
+	// Resolve registry mirror configuration from Docker daemon.
+	mirrorInfo := c.resolveRegistryMirrorConfig(ctx)
+
+	// Build candidate endpoints: mirrors first, then canonical (empty string).
+	endpoints := c.buildMirrorEndpoints(sourceContainer, mirrorInfo)
+
+	// Compare current and remote digests, trying each endpoint.
+	match, err := digest.CompareDigest(ctx, sourceContainer, registryAuth, endpoints...)
 	if err != nil {
 		clog.WithFields(logrus.Fields{
 			"match": match,

--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -356,7 +356,7 @@ func (c imageClient) shouldSkipPull(
 	mirrorInfo := c.resolveRegistryMirrorConfig(ctx)
 
 	// Build candidate endpoints: mirrors first, then canonical (empty string).
-	endpoints := c.buildMirrorEndpoints(sourceContainer, mirrorInfo)
+	endpoints := c.buildMirrorEndpoints(mirrorInfo)
 
 	// Compare current and remote digests, trying each endpoint.
 	match, err := digest.CompareDigest(ctx, sourceContainer, registryAuth, endpoints...)

--- a/pkg/container/image_test.go
+++ b/pkg/container/image_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -40,6 +41,7 @@ var _ = ginkgo.Describe("the client", func() {
 		)
 		gomega.Expect(err).To(gomega.Succeed())
 		mockServer.AppendHandlers(APIVersionPingHandler())
+		mockServer.RouteToHandler("GET", regexp.MustCompile(`/info$`), ghttp.RespondWithJSONEncoded(http.StatusOK, map[string]any{}))
 	})
 	ginkgo.AfterEach(func() {
 		mockServer.Close()
@@ -92,6 +94,7 @@ var _ = ginkgo.Describe("the client", func() {
 	})
 	ginkgo.When("pulling an image that requires authentication", func() {
 		ginkgo.It("should log at Warn level and return ErrPullImageUnauthorized for auth failures", func() {
+			mockServer.AllowUnhandledRequests = true
 			mockServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("POST", gomega.MatchRegexp("/images/create")),
@@ -119,6 +122,7 @@ var _ = ginkgo.Describe("the client", func() {
 	})
 	ginkgo.When("pulling an image that does not exist in registry", func() {
 		ginkgo.It("should log at Debug level and return ErrPullImageNotFound for not found errors", func() {
+			mockServer.AllowUnhandledRequests = true
 			mockServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("POST", gomega.MatchRegexp("/images/create")),
@@ -145,6 +149,7 @@ var _ = ginkgo.Describe("the client", func() {
 	})
 	ginkgo.When("pulling an image with a server error", func() {
 		ginkgo.It("should log at Debug level and return errPullImageFailed for other errors", func() {
+			mockServer.AllowUnhandledRequests = true
 			mockServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("POST", gomega.MatchRegexp("/images/create")),
@@ -170,6 +175,60 @@ var _ = ginkgo.Describe("the client", func() {
 			gomega.Eventually(logbuf).Should(gbytes.Say(`Failed to initiate image pull`))
 		})
 	})
+
+	ginkgo.When("pulling an image with registry mirrors configured", func() {
+		ginkgo.It("should use canonical host when mirror Info() returns no mirrors", func() {
+			// The RouteToHandler for /info already returns empty JSON (no RegistryConfig).
+			// This tests the fallback path: no mirrors configured, should use canonical host.
+			mockServer.AllowUnhandledRequests = true
+			mockServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", gomega.MatchRegexp("/images/create")),
+					ghttp.RespondWith(http.StatusUnauthorized, `{"message":"unauthorized"}`),
+				),
+			)
+
+			i := newImageClient(mockClient)
+			pullContainer := MockContainer(
+				WithImageName("private-registry.io/app:latest"),
+				WithRepoDigests([]string{"private-registry.io/app@sha256:abc"}),
+			)
+
+			err := i.PullImage(context.Background(), pullContainer, WarnAuto, types.UpdateParams{})
+			// Should proceed to pull (shouldSkipPull returns false since no mirrors and
+			// canonical registry request fails), resulting in an error from the pull attempt.
+			gomega.Expect(err).To(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should handle Info() API failure gracefully and fall back to canonical", func() {
+			// Override the /info RouteToHandler by appending a failing handler first.
+			// Since RouteToHandler always matches, we need to reset it to return an error.
+			mockServer.RouteToHandler("GET", regexp.MustCompile(`/info$`),
+				ghttp.RespondWith(http.StatusInternalServerError, "daemon error"),
+			)
+			mockServer.AllowUnhandledRequests = true
+			mockServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", gomega.MatchRegexp("/images/create")),
+					ghttp.RespondWith(http.StatusUnauthorized, `{"message":"unauthorized"}`),
+				),
+			)
+
+			i := newImageClient(mockClient)
+			pullContainer := MockContainer(
+				WithImageName("private-registry.io/app:latest"),
+				WithRepoDigests([]string{"private-registry.io/app@sha256:abc"}),
+			)
+
+			err := i.PullImage(context.Background(), pullContainer, WarnAuto, types.UpdateParams{})
+			// Info() fails, so resolveRegistryMirrorConfig returns nil, buildMirrorEndpoints
+			// returns nil, and shouldSkipPull falls back to canonical host. Since AllowUnhandledRequests
+			// is true, the canonical digest check gets a handled response, and skip returns false,
+			// proceeding to the pull which returns 401.
+			gomega.Expect(err).To(gomega.HaveOccurred())
+		})
+	})
+
 	ginkgo.When("removing a image", func() {
 		ginkgo.When("debug logging is enabled", func() {
 			ginkgo.It("should log removed and untagged images", func() {

--- a/pkg/container/image_test.go
+++ b/pkg/container/image_test.go
@@ -196,8 +196,8 @@ var _ = ginkgo.Describe("the client", func() {
 
 			err := i.PullImage(context.Background(), pullContainer, WarnAuto, types.UpdateParams{})
 			// Should proceed to pull (shouldSkipPull returns false since no mirrors and
-			// canonical registry request fails), resulting in an error from the pull attempt.
-			gomega.Expect(err).To(gomega.HaveOccurred())
+			// canonical registry request fails), resulting in ErrPullImageUnauthorized.
+			gomega.Expect(errors.Is(err, ErrPullImageUnauthorized)).To(gomega.BeTrue())
 		})
 
 		ginkgo.It("should handle Info() API failure gracefully and fall back to canonical", func() {
@@ -222,10 +222,8 @@ var _ = ginkgo.Describe("the client", func() {
 
 			err := i.PullImage(context.Background(), pullContainer, WarnAuto, types.UpdateParams{})
 			// Info() fails, so resolveRegistryMirrorConfig returns nil, buildMirrorEndpoints
-			// returns nil, and shouldSkipPull falls back to canonical host. Since AllowUnhandledRequests
-			// is true, the canonical digest check gets a handled response, and skip returns false,
-			// proceeding to the pull which returns 401.
-			gomega.Expect(err).To(gomega.HaveOccurred())
+			// returns nil, and shouldSkipPull falls back to canonical host.
+			gomega.Expect(errors.Is(err, ErrPullImageUnauthorized)).To(gomega.BeTrue())
 		})
 	})
 

--- a/pkg/container/mirror.go
+++ b/pkg/container/mirror.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"net/url"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -44,8 +45,18 @@ func (c imageClient) resolveRegistryMirrorConfig(ctx context.Context) *dockerSys
 		return nil
 	}
 
+	sanitized := make([]string, 0, len(info.Info.RegistryConfig.Mirrors))
+	for _, m := range info.Info.RegistryConfig.Mirrors {
+		u, err := url.Parse(m)
+		if err == nil && u.Host != "" {
+			sanitized = append(sanitized, u.Host)
+		} else {
+			sanitized = append(sanitized, "<redacted>")
+		}
+	}
+
 	logrus.WithFields(logrus.Fields{
-		"global_mirrors": info.Info.RegistryConfig.Mirrors,
+		"global_mirrors": sanitized,
 	}).Debug("Resolved registry mirror configuration from Docker daemon")
 
 	return &info.Info

--- a/pkg/container/mirror.go
+++ b/pkg/container/mirror.go
@@ -8,15 +8,11 @@ import (
 
 	dockerSystem "github.com/moby/moby/api/types/system"
 	dockerClient "github.com/moby/moby/client"
-
-	"github.com/nicholas-fedor/watchtower/pkg/registry/auth"
-	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
 // resolveRegistryMirrorConfig fetches the registry mirror configuration from the Docker daemon.
 //
-// It calls Info() and returns the system.Info containing both global mirrors
-// (RegistryConfig.Mirrors) and per-registry mirrors (RegistryConfig.IndexConfigs).
+// It calls Info() and returns the system.Info containing global mirrors (RegistryConfig.Mirrors).
 // Returns nil if the call fails or no mirrors are configured.
 //
 // Parameters:
@@ -42,18 +38,14 @@ func (c imageClient) resolveRegistryMirrorConfig(ctx context.Context) *dockerSys
 		return nil
 	}
 
-	hasGlobal := len(info.Info.RegistryConfig.Mirrors) > 0
-	hasPerRegistry := len(info.Info.RegistryConfig.IndexConfigs) > 0
-
-	if !hasGlobal && !hasPerRegistry {
+	if len(info.Info.RegistryConfig.Mirrors) == 0 {
 		logrus.Debug("No registry mirrors configured in Docker daemon")
 
 		return nil
 	}
 
 	logrus.WithFields(logrus.Fields{
-		"global_mirrors":     info.Info.RegistryConfig.Mirrors,
-		"per_registry_count": len(info.Info.RegistryConfig.IndexConfigs),
+		"global_mirrors": info.Info.RegistryConfig.Mirrors,
 	}).Debug("Resolved registry mirror configuration from Docker daemon")
 
 	return &info.Info
@@ -61,52 +53,25 @@ func (c imageClient) resolveRegistryMirrorConfig(ctx context.Context) *dockerSys
 
 // buildMirrorEndpoints returns the list of registry endpoints to try for digest comparison.
 //
-// It checks per-registry mirrors first (from IndexConfigs), then falls back to global mirrors.
-// An empty string in the returned list means use the canonical registry host. The canonical
-// host is always appended as the final fallback.
+// It uses the global mirrors from the Docker daemon configuration.
+// An empty string in the returned list means use the canonical registry host.
+// The canonical host is always appended as the final fallback.
 //
-// Mirrors are resolved for all registries, not just Docker Hub.
-// If no mirrors are configured for the image's registry, nil is returned (use canonical behavior).
+// If no mirrors are configured, nil is returned (use canonical behavior).
 //
 // Parameters:
-//   - sourceContainer: The container whose image is being checked.
 //   - info: System info with mirror configuration from the Docker daemon (may be nil).
 //
 // Returns:
 //   - []string: List of host overrides to try. Empty string means use canonical host.
 func (c imageClient) buildMirrorEndpoints(
-	sourceContainer types.Container,
 	info *dockerSystem.Info,
 ) []string {
 	if info == nil || info.RegistryConfig == nil {
 		return nil
 	}
 
-	registryHost, err := auth.GetRegistryAddress(sourceContainer.ImageName())
-	if err != nil {
-		return nil
-	}
-
-	var mirrors []string
-
-	// Check per-registry mirrors for the canonical host first.
-	if idx, ok := info.RegistryConfig.IndexConfigs[registryHost]; ok {
-		mirrors = append(mirrors, idx.Mirrors...)
-	}
-
-	// For Docker Hub images, fall back to the docker.io domain key
-	// (the canonical host is index.docker.io but IndexConfigs uses docker.io).
-	if len(mirrors) == 0 && registryHost == auth.DockerRegistryHost {
-		if idx, ok := info.RegistryConfig.IndexConfigs[auth.DockerRegistryDomain]; ok {
-			mirrors = append(mirrors, idx.Mirrors...)
-		}
-	}
-
-	// Fall back to global mirrors if no per-registry mirrors found.
-	if len(mirrors) == 0 {
-		mirrors = info.RegistryConfig.Mirrors
-	}
-
+	mirrors := info.RegistryConfig.Mirrors
 	if len(mirrors) == 0 {
 		return nil
 	}

--- a/pkg/container/mirror.go
+++ b/pkg/container/mirror.go
@@ -1,0 +1,127 @@
+package container
+
+import (
+	"context"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	dockerSystem "github.com/moby/moby/api/types/system"
+	dockerClient "github.com/moby/moby/client"
+
+	"github.com/nicholas-fedor/watchtower/pkg/registry/auth"
+	"github.com/nicholas-fedor/watchtower/pkg/types"
+)
+
+// resolveRegistryMirrorConfig fetches the registry mirror configuration from the Docker daemon.
+//
+// It calls Info() and returns the system.Info containing both global mirrors
+// (RegistryConfig.Mirrors) and per-registry mirrors (RegistryConfig.IndexConfigs).
+// Returns nil if the call fails or no mirrors are configured.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeout control.
+//
+// Returns:
+//   - *dockerSystem.Info: System info with mirror configuration, or nil if unavailable.
+func (c imageClient) resolveRegistryMirrorConfig(ctx context.Context) *dockerSystem.Info {
+	info, err := c.api.Info(
+		ctx,
+		dockerClient.InfoOptions{},
+	)
+	if err != nil {
+		logrus.WithError(err).
+			Debug("Failed to get system info for registry mirror resolution")
+
+		return nil
+	}
+
+	if info.Info.RegistryConfig == nil {
+		logrus.Debug("No registry mirror configuration in Docker daemon")
+
+		return nil
+	}
+
+	hasGlobal := len(info.Info.RegistryConfig.Mirrors) > 0
+	hasPerRegistry := len(info.Info.RegistryConfig.IndexConfigs) > 0
+
+	if !hasGlobal && !hasPerRegistry {
+		logrus.Debug("No registry mirrors configured in Docker daemon")
+
+		return nil
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"global_mirrors":     info.Info.RegistryConfig.Mirrors,
+		"per_registry_count": len(info.Info.RegistryConfig.IndexConfigs),
+	}).Debug("Resolved registry mirror configuration from Docker daemon")
+
+	return &info.Info
+}
+
+// buildMirrorEndpoints returns the list of registry endpoints to try for digest comparison.
+//
+// It checks per-registry mirrors first (from IndexConfigs), then falls back to global mirrors.
+// An empty string in the returned list means use the canonical registry host. The canonical
+// host is always appended as the final fallback.
+//
+// Mirrors are resolved for all registries, not just Docker Hub.
+// If no mirrors are configured for the image's registry, nil is returned (use canonical behavior).
+//
+// Parameters:
+//   - sourceContainer: The container whose image is being checked.
+//   - info: System info with mirror configuration from the Docker daemon (may be nil).
+//
+// Returns:
+//   - []string: List of host overrides to try. Empty string means use canonical host.
+func (c imageClient) buildMirrorEndpoints(
+	sourceContainer types.Container,
+	info *dockerSystem.Info,
+) []string {
+	if info == nil || info.RegistryConfig == nil {
+		return nil
+	}
+
+	registryHost, err := auth.GetRegistryAddress(sourceContainer.ImageName())
+	if err != nil {
+		return nil
+	}
+
+	var mirrors []string
+
+	// Check per-registry mirrors for the canonical host first.
+	if idx, ok := info.RegistryConfig.IndexConfigs[registryHost]; ok {
+		mirrors = append(mirrors, idx.Mirrors...)
+	}
+
+	// For Docker Hub images, fall back to the docker.io domain key
+	// (the canonical host is index.docker.io but IndexConfigs uses docker.io).
+	if len(mirrors) == 0 && registryHost == auth.DockerRegistryHost {
+		if idx, ok := info.RegistryConfig.IndexConfigs[auth.DockerRegistryDomain]; ok {
+			mirrors = append(mirrors, idx.Mirrors...)
+		}
+	}
+
+	// Fall back to global mirrors if no per-registry mirrors found.
+	if len(mirrors) == 0 {
+		mirrors = info.RegistryConfig.Mirrors
+	}
+
+	if len(mirrors) == 0 {
+		return nil
+	}
+
+	endpoints := make([]string, 0, len(mirrors)+1)
+
+	for _, mirror := range mirrors {
+		mirror = strings.TrimSpace(mirror)
+		if mirror != "" {
+			endpoints = append(endpoints, mirror)
+		}
+	}
+
+	// Always append canonical host as final fallback.
+	endpoints = append(endpoints, "")
+
+	return endpoints
+}

--- a/pkg/container/mirror_test.go
+++ b/pkg/container/mirror_test.go
@@ -11,37 +11,31 @@ import (
 
 func Test_imageClient_buildMirrorEndpoints(t *testing.T) {
 	tests := []struct {
-		name           string
-		containerImage string
-		info           *dockerSystem.Info
-		want           []string
+		name string
+		info *dockerSystem.Info
+		want []string
 	}{
 		{
-			name:           "nil info returns nil",
-			containerImage: "docker.io/library/nginx:latest",
-			info:           nil,
-			want:           nil,
+			name: "nil info returns nil",
+			info: nil,
+			want: nil,
 		},
 		{
-			name:           "nil RegistryConfig returns nil",
-			containerImage: "docker.io/library/nginx:latest",
-			info:           &dockerSystem.Info{},
-			want:           nil,
+			name: "nil RegistryConfig returns nil",
+			info: &dockerSystem.Info{},
+			want: nil,
 		},
 		{
-			name:           "no mirrors configured returns nil",
-			containerImage: "docker.io/library/nginx:latest",
+			name: "no mirrors configured returns nil",
 			info: &dockerSystem.Info{
 				RegistryConfig: &dockerRegistry.ServiceConfig{
-					Mirrors:      []string{},
-					IndexConfigs: map[string]*dockerRegistry.IndexInfo{},
+					Mirrors: []string{},
 				},
 			},
 			want: nil,
 		},
 		{
-			name:           "global mirrors applied to docker hub image",
-			containerImage: "docker.io/library/nginx:latest",
+			name: "global mirrors applied to docker hub image",
 			info: &dockerSystem.Info{
 				RegistryConfig: &dockerRegistry.ServiceConfig{
 					Mirrors: []string{"https://mirror.example.com"},
@@ -50,37 +44,7 @@ func Test_imageClient_buildMirrorEndpoints(t *testing.T) {
 			want: []string{"https://mirror.example.com", ""},
 		},
 		{
-			name:           "per-registry mirrors take precedence over global",
-			containerImage: "docker.io/library/nginx:latest",
-			info: &dockerSystem.Info{
-				RegistryConfig: &dockerRegistry.ServiceConfig{
-					Mirrors: []string{"https://global-mirror.example.com"},
-					IndexConfigs: map[string]*dockerRegistry.IndexInfo{
-						"docker.io": {
-							Mirrors: []string{"https://docker-hub-mirror.example.com"},
-						},
-					},
-				},
-			},
-			want: []string{"https://docker-hub-mirror.example.com", ""},
-		},
-		{
-			name:           "per-registry mirrors used when no global mirrors",
-			containerImage: "docker.io/library/nginx:latest",
-			info: &dockerSystem.Info{
-				RegistryConfig: &dockerRegistry.ServiceConfig{
-					IndexConfigs: map[string]*dockerRegistry.IndexInfo{
-						"docker.io": {
-							Mirrors: []string{"https://docker-hub-mirror.example.com"},
-						},
-					},
-				},
-			},
-			want: []string{"https://docker-hub-mirror.example.com", ""},
-		},
-		{
-			name:           "non-hub image uses global mirrors",
-			containerImage: "ghcr.io/owner/image:latest",
+			name: "non-hub image uses global mirrors",
 			info: &dockerSystem.Info{
 				RegistryConfig: &dockerRegistry.ServiceConfig{
 					Mirrors: []string{"https://global-mirror.example.com"},
@@ -89,38 +53,7 @@ func Test_imageClient_buildMirrorEndpoints(t *testing.T) {
 			want: []string{"https://global-mirror.example.com", ""},
 		},
 		{
-			name:           "non-hub image with per-registry mirror uses dedicated mirror",
-			containerImage: "ghcr.io/owner/image:latest",
-			info: &dockerSystem.Info{
-				RegistryConfig: &dockerRegistry.ServiceConfig{
-					Mirrors: []string{"https://global-mirror.example.com"},
-					IndexConfigs: map[string]*dockerRegistry.IndexInfo{
-						"ghcr.io": {
-							Mirrors: []string{"https://ghcr-mirror.example.com"},
-						},
-					},
-				},
-			},
-			want: []string{"https://ghcr-mirror.example.com", ""},
-		},
-		{
-			name:           "non-hub image without dedicated mirror falls back to global",
-			containerImage: "ghcr.io/owner/image:latest",
-			info: &dockerSystem.Info{
-				RegistryConfig: &dockerRegistry.ServiceConfig{
-					Mirrors: []string{"https://global-mirror.example.com"},
-					IndexConfigs: map[string]*dockerRegistry.IndexInfo{
-						"docker.io": {
-							Mirrors: []string{"https://docker-hub-mirror.example.com"},
-						},
-					},
-				},
-			},
-			want: []string{"https://global-mirror.example.com", ""},
-		},
-		{
-			name:           "multiple mirrors tried in order",
-			containerImage: "docker.io/library/nginx:latest",
+			name: "multiple mirrors tried in order",
 			info: &dockerSystem.Info{
 				RegistryConfig: &dockerRegistry.ServiceConfig{
 					Mirrors: []string{
@@ -136,8 +69,7 @@ func Test_imageClient_buildMirrorEndpoints(t *testing.T) {
 			},
 		},
 		{
-			name:           "whitespace-only mirrors are skipped",
-			containerImage: "docker.io/library/nginx:latest",
+			name: "whitespace-only mirrors are skipped",
 			info: &dockerSystem.Info{
 				RegistryConfig: &dockerRegistry.ServiceConfig{
 					Mirrors: []string{"  ", "https://mirror.example.com", "   "},
@@ -146,8 +78,7 @@ func Test_imageClient_buildMirrorEndpoints(t *testing.T) {
 			want: []string{"https://mirror.example.com", ""},
 		},
 		{
-			name:           "empty mirrors are skipped",
-			containerImage: "docker.io/library/nginx:latest",
+			name: "empty mirrors are skipped",
 			info: &dockerSystem.Info{
 				RegistryConfig: &dockerRegistry.ServiceConfig{
 					Mirrors: []string{"", "https://mirror.example.com", ""},
@@ -156,8 +87,7 @@ func Test_imageClient_buildMirrorEndpoints(t *testing.T) {
 			want: []string{"https://mirror.example.com", ""},
 		},
 		{
-			name:           "canonical host always appended as final fallback",
-			containerImage: "docker.io/library/nginx:latest",
+			name: "canonical host always appended as final fallback",
 			info: &dockerSystem.Info{
 				RegistryConfig: &dockerRegistry.ServiceConfig{
 					Mirrors: []string{"https://mirror.example.com"},
@@ -166,44 +96,7 @@ func Test_imageClient_buildMirrorEndpoints(t *testing.T) {
 			want: []string{"https://mirror.example.com", ""},
 		},
 		{
-			name:           "invalid image name returns nil",
-			containerImage: "!!!invalid:reference",
-			info: &dockerSystem.Info{
-				RegistryConfig: &dockerRegistry.ServiceConfig{
-					Mirrors: []string{"https://mirror.example.com"},
-				},
-			},
-			want: nil,
-		},
-		{
-			name:           "per-registry with empty mirrors falls back to global",
-			containerImage: "docker.io/library/nginx:latest",
-			info: &dockerSystem.Info{
-				RegistryConfig: &dockerRegistry.ServiceConfig{
-					Mirrors: []string{"https://global.example.com"},
-					IndexConfigs: map[string]*dockerRegistry.IndexInfo{
-						"docker.io": {Mirrors: []string{}},
-					},
-				},
-			},
-			want: []string{"https://global.example.com", ""},
-		},
-		{
-			name:           "per-registry with empty mirrors and no global returns nil",
-			containerImage: "docker.io/library/nginx:latest",
-			info: &dockerSystem.Info{
-				RegistryConfig: &dockerRegistry.ServiceConfig{
-					Mirrors: []string{},
-					IndexConfigs: map[string]*dockerRegistry.IndexInfo{
-						"docker.io": {Mirrors: []string{}},
-					},
-				},
-			},
-			want: nil,
-		},
-		{
-			name:           "mirror URL with path and query is kept verbatim",
-			containerImage: "docker.io/library/nginx:latest",
+			name: "mirror URL with path and query is kept verbatim",
 			info: &dockerSystem.Info{
 				RegistryConfig: &dockerRegistry.ServiceConfig{
 					Mirrors: []string{"https://mirror.example.com/v2/?foo=bar#baz"},
@@ -212,8 +105,7 @@ func Test_imageClient_buildMirrorEndpoints(t *testing.T) {
 			want: []string{"https://mirror.example.com/v2/?foo=bar#baz", ""},
 		},
 		{
-			name:           "ipv6 mirror address is supported",
-			containerImage: "docker.io/library/nginx:latest",
+			name: "ipv6 mirror address is supported",
 			info: &dockerSystem.Info{
 				RegistryConfig: &dockerRegistry.ServiceConfig{
 					Mirrors: []string{"https://[2001:db8::1]:5000"},
@@ -226,8 +118,7 @@ func Test_imageClient_buildMirrorEndpoints(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := imageClient{}
-			container := MockContainer(WithImageName(tt.containerImage))
-			got := c.buildMirrorEndpoints(container, tt.info)
+			got := c.buildMirrorEndpoints(tt.info)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/container/mirror_test.go
+++ b/pkg/container/mirror_test.go
@@ -1,0 +1,178 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	dockerRegistry "github.com/moby/moby/api/types/registry"
+	dockerSystem "github.com/moby/moby/api/types/system"
+)
+
+func Test_imageClient_buildMirrorEndpoints(t *testing.T) {
+	tests := []struct {
+		name           string
+		containerImage string
+		info           *dockerSystem.Info
+		want           []string
+	}{
+		{
+			name:           "nil info returns nil",
+			containerImage: "docker.io/library/nginx:latest",
+			info:           nil,
+			want:           nil,
+		},
+		{
+			name:           "nil RegistryConfig returns nil",
+			containerImage: "docker.io/library/nginx:latest",
+			info:           &dockerSystem.Info{},
+			want:           nil,
+		},
+		{
+			name:           "no mirrors configured returns nil",
+			containerImage: "docker.io/library/nginx:latest",
+			info: &dockerSystem.Info{
+				RegistryConfig: &dockerRegistry.ServiceConfig{
+					Mirrors:      []string{},
+					IndexConfigs: map[string]*dockerRegistry.IndexInfo{},
+				},
+			},
+			want: nil,
+		},
+		{
+			name:           "global mirrors applied to docker hub image",
+			containerImage: "docker.io/library/nginx:latest",
+			info: &dockerSystem.Info{
+				RegistryConfig: &dockerRegistry.ServiceConfig{
+					Mirrors: []string{"https://mirror.example.com"},
+				},
+			},
+			want: []string{"https://mirror.example.com", ""},
+		},
+		{
+			name:           "per-registry mirrors take precedence over global",
+			containerImage: "docker.io/library/nginx:latest",
+			info: &dockerSystem.Info{
+				RegistryConfig: &dockerRegistry.ServiceConfig{
+					Mirrors: []string{"https://global-mirror.example.com"},
+					IndexConfigs: map[string]*dockerRegistry.IndexInfo{
+						"docker.io": {
+							Mirrors: []string{"https://docker-hub-mirror.example.com"},
+						},
+					},
+				},
+			},
+			want: []string{"https://docker-hub-mirror.example.com", ""},
+		},
+		{
+			name:           "per-registry mirrors used when no global mirrors",
+			containerImage: "docker.io/library/nginx:latest",
+			info: &dockerSystem.Info{
+				RegistryConfig: &dockerRegistry.ServiceConfig{
+					IndexConfigs: map[string]*dockerRegistry.IndexInfo{
+						"docker.io": {
+							Mirrors: []string{"https://docker-hub-mirror.example.com"},
+						},
+					},
+				},
+			},
+			want: []string{"https://docker-hub-mirror.example.com", ""},
+		},
+		{
+			name:           "non-hub image uses global mirrors",
+			containerImage: "ghcr.io/owner/image:latest",
+			info: &dockerSystem.Info{
+				RegistryConfig: &dockerRegistry.ServiceConfig{
+					Mirrors: []string{"https://global-mirror.example.com"},
+				},
+			},
+			want: []string{"https://global-mirror.example.com", ""},
+		},
+		{
+			name:           "non-hub image with per-registry mirror uses dedicated mirror",
+			containerImage: "ghcr.io/owner/image:latest",
+			info: &dockerSystem.Info{
+				RegistryConfig: &dockerRegistry.ServiceConfig{
+					Mirrors: []string{"https://global-mirror.example.com"},
+					IndexConfigs: map[string]*dockerRegistry.IndexInfo{
+						"ghcr.io": {
+							Mirrors: []string{"https://ghcr-mirror.example.com"},
+						},
+					},
+				},
+			},
+			want: []string{"https://ghcr-mirror.example.com", ""},
+		},
+		{
+			name:           "non-hub image without dedicated mirror falls back to global",
+			containerImage: "ghcr.io/owner/image:latest",
+			info: &dockerSystem.Info{
+				RegistryConfig: &dockerRegistry.ServiceConfig{
+					Mirrors: []string{"https://global-mirror.example.com"},
+					IndexConfigs: map[string]*dockerRegistry.IndexInfo{
+						"docker.io": {
+							Mirrors: []string{"https://docker-hub-mirror.example.com"},
+						},
+					},
+				},
+			},
+			want: []string{"https://global-mirror.example.com", ""},
+		},
+		{
+			name:           "multiple mirrors tried in order",
+			containerImage: "docker.io/library/nginx:latest",
+			info: &dockerSystem.Info{
+				RegistryConfig: &dockerRegistry.ServiceConfig{
+					Mirrors: []string{
+						"https://primary-mirror.example.com",
+						"https://backup-mirror.example.com",
+					},
+				},
+			},
+			want: []string{
+				"https://primary-mirror.example.com",
+				"https://backup-mirror.example.com",
+				"",
+			},
+		},
+		{
+			name:           "whitespace-only mirrors are skipped",
+			containerImage: "docker.io/library/nginx:latest",
+			info: &dockerSystem.Info{
+				RegistryConfig: &dockerRegistry.ServiceConfig{
+					Mirrors: []string{"  ", "https://mirror.example.com", "   "},
+				},
+			},
+			want: []string{"https://mirror.example.com", ""},
+		},
+		{
+			name:           "empty mirrors are skipped",
+			containerImage: "docker.io/library/nginx:latest",
+			info: &dockerSystem.Info{
+				RegistryConfig: &dockerRegistry.ServiceConfig{
+					Mirrors: []string{"", "https://mirror.example.com", ""},
+				},
+			},
+			want: []string{"https://mirror.example.com", ""},
+		},
+		{
+			name:           "canonical host always appended as final fallback",
+			containerImage: "docker.io/library/nginx:latest",
+			info: &dockerSystem.Info{
+				RegistryConfig: &dockerRegistry.ServiceConfig{
+					Mirrors: []string{"https://mirror.example.com"},
+				},
+			},
+			want: []string{"https://mirror.example.com", ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := imageClient{}
+			container := MockContainer(WithImageName(tt.containerImage))
+			got := c.buildMirrorEndpoints(container, tt.info)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/container/mirror_test.go
+++ b/pkg/container/mirror_test.go
@@ -165,6 +165,62 @@ func Test_imageClient_buildMirrorEndpoints(t *testing.T) {
 			},
 			want: []string{"https://mirror.example.com", ""},
 		},
+		{
+			name:           "invalid image name returns nil",
+			containerImage: "!!!invalid:reference",
+			info: &dockerSystem.Info{
+				RegistryConfig: &dockerRegistry.ServiceConfig{
+					Mirrors: []string{"https://mirror.example.com"},
+				},
+			},
+			want: nil,
+		},
+		{
+			name:           "per-registry with empty mirrors falls back to global",
+			containerImage: "docker.io/library/nginx:latest",
+			info: &dockerSystem.Info{
+				RegistryConfig: &dockerRegistry.ServiceConfig{
+					Mirrors: []string{"https://global.example.com"},
+					IndexConfigs: map[string]*dockerRegistry.IndexInfo{
+						"docker.io": {Mirrors: []string{}},
+					},
+				},
+			},
+			want: []string{"https://global.example.com", ""},
+		},
+		{
+			name:           "per-registry with empty mirrors and no global returns nil",
+			containerImage: "docker.io/library/nginx:latest",
+			info: &dockerSystem.Info{
+				RegistryConfig: &dockerRegistry.ServiceConfig{
+					Mirrors: []string{},
+					IndexConfigs: map[string]*dockerRegistry.IndexInfo{
+						"docker.io": {Mirrors: []string{}},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name:           "mirror URL with path and query is kept verbatim",
+			containerImage: "docker.io/library/nginx:latest",
+			info: &dockerSystem.Info{
+				RegistryConfig: &dockerRegistry.ServiceConfig{
+					Mirrors: []string{"https://mirror.example.com/v2/?foo=bar#baz"},
+				},
+			},
+			want: []string{"https://mirror.example.com/v2/?foo=bar#baz", ""},
+		},
+		{
+			name:           "ipv6 mirror address is supported",
+			containerImage: "docker.io/library/nginx:latest",
+			info: &dockerSystem.Info{
+				RegistryConfig: &dockerRegistry.ServiceConfig{
+					Mirrors: []string{"https://[2001:db8::1]:5000"},
+				},
+			},
+			want: []string{"https://[2001:db8::1]:5000", ""},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/registry/age.go
+++ b/pkg/registry/age.go
@@ -138,6 +138,7 @@ func FetchImageCreationTime(
 		container,
 		registryAuth,
 		client,
+		"",
 	)
 	if err != nil {
 		logrus.WithError(err).

--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -331,11 +331,16 @@ func handleBearerAuth(
 
 // GetToken fetches a token and the challenge host for the registry hosting the provided image.
 //
+// When endpoint is non-empty, it is used as the registry host for the challenge URL
+// instead of the canonical registry host. This enables digest checks against configured
+// Docker registry mirrors.
+//
 // Parameters:
 //   - ctx: Context for request lifecycle control.
 //   - container: Container with image info.
 //   - registryAuth: Base64-encoded auth string.
 //   - client: Client for HTTP requests.
+//   - endpoint: Optional registry host override (e.g., mirror address). Empty string uses canonical host.
 //
 // Returns:
 //   - string: Authentication token (e.g., "Basic ..." or "Bearer ...").
@@ -348,6 +353,7 @@ func GetToken(
 	container types.Container,
 	registryAuth string,
 	client Client,
+	endpoint string,
 ) (string, string, bool, string, error) {
 	fields := logrus.Fields{
 		"image": container.ImageName(),
@@ -361,8 +367,8 @@ func GetToken(
 		return "", "", false, "", fmt.Errorf("%w: %w", errFailedParseImageName, err)
 	}
 
-	// Generate the challenge URL.
-	challengeURL := GetChallengeURL(normalizedRef)
+	// Generate the challenge URL, using the endpoint override if provided.
+	challengeURL := GetChallengeURL(normalizedRef, endpoint)
 	logrus.WithFields(fields).
 		WithField("url", challengeURL.String()).
 		Debug("Constructed challenge URL")
@@ -410,8 +416,9 @@ func GetToken(
 	// Extract the challenge header.
 	wwwAuthHeader := res.Header.Get(ChallengeHeader)
 	logrus.WithFields(fields).WithFields(logrus.Fields{
-		"status": res.Status,
-		"header": wwwAuthHeader,
+		"status":  res.Status,
+		"header":  wwwAuthHeader,
+		"mirrors": endpoint,
 	}).Debug("Received challenge response")
 
 	// If the header is empty, assume no authentication is required.
@@ -822,13 +829,17 @@ func TransformAuth(registryAuth string) string {
 
 // GetChallengeURL generates a challenge URL for accessing an image's registry.
 //
+// When endpoint is non-empty, it is used as the host for the challenge URL instead
+// of the canonical registry host. The endpoint may include a scheme (e.g.,
+// "https://mirror.example.com") or be a bare hostname.
+//
 // Parameters:
 //   - imageRef: Normalized image reference.
+//   - endpoint: Optional registry host override (e.g., mirror address). Empty string uses canonical host.
 //
 // Returns:
 //   - url.URL: Generated challenge URL.
-func GetChallengeURL(imageRef reference.Named) url.URL {
-	// Extract registry host from the image reference.
+func GetChallengeURL(imageRef reference.Named, endpoint string) url.URL {
 	host, _ := GetRegistryAddress(imageRef.Name())
 
 	// Special handling for lscr.io registry: use ghcr.io for challenge URL
@@ -843,6 +854,21 @@ func GetChallengeURL(imageRef reference.Named) url.URL {
 
 		logrus.WithField("host", host).
 			Debug("Using HTTP scheme due to WATCHTOWER_REGISTRY_TLS_SKIP")
+	}
+
+	// When an endpoint is provided, parse it to extract host and scheme.
+	if endpoint != "" {
+		endpointURL, err := url.Parse(endpoint)
+		if err == nil && endpointURL.Host != "" {
+			host = endpointURL.Host
+
+			if endpointURL.Scheme != "" {
+				scheme = endpointURL.Scheme
+			}
+		} else {
+			// If parsing fails, use the endpoint as a bare host.
+			host = endpoint
+		}
 	}
 
 	URL := url.URL{

--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -415,10 +415,27 @@ func GetToken(
 
 	// Extract the challenge header.
 	wwwAuthHeader := res.Header.Get(ChallengeHeader)
+	// Log endpoint in sanitized form (host only) to avoid leaking credentials.
+	sanitizedEndpoint := endpoint
+	if endpoint != "" {
+		sanitizedEndpoint = "<redacted>"
+
+		u, err := url.Parse(endpoint)
+		if err == nil && u.Host != "" {
+			sanitizedEndpoint = u.Host
+		}
+	}
+
 	logrus.WithFields(fields).WithFields(logrus.Fields{
 		"status":  res.Status,
 		"header":  wwwAuthHeader,
-		"mirrors": endpoint,
+		"mirrors": sanitizedEndpoint,
+	}).Debug("Received challenge response")
+
+	logrus.WithFields(fields).WithFields(logrus.Fields{
+		"status":  res.Status,
+		"header":  wwwAuthHeader,
+		"mirrors": sanitizedEndpoint,
 	}).Debug("Received challenge response")
 
 	// If the header is empty, assume no authentication is required.

--- a/pkg/registry/auth/auth_benchmark_test.go
+++ b/pkg/registry/auth/auth_benchmark_test.go
@@ -104,7 +104,7 @@ func BenchmarkGetChallengeURL(b *testing.B) {
 
 	for b.Loop() {
 		for _, ref := range refs {
-			_ = GetChallengeURL(ref)
+			_ = GetChallengeURL(ref, "")
 		}
 	}
 }

--- a/pkg/registry/auth/auth_test.go
+++ b/pkg/registry/auth/auth_test.go
@@ -433,6 +433,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 			containerInstance,
 			creds,
 			client,
+			"",
 		)
 
 		gomega.Expect(server.ReceivedRequests()).To(gomega.HaveLen(1))
@@ -514,6 +515,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 					mockContainerInstance,
 					creds,
 					client,
+					"",
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(token).NotTo(gomega.Equal(""))
@@ -569,6 +571,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 				containerInstance,
 				"user:pass",
 				client,
+				"",
 			)
 			gomega.Expect(err).
 				To(gomega.HaveOccurred(), "Expected error due to HTTP request failure")
@@ -618,6 +621,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 					containerInstance,
 					"",
 					client,
+					"",
 				)
 
 				gomega.Expect(server.ReceivedRequests()).To(gomega.HaveLen(1))
@@ -661,6 +665,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 				containerInstance,
 				"",
 				client,
+				"",
 			)
 
 			gomega.Expect(server.ReceivedRequests()).To(gomega.BeEmpty())
@@ -713,6 +718,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 				containerInstance,
 				"",
 				client,
+				"",
 			)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(token).To(gomega.Equal(""))
@@ -755,7 +761,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 
 			// Execute GetToken and verify the result.
-			token, _, _, _, err := auth.GetToken(context.Background(), containerInstance, "", client)
+			token, _, _, _, err := auth.GetToken(context.Background(), containerInstance, "", client, "")
 
 			gomega.Expect(server.ReceivedRequests()).To(gomega.HaveLen(1))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -806,6 +812,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 				containerInstance,
 				"",
 				client,
+				"",
 			)
 
 			gomega.Expect(server.ReceivedRequests()).To(gomega.HaveLen(1))
@@ -848,6 +855,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 				containerInstance,
 				"",
 				client,
+				"",
 			)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).
@@ -913,6 +921,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 				containerInstance,
 				"",
 				client,
+				"",
 			)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(token).To(gomega.Equal("Bearer mock-token"))
@@ -972,6 +981,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 				containerInstance,
 				"",
 				client,
+				"",
 			)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(token).To(gomega.Equal("Bearer mock-token"))
@@ -1050,6 +1060,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 				containerInstance,
 				"",
 				client,
+				"",
 			)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(token).To(gomega.Equal("Bearer mock-token"))
@@ -1135,6 +1146,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 				containerInstance,
 				"",
 				client,
+				"",
 			)
 			gomega.Expect(err).
 				To(gomega.HaveOccurred(), "Expected error due to exceeding redirect limit")
@@ -1418,7 +1430,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 				imageRef, _ := reference.ParseNormalizedNamed(
 					"ghcr.io/nicholas-fedor/watchtower:latest",
 				)
-				gomega.Expect(auth.GetChallengeURL(imageRef)).To(gomega.Equal(expected))
+				gomega.Expect(auth.GetChallengeURL(imageRef, "")).To(gomega.Equal(expected))
 			},
 		)
 
@@ -1427,7 +1439,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 		ginkgo.It("should assume Docker Hub for image refs with no explicit registry", func() {
 			expected := url.URL{Host: "index.docker.io", Scheme: "https", Path: "/v2/"}
 			imageRef, _ := reference.ParseNormalizedNamed("nickfedor/watchtower:latest")
-			gomega.Expect(auth.GetChallengeURL(imageRef)).To(gomega.Equal(expected))
+			gomega.Expect(auth.GetChallengeURL(imageRef, "")).To(gomega.Equal(expected))
 		})
 
 		// Test case: Confirms GetChallengeURL uses "index.docker.io" for "docker.io" registry
@@ -1435,7 +1447,49 @@ var _ = ginkgo.Describe("the auth module", func() {
 		ginkgo.It("should use index.docker.io if the image ref specifies docker.io", func() {
 			expected := url.URL{Host: "index.docker.io", Scheme: "https", Path: "/v2/"}
 			imageRef, _ := reference.ParseNormalizedNamed("docker.io/nickfedor/watchtower:latest")
-			gomega.Expect(auth.GetChallengeURL(imageRef)).To(gomega.Equal(expected))
+			gomega.Expect(auth.GetChallengeURL(imageRef, "")).To(gomega.Equal(expected))
+		})
+
+		// Test case: Verifies GetChallengeURL uses the endpoint host when provided.
+		ginkgo.It("should use endpoint host and scheme when provided", func() {
+			expected := url.URL{Host: "mirror.example.com", Scheme: "https", Path: "/v2/"}
+			imageRef, _ := reference.ParseNormalizedNamed("docker.io/library/nginx:latest")
+			gomega.Expect(auth.GetChallengeURL(imageRef, "https://mirror.example.com")).To(gomega.Equal(expected))
+		})
+
+		// Test case: Verifies GetChallengeURL uses default https scheme for a bare endpoint.
+		ginkgo.It("should use default https scheme for bare endpoint", func() {
+			expected := url.URL{Host: "mirror.example.com", Scheme: "https", Path: "/v2/"}
+			imageRef, _ := reference.ParseNormalizedNamed("docker.io/library/nginx:latest")
+			gomega.Expect(auth.GetChallengeURL(imageRef, "mirror.example.com")).To(gomega.Equal(expected))
+		})
+
+		// Test case: Verifies GetChallengeURL preserves http scheme when endpoint specifies it.
+		ginkgo.It("should use http scheme when endpoint specifies http", func() {
+			expected := url.URL{Host: "mirror.example.com", Scheme: "http", Path: "/v2/"}
+			imageRef, _ := reference.ParseNormalizedNamed("docker.io/library/nginx:latest")
+			gomega.Expect(auth.GetChallengeURL(imageRef, "http://mirror.example.com")).To(gomega.Equal(expected))
+		})
+
+		// Test case: Verifies GetChallengeURL preserves port from endpoint.
+		ginkgo.It("should preserve port from endpoint", func() {
+			expected := url.URL{Host: "mirror.example.com:5000", Scheme: "https", Path: "/v2/"}
+			imageRef, _ := reference.ParseNormalizedNamed("docker.io/library/nginx:latest")
+			gomega.Expect(auth.GetChallengeURL(imageRef, "https://mirror.example.com:5000")).To(gomega.Equal(expected))
+		})
+
+		// Test case: Verifies GetChallengeURL uses endpoint as bare host when URL parsing fails.
+		ginkgo.It("should use endpoint as bare host when URL parsing fails", func() {
+			expected := url.URL{Host: "invalid url with spaces", Scheme: "https", Path: "/v2/"}
+			imageRef, _ := reference.ParseNormalizedNamed("docker.io/library/nginx:latest")
+			gomega.Expect(auth.GetChallengeURL(imageRef, "invalid url with spaces")).To(gomega.Equal(expected))
+		})
+
+		// Test case: Verifies endpoint takes precedence over lscr.io special handling.
+		ginkgo.It("should use endpoint even for lscr.io images", func() {
+			expected := url.URL{Host: "mirror.example.com", Scheme: "https", Path: "/v2/"}
+			imageRef, _ := reference.ParseNormalizedNamed("lscr.io/library/nginx:latest")
+			gomega.Expect(auth.GetChallengeURL(imageRef, "https://mirror.example.com")).To(gomega.Equal(expected))
 		})
 	})
 

--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -351,8 +351,16 @@ func fetchDigest(
 
 	for _, endpoint := range endpoints {
 		epFields := logrus.Fields{}
+
 		if endpoint != "" {
-			epFields["registry_endpoint"] = endpoint
+			sanitized := "<redacted>"
+
+			u, err := url.Parse(endpoint)
+			if err == nil && u.Host != "" {
+				sanitized = u.Host
+			}
+
+			epFields["registry_endpoint"] = sanitized
 		}
 
 		// Obtain an authentication token from the current endpoint.

--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -271,10 +271,8 @@ func BuildManifestURL(
 	}
 
 	if hostOverride != "" {
-		// Support full endpoint strings (e.g. "https://mirror.example.com" or "http://mirror:5000")
-		// similar to how GetChallengeURL handles the endpoint parameter. This allows registry
-		// mirrors (including those configured with explicit schemes in daemon.json) to be used
-		// for manifest requests.
+		// Parse hostOverride to support full endpoint URLs (with scheme) in addition to bare hosts.
+		// Mirrors from daemon.json may include schemes; mirrors the logic in GetChallengeURL.
 		overrideURL, parseErr := url.Parse(hostOverride)
 		if parseErr == nil && overrideURL.Host != "" {
 			parsedURL.Host = overrideURL.Host

--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -191,22 +191,27 @@ func FetchDigest(
 	return fetchDigest(ctx, container, authToken, http.MethodGet, endpoints...)
 }
 
-// BuildManifestURL constructs and validates the manifest URL for a container.
+// BuildManifestURL constructs and validates a manifest URL for a container.
 //
-// It determines the appropriate scheme based on WATCHTOWER_REGISTRY_TLS_SKIP,
-// builds the initial manifest URL using the container's image information,
-// parses it to extract the host, optionally overrides the host if provided,
-// and validates that the host is present.
+// It determines the scheme from WATCHTOWER_REGISTRY_TLS_SKIP, builds the initial URL via
+// manifest.BuildManifestURL (which always uses the canonical host from the image reference),
+// then overrides the host and scheme if hostOverride is a non-empty bare host or full endpoint
+// URL (e.g. "https://mirror.example.com"). It returns the final URL, the original host before
+// override, and the parsed URL object.
+//
+// The hostOverride parameter accepts either a bare host or a full URL. When a full URL is
+// supplied, its scheme (if present) takes precedence over the global TLS setting.
 //
 // Parameters:
 //   - container: Container whose manifest URL is being built.
-//   - hostOverride: Optional host to override the parsed host (empty string to use original).
+//   - hostOverride: Optional host or endpoint URL to use instead of the canonical host.
+//     An empty string uses the canonical host.
 //
 // Returns:
-//   - string: The constructed manifest URL.
-//   - string: The original host extracted from the URL (before override).
-//   - *url.URL: Parsed URL object.
-//   - error: Non-nil if URL construction or validation fails, nil on success.
+//   - string: The final manifest URL.
+//   - string: The original host before applying hostOverride.
+//   - *url.URL: The parsed URL object.
+//   - error: Non-nil if construction or validation fails.
 func BuildManifestURL(
 	container types.Container,
 	hostOverride string,
@@ -266,7 +271,20 @@ func BuildManifestURL(
 	}
 
 	if hostOverride != "" {
-		parsedURL.Host = hostOverride
+		// Support full endpoint strings (e.g. "https://mirror.example.com" or "http://mirror:5000")
+		// similar to how GetChallengeURL handles the endpoint parameter. This allows registry
+		// mirrors (including those configured with explicit schemes in daemon.json) to be used
+		// for manifest requests.
+		overrideURL, parseErr := url.Parse(hostOverride)
+		if parseErr == nil && overrideURL.Host != "" {
+			parsedURL.Host = overrideURL.Host
+			if overrideURL.Scheme != "" {
+				parsedURL.Scheme = overrideURL.Scheme
+			}
+		} else {
+			parsedURL.Host = hostOverride
+		}
+
 		manifestURL = parsedURL.String()
 	}
 
@@ -366,24 +384,28 @@ func fetchDigest(
 				Debug("Received challenge host and redirect flag from GetToken")
 		}
 
-		// Build the manifest URL, using redirect host when redirected.
+		// Decide which host to use for this manifest request attempt.
+		// Priority:
+		// 1. Registry redirect host (from auth challenge, e.g. lscr.io → ghcr.io)
+		// 2. Current mirror endpoint (when using registry mirrors)
+		// 3. Canonical host (empty string)
+		hostForManifest := ""
+		if redirectHost != "" && redirectHost != originalHost && redirected {
+			hostForManifest = redirectHost
+		} else if endpoint != "" {
+			// Use the current registry mirror endpoint for the manifest request.
+			hostForManifest = endpoint
+		}
+
 		var (
 			manifestURL string
 			parsedURL   *url.URL
 		)
 
-		if redirectHost != "" && redirectHost != originalHost && redirected {
-			manifestURL, _, parsedURL, err = BuildManifestURL(
-				container,
-				redirectHost,
-			)
-		} else {
-			manifestURL, _, parsedURL, err = BuildManifestURL(
-				container,
-				"",
-			)
-		}
-
+		manifestURL, _, parsedURL, err = BuildManifestURL(
+			container,
+			hostForManifest,
+		)
 		if err != nil {
 			logrus.WithError(err).WithFields(fields).WithFields(epFields).
 				Debug("Failed to build manifest URL")

--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -81,10 +81,14 @@ func NormalizeDigest(digest string) string {
 // so it returns true to indicate the image should not be updated. This avoids
 // unnecessary HTTP requests and confusing error messages for locally built images.
 //
+// When endpoints are provided (registry mirror hosts), each is tried in order.
+// An empty string in the endpoints list means use the canonical registry host.
+//
 // Parameters:
 //   - ctx: Context for request lifecycle control.
 //   - container: Container whose digest is being compared.
 //   - registryAuth: Base64-encoded auth string.
+//   - endpoints: Optional list of registry mirror host overrides to try before the canonical host.
 //
 // Returns:
 //   - bool: True if digests match (image is up-to-date), false otherwise.
@@ -93,6 +97,7 @@ func CompareDigest(
 	ctx context.Context,
 	container types.Container,
 	registryAuth string,
+	endpoints ...string,
 ) (bool, error) {
 	fields := logrus.Fields{
 		"container": container.Name(),
@@ -129,6 +134,7 @@ func CompareDigest(
 		container,
 		registryAuth,
 		http.MethodHead,
+		endpoints...,
 	)
 	if err != nil {
 		return false, err
@@ -144,6 +150,7 @@ func CompareDigest(
 			ctx,
 			container,
 			registryAuth,
+			endpoints...,
 		)
 		if err != nil {
 			return false, err
@@ -170,6 +177,7 @@ func CompareDigest(
 //   - ctx: The context controlling the request's lifecycle, enabling cancellation or timeouts.
 //   - container: The container whose image digest is being fetched, providing the image name and reference.
 //   - authToken: A base64-encoded authentication string for registry access.
+//   - endpoints: Optional list of registry mirror host overrides to try before the canonical host.
 //
 // Returns:
 //   - string: The normalized digest (e.g., "abc..." without "sha256:") if successful.
@@ -178,8 +186,9 @@ func FetchDigest(
 	ctx context.Context,
 	container types.Container,
 	authToken string,
+	endpoints ...string,
 ) (string, error) {
-	return fetchDigest(ctx, container, authToken, http.MethodGet)
+	return fetchDigest(ctx, container, authToken, http.MethodGet, endpoints...)
 }
 
 // BuildManifestURL constructs and validates the manifest URL for a container.
@@ -266,11 +275,16 @@ func BuildManifestURL(
 
 // fetchDigest retrieves an image digest using the specified HTTP method.
 //
+// When endpoints are provided, each mirror host is tried in order. An empty string
+// endpoint means use the canonical registry host. If all endpoints fail, the last
+// error is returned.
+//
 // Parameters:
 //   - ctx: Context for request lifecycle control.
 //   - container: Container whose digest is being retrieved.
 //   - registryAuth: Base64-encoded auth string.
 //   - method: HTTP method ("HEAD" or "GET").
+//   - endpoints: Optional list of registry mirror host overrides to try before the canonical host.
 //
 // Returns:
 //   - string: Normalized digest.
@@ -280,6 +294,7 @@ func fetchDigest(
 	container types.Container,
 	registryAuth string,
 	method string,
+	endpoints ...string,
 ) (string, error) {
 	fields := logrus.Fields{
 		"container": container.Name(),
@@ -299,7 +314,7 @@ func fetchDigest(
 	// Create an authentication client for registry requests.
 	client := auth.NewAuthClient()
 
-	// Build initial manifest URL to get original host
+	// Build initial manifest URL to get canonical host
 	_, originalHost, _, err := BuildManifestURL(container, "")
 	if err != nil {
 		logrus.WithError(err).WithFields(fields).Debug("Failed to build manifest URL")
@@ -311,131 +326,153 @@ func fetchDigest(
 		WithField("original_host", originalHost).
 		Debug("Extracted original host from manifest URL")
 
-	// Obtain an authentication token and challenge host for the registry.
-	token, challengeHost, redirected, redirectHost, err := auth.GetToken(
-		ctx,
-		container,
-		registryAuth,
-		client,
-	)
-	if err != nil {
-		logrus.WithError(err).WithFields(fields).Debug("Failed to get token")
-
-		return "", fmt.Errorf("%w: %w", errFailedGetToken, err)
+	// If no endpoints specified, use a single empty endpoint (canonical host).
+	if len(endpoints) == 0 {
+		endpoints = []string{""}
 	}
 
-	// If no token is returned, authentication is not required.
-	if token == "" {
-		logrus.WithFields(fields).
-			Debug("No authentication required, proceeding with request")
-	} else {
-		logrus.WithFields(fields).
-			WithField("challenge_host", challengeHost).
-			WithField("redirected", redirected).
-			WithField("redirect_host", redirectHost).
-			Debug("Received challenge host and redirect flag from GetToken")
-	}
+	var lastErr error
 
-	// Build the manifest URL, using redirect host when redirected
-	var (
-		manifestURL string
-		parsedURL   *url.URL
-	)
+	for _, endpoint := range endpoints {
+		epFields := logrus.Fields{}
+		if endpoint != "" {
+			epFields["registry_endpoint"] = endpoint
+		}
 
-	if redirectHost != "" && redirectHost != originalHost && redirected {
-		manifestURL, _, parsedURL, err = BuildManifestURL(
-			container,
-			redirectHost,
-		)
-	} else {
-		manifestURL, _, parsedURL, err = BuildManifestURL(
-			container,
-			"",
-		)
-	}
-
-	if err != nil {
-		logrus.WithError(err).
-			WithFields(fields).
-			Debug("Failed to build manifest URL")
-
-		return "", err
-	}
-
-	logrus.WithFields(fields).WithFields(logrus.Fields{
-		"method": method,
-		"url":    manifestURL,
-	}).Debug("Fetching digest")
-
-	// Create the HTTP request for the manifest.
-	req, err := makeManifestRequest(ctx, method, manifestURL, token)
-	if err != nil {
-		logrus.WithError(err).WithFields(fields).WithFields(logrus.Fields{
-			"method": method,
-			"url":    manifestURL,
-		}).Debug("Failed to create request")
-
-		return "", err
-	}
-
-	// Execute the initial request.
-	resp, err := client.Do(req)
-	if err != nil {
-		logrus.WithError(err).WithFields(fields).WithFields(logrus.Fields{
-			"method": method,
-			"url":    manifestURL,
-		}).Debug("Failed to execute request")
-
-		return "", fmt.Errorf("%w: %w", errFailedExecuteRequest, err)
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	// Handle the manifest response, checking for redirects and extracting digest.
-	digest, updatedURL, retry, err := HandleManifestResponse(
-		resp,
-		method,
-		originalHost,
-		challengeHost,
-		redirected,
-		parsedURL,
-		parsedURL.Host,
-	)
-	if err != nil {
-		logrus.WithError(err).WithFields(fields).WithField("status", resp.Status).
-			Debug("Failed to handle manifest response")
-
-		return "", err
-	}
-
-	if retry && updatedURL != "" {
-		logrus.WithFields(fields).
-			WithField("retry_url", updatedURL).
-			Debug("Retrying manifest request with updated URL")
-
-		digest, err = retryManifestRequest(
+		// Obtain an authentication token from the current endpoint.
+		token, challengeHost, redirected, redirectHost, err := auth.GetToken(
 			ctx,
+			container,
+			registryAuth,
+			client,
+			endpoint,
+		)
+		if err != nil {
+			logrus.WithError(err).WithFields(fields).WithFields(epFields).
+				Debug("Failed to get token from endpoint")
+			lastErr = fmt.Errorf("%w: %w", errFailedGetToken, err)
+
+			continue
+		}
+
+		if token == "" {
+			logrus.WithFields(fields).WithFields(epFields).
+				Debug("No authentication required, proceeding with request")
+		} else {
+			logrus.WithFields(fields).WithFields(epFields).
+				WithField("challenge_host", challengeHost).
+				WithField("redirected", redirected).
+				WithField("redirect_host", redirectHost).
+				Debug("Received challenge host and redirect flag from GetToken")
+		}
+
+		// Build the manifest URL, using redirect host when redirected.
+		var (
+			manifestURL string
+			parsedURL   *url.URL
+		)
+
+		if redirectHost != "" && redirectHost != originalHost && redirected {
+			manifestURL, _, parsedURL, err = BuildManifestURL(
+				container,
+				redirectHost,
+			)
+		} else {
+			manifestURL, _, parsedURL, err = BuildManifestURL(
+				container,
+				"",
+			)
+		}
+
+		if err != nil {
+			logrus.WithError(err).WithFields(fields).WithFields(epFields).
+				Debug("Failed to build manifest URL")
+			lastErr = err
+
+			continue
+		}
+
+		logrus.WithFields(fields).WithFields(epFields).WithFields(logrus.Fields{
+			"method": method,
+			"url":    manifestURL,
+		}).Debug("Fetching digest")
+
+		// Create the HTTP request for the manifest.
+		req, err := makeManifestRequest(ctx, method, manifestURL, token)
+		if err != nil {
+			logrus.WithError(err).WithFields(fields).WithFields(epFields).WithFields(logrus.Fields{
+				"method": method,
+				"url":    manifestURL,
+			}).Debug("Failed to create request")
+			lastErr = err
+
+			continue
+		}
+
+		// Execute the initial request.
+		resp, err := client.Do(req)
+		if err != nil {
+			logrus.WithError(err).WithFields(fields).WithFields(epFields).WithFields(logrus.Fields{
+				"method": method,
+				"url":    manifestURL,
+			}).Debug("Failed to execute request")
+			lastErr = fmt.Errorf("%w: %w", errFailedExecuteRequest, err)
+
+			continue
+		}
+
+		// Handle the manifest response, checking for redirects and extracting digest.
+		digest, updatedURL, retry, err := HandleManifestResponse(
+			resp,
 			method,
-			updatedURL,
-			token,
 			originalHost,
 			challengeHost,
 			redirected,
 			parsedURL,
-			client,
+			parsedURL.Host,
 		)
-		if err != nil {
-			logrus.WithError(err).WithFields(fields).WithField("retry_url", updatedURL).
-				Debug("Failed to retry manifest request")
+		_ = resp.Body.Close()
 
-			return "", err
+		if err != nil {
+			logrus.WithError(err).WithFields(fields).WithFields(epFields).WithField("status", resp.Status).
+				Debug("Failed to handle manifest response")
+			lastErr = err
+
+			continue
 		}
+
+		if retry && updatedURL != "" {
+			logrus.WithFields(fields).WithFields(epFields).
+				WithField("retry_url", updatedURL).
+				Debug("Retrying manifest request with updated URL")
+
+			digest, err = retryManifestRequest(
+				ctx,
+				method,
+				updatedURL,
+				token,
+				originalHost,
+				challengeHost,
+				redirected,
+				parsedURL,
+				client,
+			)
+			if err != nil {
+				logrus.WithError(err).WithFields(fields).WithFields(epFields).WithField("retry_url", updatedURL).
+					Debug("Failed to retry manifest request")
+				lastErr = err
+
+				continue
+			}
+		}
+
+		logrus.WithFields(fields).WithFields(epFields).WithField("remote_digest", digest).
+			Debug("Fetched remote digest")
+
+		return digest, nil
 	}
 
-	logrus.WithFields(fields).WithField("remote_digest", digest).
-		Debug("Fetched remote digest")
-
-	return digest, nil
+	return "", lastErr
 }
 
 // HandleManifestResponse processes the HTTP response, handles redirects, and extracts the digest.

--- a/pkg/registry/digest/digest_integration_test.go
+++ b/pkg/registry/digest/digest_integration_test.go
@@ -179,7 +179,7 @@ var _ = ginkgo.Describe("Digests", func() {
 		client := newTestAuthClient()
 		ctx := context.Background()
 		registryAuth := auth.TransformAuth("token")
-		token, _, _, _, err := auth.GetToken(ctx, container, registryAuth, client)
+		token, _, _, _, err := auth.GetToken(ctx, container, registryAuth, client, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		url, err := manifest.BuildManifestURL(container, getScheme())
@@ -313,7 +313,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
@@ -358,7 +358,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			_, _, _, _, err := auth.GetToken(ctx, mockContainerUnreachable, registryAuth, client)
+			_, _, _, _, err := auth.GetToken(ctx, mockContainerUnreachable, registryAuth, client, "")
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).
 				To(gomega.ContainSubstring("failed to execute challenge request"))
@@ -389,7 +389,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			_, _, _, _, err := auth.GetToken(ctx, mockContainerInvalidImage, registryAuth, client)
+			_, _, _, _, err := auth.GetToken(ctx, mockContainerInvalidImage, registryAuth, client, "")
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to parse image name"))
 		})
@@ -409,7 +409,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			_, _, _, _, err := auth.GetToken(ctx, mockContainerInvalidURL, registryAuth, client)
+			_, _, _, _, err := auth.GetToken(ctx, mockContainerInvalidURL, registryAuth, client, "")
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to parse image name"))
 		})
@@ -466,7 +466,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
@@ -529,7 +529,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
@@ -603,6 +603,7 @@ var _ = ginkgo.Describe("Digests", func() {
 				mockContainerWithInvalidDigest,
 				registryAuth,
 				client,
+				"",
 			)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -678,7 +679,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
 
 			registryAuth := auth.TransformAuth("token")
-			_, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			_, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).
 				To(gomega.ContainSubstring("challenge header did not include all values needed to construct an auth url"))
@@ -939,7 +940,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
@@ -1011,7 +1012,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
@@ -1081,7 +1082,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
@@ -1150,7 +1151,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
@@ -1521,7 +1522,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			_, _, _, _, err := auth.GetToken(ctx, mockContainerUnreachable, registryAuth, client)
+			_, _, _, _, err := auth.GetToken(ctx, mockContainerUnreachable, registryAuth, client, "")
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.MatchRegexp("Temporary failure in name resolution|no such host|server misbehaving"))
 		})
@@ -1579,7 +1580,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			_, _, _, _, err := auth.GetToken(ctx, mockContainerInvalidURL, registryAuth, client)
+			_, _, _, _, err := auth.GetToken(ctx, mockContainerInvalidURL, registryAuth, client, "")
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to parse image name"))
 		})
@@ -1625,7 +1626,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
@@ -1695,7 +1696,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
@@ -1762,7 +1763,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
@@ -1829,7 +1830,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
@@ -1897,7 +1898,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
@@ -2024,7 +2025,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
@@ -2093,7 +2094,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
@@ -2163,7 +2164,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
@@ -2231,7 +2232,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
@@ -2299,7 +2300,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			client := newTestAuthClient()
 			ctx := context.Background()
 			registryAuth := auth.TransformAuth("token")
-			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+			token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			url, err := manifest.BuildManifestURL(mockContainerWithServer, getScheme())
@@ -2616,9 +2617,10 @@ var _ = ginkgo.Describe("Digests", func() {
 					mockDigest,
 				)
 
+				client := newTestAuthClient()
 				ctx := context.Background()
 				registryAuth := auth.TransformAuth("token")
-				_, err := digest.FetchDigest(ctx, mockContainerInvalid, registryAuth)
+				_, _, _, _, err := auth.GetToken(ctx, mockContainerInvalid, registryAuth, client, "")
 				gomega.Expect(err).To(gomega.HaveOccurred())
 				gomega.Expect(err.Error()).
 					To(gomega.ContainSubstring("failed to parse image name"))
@@ -2741,6 +2743,7 @@ var _ = ginkgo.Describe("Digests", func() {
 					mockContainerWithServer,
 					registryAuth,
 					client,
+					"",
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -2820,6 +2823,7 @@ var _ = ginkgo.Describe("Digests", func() {
 					mockContainerWithServer,
 					registryAuth,
 					client,
+					"",
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -2896,6 +2900,7 @@ var _ = ginkgo.Describe("Digests", func() {
 					mockContainerWithServer,
 					registryAuth,
 					client,
+					"",
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -3067,7 +3072,7 @@ func TestDigestClient_GetManifest_SlowResponse(t *testing.T) {
 
 		registryAuth := auth.TransformAuth("token")
 
-		token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client)
+		token, _, _, _, err := auth.GetToken(ctx, mockContainerWithServer, registryAuth, client, "")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/registry/manifest/manifest.go
+++ b/pkg/registry/manifest/manifest.go
@@ -32,7 +32,7 @@ var (
 //
 // Parameters:
 //   - container: Container with image info for URL construction.
-//   - scheme: The scheme to use for the URL (e.g., "https" or "http"). Empty string defaults to "https".
+//   - scheme: The scheme to use for the URL (e.g., "https" or "http").
 //
 // Returns:
 //   - string: Manifest URL using the canonical registry host from the image reference.

--- a/pkg/registry/manifest/manifest.go
+++ b/pkg/registry/manifest/manifest.go
@@ -25,15 +25,17 @@ var (
 
 // BuildManifestURL constructs a URL for accessing a container's image manifest from its registry.
 //
-// It parses the image name into a normalized reference, extracts the registry host, and builds a URL with path and tag,
-// using the provided scheme.
+// It parses the image name into a normalized reference and builds the manifest URL using the
+// registry host derived from that reference (the canonical host) together with the provided scheme.
+// The function does not support host overrides; callers that need to target registry mirrors apply
+// overrides after obtaining the canonical URL (see digest.BuildManifestURL).
 //
 // Parameters:
 //   - container: Container with image info for URL construction.
-//   - scheme: The scheme to use for the URL (e.g., "https" or "http").
+//   - scheme: The scheme to use for the URL (e.g., "https" or "http"). Empty string defaults to "https".
 //
 // Returns:
-//   - string: Manifest URL (e.g., "https://index.docker.io/v2/library/alpine/manifests/latest") if successful.
+//   - string: Manifest URL using the canonical registry host from the image reference.
 //   - error: Non-nil if parsing or tagging fails, nil on success.
 func BuildManifestURL(container types.Container, scheme string) (string, error) {
 	// Set up logging fields for consistent tracking.
@@ -63,8 +65,6 @@ func BuildManifestURL(container types.Container, scheme string) (string, error) 
 	// Extract the registry host and image components.
 	host, _ := auth.GetRegistryAddress(normalizedTaggedRef.Name())
 	img, tag := reference.Path(normalizedTaggedRef), normalizedTaggedRef.Tag()
-
-	// Use the provided scheme.
 
 	logrus.WithFields(fields).WithFields(logrus.Fields{
 		"host":       host,


### PR DESCRIPTION
Add Docker registry mirror support for digest comparison to enable update checks when primary registries are inaccessible.

## Problem

Watchtower was not using the Docker daemon's configured `registry-mirrors` when comparing image digests. Users in regions with restricted access to Docker Hub could not detect available updates.

## Solution

Watchtower now fetches the global `registry-mirrors` configuration from the Docker daemon and tries each mirror in order before falling back to the canonical registry host.

## Changes

- Added mirror configuration resolution from Docker daemon Info()
- Updated digest comparison to try multiple endpoints with fallback
- Added auth and manifest URL support for endpoint overrides
- Added registry mirrors documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for Docker registry mirrors during image update checks, using configured mirrors with automatic fallback to the canonical registry.

* **Documentation**
  * Added a Registry Mirrors guide with configuration examples, resolution order, troubleshooting (network, auth, TLS), and platform-specific guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/watchtower/pull/1693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->