### PR TITLE
feat(api): add read-only /v1/containers endpoint

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -497,6 +497,7 @@ func run(command *cobra.Command, args []string) {
 	updateOnStart, _ := command.PersistentFlags().GetBool("update-on-start")
 	enableUpdateAPI, _ := command.PersistentFlags().GetBool("http-api-update")
 	enableMetricsAPI, _ := command.PersistentFlags().GetBool("http-api-metrics")
+	enableContainersAPI, _ := command.PersistentFlags().GetBool("http-api-containers")
 	unblockHTTPAPI, _ := command.PersistentFlags().GetBool("http-api-periodic-polls")
 	noStartupMessage, _ := command.PersistentFlags().GetBool("no-startup-message")
 	apiToken, _ := command.PersistentFlags().GetString("http-api-token")
@@ -551,20 +552,21 @@ func run(command *cobra.Command, args []string) {
 
 	// Set configuration for core execution, encapsulating all operational parameters.
 	cfg := types.RunConfig{
-		Command:          command,
-		Names:            normalizedContainerNames,
-		Filter:           filter,
-		FilterDesc:       filterDesc,
-		RunOnce:          runOnce,
-		UpdateOnStart:    updateOnStart,
-		EnableUpdateAPI:  enableUpdateAPI,
-		EnableMetricsAPI: enableMetricsAPI,
-		UnblockHTTPAPI:   unblockHTTPAPI,
-		NoStartupMessage: noStartupMessage,
-		APIToken:         apiToken,
-		APIHost:          apiHost,
-		APIPort:          apiPort,
-		APIRateLimit:     apiRateLimit,
+		Command:             command,
+		Names:               normalizedContainerNames,
+		Filter:              filter,
+		FilterDesc:          filterDesc,
+		RunOnce:             runOnce,
+		UpdateOnStart:       updateOnStart,
+		EnableUpdateAPI:     enableUpdateAPI,
+		EnableMetricsAPI:    enableMetricsAPI,
+		EnableContainersAPI: enableContainersAPI,
+		UnblockHTTPAPI:      unblockHTTPAPI,
+		NoStartupMessage:    noStartupMessage,
+		APIToken:            apiToken,
+		APIHost:             apiHost,
+		APIPort:             apiPort,
+		APIRateLimit:        apiRateLimit,
 	}
 
 	// Execute core logic and exit with the returned status code (0 for success, 1 for failure).
@@ -782,6 +784,7 @@ func runMain(cfg types.RunConfig) int {
 			RateLimit:                   cfg.APIRateLimit,
 			EnableUpdateAPI:             cfg.EnableUpdateAPI,
 			EnableMetricsAPI:            cfg.EnableMetricsAPI,
+			EnableContainersAPI:         cfg.EnableContainersAPI,
 			UnblockHTTPAPI:              cfg.UnblockHTTPAPI,
 			NoStartupMessage:            cfg.NoStartupMessage,
 			Filter:                      cfg.Filter,

--- a/docs/advanced-features/http-api/index.md
+++ b/docs/advanced-features/http-api/index.md
@@ -9,11 +9,11 @@ Watchtower has an [optional](../../configuration/arguments/index.md#http_api_mod
 
 ## Endpoints
 
-|              **Name**              | **Method** | **Endpoint**  |                           **Parameters**                            |                           **Description**                            |
-|:----------------------------------:|:----------:|:-------------:|:-------------------------------------------------------------------:|:--------------------------------------------------------------------:|
-|     [Update](#http_api_update)     |   `POST`   | `/v1/update`  | [`image`](#image_parameter_usage), [`async`](#asynchronous_updates) | Triggers container updates and returns JSON results of the operation |
-| [Metrics](../metrics-api/index.md) |   `GET`    | `/v1/metrics` |                                                                     |  Exposes Prometheus-compatible metrics for monitoring and alerting   |
-|  [Containers](#http_api_containers)  |   `GET`    | `/v1/containers` |                                                                     | Lists watched containers and their current running image digests |
+|              **Name**              | **Method** |   **Endpoint**   |                           **Parameters**                            |                           **Description**                            |
+|:----------------------------------:|:----------:|:----------------:|:-------------------------------------------------------------------:|:--------------------------------------------------------------------:|
+|     [Update](#http_api_update)     |   `POST`   |   `/v1/update`   | [`image`](#image_parameter_usage), [`async`](#asynchronous_updates) | Triggers container updates and returns JSON results of the operation |
+| [Metrics](../metrics-api/index.md) |   `GET`    |  `/v1/metrics`   |                                                                     |  Exposes Prometheus-compatible metrics for monitoring and alerting   |
+| [Containers](#http_api_containers) |   `GET`    | `/v1/containers` |                                                                     |   Lists watched containers and their current running image digests   |
 
 !!! Note
     Endpoints enforce HTTP method restrictions using method-based routing.
@@ -320,17 +320,17 @@ The `/v1/containers` endpoint returns a JSON array of watched containers:
 
 ```json
 {
-  "containers": [
-    {
-      "name": "beacon",
-      "image": "ethpandaops/lighthouse:latest",
-      "image_id": "sha256:1111...",
-      "running_digest": "sha256:2222..."
-    }
-  ],
-  "count": 1,
-  "timestamp": "2025-01-20T11:30:45Z",
-  "api_version": "v1"
+    "containers": [
+        {
+            "name": "nginx",
+            "image": "nginx:latest",
+            "image_id": "sha256:1111...",
+            "running_digest": "sha256:2222..."
+        }
+    ],
+    "count": 1,
+    "timestamp": "2025-01-20T11:30:45Z",
+    "api_version": "v1"
 }
 ```
 

--- a/docs/advanced-features/http-api/index.md
+++ b/docs/advanced-features/http-api/index.md
@@ -325,7 +325,7 @@ The `/v1/containers` endpoint returns a JSON array of watched containers:
             "name": "nginx",
             "image": "nginx:latest",
             "image_id": "sha256:1111...",
-            "running_digest": "sha256:2222..."
+            "digest": "sha256:2222..."
         }
     ],
     "count": 1,
@@ -337,7 +337,7 @@ The `/v1/containers` endpoint returns a JSON array of watched containers:
 - `name`: Container name
 - `image`: Image reference with tag
 - `image_id`: Local image config ID
-- `running_digest`: Registry manifest digest the running image was pulled from (from the image's `RepoDigests`), directly comparable to a registry's `Docker-Content-Digest`. Empty for locally-built images with no registry reference.
+- `digest`: Registry manifest digest the image was pulled from (from the image's `RepoDigests`), directly comparable to a registry's `Docker-Content-Digest`. Empty for locally-built images with no registry reference.
 
 !!! Note
     `--http-api-containers` can be enabled alongside `--http-api-update` and `--http-api-metrics`.

--- a/docs/advanced-features/http-api/index.md
+++ b/docs/advanced-features/http-api/index.md
@@ -13,6 +13,7 @@ Watchtower has an [optional](../../configuration/arguments/index.md#http_api_mod
 |:----------------------------------:|:----------:|:-------------:|:-------------------------------------------------------------------:|:--------------------------------------------------------------------:|
 |     [Update](#http_api_update)     |   `POST`   | `/v1/update`  | [`image`](#image_parameter_usage), [`async`](#asynchronous_updates) | Triggers container updates and returns JSON results of the operation |
 | [Metrics](../metrics-api/index.md) |   `GET`    | `/v1/metrics` |                                                                     |  Exposes Prometheus-compatible metrics for monitoring and alerting   |
+|  [Containers](#http_api_containers)  |   `GET`    | `/v1/containers` |                                                                     | Lists watched containers and their current running image digests |
 
 !!! Note
     Endpoints enforce HTTP method restrictions using method-based routing.
@@ -306,3 +307,37 @@ services:
 
 !!! Warning
     Enabling the HTTP API with port mappings will automatically disable Watchtower's self-update functionality to prevent port conflicts during container recreation. See [Updating Watchtower](../../getting-started/updating-watchtower/index.md#port-configuration-limitation) for more details.
+
+### HTTP API Containers
+
+To enable this read-only endpoint, use the `--http-api-containers` CLI argument or the `WATCHTOWER_HTTP_API_CONTAINERS` environment variable.
+
+It lists the containers Watchtower watches along with their current image identity, so an external orchestrator can compare what is actually running against a registry without pulling any image layers.
+
+#### Response Format
+
+The `/v1/containers` endpoint returns a JSON array of watched containers:
+
+```json
+{
+  "containers": [
+    {
+      "name": "beacon",
+      "image": "ethpandaops/lighthouse:latest",
+      "image_id": "sha256:1111...",
+      "running_digest": "sha256:2222..."
+    }
+  ],
+  "count": 1,
+  "timestamp": "2025-01-20T11:30:45Z",
+  "api_version": "v1"
+}
+```
+
+- `name`: Container name
+- `image`: Image reference with tag
+- `image_id`: Local image config ID
+- `running_digest`: Registry manifest digest the running image was pulled from (from the image's `RepoDigests`), directly comparable to a registry's `Docker-Content-Digest`. Empty for locally-built images with no registry reference.
+
+!!! Note
+    `--http-api-containers` can be enabled alongside `--http-api-update` and `--http-api-metrics`.

--- a/docs/configuration/arguments/index.md
+++ b/docs/configuration/arguments/index.md
@@ -763,6 +763,19 @@ Environment Variable: WATCHTOWER_HTTP_API_METRICS
 
 !!! Note "See the [Metrics API documentation](../../advanced-features/metrics-api/index.md) for details"
 
+### HTTP API Containers
+
+Enables a read-only endpoint that lists watched containers and their current running image digests.
+
+```text
+            Argument: --http-api-containers
+Environment Variable: WATCHTOWER_HTTP_API_CONTAINERS
+                Type: Boolean
+             Default: false
+```
+
+!!! Note "See the [HTTP API documentation](../../advanced-features/http-api/index.md#http_api_containers) for details"
+
 ### HTTP API Host
 
 Sets the host interface for binding the HTTP API.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -207,7 +207,7 @@ func SetupAndStartAPI(
 					if digests := info.RepoDigests; len(digests) > 0 {
 						_, digest, found := strings.Cut(digests[0], "@")
 						if found {
-							status.RunningDigest = digest
+							status.Digest = digest
 						} else {
 							logrus.WithFields(logrus.Fields{
 								"container": c.Name(),

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -203,11 +203,17 @@ func SetupAndStartAPI(
 					ImageID: string(c.ImageID()),
 				}
 
-				if c.HasImageInfo() {
-					if digests := c.ImageInfo().RepoDigests; len(digests) > 0 {
-						// Extract digest from "repo@sha256:..." format.
-						_, digest, _ := strings.Cut(digests[0], "@")
-						status.RunningDigest = digest
+				if info := c.ImageInfo(); info != nil {
+					if digests := info.RepoDigests; len(digests) > 0 {
+						_, digest, found := strings.Cut(digests[0], "@")
+						if found {
+							status.RunningDigest = digest
+						} else {
+							logrus.WithFields(logrus.Fields{
+								"container": c.Name(),
+								"digest":    digests[0],
+							}).Debug("RepoDigest in unexpected format, missing @ separator")
+						}
 					}
 				}
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -84,17 +84,6 @@ type Options struct {
 	WriteStartupMessage func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool)
 }
 
-// normalizeRepoDigest extracts the "sha256:..." portion from a RepoDigest entry
-// such as "repo@sha256:abc...". If no "@" is present, the input is returned
-// unchanged.
-func normalizeRepoDigest(repoDigest string) string {
-	if at := strings.LastIndex(repoDigest, "@"); at >= 0 {
-		return repoDigest[at+1:]
-	}
-
-	return repoDigest
-}
-
 // GetAPIAddr formats the API address string based on host and port.
 func GetAPIAddr(host, port string) string {
 	address := host + ":" + port
@@ -216,7 +205,9 @@ func SetupAndStartAPI(
 
 				if c.HasImageInfo() {
 					if digests := c.ImageInfo().RepoDigests; len(digests) > 0 {
-						status.RunningDigest = normalizeRepoDigest(digests[0])
+						// Extract digest from "repo@sha256:..." format.
+						_, digest, _ := strings.Cut(digests[0], "@")
+						status.RunningDigest = digest
 					}
 				}
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/nicholas-fedor/watchtower/pkg/api"
+	containersAPI "github.com/nicholas-fedor/watchtower/pkg/api/containers"
 	metricsAPI "github.com/nicholas-fedor/watchtower/pkg/api/metrics"
 	"github.com/nicholas-fedor/watchtower/pkg/api/update"
 	"github.com/nicholas-fedor/watchtower/pkg/container"
@@ -45,6 +46,8 @@ type Options struct {
 	EnableUpdateAPI bool
 	// EnableMetricsAPI enables the HTTP metrics API endpoint.
 	EnableMetricsAPI bool
+	// EnableContainersAPI enables the read-only containers API endpoint.
+	EnableContainersAPI bool
 	// UnblockHTTPAPI allows periodic polling alongside the HTTP API.
 	UnblockHTTPAPI bool
 	// NoStartupMessage suppresses startup messages if true.
@@ -79,6 +82,17 @@ type Options struct {
 	DefaultMetrics func() *metrics.Metrics
 	// WriteStartupMessage writes the startup message.
 	WriteStartupMessage func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool)
+}
+
+// normalizeRepoDigest extracts the "sha256:..." portion from a RepoDigest entry
+// such as "repo@sha256:abc...". If no "@" is present, the input is returned
+// unchanged.
+func normalizeRepoDigest(repoDigest string) string {
+	if at := strings.LastIndex(repoDigest, "@"); at >= 0 {
+		return repoDigest[at+1:]
+	}
+
+	return repoDigest
 }
 
 // GetAPIAddr formats the API address string based on host and port.
@@ -168,6 +182,51 @@ func SetupAndStartAPI(
 		metricsHandler := metricsAPI.New()
 		// Use Go 1.22+ method-based routing to restrict to GET only.
 		httpAPI.RegisterHandler("GET "+metricsHandler.Path, metricsHandler.Handle)
+	}
+
+	// Register the read-only containers API endpoint if enabled, exposing the
+	// running image identity of each watched container for external orchestrators.
+	if opts.EnableContainersAPI {
+		client := opts.Client
+		filter := opts.Filter
+
+		containersHandler := containersAPI.New(func(ctx context.Context) ([]containersAPI.Status, error) {
+			var (
+				list []types.Container
+				err  error
+			)
+
+			if filter != nil {
+				list, err = client.ListContainers(ctx, filter)
+			} else {
+				list, err = client.ListContainers(ctx)
+			}
+
+			if err != nil {
+				return nil, fmt.Errorf("failed to list containers: %w", err)
+			}
+
+			statuses := make([]containersAPI.Status, 0, len(list))
+			for _, c := range list {
+				status := containersAPI.Status{
+					Name:    c.Name(),
+					Image:   c.ImageName(),
+					ImageID: string(c.ImageID()),
+				}
+
+				if c.HasImageInfo() {
+					if digests := c.ImageInfo().RepoDigests; len(digests) > 0 {
+						status.RunningDigest = normalizeRepoDigest(digests[0])
+					}
+				}
+
+				statuses = append(statuses, status)
+			}
+
+			return statuses, nil
+		})
+		// Use Go 1.22+ method-based routing to restrict to GET only.
+		httpAPI.RegisterFunc("GET "+containersHandler.Path, containersHandler.Handle)
 	}
 
 	// Warn once at startup when self-update will be skipped due to host-bound port conflicts.

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -223,6 +223,11 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		"",
 		envBool("WATCHTOWER_HTTP_API_METRICS"),
 		"Runs Watchtower with the Prometheus metrics API enabled")
+	flags.BoolP(
+		"http-api-containers",
+		"",
+		envBool("WATCHTOWER_HTTP_API_CONTAINERS"),
+		"Runs Watchtower with the read-only containers API enabled, exposing each watched container's current image digest")
 
 	flags.StringP(
 		"http-api-host",

--- a/pkg/api/containers/containers.go
+++ b/pkg/api/containers/containers.go
@@ -1,0 +1,91 @@
+// Package containers provides the /v1/containers HTTP API endpoint, exposing the
+// current image identity (name, local ID, and registry manifest digest) of each
+// container Watchtower watches.
+//
+// This lets an external orchestrator compare what each container is actually
+// running against a registry's current digest without pulling any image layers.
+package containers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Status describes a single watched container's current image identity.
+type Status struct {
+	// Name is the container name.
+	Name string `json:"name"`
+	// Image is the image reference with tag (e.g. ethpandaops/lighthouse:latest).
+	Image string `json:"image"`
+	// ImageID is the local image config ID (sha256:...).
+	ImageID string `json:"image_id"`
+	// RunningDigest is the registry manifest digest the running image was pulled
+	// from (sha256:...), derived from the image's RepoDigests. It is directly
+	// comparable to a registry's Docker-Content-Digest. Empty for locally-built
+	// images with no registry reference.
+	RunningDigest string `json:"running_digest"`
+}
+
+// ListFunc returns the current status of all watched containers.
+type ListFunc func(ctx context.Context) ([]Status, error)
+
+// Handler serves the /v1/containers endpoint.
+//
+// It holds the list function and endpoint path for the read-only
+// /v1/containers endpoint.
+type Handler struct {
+	list ListFunc // Container status lookup function.
+	Path string   // API endpoint path (e.g., "/v1/containers").
+}
+
+// New creates a new containers Handler backed by the given list function.
+//
+// Parameters:
+//   - list: Function returning the current status of all watched containers.
+//
+// Returns:
+//   - *Handler: Initialized handler serving /v1/containers.
+func New(list ListFunc) *Handler {
+	return &Handler{
+		list: list,
+		Path: "/v1/containers",
+	}
+}
+
+// Handle responds with the JSON status of every watched container.
+//
+// Parameters:
+//   - w: HTTP response writer for sending the JSON payload or error status.
+//   - r: HTTP request; its context is propagated to the Docker calls.
+func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
+	logrus.WithFields(logrus.Fields{
+		"method": r.Method,
+		"path":   r.URL.Path,
+	}).Debug("Received HTTP API containers request")
+
+	statuses, err := h.list(r.Context())
+	if err != nil {
+		logrus.WithError(err).Error("Failed to list containers for API")
+		http.Error(w, "failed to list containers", http.StatusInternalServerError)
+
+		return
+	}
+
+	response := map[string]any{
+		"containers":  statuses,
+		"count":       len(statuses),
+		"timestamp":   time.Now().UTC().Format(time.RFC3339),
+		"api_version": "v1",
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		logrus.WithError(err).Error("Failed to encode containers response")
+	}
+}

--- a/pkg/api/containers/containers.go
+++ b/pkg/api/containers/containers.go
@@ -1,9 +1,3 @@
-// Package containers provides the /v1/containers HTTP API endpoint, exposing the
-// current image identity (name, local ID, and registry manifest digest) of each
-// container Watchtower watches.
-//
-// This lets an external orchestrator compare what each container is actually
-// running against a registry's current digest without pulling any image layers.
 package containers
 
 import (

--- a/pkg/api/containers/containers.go
+++ b/pkg/api/containers/containers.go
@@ -1,6 +1,7 @@
 package containers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -76,10 +77,21 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 		"api_version": "v1",
 	}
 
+	var buf bytes.Buffer
+
+	err = json.NewEncoder(&buf).Encode(response)
+	if err != nil {
+		logrus.WithError(err).Error("Failed to encode containers response")
+		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		logrus.WithError(err).Error("Failed to encode containers response")
+	_, err = w.Write(buf.Bytes())
+	if err != nil {
+		logrus.WithError(err).Error("Failed to write containers response")
 	}
 }

--- a/pkg/api/containers/containers.go
+++ b/pkg/api/containers/containers.go
@@ -18,11 +18,11 @@ type Status struct {
 	Image string `json:"image"`
 	// ImageID is the local image config ID (sha256:...).
 	ImageID string `json:"image_id"`
-	// RunningDigest is the registry manifest digest the running image was pulled
-	// from (sha256:...), derived from the image's RepoDigests. It is directly
+	// Digest is the registry manifest digest the image was pulled from
+	// (sha256:...), derived from the image's RepoDigests. It is directly
 	// comparable to a registry's Docker-Content-Digest. Empty for locally-built
 	// images with no registry reference.
-	RunningDigest string `json:"running_digest"`
+	Digest string `json:"digest"`
 }
 
 // ListFunc returns the current status of all watched containers.

--- a/pkg/api/containers/containers_test.go
+++ b/pkg/api/containers/containers_test.go
@@ -1,0 +1,90 @@
+package containers_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+
+	"github.com/nicholas-fedor/watchtower/pkg/api"
+	containersAPI "github.com/nicholas-fedor/watchtower/pkg/api/containers"
+)
+
+const (
+	token       = "123123123"
+	rateLimit60 = 60 // Maximum authentication requests per minute per IP address.
+)
+
+func TestContainers(t *testing.T) {
+	t.Parallel()
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Containers Suite")
+}
+
+var _ = ginkgo.Describe("the containers API", func() {
+	var server *ghttp.Server
+
+	ginkgo.BeforeEach(func() {
+		httpAPI := api.New(token, ":8080", rateLimit60)
+		handler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
+			return []containersAPI.Status{
+				{
+					Name:          "beacon",
+					Image:         "ethpandaops/lighthouse:latest",
+					ImageID:       "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+					RunningDigest: "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+				},
+			}, nil
+		})
+		handleReq := httpAPI.RequireToken(handler.Handle)
+		server = ghttp.NewServer()
+		server.RouteToHandler("GET", "/v1/containers", ghttp.CombineHandlers(
+			ghttp.VerifyRequest("GET", "/v1/containers"),
+			ghttp.VerifyHeaderKV("Authorization", "Bearer "+token),
+			handleReq,
+		))
+	})
+
+	ginkgo.AfterEach(func() {
+		server.Close()
+	})
+
+	ginkgo.It("should serve the running image identity of each container", func() {
+		req, _ := http.NewRequestWithContext(
+			context.Background(),
+			http.MethodGet,
+			server.URL()+"/v1/containers",
+			nil,
+		)
+		req.Header.Add("Authorization", "Bearer "+token)
+
+		resp, err := http.DefaultClient.Do(req)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		defer resp.Body.Close()
+
+		gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
+
+		body, _ := io.ReadAll(resp.Body)
+
+		var parsed struct {
+			Containers []containersAPI.Status `json:"containers"`
+			Count      int                    `json:"count"`
+			APIVersion string                 `json:"api_version"`
+		}
+
+		gomega.Expect(json.Unmarshal(body, &parsed)).To(gomega.Succeed())
+		gomega.Expect(parsed.APIVersion).To(gomega.Equal("v1"))
+		gomega.Expect(parsed.Count).To(gomega.Equal(1))
+		gomega.Expect(parsed.Containers).To(gomega.HaveLen(1))
+		gomega.Expect(parsed.Containers[0].Name).To(gomega.Equal("beacon"))
+		gomega.Expect(parsed.Containers[0].Image).To(gomega.Equal("ethpandaops/lighthouse:latest"))
+		gomega.Expect(parsed.Containers[0].RunningDigest).
+			To(gomega.Equal("sha256:2222222222222222222222222222222222222222222222222222222222222222"))
+	})
+})

--- a/pkg/api/containers/containers_test.go
+++ b/pkg/api/containers/containers_test.go
@@ -3,13 +3,16 @@ package containers_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
+	"github.com/sirupsen/logrus"
 
 	"github.com/nicholas-fedor/watchtower/pkg/api"
 	containersAPI "github.com/nicholas-fedor/watchtower/pkg/api/containers"
@@ -34,8 +37,8 @@ var _ = ginkgo.Describe("the containers API", func() {
 		handler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
 			return []containersAPI.Status{
 				{
-					Name:          "beacon",
-					Image:         "ethpandaops/lighthouse:latest",
+					Name:          "test-container-1",
+					Image:         "example/test-image:latest",
 					ImageID:       "sha256:1111111111111111111111111111111111111111111111111111111111111111",
 					RunningDigest: "sha256:2222222222222222222222222222222222222222222222222222222222222222",
 				},
@@ -54,37 +57,343 @@ var _ = ginkgo.Describe("the containers API", func() {
 		server.Close()
 	})
 
-	ginkgo.It("should serve the running image identity of each container", func() {
-		req, _ := http.NewRequestWithContext(
-			context.Background(),
-			http.MethodGet,
-			server.URL()+"/v1/containers",
-			nil,
-		)
-		req.Header.Add("Authorization", "Bearer "+token)
+	ginkgo.Describe("Successful responses", func() {
+		ginkgo.It("should serve the running image identity of each container", func() {
+			req, _ := http.NewRequestWithContext(
+				context.Background(),
+				http.MethodGet,
+				server.URL()+"/v1/containers",
+				nil,
+			)
+			req.Header.Add("Authorization", "Bearer "+token)
 
-		resp, err := http.DefaultClient.Do(req)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			resp, err := http.DefaultClient.Do(req)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		defer resp.Body.Close()
+			defer resp.Body.Close()
 
-		gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
+			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
 
-		body, _ := io.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 
-		var parsed struct {
-			Containers []containersAPI.Status `json:"containers"`
-			Count      int                    `json:"count"`
-			APIVersion string                 `json:"api_version"`
-		}
+			var parsed struct {
+				Containers []containersAPI.Status `json:"containers"`
+				Count      int                    `json:"count"`
+				APIVersion string                 `json:"api_version"`
+				Timestamp  string                 `json:"timestamp"`
+			}
 
-		gomega.Expect(json.Unmarshal(body, &parsed)).To(gomega.Succeed())
-		gomega.Expect(parsed.APIVersion).To(gomega.Equal("v1"))
-		gomega.Expect(parsed.Count).To(gomega.Equal(1))
-		gomega.Expect(parsed.Containers).To(gomega.HaveLen(1))
-		gomega.Expect(parsed.Containers[0].Name).To(gomega.Equal("beacon"))
-		gomega.Expect(parsed.Containers[0].Image).To(gomega.Equal("ethpandaops/lighthouse:latest"))
-		gomega.Expect(parsed.Containers[0].RunningDigest).
-			To(gomega.Equal("sha256:2222222222222222222222222222222222222222222222222222222222222222"))
+			gomega.Expect(json.Unmarshal(body, &parsed)).To(gomega.Succeed())
+			gomega.Expect(parsed.APIVersion).To(gomega.Equal("v1"))
+			gomega.Expect(parsed.Count).To(gomega.Equal(1))
+			gomega.Expect(parsed.Containers).To(gomega.HaveLen(1))
+			gomega.Expect(parsed.Containers[0].Name).To(gomega.Equal("test-container-1"))
+			gomega.Expect(parsed.Containers[0].Image).To(gomega.Equal("example/test-image:latest"))
+			gomega.Expect(parsed.Containers[0].ImageID).To(gomega.Equal("sha256:1111111111111111111111111111111111111111111111111111111111111111"))
+			gomega.Expect(parsed.Containers[0].RunningDigest).
+				To(gomega.Equal("sha256:2222222222222222222222222222222222222222222222222222222222222222"))
+			gomega.Expect(parsed.Timestamp).ToNot(gomega.BeEmpty())
+		})
+
+		ginkgo.It("should return empty list when no containers are watched", func() {
+			httpAPI := api.New(token, ":8080", rateLimit60)
+			handler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
+				return []containersAPI.Status{}, nil
+			})
+			handleReq := httpAPI.RequireToken(handler.Handle)
+
+			emptyServer := ghttp.NewServer()
+			defer emptyServer.Close()
+
+			emptyServer.RouteToHandler("GET", "/v1/containers", handleReq)
+
+			req, _ := http.NewRequestWithContext(
+				context.Background(),
+				http.MethodGet,
+				emptyServer.URL()+"/v1/containers",
+				nil,
+			)
+			req.Header.Add("Authorization", "Bearer "+token)
+
+			resp, err := http.DefaultClient.Do(req)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			defer resp.Body.Close()
+
+			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
+
+			body, _ := io.ReadAll(resp.Body)
+
+			var parsed struct {
+				Containers []containersAPI.Status `json:"containers"`
+				Count      int                    `json:"count"`
+			}
+
+			gomega.Expect(json.Unmarshal(body, &parsed)).To(gomega.Succeed())
+			gomega.Expect(parsed.Count).To(gomega.Equal(0))
+			gomega.Expect(parsed.Containers).To(gomega.BeEmpty())
+		})
+
+		ginkgo.It("should return multiple containers when multiple are watched", func() {
+			httpAPI := api.New(token, ":8080", rateLimit60)
+			handler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
+				return []containersAPI.Status{
+					{
+						Name:          "test-container-1",
+						Image:         "example/test-image:latest",
+						ImageID:       "sha256:1111",
+						RunningDigest: "sha256:2222",
+					},
+					{
+						Name:          "test-container-2",
+						Image:         "example/other-image:latest",
+						ImageID:       "sha256:3333",
+						RunningDigest: "",
+					},
+				}, nil
+			})
+			handleReq := httpAPI.RequireToken(handler.Handle)
+
+			multiServer := ghttp.NewServer()
+			defer multiServer.Close()
+
+			multiServer.RouteToHandler("GET", "/v1/containers", handleReq)
+
+			req, _ := http.NewRequestWithContext(
+				context.Background(),
+				http.MethodGet,
+				multiServer.URL()+"/v1/containers",
+				nil,
+			)
+			req.Header.Add("Authorization", "Bearer "+token)
+
+			resp, err := http.DefaultClient.Do(req)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			defer resp.Body.Close()
+
+			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
+
+			body, _ := io.ReadAll(resp.Body)
+
+			var parsed struct {
+				Containers []containersAPI.Status `json:"containers"`
+				Count      int                    `json:"count"`
+			}
+
+			gomega.Expect(json.Unmarshal(body, &parsed)).To(gomega.Succeed())
+			gomega.Expect(parsed.Count).To(gomega.Equal(2))
+			gomega.Expect(parsed.Containers).To(gomega.HaveLen(2))
+			gomega.Expect(parsed.Containers[0].Name).To(gomega.Equal("test-container-1"))
+			gomega.Expect(parsed.Containers[1].Name).To(gomega.Equal("test-container-2"))
+			gomega.Expect(parsed.Containers[1].RunningDigest).To(gomega.BeEmpty())
+		})
+	})
+
+	ginkgo.Describe("Authentication", func() {
+		ginkgo.It("should return 401 Unauthorized without token", func() {
+			httpAPI := api.New(token, ":8080", rateLimit60)
+			handler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
+				return []containersAPI.Status{}, nil
+			})
+			handleReq := httpAPI.RequireToken(handler.Handle)
+
+			authTestServer := ghttp.NewServer()
+			defer authTestServer.Close()
+
+			authTestServer.RouteToHandler("GET", "/v1/containers", handleReq)
+
+			req, _ := http.NewRequestWithContext(
+				context.Background(),
+				http.MethodGet,
+				authTestServer.URL()+"/v1/containers",
+				nil,
+			)
+
+			resp, err := http.DefaultClient.Do(req)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			defer resp.Body.Close()
+
+			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusUnauthorized))
+		})
+
+		ginkgo.It("should return 401 Unauthorized with invalid token", func() {
+			httpAPI := api.New(token, ":8080", rateLimit60)
+			handler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
+				return []containersAPI.Status{}, nil
+			})
+			handleReq := httpAPI.RequireToken(handler.Handle)
+
+			authTestServer := ghttp.NewServer()
+			defer authTestServer.Close()
+
+			authTestServer.RouteToHandler("GET", "/v1/containers", handleReq)
+
+			req, _ := http.NewRequestWithContext(
+				context.Background(),
+				http.MethodGet,
+				authTestServer.URL()+"/v1/containers",
+				nil,
+			)
+			req.Header.Add("Authorization", "Bearer invalid-token")
+
+			resp, err := http.DefaultClient.Do(req)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			defer resp.Body.Close()
+
+			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusUnauthorized))
+		})
+
+		ginkgo.It("should return 401 Unauthorized with malformed Authorization header", func() {
+			httpAPI := api.New(token, ":8080", rateLimit60)
+			handler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
+				return []containersAPI.Status{}, nil
+			})
+			handleReq := httpAPI.RequireToken(handler.Handle)
+
+			authTestServer := ghttp.NewServer()
+			defer authTestServer.Close()
+
+			authTestServer.RouteToHandler("GET", "/v1/containers", handleReq)
+
+			req, _ := http.NewRequestWithContext(
+				context.Background(),
+				http.MethodGet,
+				authTestServer.URL()+"/v1/containers",
+				nil,
+			)
+			req.Header.Add("Authorization", "InvalidFormat token")
+
+			resp, err := http.DefaultClient.Do(req)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			defer resp.Body.Close()
+
+			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusUnauthorized))
+		})
+	})
+
+	ginkgo.Describe("Content-Type headers", func() {
+		ginkgo.It("should return application/json Content-Type", func() {
+			req, _ := http.NewRequestWithContext(
+				context.Background(),
+				http.MethodGet,
+				server.URL()+"/v1/containers",
+				nil,
+			)
+			req.Header.Add("Authorization", "Bearer "+token)
+
+			resp, err := http.DefaultClient.Do(req)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			defer resp.Body.Close()
+
+			gomega.Expect(resp.Header.Get("Content-Type")).To(gomega.Equal("application/json"))
+		})
 	})
 })
+
+// TestHandleReturns500OnListError verifies that the handler returns 500 Internal
+// Server Error when the list function returns an error.
+func TestHandleReturns500OnListError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("list error")
+	handler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
+		return nil, expectedErr
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"/v1/containers",
+		nil,
+	)
+
+	handler.Handle(rec, req)
+
+	gomega.Expect(rec.Code).To(gomega.Equal(http.StatusInternalServerError))
+
+	body, err := io.ReadAll(rec.Body)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	gomega.Expect(string(body)).To(gomega.ContainSubstring("failed to list containers"))
+}
+
+// TestHandleReturnsEmptyRunningDigestForLocalImages verifies that RunningDigest
+// is empty for locally-built images with no registry reference.
+func TestHandleReturnsEmptyRunningDigestForLocalImages(t *testing.T) {
+	t.Parallel()
+
+	handler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
+		return []containersAPI.Status{
+			{
+				Name:          "test-container-local",
+				Image:         "local-image:latest",
+				ImageID:       "sha256:abc123",
+				RunningDigest: "",
+			},
+		}, nil
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"/v1/containers",
+		nil,
+	)
+
+	handler.Handle(rec, req)
+
+	gomega.Expect(rec.Code).To(gomega.Equal(http.StatusOK))
+
+	var parsed struct {
+		Containers []containersAPI.Status `json:"containers"`
+	}
+
+	gomega.Expect(json.Unmarshal(rec.Body.Bytes(), &parsed)).To(gomega.Succeed())
+	gomega.Expect(parsed.Containers).To(gomega.HaveLen(1))
+	gomega.Expect(parsed.Containers[0].RunningDigest).To(gomega.BeEmpty())
+}
+
+// TestNewHandlerSetsCorrectPath verifies that New creates a handler with the
+// correct endpoint path.
+func TestNewHandlerSetsCorrectPath(t *testing.T) {
+	t.Parallel()
+
+	handler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
+		return nil, nil
+	})
+
+	gomega.Expect(handler.Path).To(gomega.Equal("/v1/containers"))
+}
+
+// TestHandlerStartsDebugLogging verifies debug logging on request.
+func TestHandlerStartsDebugLogging(t *testing.T) {
+	t.Parallel()
+
+	// Suppress log output during test.
+	originalOutput := logrus.StandardLogger().Out
+
+	logrus.SetOutput(io.Discard)
+	defer logrus.SetOutput(originalOutput)
+
+	handler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
+		return []containersAPI.Status{}, nil
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"/v1/containers",
+		nil,
+	)
+
+	handler.Handle(rec, req)
+
+	gomega.Expect(rec.Code).To(gomega.Equal(http.StatusOK))
+}

