### PR TITLE
fix(notifications): update Shoutrrr MS Teams integration

### DIFF
--- a/docs/configuration/arguments/index.md
+++ b/docs/configuration/arguments/index.md
@@ -38,7 +38,7 @@ Certain flags support referencing a file, using its contents as the value, to se
 | `--http-api-token`                     | `WATCHTOWER_HTTP_API_TOKEN`                     |
 | `--notification-email-server-password` | `WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD` |
 | `--notification-gotify-token`          | `WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN`          |
-| `--notification-msteams-hook`          | `WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK`          |
+| `--notification-msteams-hook`          | `WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL`      |
 | `--notification-slack-hook-url`        | `WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL`        |
 | `--notification-url`                   | `WATCHTOWER_NOTIFICATION_URL`                   |
 
@@ -897,7 +897,7 @@ Can reference a file for security.
 
 ```text
             Argument: --notification-msteams-hook
-Environment Variable: WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK
+Environment Variable: WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL
                 Type: String
              Default: None
 ```

--- a/docs/notifications/overview/index.md
+++ b/docs/notifications/overview/index.md
@@ -793,7 +793,6 @@ Environment Variable: WATCHTOWER_NOTIFICATION_SLACK_CHANNEL
       -v /var/run/docker.sock:/var/run/docker.sock \
       -e WATCHTOWER_NOTIFICATIONS=msteams \
       -e WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL="https://default.environment.api.powerplatform.com/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=XXXXXXXX" \
-      -e WATCHTOWER_NOTIFICATION_MSTEAMS_USE_LOG_DATA=true \
       nickfedor/watchtower
     ```
 
@@ -805,8 +804,7 @@ Environment Variable: WATCHTOWER_NOTIFICATION_SLACK_CHANNEL
       -v /var/run/docker.sock:/var/run/docker.sock \
       nickfedor/watchtower \
       --notifications msteams \
-      --notification-msteams-hook "https://default.environment.api.powerplatform.com/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=XXXXXXXX" \
-      --notification-msteams-data
+      --notification-msteams-hook "https://default.environment.api.powerplatform.com/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=XXXXXXXX"
     ```
 
 === "Docker Compose"
@@ -818,7 +816,6 @@ Environment Variable: WATCHTOWER_NOTIFICATION_SLACK_CHANNEL
         environment:
           WATCHTOWER_NOTIFICATIONS: msteams
            WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL: "https://default.environment.api.powerplatform.com/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=XXXXXXXX"
-          WATCHTOWER_NOTIFICATION_MSTEAMS_USE_LOG_DATA: true
         volumes:
           - /var/run/docker.sock:/var/run/docker.sock
     ```
@@ -827,7 +824,7 @@ Environment Variable: WATCHTOWER_NOTIFICATION_SLACK_CHANNEL
 
 To receive notifications in Microsoft Teams, add `msteams` to the `--notifications` option or the `WATCHTOWER_NOTIFICATIONS` environment variable.
 
-Watchtower supports the following Microsoft Teams-related options:
+Watchtower supports the following Microsoft Teams-related option:
 
 #### MSTeams Hook URL
 
@@ -842,17 +839,6 @@ Environment Variable: WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL
 
 !!! Note
     This option can also reference a file, in which case the contents of the file are used.
-
-#### MSTeams Use Log Data
-
-Enable sending keys/values filled by `log.WithField` or `log.WithFields` as Microsoft Teams message facts.
-
-```text
-            Argument: --notification-msteams-data
-Environment Variable: WATCHTOWER_NOTIFICATION_MSTEAMS_USE_LOG_DATA
-                Type: Boolean
-             Default: false
-```
 
 ## Gotify Notifications
 

--- a/docs/notifications/overview/index.md
+++ b/docs/notifications/overview/index.md
@@ -815,7 +815,7 @@ Environment Variable: WATCHTOWER_NOTIFICATION_SLACK_CHANNEL
         image: nickfedor/watchtower:latest
         environment:
           WATCHTOWER_NOTIFICATIONS: msteams
-           WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL: "https://default.environment.api.powerplatform.com/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=XXXXXXXX"
+          WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL: "https://default.environment.api.powerplatform.com/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=XXXXXXXX"
         volumes:
           - /var/run/docker.sock:/var/run/docker.sock
     ```

