### PR TITLE
fix: resolve stale predecessor misidentification during self-update

### DIFF
--- a/internal/actions/actions_internal_test.go
+++ b/internal/actions/actions_internal_test.go
@@ -127,7 +127,7 @@ var _ = ginkgo.Describe("restartStaleContainer", func() {
 		testContainer := client.TestData.Containers[0]
 		newID, renamed, err := restartStaleContainer(context.Background(), testContainer, client, params)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(renamed).To(gomega.BeFalse())
+		gomega.Expect(renamed).To(gomega.BeTrue())
 		gomega.Expect(client.TestData.RenameContainerCount.Load()).To(gomega.Equal(int32(0)))
 		gomega.Expect(newID).NotTo(gomega.BeEmpty())
 	})

--- a/internal/actions/actions_internal_test.go
+++ b/internal/actions/actions_internal_test.go
@@ -96,6 +96,41 @@ var _ = ginkgo.Describe("restartStaleContainer", func() {
 		gomega.Expect(client.TestData.RenameContainerCount.Load()).To(gomega.Equal(int32(1)))
 		gomega.Expect(newID).NotTo(gomega.BeEmpty())
 	})
+
+	ginkgo.It("should skip rename if source container is already named with the target old name", func() {
+		client := mockActions.CreateMockClient(
+			&mockActions.TestData{
+				Containers: []types.Container{
+					mockActions.CreateMockContainerWithConfig(
+						"abc123def456",
+						"/watchtower-old-abc123def456",
+						"watchtower:latest",
+						true,
+						false,
+						time.Now(),
+						&dockerContainer.Config{
+							Labels: map[string]string{
+								"com.centurylinklabs.watchtower": "true",
+							},
+						}),
+				},
+				Staleness: map[string]bool{
+					"watchtower": true,
+				},
+			},
+			false,
+			false,
+		)
+		params := types.UpdateParams{
+			RunOnce: false,
+		}
+		testContainer := client.TestData.Containers[0]
+		newID, renamed, err := restartStaleContainer(context.Background(), testContainer, client, params)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(renamed).To(gomega.BeFalse())
+		gomega.Expect(client.TestData.RenameContainerCount.Load()).To(gomega.Equal(int32(0)))
+		gomega.Expect(newID).NotTo(gomega.BeEmpty())
+	})
 })
 
 var _ = ginkgo.Describe("handleUpdateResult", func() {

--- a/internal/actions/cleanup.go
+++ b/internal/actions/cleanup.go
@@ -187,14 +187,58 @@ func getFilteredContainers(
 
 	currentID := string(currentContainer.ID())
 	if container.IsOldNamedContainer(currentContainer.Name()) {
-		// Detection selected an old-named predecessor. Use the non-old-named
-		// successor as the effective "current" to keep.
-		for _, c := range filteredContainers {
-			if !container.IsOldNamedContainer(c.Name()) {
-				currentID = string(c.ID())
+		// Detection selected an old-named predecessor. Resolve the true
+		// successor by lineage: prefer a non-old-named container whose
+		// chain label contains the old container's ID, confirming it is
+		// the direct successor in the self-update chain.
+		currentScope, currentHasScope := currentContainer.Scope()
+		if !currentHasScope || currentScope == "" {
+			currentScope = "none"
+		}
 
+		chainMatchID := ""
+		scopeMatchID := ""
+
+		for _, c := range filteredContainers {
+			if container.IsOldNamedContainer(c.Name()) {
+				continue
+			}
+
+			candidateScope, candidateHasScope := c.Scope()
+			if !candidateHasScope || candidateScope == "" {
+				candidateScope = "none"
+			}
+
+			if candidateScope != currentScope {
+				continue
+			}
+
+			if scopeMatchID == "" {
+				scopeMatchID = string(c.ID())
+			}
+
+			chainValue, hasChain := c.GetContainerChain()
+			if !hasChain || chainValue == "" {
+				continue
+			}
+
+			for chainID := range strings.SplitSeq(chainValue, ",") {
+				if strings.TrimSpace(chainID) == string(currentContainer.ID()) {
+					chainMatchID = string(c.ID())
+
+					break
+				}
+			}
+
+			if chainMatchID != "" {
 				break
 			}
+		}
+
+		if chainMatchID != "" {
+			currentID = chainMatchID
+		} else if scopeMatchID != "" {
+			currentID = scopeMatchID
 		}
 	}
 
@@ -233,15 +277,16 @@ func getChainedContainers(
 
 	effectiveCurrent := currentContainer
 	if currentContainer != nil && container.IsOldNamedContainer(currentContainer.Name()) {
-		// Detection selected old-named. Prefer the non-old-named successor
-		// which carries the updated chain label. Match by scope to avoid
-		// selecting a Watchtower from a different lineage.
+		// Detection selected old-named. Resolve the true successor by
+		// lineage: prefer a non-old-named Watchtower container whose chain
+		// label contains the old container's ID. Fall back to scope-only
+		// matching if no explicit lineage link exists.
 		currentScope, currentHasScope := currentContainer.Scope()
 		if !currentHasScope || currentScope == "" {
 			currentScope = "none"
 		}
 
-		found := false
+		chainMatch := false
 
 		for _, c := range allContainers {
 			if !c.IsWatchtower() || container.IsOldNamedContainer(c.Name()) {
@@ -257,13 +302,30 @@ func getChainedContainers(
 				continue
 			}
 
-			effectiveCurrent = c
-			found = true
+			chainValue, hasChain := c.GetContainerChain()
+			if !hasChain || chainValue == "" {
+				if !chainMatch {
+					effectiveCurrent = c
+				}
 
-			break
+				continue
+			}
+
+			for chainID := range strings.SplitSeq(chainValue, ",") {
+				if strings.TrimSpace(chainID) == string(currentContainer.ID()) {
+					effectiveCurrent = c
+					chainMatch = true
+
+					break
+				}
+			}
+
+			if chainMatch {
+				break
+			}
 		}
 
-		if !found {
+		if !chainMatch && effectiveCurrent == currentContainer {
 			effectiveCurrent = nil
 		}
 	}

--- a/internal/actions/cleanup.go
+++ b/internal/actions/cleanup.go
@@ -185,8 +185,21 @@ func getFilteredContainers(
 
 	var excessContainers []types.Container
 
+	currentID := string(currentContainer.ID())
+	if container.IsOldNamedContainer(currentContainer.Name()) {
+		// Detection selected an old-named predecessor. Use the non-old-named
+		// successor as the effective "current" to keep.
+		for _, c := range filteredContainers {
+			if !container.IsOldNamedContainer(c.Name()) {
+				currentID = string(c.ID())
+
+				break
+			}
+		}
+	}
+
 	for _, c := range filteredContainers {
-		if string(c.ID()) != string(currentContainer.ID()) {
+		if string(c.ID()) != currentID {
 			excessContainers = append(excessContainers, c)
 		}
 	}
@@ -218,8 +231,42 @@ func getChainedContainers(
 ) []types.Container {
 	var chainedContainers []types.Container
 
-	// Get the current Watchtower container's com.centurylinklabs.watchtower.container-chain label.
-	chainLabelValue, present := currentContainer.GetContainerChain()
+	effectiveCurrent := currentContainer
+	if currentContainer != nil && container.IsOldNamedContainer(currentContainer.Name()) {
+		// Detection selected old-named. Prefer the non-old-named successor
+		// which carries the updated chain label. Match by scope to avoid
+		// selecting a Watchtower from a different lineage.
+		currentScope, currentHasScope := currentContainer.Scope()
+		if !currentHasScope || currentScope == "" {
+			currentScope = "none"
+		}
+
+		for _, c := range allContainers {
+			if !c.IsWatchtower() || container.IsOldNamedContainer(c.Name()) {
+				continue
+			}
+
+			candidateScope, candidateHasScope := c.Scope()
+			if !candidateHasScope || candidateScope == "" {
+				candidateScope = "none"
+			}
+
+			if candidateScope != currentScope {
+				continue
+			}
+
+			effectiveCurrent = c
+
+			break
+		}
+	}
+
+	if effectiveCurrent == nil {
+		return []types.Container{}
+	}
+
+	// Get the (effective) current Watchtower container's com.centurylinklabs.watchtower.container-chain label.
+	chainLabelValue, present := effectiveCurrent.GetContainerChain()
 
 	// If it's not present, there are no chained containers.
 	if !present {
@@ -240,11 +287,11 @@ func getChainedContainers(
 		containerChainMap[id] = struct{}{}
 	}
 
-	// Filter containers that are in the chain, present on the host, and not the current container.
+	// Filter containers that are in the chain, present on the host, and not the effective current.
 	// Chained containers are parent containers that must be removed regardless of scope.
 	for _, c := range allContainers {
 		if _, exists := containerChainMap[string(c.ID())]; exists &&
-			c.ID() != currentContainer.ID() {
+			c.ID() != effectiveCurrent.ID() {
 			chainedContainers = append(chainedContainers, c)
 		}
 	}

--- a/internal/actions/cleanup.go
+++ b/internal/actions/cleanup.go
@@ -241,6 +241,8 @@ func getChainedContainers(
 			currentScope = "none"
 		}
 
+		found := false
+
 		for _, c := range allContainers {
 			if !c.IsWatchtower() || container.IsOldNamedContainer(c.Name()) {
 				continue
@@ -256,8 +258,13 @@ func getChainedContainers(
 			}
 
 			effectiveCurrent = c
+			found = true
 
 			break
+		}
+
+		if !found {
+			effectiveCurrent = nil
 		}
 	}
 

--- a/internal/actions/cleanup_test.go
+++ b/internal/actions/cleanup_test.go
@@ -723,6 +723,139 @@ var _ = ginkgo.Describe("CheckForMultipleWatchtowerInstances", func() {
 			gomega.Expect(cleanupImageInfos).To(gomega.BeEmpty())
 		})
 
+		ginkgo.It("should cleanup old-named container via name belt even when current detection points to the old-named one", func() {
+			oldID := types.ContainerID("old123")
+
+			oldContainer := createMockContainer(
+				string(oldID),
+				"watchtower-old-old123",
+				"watchtower:latest",
+				true,
+				false,
+				time.Now().Add(-time.Hour),
+				map[string]string{
+					"com.centurylinklabs.watchtower": "true",
+				},
+			)
+
+			newID := types.ContainerID("new456")
+
+			newContainer := createMockContainer(
+				string(newID),
+				"watchtower",
+				"watchtower:latest",
+				true,
+				false,
+				time.Now(),
+				map[string]string{
+					"com.centurylinklabs.watchtower":                 "true",
+					"com.centurylinklabs.watchtower.container-chain": string(oldID),
+				},
+			)
+
+			mockClient := mockContainer.NewMockClient(ginkgo.GinkgoT())
+
+			mockClient.EXPECT().
+				ListContainers(mock.Anything, mock.Anything).
+				Return([]types.Container{oldContainer, newContainer}, nil)
+			mockClient.EXPECT().
+				StopAndRemoveContainer(context.Background(), oldContainer, 10*time.Minute).
+				Return(nil).
+				Times(1)
+
+			var cleanupImageInfos []types.RemovedImageInfo
+
+			// Belt case: current detection selected the old-named predecessor.
+			cleanupOccurred, err := RemoveExcessWatchtowerInstances(
+				context.Background(),
+				mockClient,
+				true,
+				"",
+				&cleanupImageInfos,
+				oldContainer,
+			)
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(cleanupOccurred).To(gomega.Equal(1))
+			gomega.Expect(cleanupImageInfos).To(gomega.BeEmpty())
+		})
+
+		ginkgo.It("should select same-scope successor when resolving old-named current container", func() {
+			// Old-named current in scope-a with two non-old successors in different scopes.
+			// Must pick the scope-a successor, not the scope-b one.
+			oldID := types.ContainerID("old-scoped-a")
+
+			oldContainer := createMockContainer(
+				string(oldID),
+				"watchtower-old-scoped-a",
+				"watchtower:latest",
+				true,
+				false,
+				time.Now().Add(-2*time.Hour),
+				map[string]string{
+					"com.centurylinklabs.watchtower":       "true",
+					"com.centurylinklabs.watchtower.scope": "scope-a",
+				},
+			)
+
+			scopeANewID := types.ContainerID("new-scoped-a")
+
+			scopeANewContainer := createMockContainer(
+				string(scopeANewID),
+				"watchtower",
+				"watchtower:latest",
+				true,
+				false,
+				time.Now(),
+				map[string]string{
+					"com.centurylinklabs.watchtower":                 "true",
+					"com.centurylinklabs.watchtower.scope":           "scope-a",
+					"com.centurylinklabs.watchtower.container-chain": string(oldID),
+				},
+			)
+
+			scopeBNewID := types.ContainerID("new-scoped-b")
+
+			scopeBNewContainer := createMockContainer(
+				string(scopeBNewID),
+				"watchtower",
+				"watchtower:latest",
+				true,
+				false,
+				time.Now().Add(-time.Hour),
+				map[string]string{
+					"com.centurylinklabs.watchtower":       "true",
+					"com.centurylinklabs.watchtower.scope": "scope-b",
+				},
+			)
+
+			mockClient := mockContainer.NewMockClient(ginkgo.GinkgoT())
+
+			// scope-b container appears first in the list to test that it is skipped
+			mockClient.EXPECT().
+				ListContainers(mock.Anything, mock.Anything).
+				Return([]types.Container{scopeBNewContainer, oldContainer, scopeANewContainer}, nil)
+			mockClient.EXPECT().
+				StopAndRemoveContainer(context.Background(), oldContainer, 10*time.Minute).
+				Return(nil).
+				Times(1)
+
+			var cleanupImageInfos []types.RemovedImageInfo
+
+			cleanupOccurred, err := RemoveExcessWatchtowerInstances(
+				context.Background(),
+				mockClient,
+				true,
+				"scope-a",
+				&cleanupImageInfos,
+				oldContainer,
+			)
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(cleanupOccurred).To(gomega.Equal(1))
+			gomega.Expect(cleanupImageInfos).To(gomega.BeEmpty())
+		})
+
 		ginkgo.It("should respect scope boundaries when cleaning up container chains", func() {
 			oldID := types.ContainerID("old-scoped")
 

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -1673,7 +1673,7 @@ func restartStaleContainer(
 			return "", renamed, nil
 		}
 
-		targetOldName := "watchtower-old-" + sourceContainer.ID().ShortID()
+		targetOldName := container.WatchtowerOldPrefix + sourceContainer.ID().ShortID()
 
 		// Redundant rename guard: the lingering old instance already has the
 		// target name from a prior rename. Skip to avoid a same-name error.

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -1681,6 +1681,8 @@ func restartStaleContainer(
 			logrus.WithFields(fields).
 				WithField("target_name", targetOldName).
 				Debug("Skipping rename of already-renamed Watchtower container")
+
+			renamed = true
 		} else {
 			newName := targetOldName
 

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -1673,38 +1673,48 @@ func restartStaleContainer(
 			return "", renamed, nil
 		}
 
-		newName := "watchtower-old-" + sourceContainer.ID().ShortID()
+		targetOldName := "watchtower-old-" + sourceContainer.ID().ShortID()
 
-		err := client.RenameContainer(
-			ctx,
-			sourceContainer,
-			newName,
-		)
-		if err != nil {
-			logrus.WithError(err).
-				WithFields(
-					logrus.Fields{
-						"container": sourceContainer.Name(),
-						"new_name":  newName,
-					}).
-				Debug("Failed to rename Watchtower container")
+		// Redundant rename guard: the lingering old instance already has the
+		// target name from a prior rename. Skip to avoid a same-name error.
+		if container.IsOldNamedContainer(sourceContainer.Name()) {
+			logrus.WithFields(fields).
+				WithField("target_name", targetOldName).
+				Debug("Skipping rename of already-renamed Watchtower container")
+		} else {
+			newName := targetOldName
 
-			return "",
-				false,
-				fmt.Errorf(
-					"%w: %w",
-					errRenameWatchtowerFailed,
-					err,
-				)
-		}
-
-		logrus.WithFields(fields).
-			WithField(
-				"new_name",
+			err := client.RenameContainer(
+				ctx,
+				sourceContainer,
 				newName,
-			).Debug("Renamed Watchtower container")
+			)
+			if err != nil {
+				logrus.WithError(err).
+					WithFields(
+						logrus.Fields{
+							"container": sourceContainer.Name(),
+							"new_name":  newName,
+						}).
+					Debug("Failed to rename Watchtower container")
 
-		renamed = true
+				return "",
+					false,
+					fmt.Errorf(
+						"%w: %w",
+						errRenameWatchtowerFailed,
+						err,
+					)
+			}
+
+			logrus.WithFields(fields).
+				WithField(
+					"new_name",
+					newName,
+				).Debug("Renamed Watchtower container")
+
+			renamed = true
+		}
 	}
 
 	// For Watchtower self-updates, accumulate container ID chain in labels.

--- a/pkg/container/container_id.go
+++ b/pkg/container/container_id.go
@@ -32,10 +32,15 @@ var (
 	ReadCgroupFunc    = os.ReadFile
 )
 
+// WatchtowerOldPrefix is the prefix used when renaming Watchtower containers
+// during self-update. It is the single source of truth for both rename
+// generation and old-name detection to prevent cross-file protocol drift.
+const WatchtowerOldPrefix = "watchtower-old-"
+
 // IsOldNamedContainer reports whether the container's runtime name (from Name()
 // or raw inspect) indicates a predecessor renamed during Watchtower self-update.
 // It trims any leading '/' (as Docker names have) and checks for the
-// "watchtower-old-" prefix convention. Used for disambiguation in hostname
+// WatchtowerOldPrefix convention. Used for disambiguation in hostname
 // fallback, forcing excess cleanup of old instances, skipping redundant renames,
 // and suppressing notifs for self-cleanup of prior incarnations.
 //
@@ -51,7 +56,7 @@ func IsOldNamedContainer(name string) bool {
 
 	n := strings.TrimLeft(name, "/")
 
-	return strings.HasPrefix(n, "watchtower-old-")
+	return strings.HasPrefix(n, WatchtowerOldPrefix)
 }
 
 // GetCurrentContainerID retrieves the current container ID using a fallback strategy.

--- a/pkg/container/container_id.go
+++ b/pkg/container/container_id.go
@@ -32,6 +32,28 @@ var (
 	ReadCgroupFunc    = os.ReadFile
 )
 
+// IsOldNamedContainer reports whether the container's runtime name (from Name()
+// or raw inspect) indicates a predecessor renamed during Watchtower self-update.
+// It trims any leading '/' (as Docker names have) and checks for the
+// "watchtower-old-" prefix convention. Used for disambiguation in hostname
+// fallback, forcing excess cleanup of old instances, skipping redundant renames,
+// and suppressing notifs for self-cleanup of prior incarnations.
+//
+// Parameters:
+//   - name: The container name (may be empty, with or without leading '/').
+//
+// Returns:
+//   - bool: true if the (normalized) name has the old- prefix.
+func IsOldNamedContainer(name string) bool {
+	if name == "" {
+		return false
+	}
+
+	n := strings.TrimLeft(name, "/")
+
+	return strings.HasPrefix(n, "watchtower-old-")
+}
+
 // GetCurrentContainerID retrieves the current container ID using a fallback strategy.
 // It attempts multiple detection methods in order of preference and reliability.
 //
@@ -278,10 +300,21 @@ func GetContainerIDFromHostname(ctx context.Context, client Client) (types.Conta
 				firstMatchID = c.ID()
 			}
 
-			// Track the Watchtower container separately to prefer it over non-Watchtower matches.
-			// Only capture the first Watchtower match to mirror firstMatchID's behavior.
-			if c.IsWatchtower() && watchtowerMatch == "" {
-				watchtowerMatch = c.ID()
+			// Prefer non-old-named WT to avoid selecting a lingering predecessor
+			// as "current" for the running (successor) process.
+			if c.IsWatchtower() {
+				contName := c.Name()
+				if contName == "" {
+					contName = containerInfo.Name
+				}
+
+				isOldNamed := IsOldNamedContainer(contName)
+
+				if watchtowerMatch == "" {
+					watchtowerMatch = c.ID()
+				} else if !isOldNamed {
+					watchtowerMatch = c.ID()
+				}
 			}
 		}
 	}

--- a/pkg/container/container_id_test.go
+++ b/pkg/container/container_id_test.go
@@ -483,6 +483,41 @@ var _ = ginkgo.Describe("GetContainerIDFromHostname", func() {
 				ListContainers(context.Background()).
 				Return([]types.Container{nonWatchtowerContainer, watchtowerContainer}, nil)
 		}, types.ContainerID("watchtower-container-id"), false, ""),
+
+		ginkgo.Entry("when multiple Watchtower containers share hostname, prefer the non-old-named one", func() {
+			hostname := testHostname
+
+			// Set HOSTNAME environment variable
+			os.Setenv("HOSTNAME", hostname)
+
+			// Old-named first in list (simulates arbitrary daemon order)
+			oldNamed := MockContainer(
+				WithHostname(hostname),
+				WithName("watchtower-old-6bfdffce0700"),
+				WithLabels(map[string]string{
+					"com.centurylinklabs.watchtower": "true",
+				}),
+				func(c *dockerContainer.InspectResponse, _ *dockerImage.InspectResponse) {
+					c.ID = "old-watchtower-id"
+				},
+			)
+
+			// Main (non-old) Watchtower
+			mainNamed := MockContainer(
+				WithHostname(hostname),
+				WithName("watchtower"),
+				WithLabels(map[string]string{
+					"com.centurylinklabs.watchtower": "true",
+				}),
+				func(c *dockerContainer.InspectResponse, _ *dockerImage.InspectResponse) {
+					c.ID = "main-watchtower-id"
+				},
+			)
+
+			mockClient.EXPECT().
+				ListContainers(context.Background()).
+				Return([]types.Container{oldNamed, mainNamed}, nil)
+		}, types.ContainerID("main-watchtower-id"), false, ""),
 	)
 })
 


### PR DESCRIPTION
This PR addresses issues that intermittently materialize during self-updates.

## Problem

When Watchtower updates itself, the old instance is renamed to `watchtower-old-<id>` and continues running with the expectation of the new container performing the cleanup of excess Watchtower containers. Multiple code paths failed to distinguish this stale predecessor from the running successor, causing intermittent failures. This manifests at several points:

- Hostname self-detection matches both predecessor and successor, returning whichever the daemon lists first. The predecessor being selected causes Watchtower to lose track of itself on the next run.
- Excess instance cleanup uses the detected container's ID as the exclusion target. When the predecessor is selected, the running successor's ID doesn't match and is removed as excess.
- Chained container resolution reads the container-chain label from the predecessor, which lacks the updated chain, so parent containers are not cleaned up.
- The rename step attempts to rename a container that already has the `watchtower-old-` prefix, causing a same-name error.

## Solution

Added `IsOldNamedContainer(name)` to detect the `watchtower-old-` prefix convention, then resolved to the successor at each affected decision point:

- Hostname fallback prefers the Watchtower container without the predecessor prefix.
- Excess cleanup and chained container resolution find the non-predecessor successor when the detected container has the prefix; chained resolution falls back to empty when no successor exists.
- Rename step skips containers that already carry the predecessor name.

## Changes

- `pkg/container/container_id.go` — added `IsOldNamedContainer`; hostname fallback prefers non-predecessor matches
- `internal/actions/cleanup.go` — `getFilteredContainers` and `getChainedContainers` resolve successors when current is a predecessor; `getChainedContainers` returns empty when no successor found
- `internal/actions/update.go` — `restartStaleContainer` skips redundant rename
- Tests for hostname preference, successor selection (scoped and unscoped), and rename skip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup to correctly identify and remove predecessor instances when names were rotated.
  * Selection logic now prefers current (non-old-named) instances when multiple versions share a scope or hostname.
  * Avoids redundant rename operations by detecting already-renamed instances and skipping renames.
  * Added tests covering rename-skip and multi-instance selection edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->