--- a/pkg/api/containers/containers_test.go
+++ b/pkg/api/containers/containers_test.go
@@ -96,16 +96,20 @@ var _ = ginkgo.Describe("the containers API", func() {
 		})
 
 		ginkgo.It("should return empty list when no containers are watched", func() {
-			httpAPI := api.New(token, ":8080", rateLimit60)
-			handler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
+			emptyHTTPAPI := api.New(token, ":8080", rateLimit60)
+			emptyHandler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
 				return []containersAPI.Status{}, nil
 			})
-			handleReq := httpAPI.RequireToken(handler.Handle)
+			emptyTokenHandler := emptyHTTPAPI.RequireToken(emptyHandler.Handle)
 
 			emptyServer := ghttp.NewServer()
 			defer emptyServer.Close()
 
-			emptyServer.RouteToHandler("GET", "/v1/containers", handleReq)
+			emptyServer.RouteToHandler("GET", "/v1/containers", ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", "/v1/containers"),
+				ghttp.VerifyHeaderKV("Authorization", "Bearer "+token),
+				emptyTokenHandler,
+			))
 
 			req, _ := http.NewRequestWithContext(
 				context.Background(),
@@ -135,8 +139,8 @@ var _ = ginkgo.Describe("the containers API", func() {
 		})
 
 		ginkgo.It("should return multiple containers when multiple are watched", func() {
-			httpAPI := api.New(token, ":8080", rateLimit60)
-			handler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
+			multiHTTPAPI := api.New(token, ":8080", rateLimit60)
+			multiHandler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
 				return []containersAPI.Status{
 					{
 						Name:          "test-container-1",
@@ -152,12 +156,16 @@ var _ = ginkgo.Describe("the containers API", func() {
 					},
 				}, nil
 			})
-			handleReq := httpAPI.RequireToken(handler.Handle)
+			multiTokenHandler := multiHTTPAPI.RequireToken(multiHandler.Handle)
 
 			multiServer := ghttp.NewServer()
 			defer multiServer.Close()
 
-			multiServer.RouteToHandler("GET", "/v1/containers", handleReq)
+			multiServer.RouteToHandler("GET", "/v1/containers", ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", "/v1/containers"),
+				ghttp.VerifyHeaderKV("Authorization", "Bearer "+token),
+				multiTokenHandler,
+			))
 
 			req, _ := http.NewRequestWithContext(
 				context.Background(),
@@ -192,21 +200,24 @@ var _ = ginkgo.Describe("the containers API", func() {
 
 	ginkgo.Describe("Authentication", func() {
 		ginkgo.It("should return 401 Unauthorized without token", func() {
-			httpAPI := api.New(token, ":8080", rateLimit60)
-			handler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
+			noAuthHTTPAPI := api.New(token, ":8080", rateLimit60)
+			noAuthHandler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
 				return []containersAPI.Status{}, nil
 			})
-			handleReq := httpAPI.RequireToken(handler.Handle)
+			noAuthTokenHandler := noAuthHTTPAPI.RequireToken(noAuthHandler.Handle)
 
-			authTestServer := ghttp.NewServer()
-			defer authTestServer.Close()
+			noAuthServer := ghttp.NewServer()
+			defer noAuthServer.Close()
 
-			authTestServer.RouteToHandler("GET", "/v1/containers", handleReq)
+			noAuthServer.RouteToHandler("GET", "/v1/containers", ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", "/v1/containers"),
+				noAuthTokenHandler,
+			))
 
 			req, _ := http.NewRequestWithContext(
 				context.Background(),
 				http.MethodGet,
-				authTestServer.URL()+"/v1/containers",
+				noAuthServer.URL()+"/v1/containers",
 				nil,
 			)
 
@@ -219,21 +230,24 @@ var _ = ginkgo.Describe("the containers API", func() {
 		})
 
 		ginkgo.It("should return 401 Unauthorized with invalid token", func() {
-			httpAPI := api.New(token, ":8080", rateLimit60)
-			handler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
+			invalidHTTPAPI := api.New(token, ":8080", rateLimit60)
+			invalidHandler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
 				return []containersAPI.Status{}, nil
 			})
-			handleReq := httpAPI.RequireToken(handler.Handle)
+			invalidTokenHandler := invalidHTTPAPI.RequireToken(invalidHandler.Handle)
 
-			authTestServer := ghttp.NewServer()
-			defer authTestServer.Close()
+			invalidServer := ghttp.NewServer()
+			defer invalidServer.Close()
 
-			authTestServer.RouteToHandler("GET", "/v1/containers", handleReq)
+			invalidServer.RouteToHandler("GET", "/v1/containers", ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", "/v1/containers"),
+				invalidTokenHandler,
+			))
 
 			req, _ := http.NewRequestWithContext(
 				context.Background(),
 				http.MethodGet,
-				authTestServer.URL()+"/v1/containers",
+				invalidServer.URL()+"/v1/containers",
 				nil,
 			)
 			req.Header.Add("Authorization", "Bearer invalid-token")
@@ -247,21 +261,24 @@ var _ = ginkgo.Describe("the containers API", func() {
 		})
 
 		ginkgo.It("should return 401 Unauthorized with malformed Authorization header", func() {
-			httpAPI := api.New(token, ":8080", rateLimit60)
-			handler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
+			malformedHTTPAPI := api.New(token, ":8080", rateLimit60)
+			malformedHandler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
 				return []containersAPI.Status{}, nil
 			})
-			handleReq := httpAPI.RequireToken(handler.Handle)
+			malformedTokenHandler := malformedHTTPAPI.RequireToken(malformedHandler.Handle)
 
-			authTestServer := ghttp.NewServer()
-			defer authTestServer.Close()
+			malformedServer := ghttp.NewServer()
+			defer malformedServer.Close()
 
-			authTestServer.RouteToHandler("GET", "/v1/containers", handleReq)
+			malformedServer.RouteToHandler("GET", "/v1/containers", ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", "/v1/containers"),
+				malformedTokenHandler,
+			))
 
 			req, _ := http.NewRequestWithContext(
 				context.Background(),
 				http.MethodGet,
-				authTestServer.URL()+"/v1/containers",
+				malformedServer.URL()+"/v1/containers",
 				nil,
 			)
 			req.Header.Add("Authorization", "InvalidFormat token")

--- a/pkg/api/containers/containers_test.go
+++ b/pkg/api/containers/containers_test.go
@@ -37,10 +37,10 @@ var _ = ginkgo.Describe("the containers API", func() {
 		handler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
 			return []containersAPI.Status{
 				{
-					Name:          "test-container-1",
-					Image:         "example/test-image:latest",
-					ImageID:       "sha256:1111111111111111111111111111111111111111111111111111111111111111",
-					RunningDigest: "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+					Name:    "test-container-1",
+					Image:   "example/test-image:latest",
+					ImageID: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+					Digest:  "sha256:2222222222222222222222222222222222222222222222222222222222222222",
 				},
 			}, nil
 		})
@@ -90,7 +90,7 @@ var _ = ginkgo.Describe("the containers API", func() {
 			gomega.Expect(parsed.Containers[0].Name).To(gomega.Equal("test-container-1"))
 			gomega.Expect(parsed.Containers[0].Image).To(gomega.Equal("example/test-image:latest"))
 			gomega.Expect(parsed.Containers[0].ImageID).To(gomega.Equal("sha256:1111111111111111111111111111111111111111111111111111111111111111"))
-			gomega.Expect(parsed.Containers[0].RunningDigest).
+			gomega.Expect(parsed.Containers[0].Digest).
 				To(gomega.Equal("sha256:2222222222222222222222222222222222222222222222222222222222222222"))
 			gomega.Expect(parsed.Timestamp).ToNot(gomega.BeEmpty())
 		})
@@ -143,16 +143,16 @@ var _ = ginkgo.Describe("the containers API", func() {
 			multiHandler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
 				return []containersAPI.Status{
 					{
-						Name:          "test-container-1",
-						Image:         "example/test-image:latest",
-						ImageID:       "sha256:1111",
-						RunningDigest: "sha256:2222",
+						Name:    "test-container-1",
+						Image:   "example/test-image:latest",
+						ImageID: "sha256:1111",
+						Digest:  "sha256:2222",
 					},
 					{
-						Name:          "test-container-2",
-						Image:         "example/other-image:latest",
-						ImageID:       "sha256:3333",
-						RunningDigest: "",
+						Name:    "test-container-2",
+						Image:   "example/other-image:latest",
+						ImageID: "sha256:3333",
+						Digest:  "",
 					},
 				}, nil
 			})
@@ -194,7 +194,7 @@ var _ = ginkgo.Describe("the containers API", func() {
 			gomega.Expect(parsed.Containers).To(gomega.HaveLen(2))
 			gomega.Expect(parsed.Containers[0].Name).To(gomega.Equal("test-container-1"))
 			gomega.Expect(parsed.Containers[1].Name).To(gomega.Equal("test-container-2"))
-			gomega.Expect(parsed.Containers[1].RunningDigest).To(gomega.BeEmpty())
+			gomega.Expect(parsed.Containers[1].Digest).To(gomega.BeEmpty())
 		})
 	})
 
@@ -339,18 +339,18 @@ func TestHandleReturns500OnListError(t *testing.T) {
 	gomega.Expect(string(body)).To(gomega.ContainSubstring("failed to list containers"))
 }
 
-// TestHandleReturnsEmptyRunningDigestForLocalImages verifies that RunningDigest
+// TestHandleReturnsEmptyDigestForLocalImages verifies that Digest
 // is empty for locally-built images with no registry reference.
-func TestHandleReturnsEmptyRunningDigestForLocalImages(t *testing.T) {
+func TestHandleReturnsEmptyDigestForLocalImages(t *testing.T) {
 	t.Parallel()
 
 	handler := containersAPI.New(func(_ context.Context) ([]containersAPI.Status, error) {
 		return []containersAPI.Status{
 			{
-				Name:          "test-container-local",
-				Image:         "local-image:latest",
-				ImageID:       "sha256:abc123",
-				RunningDigest: "",
+				Name:    "test-container-local",
+				Image:   "local-image:latest",
+				ImageID: "sha256:abc123",
+				Digest:  "",
 			},
 		}, nil
 	})
@@ -373,7 +373,7 @@ func TestHandleReturnsEmptyRunningDigestForLocalImages(t *testing.T) {
 
 	gomega.Expect(json.Unmarshal(rec.Body.Bytes(), &parsed)).To(gomega.Succeed())
 	gomega.Expect(parsed.Containers).To(gomega.HaveLen(1))
-	gomega.Expect(parsed.Containers[0].RunningDigest).To(gomega.BeEmpty())
+	gomega.Expect(parsed.Containers[0].Digest).To(gomega.BeEmpty())
 }
 
 // TestNewHandlerSetsCorrectPath verifies that New creates a handler with the

--- a/pkg/api/containers/doc.go
+++ b/pkg/api/containers/doc.go
@@ -7,7 +7,7 @@
 //
 // Key components:
 //   - Handler: Serves the /v1/containers endpoint with container status information.
-//   - Status: Data model for container image identity (name, image, image ID, running digest).
+//   - Status: Data model for container image identity (name, image, image ID, digest).
 //   - New: Creates a handler with a list function for fetching container statuses.
 //
 // Usage example:

--- a/pkg/api/containers/doc.go
+++ b/pkg/api/containers/doc.go
@@ -1,0 +1,20 @@
+// Package containers provides the /v1/containers HTTP API endpoint, exposing the
+// current image identity (name, local ID, and registry manifest digest) of each
+// container Watchtower watches.
+//
+// This lets an external orchestrator compare what each container is actually
+// running against a registry's current digest without pulling any image layers.
+//
+// Key components:
+//   - Handler: Serves the /v1/containers endpoint with container status information.
+//   - Status: Data model for container image identity (name, image, image ID, running digest).
+//   - New: Creates a handler with a list function for fetching container statuses.
+//
+// Usage example:
+//
+//	handler := containers.New(listFunc)
+//	http.HandleFunc("GET "+handler.Path, handler.Handle)
+//
+// The package returns JSON responses with container array, count, timestamp,
+// and API version.
+package containers

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -26,6 +26,8 @@ type RunConfig struct {
 	EnableUpdateAPI bool
 	// EnableMetricsAPI enables the HTTP metrics API endpoint, set via the --http-api-metrics flag.
 	EnableMetricsAPI bool
+	// EnableContainersAPI enables the read-only containers API endpoint, set via the --http-api-containers flag.
+	EnableContainersAPI bool
 	// UnblockHTTPAPI allows periodic polling alongside the HTTP API, set via the --http-api-periodic-polls flag.
 	UnblockHTTPAPI bool
 	// APIToken is the authentication token for HTTP API access, set via the --http-api-token flag.


### PR DESCRIPTION
## Summary

Adds an optional, read-only `GET /v1/containers` HTTP API endpoint (enabled with `--http-api-containers` / `WATCHTOWER_HTTP_API_CONTAINERS`) that lists each watched container's current image identity:

- `name` — container name
- `image` — image reference with tag
- `image_id` — local image config ID
- `running_digest` — the registry manifest digest the running image was pulled from (from the image's `RepoDigests`), directly comparable to a registry's `Docker-Content-Digest`. Empty for locally-built images with no registry reference.

It's the read-only counterpart to `/v1/update`: it lets an external orchestrator see what each container is actually running and compare it against a registry **without pulling any image layers**. Addresses the use case in #979.

## Motivation

We drive gated, sequential image rollouts across an Ethereum node fleet and need to know which container is on which digest — both to decide what to roll and to confirm a node recovered onto the new digest afterwards. Watchtower already inspects this information internally; this just exposes it read-only.

## Changes

- New `pkg/api/containers` handler (+ test)
- Wire-up in `internal/api` behind the new flag, listing via the existing container client + filter and reading `ImageInfo().RepoDigests`
- Flag + config plumbing (`internal/flags`, `pkg/types`, `cmd/root.go`)
- Docs: HTTP API + arguments pages

## Notes

- Token-authenticated and GET-only, same as `/v1/metrics`.
- Coexists with `--http-api-update` and `--http-api-metrics`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/api/containers/...`
- [ ] Manual: `curl -H "Authorization: Bearer <token>" localhost:8080/v1/containers`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only GET /v1/containers HTTP API that lists watched containers with name, image, image ID, and registry-derived digest; response includes containers, count, timestamp, and api_version.
  * Added a CLI flag (--http-api-containers) and environment variable to enable the containers API.

* **Documentation**
  * Documented the new endpoint, response fields, and how to enable the option.

* **Tests**
  * Added unit and integration tests covering success, empty results, auth failures, handler errors, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/watchtower/pull/1700?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->