--- a/docs/notifications/overview/index.md
+++ b/docs/notifications/overview/index.md
@@ -840,6 +840,9 @@ Environment Variable: WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL
 !!! Note
     This option can also reference a file, in which case the contents of the file are used.
 
+!!! Warning
+    The value of `--notification-msteams-hook` **must** be an absolute URL using the `https://` scheme (including the host). Relative URLs and non-HTTPS schemes are rejected at runtime.
+
 ## Gotify Notifications
 
 === "Docker CLI (Env Vars)"

--- a/docs/notifications/overview/index.md
+++ b/docs/notifications/overview/index.md
@@ -792,7 +792,7 @@ Environment Variable: WATCHTOWER_NOTIFICATION_SLACK_CHANNEL
       --name watchtower \
       -v /var/run/docker.sock:/var/run/docker.sock \
       -e WATCHTOWER_NOTIFICATIONS=msteams \
-      -e WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL="https://outlook.office.com/webhook/xxxxxxxx@xxxxxxx/IncomingWebhook/yyyyyyyy/zzzzzzzzzz" \
+      -e WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL="https://default.environment.api.powerplatform.com/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=XXXXXXXX" \
       -e WATCHTOWER_NOTIFICATION_MSTEAMS_USE_LOG_DATA=true \
       nickfedor/watchtower
     ```
@@ -805,7 +805,7 @@ Environment Variable: WATCHTOWER_NOTIFICATION_SLACK_CHANNEL
       -v /var/run/docker.sock:/var/run/docker.sock \
       nickfedor/watchtower \
       --notifications msteams \
-      --notification-msteams-hook "https://outlook.office.com/webhook/xxxxxxxx@xxxxxxx/IncomingWebhook/yyyyyyyy/zzzzzzzzzz" \
+      --notification-msteams-hook "https://default.environment.api.powerplatform.com/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=XXXXXXXX" \
       --notification-msteams-data
     ```
 
@@ -817,7 +817,7 @@ Environment Variable: WATCHTOWER_NOTIFICATION_SLACK_CHANNEL
         image: nickfedor/watchtower:latest
         environment:
           WATCHTOWER_NOTIFICATIONS: msteams
-          WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL: "https://outlook.office.com/webhook/xxxxxxxx@xxxxxxx/IncomingWebhook/yyyyyyyy/zzzzzzzzzz"
+           WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL: "https://default.environment.api.powerplatform.com/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=XXXXXXXX"
           WATCHTOWER_NOTIFICATION_MSTEAMS_USE_LOG_DATA: true
         volumes:
           - /var/run/docker.sock:/var/run/docker.sock
@@ -831,7 +831,7 @@ Watchtower supports the following Microsoft Teams-related options:
 
 #### MSTeams Hook URL
 
