### PR TITLE
feat: add eligible_at timestamp to cooldown deferral logs and notifications

### DIFF
--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -1030,6 +1030,7 @@ func sendSplitNotifications(
 						"image_age":   containerStatus.CooldownAge(),
 						"cooldown":    containerStatus.CooldownDelay(),
 						"eligible_in": containerStatus.CooldownRemaining(),
+						"eligible_at": containerStatus.CooldownEligibleAt().Format(time.RFC3339),
 					},
 					Time: now,
 				}

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -269,11 +269,12 @@ func Update(
 					cooldownErr.Age,
 					cooldownErr.Delay,
 					cooldownErr.Remaining,
+					cooldownErr.EligibleAt,
 					cooldownErr.Passed,
 				)
 			} else if errors.Is(err, container.ErrImageCooldown) {
 				// Fallback for plain sentinel (keeps basic deferral visible)
-				progress.SetCooldownInfo(sourceContainer.ID(), "", "", "", false)
+				progress.SetCooldownInfo(sourceContainer.ID(), "", "", "", time.Time{}, false)
 			}
 
 			// Track if Watchtower self-update pull failed for safeguard.

--- a/pkg/container/cooldown.go
+++ b/pkg/container/cooldown.go
@@ -19,11 +19,12 @@ import (
 // while still extracting the fields needed for progress reports and
 // rich notifications.
 type CooldownError struct {
-	Age       string
-	Delay     string
-	Remaining string
-	Passed    bool
-	err       error
+	Age        string
+	Delay      string
+	Remaining  string
+	EligibleAt time.Time
+	Passed     bool
+	err        error
 }
 
 func (e *CooldownError) Error() string {
@@ -179,14 +180,16 @@ func evalImageAge(creationTime time.Time, delay time.Duration, clog *logrus.Entr
 		ageStr := util.FormatDuration(imageAge)
 		cooldownStr := util.FormatDuration(delay)
 		remainingStr := util.FormatDuration(remaining)
+		eligibleAt := time.Now().Add(remaining)
 
 		clog.WithFields(logrus.Fields{
 			"image_age":   ageStr,
 			"cooldown":    cooldownStr,
 			"eligible_in": remainingStr,
+			"eligible_at": eligibleAt.Format(time.RFC3339),
 		}).Info("Image is within cooldown period - deferring update")
 
-		return false, buildCooldownError(imageAge, delay)
+		return false, buildCooldownError(imageAge, delay, eligibleAt)
 	}
 
 	logCooldownExceeded(imageAge, delay, clog)
@@ -200,17 +203,19 @@ func evalImageAge(creationTime time.Time, delay time.Duration, clog *logrus.Entr
 // Parameters:
 //   - imageAge: Elapsed time since the image was created.
 //   - delay: The configured cooldown delay.
+//   - eligibleAt: Precomputed time when the container becomes eligible.
 //
 // Returns:
 //   - *CooldownError: Populated with formatted age, delay, and remaining strings.
-func buildCooldownError(imageAge, delay time.Duration) *CooldownError {
+func buildCooldownError(imageAge, delay time.Duration, eligibleAt time.Time) *CooldownError {
 	remaining := delay - imageAge
 
 	return &CooldownError{
-		Age:       util.FormatDuration(imageAge),
-		Delay:     util.FormatDuration(delay),
-		Remaining: util.FormatDuration(remaining),
-		err:       ErrImageCooldown,
+		Age:        util.FormatDuration(imageAge),
+		Delay:      util.FormatDuration(delay),
+		Remaining:  util.FormatDuration(remaining),
+		EligibleAt: eligibleAt,
+		err:        ErrImageCooldown,
 	}
 }
 

--- a/pkg/notifications/common_templates.go
+++ b/pkg/notifications/common_templates.go
@@ -43,8 +43,8 @@ var commonTemplates = map[string]string{
     Detected {{index $e.Data "count"}} Watchtower instances - initiating cleanup
 {{- else if eq $msg "Successfully removed all excess Watchtower instances" -}}
     Successfully removed {{index $e.Data "removed_instances"}} excess Watchtower{{if eq (index $e.Data "removed_instances") 1}} instance{{else}} instances{{end}}
-{{- else if eq $msg "Image is within cooldown period - deferring update" -}}
-    {{with (index $e.Data "image")}}{{.}}{{else}}unknown{{end}} created less than {{with (index $e.Data "cooldown")}}{{.}}{{else}}unknown{{end}} ago - eligible in {{with (index $e.Data "eligible_in")}}{{.}}{{else}}unknown{{end}}
+    {{- else if eq $msg "Image is within cooldown period - deferring update" -}}
+    {{with (index $e.Data "image")}}{{.}}{{else}}unknown{{end}} created less than {{with (index $e.Data "cooldown")}}{{.}}{{else}}unknown{{end}} ago - eligible in {{with (index $e.Data "eligible_in")}}{{.}}{{else}}unknown{{end}} ({{with (index $e.Data "eligible_at")}}{{RFC1123 .}}{{else}}unknown{{end}})
 {{- else if eq $msg "Image age exceeds cooldown - proceeding with update" -}}
     {{with (index $e.Data "image")}}{{.}}{{else}}unknown{{end}} created more than {{with (index $e.Data "cooldown")}}{{.}}{{else}}unknown{{end}} ago - proceeding with update
 {{- else if eq $msg "Image creation time unavailable - deferring update" -}}

--- a/pkg/notifications/common_templates.go
+++ b/pkg/notifications/common_templates.go
@@ -43,7 +43,7 @@ var commonTemplates = map[string]string{
     Detected {{index $e.Data "count"}} Watchtower instances - initiating cleanup
 {{- else if eq $msg "Successfully removed all excess Watchtower instances" -}}
     Successfully removed {{index $e.Data "removed_instances"}} excess Watchtower{{if eq (index $e.Data "removed_instances") 1}} instance{{else}} instances{{end}}
-    {{- else if eq $msg "Image is within cooldown period - deferring update" -}}
+{{- else if eq $msg "Image is within cooldown period - deferring update" -}}
     {{with (index $e.Data "image")}}{{.}}{{else}}unknown{{end}} created less than {{with (index $e.Data "cooldown")}}{{.}}{{else}}unknown{{end}} ago - eligible in {{with (index $e.Data "eligible_in")}}{{.}}{{else}}unknown{{end}} ({{with (index $e.Data "eligible_at")}}{{RFC1123 .}}{{else}}unknown{{end}})
 {{- else if eq $msg "Image age exceeds cooldown - proceeding with update" -}}
     {{with (index $e.Data "image")}}{{.}}{{else}}unknown{{end}} created more than {{with (index $e.Data "cooldown")}}{{.}}{{else}}unknown{{end}} ago - proceeding with update

--- a/pkg/notifications/templates/funcs.go
+++ b/pkg/notifications/templates/funcs.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/text/cases"
@@ -25,6 +26,7 @@ var Funcs = template.FuncMap{
 	"ToLower": strings.ToLower,
 	"ToJSON":  toJSON,
 	"Title":   cases.Title(language.AmericanEnglish).String,
+	"RFC1123": formatRFC1123,
 }
 
 // toJSON marshals a value to a formatted JSON string for use in templates.
@@ -40,4 +42,15 @@ func toJSON(v any) string {
 	}
 
 	return string(bytes)
+}
+
+// formatRFC1123 parses an RFC3339 timestamp string and formats it as RFC1123.
+// If parsing fails, it returns the original string unchanged.
+func formatRFC1123(s string) string {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return s
+	}
+
+	return t.Format(time.RFC1123)
 }

--- a/pkg/notifications/templates/funcs.go
+++ b/pkg/notifications/templates/funcs.go
@@ -45,12 +45,15 @@ func toJSON(v any) string {
 }
 
 // formatRFC1123 parses an RFC3339 timestamp string and formats it as RFC1123.
-// If parsing fails, it returns the original string unchanged.
-func formatRFC1123(s string) string {
-	t, err := time.Parse(time.RFC3339, s)
+// If parsing fails, it logs a warning and returns the original string.
+func formatRFC1123(value string) string {
+	timestamp, err := time.Parse(time.RFC3339, value)
 	if err != nil {
-		return s
+		logrus.WithError(err).WithField("value", value).
+			Warn("Failed to parse RFC3339 timestamp in notification template")
+
+		return value
 	}
 
-	return t.Format(time.RFC1123)
+	return timestamp.Format(time.RFC1123)
 }

--- a/pkg/session/container_status.go
+++ b/pkg/session/container_status.go
@@ -1,6 +1,8 @@
 package session
 
 import (
+	"time"
+
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
@@ -35,19 +37,20 @@ const (
 //
 //nolint:errname // ContainerStatus is not an error type, it contains an error field.
 type ContainerStatus struct {
-	containerID       types.ContainerID // Container ID.
-	oldImage          types.ImageID     // Original image ID.
-	newImage          types.ImageID     // Latest image ID.
-	containerName     string            // Container name.
-	imageName         string            // Image name with tag.
-	containerError    error             // Error encountered, if any.
-	state             State             // Current state.
-	monitorOnly       bool              // Monitor-only flag.
-	newContainerID    types.ContainerID // New container ID after update.
-	cooldownPassed    bool              // True if image passed cooldown check.
-	cooldownAge       string            // Human-readable image age (e.g., "47 days, 11 hours").
-	cooldownDelay     string            // Human-readable cooldown duration (e.g., "24 hours").
-	cooldownRemaining string            // Human-readable remaining time (empty if passed).
+	containerID        types.ContainerID // Container ID.
+	oldImage           types.ImageID     // Original image ID.
+	newImage           types.ImageID     // Latest image ID.
+	containerName      string            // Container name.
+	imageName          string            // Image name with tag.
+	containerError     error             // Error encountered, if any.
+	state              State             // Current state.
+	monitorOnly        bool              // Monitor-only flag.
+	newContainerID     types.ContainerID // New container ID after update.
+	cooldownPassed     bool              // True if image passed cooldown check.
+	cooldownAge        string            // Human-readable image age (e.g., "47 days, 11 hours").
+	cooldownDelay      string            // Human-readable cooldown duration (e.g., "24 hours").
+	cooldownRemaining  string            // Human-readable remaining time (empty if passed).
+	cooldownEligibleAt time.Time         // Time when the container becomes eligible for update.
 }
 
 // ID returns the container ID.
@@ -159,12 +162,28 @@ func (u *ContainerStatus) SetNewContainerID(newID types.ContainerID) {
 //   - age: Human-readable image age (e.g., "47 days, 11 hours").
 //   - delay: Human-readable cooldown duration (e.g., "24 hours").
 //   - remaining: Human-readable remaining time (empty if passed).
+//   - eligibleAt: Time when the container becomes eligible for update.
 //   - passed: True if the image passed the cooldown check.
-func (u *ContainerStatus) SetCooldownInfo(age, delay, remaining string, passed bool) {
+func (u *ContainerStatus) SetCooldownInfo(
+	age,
+	delay,
+	remaining string,
+	eligibleAt time.Time,
+	passed bool,
+) {
 	u.cooldownPassed = passed
 	u.cooldownAge = age
 	u.cooldownDelay = delay
 	u.cooldownRemaining = remaining
+	u.cooldownEligibleAt = eligibleAt
+}
+
+// CooldownEligibleAt returns the time when the container becomes eligible for update.
+//
+// Returns:
+//   - time.Time: The eligible-at timestamp (zero if not set).
+func (u *ContainerStatus) CooldownEligibleAt() time.Time {
+	return u.cooldownEligibleAt
 }
 
 // CooldownPassed returns whether the image passed the cooldown check.

--- a/pkg/session/container_status_test.go
+++ b/pkg/session/container_status_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
@@ -389,49 +390,54 @@ func TestContainerStatus_RestartedStateWithMissingData(t *testing.T) {
 
 func TestContainerStatus_SetCooldownInfo(t *testing.T) {
 	tests := []struct {
-		name      string
-		u         *ContainerStatus
-		age       string
-		delay     string
-		remaining string
-		passed    bool
+		name       string
+		u          *ContainerStatus
+		age        string
+		delay      string
+		remaining  string
+		eligibleAt time.Time
+		passed     bool
 	}{
 		{
-			name:      "cooldown passed with age",
-			u:         &ContainerStatus{containerID: "cont1"},
-			age:       "47 days, 11 hours",
-			delay:     "24 hours",
-			remaining: "",
-			passed:    true,
+			name:       "cooldown passed with age",
+			u:          &ContainerStatus{containerID: "cont1"},
+			age:        "47 days, 11 hours",
+			delay:      "24 hours",
+			remaining:  "",
+			eligibleAt: time.Time{},
+			passed:     true,
 		},
 		{
-			name:      "cooldown not passed with remaining",
-			u:         &ContainerStatus{containerID: "cont2"},
-			age:       "2 hours",
-			delay:     "24 hours",
-			remaining: "22 hours",
-			passed:    false,
+			name:       "cooldown not passed with remaining",
+			u:          &ContainerStatus{containerID: "cont2"},
+			age:        "2 hours",
+			delay:      "24 hours",
+			remaining:  "22 hours",
+			eligibleAt: time.Date(2026, 5, 26, 0, 45, 0, 0, time.UTC),
+			passed:     false,
 		},
 		{
-			name:      "empty values",
-			u:         &ContainerStatus{containerID: "cont3"},
-			age:       "",
-			delay:     "",
-			remaining: "",
-			passed:    false,
+			name:       "empty values",
+			u:          &ContainerStatus{containerID: "cont3"},
+			age:        "",
+			delay:      "",
+			remaining:  "",
+			eligibleAt: time.Time{},
+			passed:     false,
 		},
 		{
-			name:      "overwrites previous values",
-			u:         &ContainerStatus{containerID: "cont4", cooldownAge: "old age", cooldownDelay: "old delay", cooldownRemaining: "old remaining", cooldownPassed: true},
-			age:       "new age",
-			delay:     "new delay",
-			remaining: "new remaining",
-			passed:    false,
+			name:       "overwrites previous values",
+			u:          &ContainerStatus{containerID: "cont4", cooldownAge: "old age", cooldownDelay: "old delay", cooldownRemaining: "old remaining", cooldownPassed: true},
+			age:        "new age",
+			delay:      "new delay",
+			remaining:  "new remaining",
+			eligibleAt: time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC),
+			passed:     false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.u.SetCooldownInfo(tt.age, tt.delay, tt.remaining, tt.passed)
+			tt.u.SetCooldownInfo(tt.age, tt.delay, tt.remaining, tt.eligibleAt, tt.passed)
 
 			if got := tt.u.CooldownAge(); got != tt.age {
 				t.Errorf("CooldownAge() = %v, want %v", got, tt.age)
@@ -447,6 +453,10 @@ func TestContainerStatus_SetCooldownInfo(t *testing.T) {
 
 			if got := tt.u.CooldownPassed(); got != tt.passed {
 				t.Errorf("CooldownPassed() = %v, want %v", got, tt.passed)
+			}
+
+			if got := tt.u.CooldownEligibleAt(); got != tt.eligibleAt {
+				t.Errorf("CooldownEligibleAt() = %v, want %v", got, tt.eligibleAt)
 			}
 		})
 	}
@@ -473,12 +483,14 @@ func TestContainerStatus_CooldownDefaults(t *testing.T) {
 }
 
 func TestContainerStatus_CooldownGettersReturnDirectValues(t *testing.T) {
+	eligibleAt := time.Date(2026, 5, 26, 0, 45, 0, 0, time.UTC)
 	u := &ContainerStatus{
-		containerID:       "cont1",
-		cooldownPassed:    true,
-		cooldownAge:       "3 days",
-		cooldownDelay:     "48 hours",
-		cooldownRemaining: "12 hours",
+		containerID:        "cont1",
+		cooldownPassed:     true,
+		cooldownAge:        "3 days",
+		cooldownDelay:      "48 hours",
+		cooldownRemaining:  "12 hours",
+		cooldownEligibleAt: eligibleAt,
 	}
 
 	if got := u.CooldownPassed(); got != true {
@@ -495,6 +507,10 @@ func TestContainerStatus_CooldownGettersReturnDirectValues(t *testing.T) {
 
 	if got := u.CooldownRemaining(); got != "12 hours" {
 		t.Errorf("CooldownRemaining() = %v, want '12 hours'", got)
+	}
+
+	if got := u.CooldownEligibleAt(); got != eligibleAt {
+		t.Errorf("CooldownEligibleAt() = %v, want %v", got, eligibleAt)
 	}
 }
 

--- a/pkg/session/container_status_test.go
+++ b/pkg/session/container_status_test.go
@@ -480,6 +480,10 @@ func TestContainerStatus_CooldownDefaults(t *testing.T) {
 	if got := u.CooldownRemaining(); got != "" {
 		t.Errorf("CooldownRemaining() default = %v, want empty", got)
 	}
+
+	if !u.CooldownEligibleAt().IsZero() {
+		t.Errorf("CooldownEligibleAt() default = %v, want zero", u.CooldownEligibleAt())
+	}
 }
 
 func TestContainerStatus_CooldownGettersReturnDirectValues(t *testing.T) {

--- a/pkg/session/progress.go
+++ b/pkg/session/progress.go
@@ -1,6 +1,8 @@
 package session
 
 import (
+	"time"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/nicholas-fedor/watchtower/pkg/types"
@@ -163,8 +165,16 @@ func (m Progress) MarkRestarted(containerID types.ContainerID) {
 //   - age: Human-readable image age.
 //   - delay: Human-readable cooldown duration.
 //   - remaining: Human-readable remaining time (empty if passed).
+//   - eligibleAt: Time when the container becomes eligible for update.
 //   - passed: True if the image passed the cooldown check.
-func (m Progress) SetCooldownInfo(containerID types.ContainerID, age, delay, remaining string, passed bool) {
+func (m Progress) SetCooldownInfo(
+	containerID types.ContainerID,
+	age,
+	delay,
+	remaining string,
+	eligibleAt time.Time,
+	passed bool,
+) {
 	update, exists := m[containerID]
 	if !exists {
 		logrus.WithField("container_id", containerID.ShortID()).
@@ -173,7 +183,7 @@ func (m Progress) SetCooldownInfo(containerID types.ContainerID, age, delay, rem
 		return
 	}
 
-	update.SetCooldownInfo(age, delay, remaining, passed)
+	update.SetCooldownInfo(age, delay, remaining, eligibleAt, passed)
 	logrus.WithFields(logrus.Fields{
 		"container_id": containerID.ShortID(),
 		"name":         update.Name(),

--- a/pkg/session/progress_test.go
+++ b/pkg/session/progress_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	testifyMock "github.com/stretchr/testify/mock"
 
@@ -1157,6 +1158,7 @@ func TestProgress_SetCooldownInfo(t *testing.T) {
 		age         string
 		delay       string
 		remaining   string
+		eligibleAt  time.Time
 		passed      bool
 	}
 
@@ -1176,16 +1178,18 @@ func TestProgress_SetCooldownInfo(t *testing.T) {
 				age:         "47 days, 11 hours",
 				delay:       "24 hours",
 				remaining:   "",
+				eligibleAt:  time.Time{},
 				passed:      true,
 			},
 			want: Progress{
 				"cont1": &ContainerStatus{
-					containerID:       "cont1",
-					state:             ScannedState,
-					cooldownPassed:    true,
-					cooldownAge:       "47 days, 11 hours",
-					cooldownDelay:     "24 hours",
-					cooldownRemaining: "",
+					containerID:        "cont1",
+					state:              ScannedState,
+					cooldownPassed:     true,
+					cooldownAge:        "47 days, 11 hours",
+					cooldownDelay:      "24 hours",
+					cooldownRemaining:  "",
+					cooldownEligibleAt: time.Time{},
 				},
 			},
 		},
@@ -1199,16 +1203,18 @@ func TestProgress_SetCooldownInfo(t *testing.T) {
 				age:         "2 hours",
 				delay:       "24 hours",
 				remaining:   "22 hours",
+				eligibleAt:  time.Date(2026, 5, 26, 0, 45, 0, 0, time.UTC),
 				passed:      false,
 			},
 			want: Progress{
 				"cont1": &ContainerStatus{
-					containerID:       "cont1",
-					state:             SkippedState,
-					cooldownPassed:    false,
-					cooldownAge:       "2 hours",
-					cooldownDelay:     "24 hours",
-					cooldownRemaining: "22 hours",
+					containerID:        "cont1",
+					state:              SkippedState,
+					cooldownPassed:     false,
+					cooldownAge:        "2 hours",
+					cooldownDelay:      "24 hours",
+					cooldownRemaining:  "22 hours",
+					cooldownEligibleAt: time.Date(2026, 5, 26, 0, 45, 0, 0, time.UTC),
 				},
 			},
 		},
@@ -1220,6 +1226,7 @@ func TestProgress_SetCooldownInfo(t *testing.T) {
 				age:         "1 day",
 				delay:       "24 hours",
 				remaining:   "",
+				eligibleAt:  time.Time{},
 				passed:      true,
 			},
 			want: Progress{},
@@ -1241,16 +1248,18 @@ func TestProgress_SetCooldownInfo(t *testing.T) {
 				age:         "new age",
 				delay:       "new delay",
 				remaining:   "new remaining",
+				eligibleAt:  time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC),
 				passed:      true,
 			},
 			want: Progress{
 				"cont1": &ContainerStatus{
-					containerID:       "cont1",
-					state:             ScannedState,
-					cooldownPassed:    true,
-					cooldownAge:       "new age",
-					cooldownDelay:     "new delay",
-					cooldownRemaining: "new remaining",
+					containerID:        "cont1",
+					state:              ScannedState,
+					cooldownPassed:     true,
+					cooldownAge:        "new age",
+					cooldownDelay:      "new delay",
+					cooldownRemaining:  "new remaining",
+					cooldownEligibleAt: time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC),
 				},
 			},
 		},
@@ -1264,6 +1273,7 @@ func TestProgress_SetCooldownInfo(t *testing.T) {
 				age:         "",
 				delay:       "",
 				remaining:   "",
+				eligibleAt:  time.Time{},
 				passed:      false,
 			},
 			want: Progress{
@@ -1280,7 +1290,7 @@ func TestProgress_SetCooldownInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.m.SetCooldownInfo(tt.args.containerID, tt.args.age, tt.args.delay, tt.args.remaining, tt.args.passed)
+			tt.m.SetCooldownInfo(tt.args.containerID, tt.args.age, tt.args.delay, tt.args.remaining, tt.args.eligibleAt, tt.args.passed)
 
 			if len(tt.m) != len(tt.want) {
 				t.Errorf(
@@ -1356,13 +1366,13 @@ func TestProgress_SetCooldownInfo_Concurrent(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		m.SetCooldownInfo("cont1", "1 day", "24 hours", "", true)
+		m.SetCooldownInfo("cont1", "1 day", "24 hours", "", time.Time{}, true)
 	}()
 
 	go func() {
 		defer wg.Done()
 
-		m.SetCooldownInfo("cont2", "2 hours", "24 hours", "22 hours", false)
+		m.SetCooldownInfo("cont2", "2 hours", "24 hours", "22 hours", time.Date(2026, 5, 26, 0, 45, 0, 0, time.UTC), false)
 	}()
 
 	wg.Wait()

--- a/pkg/session/progress_test.go
+++ b/pkg/session/progress_test.go
@@ -1349,6 +1349,15 @@ func TestProgress_SetCooldownInfo(t *testing.T) {
 						wantStatus.cooldownRemaining,
 					)
 				}
+
+				if gotStatus.CooldownEligibleAt() != wantStatus.cooldownEligibleAt {
+					t.Errorf(
+						"Progress.SetCooldownInfo() CooldownEligibleAt for %v = %v, want %v",
+						id,
+						gotStatus.CooldownEligibleAt(),
+						wantStatus.cooldownEligibleAt,
+					)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
This PR introduces an `eligible_at` timestamp field to cooldown deferral logs and notifications, showing the exact time a container becomes eligible for update.

## Problem

The cooldown deferral log message only showed a human-readable duration (`eligible_in`, e.g. "11 hours 18 minutes 21 seconds"), forcing users to manually calculate the actual time when a container becomes eligible for update.

## Solution

Compute the exact eligible-at timestamp once in `evalImageAge`, store it in `CooldownError.EligibleAt`, and thread it through `Progress` and `ContainerStatus` so it can be displayed as an RFC3339 string in logs and RFC1123 in notifications.

## Changes

- Added `EligibleAt time.Time` to `CooldownError`; computed once in `evalImageAge` and passed into `buildCooldownError`
- Added `cooldownEligibleAt time.Time` field and `CooldownEligibleAt()` getter to `ContainerStatus`; updated `SetCooldownInfo` signature
- Updated `Progress.SetCooldownInfo` to thread through `eligibleAt time.Time`
- Pass `cooldownErr.EligibleAt` from `CooldownError` through to progress in `update.go`
- Added `eligible_at` (RFC3339) to the cooldown deferral log entry in `actions.go`
- Added `RFC1123` template function for human-friendly notification formatting
- Updated cooldown notification template to show eligible-at time via `{{RFC1123 .}}`
- Updated all affected tests with the new `eligibleAt` parameter and assertions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications now show exact cooldown eligibility timestamps so users see when containers become eligible for updates.
  * Progress/status displays include the cooldown eligibility time alongside existing age/delay information.
  * Improved timestamp formatting in notification messages for clearer, human-readable cooldown times.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/watchtower/pull/1698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->