-The Microsoft Teams webhook URL for notifications.
+The Microsoft Teams Power Automate workflow webhook URL for notifications.
 
 ```text
             Argument: --notification-msteams-hook

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -491,12 +491,6 @@ func RegisterNotificationFlags(rootCmd *cobra.Command) {
 		envString("WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL"),
 		"The MSTeams WebHook URL to send notifications to")
 
-	flags.BoolP(
-		"notification-msteams-data",
-		"",
-		envBool("WATCHTOWER_NOTIFICATION_MSTEAMS_USE_LOG_DATA"),
-		"The MSTeams notifier will try to extract log entry fields as MSTeams message facts")
-
 	flags.StringP(
 		"notification-gotify-url",
 		"",

--- a/pkg/notifications/msteams.go
+++ b/pkg/notifications/msteams.go
@@ -65,12 +65,16 @@ func (n *msTeamsTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 	clog := logrus.WithField("url", n.webHookURL)
 	clog.Debug("Generating Microsoft Teams service URL")
 
-	// Validate the webhook URL is parseable.
-	_, err := url.Parse(n.webHookURL)
+	// Validate the webhook URL is parseable and absolute.
+	parsed, err := url.Parse(n.webHookURL)
 	if err != nil {
 		clog.WithError(err).Debug("Failed to parse Microsoft Teams webhook URL")
 
 		return "", fmt.Errorf("%w: %w", errParseWebhookFailed, err)
+	}
+
+	if parsed.Scheme != "https" || parsed.Host == "" {
+		return "", fmt.Errorf("%w: expected https URL", errParseWebhookFailed)
 	}
 
 	// Create Teams config with the full webhook URL as the host.

--- a/pkg/notifications/msteams.go
+++ b/pkg/notifications/msteams.go
@@ -19,16 +19,11 @@ const msTeamsType = "msteams"
 var (
 	// errParseWebhookFailed indicates a failure to parse the Microsoft Teams webhook URL.
 	errParseWebhookFailed = errors.New("failed to parse Microsoft Teams webhook URL")
-	// errConfigWebhookFailed indicates a failure to create a Teams config from the webhook URL.
-	errConfigWebhookFailed = errors.New("failed to create Microsoft Teams config from webhook URL")
 )
 
 // msTeamsTypeNotifier handles Microsoft Teams notifications via webhook.
-//
-// It supports optional data inclusion for detailed messages.
 type msTeamsTypeNotifier struct {
 	webHookURL string
-	data       bool
 }
 
 // newMsTeamsNotifier creates a Teams notifier from command-line flags.
@@ -55,10 +50,7 @@ func newMsTeamsNotifier(cmd *cobra.Command) types.ConvertibleNotifier {
 	withData, _ := flags.GetBool("notification-msteams-data")
 	clog.WithField("with_data", withData).Debug("Initializing Microsoft Teams notifier")
 
-	return &msTeamsTypeNotifier{
-		webHookURL: webHookURL,
-		data:       withData,
-	}
+	return &msTeamsTypeNotifier{webHookURL: webHookURL}
 }
 
 // GetURL generates the Teams service URL from the notifier's webhook.
@@ -68,32 +60,24 @@ func newMsTeamsNotifier(cmd *cobra.Command) types.ConvertibleNotifier {
 //
 // Returns:
 //   - string: Teams service URL.
-//   - error: Non-nil if parsing or config fails, nil on success.
+//   - error: Non-nil if parsing fails, nil on success.
 func (n *msTeamsTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 	clog := logrus.WithField("url", n.webHookURL)
 	clog.Debug("Generating Microsoft Teams service URL")
 
-	// Parse the webhook URL.
-	webhookURL, err := url.Parse(n.webHookURL)
+	// Validate the webhook URL is parseable.
+	_, err := url.Parse(n.webHookURL)
 	if err != nil {
 		clog.WithError(err).Debug("Failed to parse Microsoft Teams webhook URL")
 
 		return "", fmt.Errorf("%w: %w", errParseWebhookFailed, err)
 	}
 
-	clog.Debug("Parsed Microsoft Teams webhook URL")
-
-	// Create Teams config from webhook.
-	config, err := teams.ConfigFromWebhookURL(webhookURL)
-	if err != nil {
-		clog.WithError(err).
-			Debug("Failed to create Microsoft Teams config from webhook URL")
-
-		return "", fmt.Errorf("%w: %w", errConfigWebhookFailed, err)
+	// Create Teams config with the full webhook URL as the host.
+	config := &teams.Config{
+		Host:  n.webHookURL,
+		Color: ColorHex,
 	}
-
-	// Set predefined color and generate URL.
-	config.Color = ColorHex
 
 	urlStr := config.GetURL().String()
 	clog.WithField("service_url", urlStr).Debug("Generated Microsoft Teams service URL")

--- a/pkg/notifications/msteams.go
+++ b/pkg/notifications/msteams.go
@@ -46,10 +46,6 @@ func newMsTeamsNotifier(cmd *cobra.Command) types.ConvertibleNotifier {
 		)
 	}
 
-	// Get data inclusion flag.
-	withData, _ := flags.GetBool("notification-msteams-data")
-	clog.WithField("with_data", withData).Debug("Initializing Microsoft Teams notifier")
-
 	return &msTeamsTypeNotifier{webHookURL: webHookURL}
 }
 

--- a/pkg/notifications/notifier_test.go
+++ b/pkg/notifications/notifier_test.go
@@ -434,30 +434,14 @@ var _ = ginkgo.Describe("notifications", func() {
 				command := cmd.NewRootCommand()
 				flags.RegisterNotificationFlags(command)
 
-				tokenA := "11111111-4444-4444-8444-cccccccccccc"            // Group
-				tokenB := "22222222-4444-4444-8444-cccccccccccc"            // Tenant
-				tokenC := "33333301222222222233333333333344"                // AltID
-				tokenD := "44444444-4444-4444-8444-cccccccccccc"            // GroupOwner
-				extraID := "V2ESyij_gAljSoUQHvZoZYzlpAoAXExyOl26dlf1xHEx05" // ExtraID from shoutrrr test
 				color := url.QueryEscape(notifications.ColorHex)
 
-				// Use a more specific org domain instead of "test"
-				hookURL := fmt.Sprintf(
-					"https://myorg.webhook.office.com/webhookb2/%s@%s/IncomingWebhook/%s/%s/%s",
-					tokenA,
-					tokenB,
-					tokenC,
-					tokenD,
-					extraID,
-				)
+				// Power Automate workflow incoming webhook URL.
+				hookURL := "https://default.environment.api.powerplatform.com/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=XXXXXXXX"
 				expectedOutput := fmt.Sprintf(
-					"teams://%s@%s/%s/%s/%s?color=%s&host=myorg.webhook.office.com",
-					tokenA,
-					tokenB,
-					tokenC,
-					tokenD,
-					extraID,
+					"teams:?color=%s&host=%s",
 					color,
+					url.QueryEscape(hookURL),
 				)
 
 				args := []string{


### PR DESCRIPTION
This PR updates the Microsoft Teams notification integration to work with the updated Shoutrrr MS Teams service SDK, which removed `ConfigFromWebhookURL()` and changed the webhook format from legacy `outlook.office.com/webhookb2/...` URLs to Power Automate workflow URLs. It also removes the dead `--notification-msteams-data` flag that was registered but never consumed.

## Problems

A recent change to Microsoft Teams webhook format was recently implemented in Shoutrrr's MS Teams service. This change removed `ConfigFromWebhookURL()` and changed the webhook URL format, causing a compiler error (`undefined: teams.ConfigFromWebhookURL`). The test suite also used the old webhook format and expected the old `teams://path?...` URL serialization. Additionally, the `--notification-msteams-data` flag was dead code — registered in flags.go and parsed in msteams.go but never stored or used in any behavior.

## Solution

Updated the Teams notifier to construct `teams.Config` directly with the full Power Automate workflow URL as `Config.Host`, which is the new SDK pattern. Removed the dead `--notification-msteams-data` flag registration, parsing, and all documentation references. Updated tests and docs to use the current webhook URL format.

## Changes

- `pkg/notifications/msteams.go` — replaced `teams.ConfigFromWebhookURL()` with direct `teams.Config{Host: webhookURL, Color: ColorHex}` construction; removed `data` field, `errConfigWebhookFailed` sentinel, and dead flag parsing
- `pkg/notifications/notifier_test.go` — updated test to use Power Automate workflow URL and new `teams:?color=...&host=...` URL format
- `internal/flags/flags.go` — removed `--notification-msteams-data` flag registration
- `docs/notifications/overview/index.md` — updated all 3 code examples with new webhook URL, removed MSTeams Use Log Data config section, fixed env var references
- `docs/configuration/arguments/index.md` — fixed env var name `WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK` → `WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Microsoft Teams notification docs: renamed environment variable for the Teams hook, replaced example webhook with a Power Automate webhook, and added a warning that the hook must be an absolute https:// URL.

* **Refactor**
  * Simplified Microsoft Teams notifier and removed the log-data extraction option; notifier now expects a single webhook URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->