### PR TITLE
chore(notifications): deprecate legacy notification types for v2 removal

### DIFF
--- a/build/mkdocs/mkdocs.yaml
+++ b/build/mkdocs/mkdocs.yaml
@@ -125,8 +125,8 @@ markdown_extensions:
   # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#definition-lists
   - def_list:
   # Enables collapsible details blocks.
-  # https://facelessuser.github.io/pymdown-extensions/extensions/details/
-  - pymdownx.details:
+  # https://facelessuser.github.io/pymdown-extensions/extensions/blocks/plugins/details/
+  - pymdownx.blocks.details:
   # Enables code highlighting for fenced code blocks.
   # https://facelessuser.github.io/pymdown-extensions/extensions/highlight/
   - pymdownx.highlight:

--- a/docs/configuration/arguments/index.md
+++ b/docs/configuration/arguments/index.md
@@ -1,5 +1,20 @@
 # Arguments
 
+## Deprecation Notice
+
+!!! Warning "Watchtower v2 Legacy Notification Deprecation"
+    **Watchtower has a number of legacy notification options that will be removed with the release of Watchtower v2:**
+
+    - [Email Notifications](../../notifications/overview/index.md#email_notifications)
+    - [Slack Notifications](../../notifications/overview/index.md#slack_notifications)
+    - [Microsoft Teams Notifications](../../notifications/overview/index.md#microsoft_teams_notifications)
+    - [Gotify Notifications](../../notifications/overview/index.md#gotify_notifications)
+    - [Signal Notifications](../../notifications/overview/index.md#signal_notifications)
+
+    Migration to the [`NOTIFICATION URL`](#notification_url) with the appropriate Shoutrrr URL scheme is strongly recommended.
+
+    Use [`watchtower notify-upgrade`](../../notifications/overview/index.md#migrating_deprecated_smtp_notifications_to_shoutrrr_urls) to help convert legacy email configurations to Shoutrrr URLs or use the [Shoutrrr Playground](https://shoutrrr.nickfedor.com/latest/playground/){target="_blank" rel="noopener noreferrer"} to help convert configurations for other services to Shoutrrr URLs.
+
 ## Overview
 
 By default, Watchtower monitors all containers running on the Docker daemon it connects to (typically the local daemon, configurable via the `--host` flag).
@@ -33,14 +48,18 @@ This command triggers an update attempt for "nginx" and "redis" containers, disp
 
 Certain flags support referencing a file, using its contents as the value, to securely handle sensitive data like passwords or tokens, avoiding exposure in configuration files or command lines.
 
-| Flag                                   | Environment Variable                            |
-|----------------------------------------|-------------------------------------------------|
-| `--http-api-token`                     | `WATCHTOWER_HTTP_API_TOKEN`                     |
-| `--notification-email-server-password` | `WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD` |
-| `--notification-gotify-token`          | `WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN`          |
-| `--notification-msteams-hook`          | `WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL`      |
-| `--notification-slack-hook-url`        | `WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL`        |
-| `--notification-url`                   | `WATCHTOWER_NOTIFICATION_URL`                   |
+| Flag                                   | Environment Variable                            | Deprecated |
+|----------------------------------------|-------------------------------------------------|------------|
+| `--http-api-token`                     | `WATCHTOWER_HTTP_API_TOKEN`                     | No         |
+| `--notification-email-server-password` | `WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD` | Yes        |
+| `--notification-gotify-token`          | `WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN`          | Yes        |
+| `--notification-msteams-hook`          | `WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL`      | Yes        |
+| `--notification-slack-hook-url`        | `WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL`        | Yes        |
+| `--notification-url`                   | `WATCHTOWER_NOTIFICATION_URL`                   | No         |
+
+!!! Warning "Watchtower v2 Legacy Notification Deprecation"
+    Deprecated flags / environment variables will be removed with the release of Watchtower v2.
+    Use the the [`NOTIFICATION URL`](#notification_url) with the appropriate Shoutrrr URL scheme instead.
 
 ### Example Docker Compose Usage
 
@@ -868,6 +887,10 @@ Environment Variable: WATCHTOWER_NOTIFICATION_SPLIT_BY_CONTAINER
 
 ### Notification Email Server Password
 
+!!! Warning "Watchtower v2 Legacy Notification Deprecation"
+    This flag will be removed with the release of Watchtower v2.
+    Use the [`NOTIFICATION URL`](#notification_url) with the appropriate Shoutrrr `smtp://` URL instead.
+
 Sets the password for the email notification server.
 Can reference a file for security.
 
@@ -879,6 +902,10 @@ Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD
 ```
 
 ### Notification Slack Hook URL
+
+!!! Warning "Watchtower v2 Legacy Notification Deprecation"
+    This flag will be removed with the release of Watchtower v2.
+    Use the [`NOTIFICATION URL`](#notification_url) with the appropriate Shoutrrr `discord://` URL instead.
 
 Sets the Slack webhook URL for notifications.
 Can reference a file for security.
@@ -892,6 +919,10 @@ Environment Variable: WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL
 
 ### Notification Microsoft Teams Hook
 
+!!! Warning "Watchtower v2 Legacy Notification Deprecation"
+    This flag will be removed with the release of Watchtower v2.
+    Use the [`NOTIFICATION URL`](#notification_url) with the appropriate Shoutrrr `teams://` URL instead.
+
 Sets the Microsoft Teams webhook URL for notifications.
 Can reference a file for security.
 
@@ -903,6 +934,10 @@ Environment Variable: WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL
 ```
 
 ### Notification Gotify Token
+
+!!! Warning "Watchtower v2 Legacy Notification Deprecation"
+    This flag will be removed with the release of Watchtower v2.
+    Use the [`NOTIFICATION URL`](#notification_url) with the appropriate Shoutrrr `gotify://` URL instead.
 
 Sets the Gotify token for notifications.
 Can reference a file for security.

--- a/docs/notifications/overview/index.md
+++ b/docs/notifications/overview/index.md
@@ -1,5 +1,19 @@
 # Configuration
 
+## Deprecation Notice
+
+!!! Warning "Watchtower v2 Legacy Notification Deprecation"
+    **Watchtower has a number of legacy notification options that will be removed with the release of Watchtower v2:**
+
+    - [Email Notifications](#email_notifications)
+    - [Slack Notifications](#slack_notifications)
+    - [Microsoft Teams Notifications](#microsoft_teams_notifications)
+    - [Gotify Notifications](#gotify_notifications)
+
+    Migration to the [`NOTIFICATION URL`](../../configuration/arguments/index.md#notification_url) with the appropriate Shoutrrr URL scheme is strongly recommended.
+
+    Use [`watchtower notify-upgrade`](#migrating_deprecated_smtp_notifications_to_shoutrrr_urls) to help convert legacy email configurations to Shoutrrr URLs or use the [Shoutrrr Playground](https://shoutrrr.nickfedor.com/latest/playground/){target="_blank" rel="noopener noreferrer"} to help convert configurations for other services to Shoutrrr URLs.
+
 ## Overview
 
 Watchtower uses [Shoutrrr](https://github.com/nicholas-fedor/shoutrrr){target="_blank" rel="noopener noreferrer"} to provide notification functionality.
@@ -28,7 +42,7 @@ For most Watchtower deployments via Docker Compose, this is best achieved via us
 When running Watchtower via the Docker CLI, the [`--notification-url`](../../configuration/arguments/index.md#notification_url) CLI flag can be used multiple times, or use a comma-separated list.
 
 !!! Note "Environment Variable Format"
-    - Both `WATCHTOWER_NOTIFICATION_URL` and `WATCHTOWER_NOTIFICATIONS` support comma-separated and space-separated values via custom parsers that bypass Viper's default behavior.
+    - `WATCHTOWER_NOTIFICATION_URL` supports comma-separated and space-separated values.
     - Commas within URLs (e.g., in query parameters) are preserved.
     - For Docker Compose, the YAML array syntax is the recommended approach.
 
@@ -147,7 +161,8 @@ Environment Variable: WATCHTOWER_NOTIFICATIONS_LEVEL
 ```
 
 !!! Note
-    The notification level setting applies to both report mode (`--notification-report=true`) and legacy mode (`--notification-report=false`).
+    The notification level setting applies to both report mode (`--notification-report=true`) and legacy (log-only) mode (`--notification-report=false`).
+    Legacy mode is **deprecated**; use report mode with `--notification-url` for new configurations.
 
 ### Hostname
 
@@ -231,8 +246,7 @@ To enable separate notifications per container:
 docker run -d \
   --name watchtower \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -e WATCHTOWER_NOTIFICATIONS=slack \
-  -e WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL="https://hooks.slack.com/services/xxx/yyyyyyyyyyyyyyy" \
+  -e WATCHTOWER_NOTIFICATION_URL="slack://hook:xxxx-yyyy-zzzz@webhook?botname=watchtower" \
   -e WATCHTOWER_NOTIFICATION_SPLIT_BY_CONTAINER=true \
   nickfedor/watchtower
 ```
@@ -258,11 +272,42 @@ For detailed information about template syntax, available data structures, and e
 
 Watchtower uses Shoutrrr's [smtp service](https://shoutrrr.nickfedor.com/services/email/){target="_blank" rel="noopener noreferrer"} to send email notifications.
 
-Either legacy email notification flags or Shoutrrr URLs can be used; however, directly using URLs is recommended for greater control and clarity, especially for configuring TLS settings (e.g., STARTTLS or Implicit TLS).
+!!! Warning "Deprecated"
+    Legacy email notification flags (e.g., `--notification-email-from`, `--notification-email-to`, `--notification-email-server`) are **deprecated**. Use `--notification-url` with an `smtp://` URL instead. See [Transitioning from Legacy Email Notifications to Shoutrrr](#transitioning-from-legacy-email-notifications-to-shoutrrr) below.
 
-To send notifications via e-mail, add `email` to the `--notifications` option or the `WATCHTOWER_NOTIFICATIONS` environment variable.
+To send notifications via e-mail, use an `smtp://` URL with `--notification-url`:
 
-Email notification flags (e.g., `WATCHTOWER_NOTIFICATION_EMAIL_SERVER`, `WATCHTOWER_NOTIFICATION_EMAIL_FROM`) are automatically converted to a Shoutrrr SMTP URL internally.
+=== "Docker CLI (Env Vars)"
+
+    ```bash
+    docker run -d \
+    --name watchtower \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -e WATCHTOWER_NOTIFICATION_URL="smtp://user:secret@smtp.example.com:587/?fromaddress=sender@example.com&toaddresses=recipient@example.com" \
+    nickfedor/watchtower
+    ```
+
+=== "Docker CLI (Flags)"
+
+    ```bash
+    docker run -d \
+    --name watchtower \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    nickfedor/watchtower \
+    --notification-url "smtp://user:secret@smtp.example.com:587/?fromaddress=sender@example.com&toaddresses=recipient@example.com"
+    ```
+
+=== "Docker Compose"
+
+    ```yaml
+    services:
+    watchtower:
+        image: nickfedor/watchtower:latest
+        environment:
+        WATCHTOWER_NOTIFICATION_URL: smtp://user:secret@smtp.example.com:587/?fromaddress=sender@example.com&toaddresses=recipient@example.com
+        volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+    ```
 
 ### Common SMTP Configurations
 
@@ -355,7 +400,114 @@ Email notification flags (e.g., `WATCHTOWER_NOTIFICATION_EMAIL_SERVER`, `WATCHTO
     * Test connectivity with `telnet ${SMTP_HOST} ${SMTP_PORT}` inside the container.
 <!-- markdownlint-restore -->
 
-### Example Legacy Email Configuration
+/// details | The following legacy smtp configuration options and examples are deprecated and will be removed with the release of Watchtower v2.
+    type: warning
+
+### Deprecated SMTP Configuration Options
+
+#### Email From
+
+The e-mail address from which notifications will be sent.
+
+```text
+            Argument: --notification-email-from
+Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_FROM
+                Type: String
+             Default: None
+```
+
+#### Email To
+
+The e-mail address to which notifications will be sent.
+
+```text
+            Argument: --notification-email-to
+Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_TO
+                Type: String
+             Default: None
+```
+
+#### Email Server
+
+The SMTP server (IP or FQDN) to send notifications through.
+
+```text
+            Argument: --notification-email-server
+Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_SERVER
+                Type: String
+             Default: None
+```
+
+#### Email Server TLS Skip Verify
+
+Skip verification of the server certificate when using TLS.
+
+```text
+            Argument: --notification-email-server-tls-skip-verify
+Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_SERVER_TLS_SKIP_VERIFY
+                Type: Boolean
+             Default: false
+```
+
+#### Email Server User
+
+The username for the SMTP server if it requires authentication.
+
+```text
+            Argument: --notification-email-server-user
+Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_SERVER_USER
+                Type: String
+             Default: None
+```
+
+#### Email Server Password
+
+The password for the SMTP server if it requires authentication.
+
+```text
+            Argument: --notification-email-server-password
+Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD
+                Type: String
+             Default: None
+```
+
+!!! Note
+    This option can also reference a file, in which case the contents of the file are used.
+
+#### Email Subject Tag
+
+Subject prefix tag for notifications via mail.
+
+```text
+            Argument: --notification-email-subjecttag
+Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_SUBJECTTAG
+                Type: String
+             Default: ""
+```
+
+#### Email Server Port
+
+The port the SMTP server listens on.
+
+```text
+            Argument: --notification-email-server-port
+Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT
+                Type: Integer
+             Default: 25
+```
+
+#### Email Delay
+
+The delay (in seconds) between sending notifications if multiple containers are updated at once.
+
+```text
+            Argument: --notification-email-delay
+Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_DELAY
+                Type: Integer
+             Default: None
+```
+
+### Deprecated SMTP Configuration Examples
 
 === "Docker CLI"
 
@@ -468,113 +620,14 @@ Email notification flags (e.g., `WATCHTOWER_NOTIFICATION_EMAIL_SERVER`, `WATCHTO
 
             If you also want to enable DKIM or other features on the SMTP server, then you will find more information at [freinet/postfix-relay](https://hub.docker.com/r/freinet/postfix-relay){target="_blank" rel="noopener noreferrer"}
 
-### Legacy Notification Flags
+///
 
-#### Email From
+### Migrating Deprecated SMTP Notifications to Shoutrrr URLs
 
-The e-mail address from which notifications will be sent.
+!!! Important
+    Legacy email notification flags are **deprecated**. Follow the steps below to migrate to `--notification-url` with an `smtp://` URL.
 
-```text
-            Argument: --notification-email-from
-Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_FROM
-                Type: String
-             Default: None
-```
-
-#### Email To
-
-The e-mail address to which notifications will be sent.
-
-```text
-            Argument: --notification-email-to
-Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_TO
-                Type: String
-             Default: None
-```
-
-#### Email Server
-
-The SMTP server (IP or FQDN) to send notifications through.
-
-```text
-            Argument: --notification-email-server
-Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_SERVER
-                Type: String
-             Default: None
-```
-
-#### Email Server TLS Skip Verify
-
-Skip verification of the server certificate when using TLS.
-
-```text
-            Argument: --notification-email-server-tls-skip-verify
-Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_SERVER_TLS_SKIP_VERIFY
-                Type: Boolean
-             Default: false
-```
-
-#### Email Server User
-
-The username for the SMTP server if it requires authentication.
-
-```text
-            Argument: --notification-email-server-user
-Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_SERVER_USER
-                Type: String
-             Default: None
-```
-
-#### Email Server Password
-
-The password for the SMTP server if it requires authentication.
-
-```text
-            Argument: --notification-email-server-password
-Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD
-                Type: String
-             Default: None
-```
-
-!!! Note
-    This option can also reference a file, in which case the contents of the file are used.
-
-#### Email Subject Tag
-
-Subject prefix tag for notifications via mail.
-
-```text
-            Argument: --notification-email-subjecttag
-Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_SUBJECTTAG
-                Type: String
-             Default: ""
-```
-
-#### Email Server Port
-
-The port the SMTP server listens on.
-
-```text
-            Argument: --notification-email-server-port
-Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT
-                Type: Integer
-             Default: 25
-```
-
-#### Email Delay
-
-The delay (in seconds) between sending notifications if multiple containers are updated at once.
-
-```text
-            Argument: --notification-email-delay
-Environment Variable: WATCHTOWER_NOTIFICATION_EMAIL_DELAY
-                Type: Integer
-             Default: None
-```
-
-### Transitioning from Legacy Email Notifications to Shoutrrr
-
-Watchtower includes a `watchtower notify-upgrade` command to convert legacy flags to a Shoutrrr URL.
+Watchtower includes a `watchtower notify-upgrade` command to automatically convert legacy flags to a Shoutrrr URL.
 
 The output is written to a temporary file, which you can copy using:
 
@@ -648,7 +701,7 @@ Example Legacy Configuration:
       smtp://user@example.com:secret@smtp.example.com:587/?fromaddress=sender@example.com&toaddresses=recipient@example.com&encryption=ExplicitTLS&usestarttls=yes
       ```
 
-2. Replace the legacy flags with:
+2. Replace the deprecated configuration with:
 <!-- markdownlint-disable -->
 === "Docker CLI (Env Vars)"
 
@@ -656,10 +709,9 @@ Example Legacy Configuration:
     docker run -d \
       --name watchtower \
       -v /var/run/docker.sock:/var/run/docker.sock \
-      -e WATCHTOWER_NOTIFICATIONS=shoutrrr \
       -e WATCHTOWER_NOTIFICATION_URL=smtp://user@example.com:secret@smtp.example.com:587/?fromaddress=sender@example.com&toaddresses=recipient@example.com&encryption=ExplicitTLS&usestarttls=yes \
-      -e WATCHTOWER_NOTIFICATION_EMAIL_DELAY=10 \
-      -e WATCHTOWER_NOTIFICATION_EMAIL_SUBJECTTAG=Watchtower \
+      -e WATCHTOWER_NOTIFICATIONS_DELAY=10 \
+      -e WATCHTOWER_NOTIFICATION_TITLE_TAG=Watchtower \
       nickfedor/watchtower
     ```
 
@@ -670,10 +722,9 @@ Example Legacy Configuration:
       --name watchtower \
       -v /var/run/docker.sock:/var/run/docker.sock \
       nickfedor/watchtower \
-      --notifications shoutrrr \
       --notification-url "smtp://user@example.com:secret@smtp.example.com:587/?fromaddress=sender@example.com&toaddresses=recipient@example.com&encryption=ExplicitTLS&usestarttls=yes" \
-      --notification-email-delay 10 \
-      --notification-email-subjecttag Watchtower
+      --notifications-delay 10 \
+      --notification-title-tag Watchtower
     ```
 
 === "Docker Compose"
@@ -683,10 +734,9 @@ Example Legacy Configuration:
       watchtower:
         image: nickfedor/watchtower:latest
         environment:
-          WATCHTOWER_NOTIFICATIONS: shoutrrr
           WATCHTOWER_NOTIFICATION_URL: smtp://user@example.com:secret@smtp.example.com:587/?fromaddress=sender@example.com&toaddresses=recipient@example.com&encryption=ExplicitTLS&usestarttls=yes
-          WATCHTOWER_NOTIFICATION_EMAIL_DELAY: "10"
-          WATCHTOWER_NOTIFICATION_EMAIL_SUBJECTTAG: Watchtower
+          WATCHTOWER_NOTIFICATIONS_DELAY: "10"
+          WATCHTOWER_NOTIFICATION_TITLE_TAG: Watchtower
         volumes:
           - /var/run/docker.sock:/var/run/docker.sock
     ```
@@ -694,11 +744,92 @@ Example Legacy Configuration:
 !!! Note
     Avoid using unrecognized flags like `WATCHTOWER_NOTIFICATION_EMAIL_SERVER_SSL`, as they are ignored and may cause confusion.
 
-    Use `WATCHTOWER_NOTIFICATION_EMAIL_SERVER_TLS_SKIP_VERIFY` to disable TLS verification if needed (not recommended for production).
+    Use the `encryption` and `usestarttls` URL parameters in the `smtp://` URL to control TLS behavior rather than deprecated flags.
 
 ## Slack Notifications
 
+!!! Warning "Deprecated"
+    Legacy Slack flags (`--notification-slack-hook-url`, `--notification-slack-identifier`, etc.) are **deprecated**. Use `--notification-url` with a `slack://` URL instead.
+
 ### Example Slack Configuration
+
+To receive notifications in Slack, use a `slack://` or `discord://` URL with `--notification-url`:
+
+=== "Docker CLI"
+
+    ```bash
+    docker run -d \
+      --name watchtower \
+      -v /var/run/docker.sock:/var/run/docker.sock \
+      nickfedor/watchtower \
+      --notification-url "slack://hook:AAAA-BBBB-CCCC@webhook?botname=watchtower"
+    ```
+
+=== "Docker Compose"
+
+    ```yaml
+    services:
+      watchtower:
+        image: nickfedor/watchtower:latest
+        environment:
+          WATCHTOWER_NOTIFICATION_URL: "slack://hook:AAAA-BBBB-CCCC@webhook?botname=watchtower"
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+    ```
+
+/// details | The following legacy Slack configuration options and examples are deprecated and will be removed with the release of Watchtower v2.
+    type: warning
+
+### Slack Legacy Configuration Options
+
+The following legacy Slack flags are **deprecated**. Use `--notification-url` with a `slack://` URL instead.
+
+#### Slack Hook URL
+
+!!! Deprecated
+    Use `--notification-url` with a `slack://` URL.
+
+The Slack webhook URL for notifications.
+
+```text
+            Argument: --notification-slack-hook-url
+Environment Variable: WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL
+                Type: String
+             Default: None
+```
+
+#### Slack Identifier
+
+!!! Deprecated
+    Use the `botname` query parameter in the `slack://` URL.
+
+Custom name under which messages are sent.
+
+```text
+            Argument: --notification-slack-identifier
+Environment Variable: WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER
+                Type: String
+             Default: watchtower
+```
+
+#### Slack Channel
+
+!!! Deprecated
+    Configure the channel in your Slack webhook settings or use the appropriate `slack://` URL parameters.
+
+A string which overrides the webhook's default channel (optional).
+
+```text
+            Argument: --notification-slack-channel
+Environment Variable: WATCHTOWER_NOTIFICATION_SLACK_CHANNEL
+                Type: String
+             Default: None
+```
+
+### Slack Legacy Configuration Examples
+
+!!! Deprecated
+    The following examples use deprecated legacy Slack flags. Migrate to `--notification-url` with a `slack://` URL.
 
 === "Docker CLI (Env Vars)"
 
@@ -741,49 +872,44 @@ Example Legacy Configuration:
           - /var/run/docker.sock:/var/run/docker.sock
     ```
 
-### Slack Configuration Options
-
-To receive notifications in Slack, add `slack` to the `--notifications` option or the `WATCHTOWER_NOTIFICATIONS` environment variable.
-
-Watchtower supports the following Slack-related options:
-
-#### Slack Hook URL
-
-The Slack webhook URL for notifications.
-
-```text
-            Argument: --notification-slack-hook-url
-Environment Variable: WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL
-                Type: String
-             Default: None
-```
-
-!!! Note
-    This option can also reference a file, in which case the contents of the file are used.
-
-#### Slack Identifier
-
-Custom name under which messages are sent.
-
-```text
-            Argument: --notification-slack-identifier
-Environment Variable: WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER
-                Type: String
-             Default: watchtower
-```
-
-#### Slack Channel
-
-A string which overrides the webhook's default channel (optional).
-
-```text
-            Argument: --notification-slack-channel
-Environment Variable: WATCHTOWER_NOTIFICATION_SLACK_CHANNEL
-                Type: String
-             Default: None
-```
+///
 
 ## Microsoft Teams Notifications
+
+!!! Warning "Deprecated"
+    Legacy MSTeams flags (`--notification-msteams-hook`) are **deprecated**. Use `--notification-url` with a `teams://` URL instead.
+
+### Example MSTeams Configuration
+
+=== "Docker CLI"
+
+    ```bash
+    docker run -d \
+      --name watchtower \
+      -v /var/run/docker.sock:/var/run/docker.sock \
+      nickfedor/watchtower \
+      --notification-url "teams:?color=%23406170&host=https://default.environment.api.powerplatform.com/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=XXXXXXXX"
+    ```
+
+=== "Docker Compose"
+
+    ```yaml
+    services:
+      watchtower:
+        image: nickfedor/watchtower:latest
+        environment:
+          WATCHTOWER_NOTIFICATION_URL: "teams:?color=%23406170&host=https://default.environment.api.powerplatform.com/powerautomate/automations/direct/workflows/abc123/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=XXXXXXXX"
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+    ```
+
+/// details | The following legacy Microsoft Teams configuration options and examples are deprecated and will be removed with the release of Watchtower v2.
+    type: warning
+
+### Legacy MSTeams Configuration (Deprecated)
+
+!!! Deprecated
+    The following examples use deprecated legacy MSTeams flags.
 
 === "Docker CLI (Env Vars)"
 
@@ -822,11 +948,12 @@ Environment Variable: WATCHTOWER_NOTIFICATION_SLACK_CHANNEL
 
 ### Microsoft Teams Configuration Options
 
-To receive notifications in Microsoft Teams, add `msteams` to the `--notifications` option or the `WATCHTOWER_NOTIFICATIONS` environment variable.
-
-Watchtower supports the following Microsoft Teams-related option:
+The following legacy MSTeams flag is **deprecated**. Use `--notification-url` with a `teams://` URL instead.
 
 #### MSTeams Hook URL
+
+!!! Deprecated
+    Use `--notification-url` with a `teams://` URL.
 
 The Microsoft Teams Power Automate workflow webhook URL for notifications.
 
@@ -837,13 +964,46 @@ Environment Variable: WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL
              Default: None
 ```
 
-!!! Note
-    This option can also reference a file, in which case the contents of the file are used.
-
 !!! Warning
     The value of `--notification-msteams-hook` **must** be an absolute URL using the `https://` scheme (including the host). Relative URLs and non-HTTPS schemes are rejected at runtime.
 
+///
+
 ## Gotify Notifications
+
+!!! Warning "Deprecated"
+    Legacy Gotify flags (`--notification-gotify-url`, `--notification-gotify-token`, `--notification-gotify-tls-skip-verify`) are **deprecated**. Use `--notification-url` with a `gotify://` URL instead.
+
+### Example Gotify Configuration
+
+=== "Docker CLI"
+
+    ```bash
+    docker run -d \
+      --name watchtower \
+      -v /var/run/docker.sock:/var/run/docker.sock \
+      nickfedor/watchtower \
+      --notification-url "gotify://my.gotify.tld/SuperSecretToken"
+    ```
+
+=== "Docker Compose"
+
+    ```yaml
+    services:
+      watchtower:
+        image: nickfedor/watchtower:latest
+        environment:
+          WATCHTOWER_NOTIFICATION_URL: "gotify://my.gotify.tld/SuperSecretToken"
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+    ```
+/// details | The following legacy Gotify configuration options and examples are deprecated and will be removed with the release of Watchtower v2.
+    type: warning
+
+### Legacy Gotify Configuration (Deprecated)
+
+!!! Deprecated
+    The following examples use deprecated legacy Gotify flags.
 
 === "Docker CLI (Env Vars)"
 
@@ -888,11 +1048,12 @@ Environment Variable: WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL
 
 ### Gotify Configuration Options
 
-To push a notification to your Gotify instance, add `gotify` to the `--notifications` option or the `WATCHTOWER_NOTIFICATIONS` environment variable.
-
-Watchtower supports the following Gotify-related options:
+The following legacy Gotify flags are **deprecated**. Use `--notification-url` with a `gotify://` URL instead.
 
 #### Gotify URL
+
+!!! Deprecated
+    Use `--notification-url` with a `gotify://` URL.
 
 The URL of the Gotify instance.
 
@@ -905,6 +1066,9 @@ Environment Variable: WATCHTOWER_NOTIFICATION_GOTIFY_URL
 
 #### Gotify Token
 
+!!! Deprecated
+    Use `--notification-url` with a `gotify://` URL (token is part of the URL path).
+
 The app token for the Gotify instance.
 
 ```text
@@ -914,10 +1078,10 @@ Environment Variable: WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN
              Default: None
 ```
 
-!!! Note
-    This option can also reference a file, in which case the contents of the file are used.
-
 #### Gotify TLS Skip Verify
+
+!!! Deprecated
+    Use `disabletls=yes` query parameter in the `gotify://` URL.
 
 Skip verification of the server certificate when using TLS.
 
@@ -927,6 +1091,8 @@ Environment Variable: WATCHTOWER_NOTIFICATION_GOTIFY_TLS_SKIP_VERIFY
                 Type: Boolean
              Default: false
 ```
+
+///
 
 ## Signal Notifications
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -379,7 +379,7 @@ func RegisterNotificationFlags(rootCmd *cobra.Command) {
 		filterEmptyStrings(
 			regexp.MustCompile("[, ]+").Split(envString("WATCHTOWER_NOTIFICATIONS"), -1),
 		),
-		"Notification types to send (valid: email, slack, msteams, gotify, shoutrrr)",
+		"Notification types to send [legacy types (email, slack, msteams, gotify) are deprecated. Use a Shoutrrr URL instead]",
 	)
 
 	flags.String(
@@ -399,6 +399,11 @@ func RegisterNotificationFlags(rootCmd *cobra.Command) {
 		"",
 		envString("WATCHTOWER_NOTIFICATIONS_HOSTNAME"),
 		"Custom hostname for notification titles")
+
+	//nolint:godox
+	// TODO: Remove legacy notification flags below for the v2 release.
+	// They are kept for backwards compatibility but are deprecated.
+	// Use --notification-url instead.
 
 	flags.StringP(
 		"notification-email-from",
@@ -555,10 +560,49 @@ func RegisterNotificationFlags(rootCmd *cobra.Command) {
 		"",
 		envBool("WATCHTOWER_NOTIFICATION_SPLIT_BY_CONTAINER"),
 		"Send separate notifications for each updated container instead of grouping them")
+
+	//nolint:godox
+	// TODO: Remove just before v2 Release.
+	// Mark legacy notification flags as deprecated.
+	// These flags are still functional but will be removed in the v2 release.
+	// Users should migrate to --notification-url instead.
+	markFlagDeprecated(flags, "notification-email-from", "Use --notification-url with an smtp:// URL.")
+	markFlagDeprecated(flags, "notification-email-to", "Use --notification-url with an smtp:// URL.")
+	markFlagDeprecated(flags, "notification-email-delay", "Use --notifications-delay instead.")
+	markFlagDeprecated(flags, "notification-email-server", "Use --notification-url with an smtp:// URL.")
+	markFlagDeprecated(flags, "notification-email-server-port", "Use --notification-url with an smtp:// URL.")
+	markFlagDeprecated(flags, "notification-email-server-tls-skip-verify", "Use --notification-url with an smtp:// URL.")
+	markFlagDeprecated(flags, "notification-email-server-user", "Use --notification-url with an smtp:// URL.")
+	markFlagDeprecated(flags, "notification-email-server-password", "Use --notification-url with an smtp:// URL.")
+	markFlagDeprecated(flags, "notification-email-subjecttag", "Use --notification-title-tag instead.")
+	markFlagDeprecated(flags, "notification-slack-hook-url", "Use --notification-url with a slack:// or discord:// URL.")
+	markFlagDeprecated(flags, "notification-slack-identifier", "Use --notification-url with a slack:// or discord:// URL.")
+	markFlagDeprecated(flags, "notification-slack-channel", "Use --notification-url with a slack:// or discord:// URL.")
+	markFlagDeprecated(flags, "notification-slack-icon-emoji", "Use --notification-url with a slack:// or discord:// URL.")
+	markFlagDeprecated(flags, "notification-slack-icon-url", "Use --notification-url with a slack:// or discord:// URL.")
+	markFlagDeprecated(flags, "notification-msteams-hook", "Use --notification-url with a teams:// URL.")
+	markFlagDeprecated(flags, "notification-gotify-url", "Use --notification-url with a gotify:// URL.")
+	markFlagDeprecated(flags, "notification-gotify-token", "Use --notification-url with a gotify:// URL.")
+	markFlagDeprecated(flags, "notification-gotify-tls-skip-verify", "Use --notification-url with a gotify:// URL.")
 }
 
-// envString fetches a string from an environment variable.
+// markFlagDeprecated marks a pflag as deprecated with a migration hint.
 //
+// Parameters:
+//   - flags: Flag set containing the flag.
+//   - name: Flag name.
+//   - hint: Migration hint message.
+//
+// TODO: Remove markFlagDeprecated and all legacy flags in the v2 release.
+//
+//nolint:godox
+func markFlagDeprecated(flags *pflag.FlagSet, name, hint string) {
+	if f := flags.Lookup(name); f != nil {
+		f.Deprecated = hint
+		f.Hidden = false // Keep visible so users see the hint in --help
+	}
+}
+
 // Parameters:
 //   - key: Environment variable key.
 //

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -648,7 +648,9 @@ func TestSetupLogging(t *testing.T) {
 // TestFlagsArePresentInDocumentation verifies that all flags are documented.
 // It checks documentation files for flag and environment variable mentions.
 func TestFlagsArePresentInDocumentation(t *testing.T) {
-	// Legacy notifications ignored due to soft deprecation.
+	//nolint:godox
+	// TODO: Remove legacy flags from ignoredEnvs/ignoredFlags when legacy notification types are removed.
+	// Legacy notifications are ignored due to soft deprecation.
 	ignoredEnvs := map[string]string{
 		"WATCHTOWER_NOTIFICATION_SLACK_ICON_EMOJI": "legacy",
 		"WATCHTOWER_NOTIFICATION_SLACK_ICON_URL":   "legacy",

--- a/pkg/notifications/doc.go
+++ b/pkg/notifications/doc.go
@@ -1,13 +1,16 @@
 // Package notifications provides mechanisms for sending notifications via various services in Watchtower.
-// It supports multiple notifiers (e.g., email, Slack, Microsoft Teams, Gotify) with templating, batching,
-// and JSON marshaling, integrating with Shoutrrr for service delivery.
+// It integrates with Shoutrrr for service delivery, supporting custom templates, batching, and JSON marshaling.
 //
 // Key components:
 //   - Notifier Creation: Configures notifiers from flags (notifier.go).
-//   - Service Notifiers: Implement specific services (email.go, slack.go, etc.).
 //   - Shoutrrr Integration: Handles message sending and batching (shoutrrr.go).
 //   - JSON Marshaling: Formats notification data (json.go).
 //   - Preview: Renders notification previews (preview.go).
+//
+// Note: The legacy notification types (email, slack, msteams, gotify) and their individual flags
+// (e.g., --notification-email-from, --notification-slack-hook-url) are deprecated.
+// Use --notification-url with the appropriate shoutrrr URL scheme instead.
+// See the deprecation notices on specific types and functions for details.
 //
 // Usage example:
 //

--- a/pkg/notifications/email.go
+++ b/pkg/notifications/email.go
@@ -13,6 +13,13 @@ import (
 )
 
 // emailType is the identifier for email notifications.
+//
+// Deprecated: Legacy email notification type is deprecated.
+// Use --notification-url with an smtp:// URL instead.
+//
+// TODO: Remove emailType constant for the v2 release.
+//
+//nolint:godox
 const emailType = "email"
 
 // defaultTimeout is the default duration for SMTP operations.
@@ -27,6 +34,13 @@ var (
 // emailTypeNotifier handles email notifications via SMTP.
 //
 // It batches log entries with a configurable delay.
+//
+// Deprecated: Legacy email notifier is deprecated.
+// Use --notification-url with an smtp:// URL instead.
+//
+// TODO: Remove emailTypeNotifier for the v2 release.
+//
+//nolint:godox
 type emailTypeNotifier struct {
 	From, To               string          // Sender and recipient email addresses.
 	Server, User, Password string          // SMTP server details.
@@ -43,6 +57,13 @@ type emailTypeNotifier struct {
 //
 // Returns:
 //   - types.ConvertibleNotifier: New email notifier instance.
+//
+// Deprecated: Legacy email notifier is deprecated.
+// Use --notification-url with an smtp:// URL instead.
+//
+// TODO: Remove newEmailNotifier for the v2 release.
+//
+//nolint:godox
 func newEmailNotifier(c *cobra.Command) types.ConvertibleNotifier {
 	flags := c.Flags()
 
@@ -94,6 +115,9 @@ func newEmailNotifier(c *cobra.Command) types.ConvertibleNotifier {
 // Returns:
 //   - string: SMTP URL.
 //   - error: Non-nil if port is invalid, nil on success.
+//
+// Deprecated: This method is part of the legacy email notifier and will be removed
+// for the v2 release. Use --notification-url with an smtp:// URL instead.
 func (e *emailTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 	clog := logrus.WithFields(logrus.Fields{
 		"from":   e.From,
@@ -157,6 +181,9 @@ func (e *emailTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 //
 // Returns:
 //   - time.Duration: Configured delay.
+//
+// Deprecated: This method is part of the legacy email notifier and will be removed
+// for the v2 release. Use --notifications-delay instead.
 func (e *emailTypeNotifier) GetDelay() time.Duration {
 	clog := logrus.WithFields(logrus.Fields{
 		"from":   e.From,
@@ -173,6 +200,9 @@ func (e *emailTypeNotifier) GetDelay() time.Duration {
 //
 // Returns:
 //   - []*logrus.Entry: Always nil.
+//
+// Deprecated: This method is part of the legacy email notifier and will be removed
+// for the v2 release.
 func (e *emailTypeNotifier) GetEntries() []*logrus.Entry {
 	return nil
 }
@@ -182,6 +212,9 @@ func (e *emailTypeNotifier) GetEntries() []*logrus.Entry {
 // Parameters:
 //   - entries: Ignored.
 //   - report: Ignored.
+//
+// Deprecated: This method is part of the legacy email notifier and will be removed
+// for the v2 release.
 func (e *emailTypeNotifier) SendFilteredEntries(_ []*logrus.Entry, _ types.Report) {
 	// Legacy notifiers do not support filtered entries.
 }

--- a/pkg/notifications/gotify.go
+++ b/pkg/notifications/gotify.go
@@ -14,11 +14,25 @@ import (
 )
 
 // gotifyType is the identifier for Gotify notifications.
+//
+// Deprecated: Legacy gotify notification type is deprecated.
+// Use --notification-url with a gotify:// URL instead.
+//
+// TODO: Remove gotifyType constant for the v2 release.
+//
+//nolint:godox
 const gotifyType = "gotify"
 
 // gotifyTypeNotifier handles Gotify notifications.
 //
 // It configures URL, token, and TLS settings.
+//
+// Deprecated: Legacy gotify notifier is deprecated.
+// Use --notification-url with a gotify:// URL instead.
+//
+// TODO: Remove gotifyTypeNotifier for the v2 release.
+//
+//nolint:godox
 type gotifyTypeNotifier struct {
 	gotifyURL                string // Gotify server URL.
 	gotifyAppToken           string // Gotify application token.
@@ -32,6 +46,13 @@ type gotifyTypeNotifier struct {
 //
 // Returns:
 //   - types.ConvertibleNotifier: New Gotify notifier instance.
+//
+// Deprecated: Legacy gotify notifier is deprecated.
+// Use --notification-url with a gotify:// URL instead.
+//
+// TODO: Remove newGotifyNotifier for the v2 release.
+//
+//nolint:godox
 func newGotifyNotifier(c *cobra.Command) types.ConvertibleNotifier {
 	flags := c.Flags()
 
@@ -65,6 +86,9 @@ func newGotifyNotifier(c *cobra.Command) types.ConvertibleNotifier {
 //
 // Returns:
 //   - string: Token value (fatal if empty).
+//
+// Deprecated: This function is part of the legacy gotify notifier and will be removed
+// for the v2 release. Use --notification-url with a gotify:// URL instead.
 func getGotifyToken(flags *pflag.FlagSet) string {
 	gotifyToken, _ := flags.GetString("notification-gotify-token")
 	clog := logrus.WithField("flag", "notification-gotify-token")
@@ -88,6 +112,9 @@ func getGotifyToken(flags *pflag.FlagSet) string {
 //
 // Returns:
 //   - string: Validated URL (fatal if empty or malformed).
+//
+// Deprecated: This function is part of the legacy gotify notifier and will be removed
+// for the v2 release. Use --notification-url with a gotify:// URL instead.
 func getGotifyURL(flags *pflag.FlagSet) string {
 	gotifyURL, _ := flags.GetString("notification-gotify-url")
 	clog := logrus.WithFields(logrus.Fields{
@@ -125,6 +152,9 @@ func getGotifyURL(flags *pflag.FlagSet) string {
 // Returns:
 //   - string: Gotify service URL.
 //   - error: Non-nil if URL parsing fails, nil on success.
+//
+// Deprecated: This method is part of the legacy gotify notifier and will be removed
+// for the v2 release. Use --notification-url with a gotify:// URL instead.
 func (n *gotifyTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 	clog := logrus.WithField("url", n.gotifyURL)
 	clog.Debug("Generating Gotify service URL")
@@ -158,6 +188,9 @@ func (n *gotifyTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 //
 // Returns:
 //   - []*logrus.Entry: Always nil.
+//
+// Deprecated: This method is part of the legacy gotify notifier and will be removed
+// for the v2 release.
 func (n *gotifyTypeNotifier) GetEntries() []*logrus.Entry {
 	return nil
 }
@@ -167,6 +200,9 @@ func (n *gotifyTypeNotifier) GetEntries() []*logrus.Entry {
 // Parameters:
 //   - entries: Ignored.
 //   - report: Ignored.
+//
+// Deprecated: This method is part of the legacy gotify notifier and will be removed
+// for the v2 release.
 func (n *gotifyTypeNotifier) SendFilteredEntries(_ []*logrus.Entry, _ types.Report) {
 	// Legacy notifiers do not support filtered entries.
 }

--- a/pkg/notifications/msteams.go
+++ b/pkg/notifications/msteams.go
@@ -13,6 +13,13 @@ import (
 )
 
 // msTeamsType is the identifier for Microsoft Teams notifications.
+//
+// Deprecated: Legacy msteams notification type is deprecated.
+// Use --notification-url with a teams:// URL instead.
+//
+// TODO: Remove msTeamsType constant for the v2 release.
+//
+//nolint:godox
 const msTeamsType = "msteams"
 
 // Errors for Microsoft Teams notification configuration.
@@ -22,6 +29,13 @@ var (
 )
 
 // msTeamsTypeNotifier handles Microsoft Teams notifications via webhook.
+//
+// Deprecated: Legacy msteams notifier is deprecated.
+// Use --notification-url with a teams:// URL instead.
+//
+// TODO: Remove msTeamsTypeNotifier for the v2 release.
+//
+//nolint:godox
 type msTeamsTypeNotifier struct {
 	webHookURL string
 }
@@ -33,6 +47,13 @@ type msTeamsTypeNotifier struct {
 //
 // Returns:
 //   - types.ConvertibleNotifier: New Teams notifier instance.
+//
+// Deprecated: Legacy msteams notifier is deprecated.
+// Use --notification-url with a teams:// URL instead.
+//
+// TODO: Remove newMsTeamsNotifier for the v2 release.
+//
+//nolint:godox
 func newMsTeamsNotifier(cmd *cobra.Command) types.ConvertibleNotifier {
 	flags := cmd.Flags()
 
@@ -57,6 +78,9 @@ func newMsTeamsNotifier(cmd *cobra.Command) types.ConvertibleNotifier {
 // Returns:
 //   - string: Teams service URL.
 //   - error: Non-nil if parsing fails, nil on success.
+//
+// Deprecated: This method is part of the legacy msteams notifier and will be removed
+// for the v2 release. Use --notification-url with a teams:// URL instead.
 func (n *msTeamsTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 	clog := logrus.WithField("url", n.webHookURL)
 	clog.Debug("Generating Microsoft Teams service URL")
@@ -89,6 +113,9 @@ func (n *msTeamsTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 //
 // Returns:
 //   - []*logrus.Entry: Always nil.
+//
+// Deprecated: This method is part of the legacy msteams notifier and will be removed
+// for the v2 release.
 func (n *msTeamsTypeNotifier) GetEntries() []*logrus.Entry {
 	return nil
 }
@@ -98,6 +125,9 @@ func (n *msTeamsTypeNotifier) GetEntries() []*logrus.Entry {
 // Parameters:
 //   - entries: Ignored.
 //   - report: Ignored.
+//
+// Deprecated: This method is part of the legacy msteams notifier and will be removed
+// for the v2 release.
 func (n *msTeamsTypeNotifier) SendFilteredEntries(_ []*logrus.Entry, _ types.Report) {
 	// Legacy notifiers do not support filtered entries.
 }

--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -86,6 +86,13 @@ func NewNotifier(c *cobra.Command) types.Notifier {
 // Returns:
 //   - []string: Updated URL list.
 //   - time.Duration: Notification delay.
+//
+// Deprecated: Legacy notification types are deprecated.
+// Use --notification-url instead.
+//
+// TODO: Remove AppendLegacyUrls for the v2 release.
+//
+//nolint:godox
 func AppendLegacyUrls(urls []string, cmd *cobra.Command) ([]string, time.Duration) {
 	clog := logrus.WithField("function", "AppendLegacyUrls")
 	clog.Debug("Appending legacy notification URLs")
@@ -105,12 +112,28 @@ func AppendLegacyUrls(urls []string, cmd *cobra.Command) ([]string, time.Duratio
 
 		switch notificationType {
 		case emailType:
+			clog.Warn(
+				"Legacy email notification type is deprecated; use --notification-url with an smtp:// URL instead. See https://docs.nickfedor.com/watchtower/notifications/ for migration guidance.",
+			)
+
 			legacyNotifier = newEmailNotifier(cmd)
 		case slackType:
+			clog.Warn(
+				"Legacy slack notification type is deprecated; use --notification-url with a slack:// or discord:// URL instead. See https://docs.nickfedor.com/watchtower/notifications/ for migration guidance.",
+			)
+
 			legacyNotifier = newSlackNotifier(cmd)
 		case msTeamsType:
+			clog.Warn(
+				"Legacy msteams notification type is deprecated; use --notification-url with a teams:// URL instead. See https://docs.nickfedor.com/watchtower/notifications/ for migration guidance.",
+			)
+
 			legacyNotifier = newMsTeamsNotifier(cmd)
 		case gotifyType:
+			clog.Warn(
+				"Legacy gotify notification type is deprecated; use --notification-url with a gotify:// URL instead. See https://docs.nickfedor.com/watchtower/notifications/ for migration guidance.",
+			)
+
 			legacyNotifier = newGotifyNotifier(cmd)
 		case shoutrrrType:
 			continue
@@ -162,6 +185,10 @@ func AppendLegacyUrls(urls []string, cmd *cobra.Command) ([]string, time.Duratio
 //
 // Returns:
 //   - time.Duration: Selected delay.
+//
+// TODO: Simplify GetDelay to only use --notifications-delay when legacy types are removed.
+//
+//nolint:godox
 func GetDelay(c *cobra.Command, legacyDelay time.Duration) time.Duration {
 	clog := logrus.WithField("legacy_delay", legacyDelay)
 	clog.Debug("Determining notification delay")
@@ -252,7 +279,8 @@ func GetTemplateData(c *cobra.Command) StaticData {
 		if tag == "" {
 			// Check legacy email tag.
 			tag, _ = flag.GetString("notification-email-subjecttag")
-			clog.WithField("tag", tag).Debug("Using legacy email subject tag")
+			clog.WithField("tag", tag).
+				Warn("Using deprecated email subject tag flag: --notification-email-subjecttag. Use --notification-title-tag instead.")
 		}
 
 		title = GetTitle(hostname, tag)

--- a/pkg/notifications/notifier_test.go
+++ b/pkg/notifications/notifier_test.go
@@ -69,6 +69,8 @@ var _ = ginkgo.Describe("notifications", func() {
 			})
 		})
 		ginkgo.When("legacy email tag is set", func() {
+			//nolint:godox
+			// TODO: Remove legacy email subjecttag test when legacy notification types are removed.
 			ginkgo.It("should use the prefix in the title", func() {
 				command := cmd.NewRootCommand()
 				flags.RegisterNotificationFlags(command)
@@ -120,6 +122,8 @@ var _ = ginkgo.Describe("notifications", func() {
 			})
 		})
 		ginkgo.When("legacy delay is defined", func() {
+			//nolint:godox
+			// TODO: Remove legacy delay tests when legacy notification types are removed.
 			ginkgo.It("should use the specified legacy delay", func() {
 				command := cmd.NewRootCommand()
 				flags.RegisterNotificationFlags(command)
@@ -128,6 +132,8 @@ var _ = ginkgo.Describe("notifications", func() {
 			})
 		})
 		ginkgo.When("legacy delay and delay is defined", func() {
+			//nolint:godox
+			// TODO: Remove legacy delay tests when legacy notification types are removed.
 			ginkgo.It(
 				"should use the specified legacy delay and ignore the specified delay",
 				func() {
@@ -174,6 +180,8 @@ var _ = ginkgo.Describe("notifications", func() {
 			})
 		})
 	})
+	//nolint:godox
+	// TODO: Remove legacy slack notifier tests when legacy notification types are removed.
 	ginkgo.Describe("the slack notifier", func() {
 		// builderFn := notifications.NewSlackNotifier
 		ginkgo.When("passing a discord url to the slack notifier", func() {
@@ -341,6 +349,8 @@ var _ = ginkgo.Describe("notifications", func() {
 		})
 	})
 
+	//nolint:godox
+	// TODO: Remove legacy gotify notifier tests when legacy notification types are removed.
 	ginkgo.Describe("the gotify notifier", func() {
 		ginkgo.When("converting a gotify service config into a shoutrrr url", func() {
 			ginkgo.It("should return the expected URL", func() {
@@ -425,6 +435,8 @@ var _ = ginkgo.Describe("notifications", func() {
 		})
 	})
 
+	//nolint:godox
+	// TODO: Remove legacy msteams notifier tests when legacy notification types are removed.
 	ginkgo.Describe("the teams notifier", func() {
 		ginkgo.BeforeEach(func() {
 			logrus.SetLevel(logrus.DebugLevel) // Ensure debug logs are visible
@@ -456,6 +468,8 @@ var _ = ginkgo.Describe("notifications", func() {
 		})
 	})
 
+	//nolint:godox
+	// TODO: Remove legacy email notifier tests when legacy notification types are removed.
 	ginkgo.Describe("the email notifier", func() {
 		ginkgo.When("converting an email service config into a shoutrrr url", func() {
 			ginkgo.It("should set the from address in the URL", func() {
@@ -527,6 +541,9 @@ var _ = ginkgo.Describe("notifications", func() {
 	})
 })
 
+// TODO: Remove buildExpectedURL helper when legacy notification tests are removed.
+//
+//nolint:godox
 func buildExpectedURL(
 	username string,
 	password string,
@@ -546,6 +563,9 @@ func buildExpectedURL(
 		url.QueryEscape(destAddress))
 }
 
+// TODO: Remove testURL helper when legacy notification tests are removed.
+//
+//nolint:godox
 func testURL(args []string, expectedURL string, expectedDelay time.Duration) {
 	defer ginkgo.GinkgoRecover()
 

--- a/pkg/notifications/shoutrrr_fuzz_test.go
+++ b/pkg/notifications/shoutrrr_fuzz_test.go
@@ -16,7 +16,8 @@ func FuzzGetShoutrrrTemplate(f *testing.F) {
 	f.Add(strings.Repeat("a", 1000))
 
 	f.Fuzz(func(_ *testing.T, tplString string) {
-		// Test both legacy and non-legacy modes
+		//nolint:godox
+		// TODO: Remove legacy mode fuzzing when legacy notification types are removed.
 		_, _ = getShoutrrrTemplate(tplString, true)
 		_, _ = getShoutrrrTemplate(tplString, false)
 	})

--- a/pkg/notifications/shoutrrr_test.go
+++ b/pkg/notifications/shoutrrr_test.go
@@ -25,6 +25,9 @@ import (
 
 var allButTrace = logrus.DebugLevel
 
+// TODO: Remove legacyMockData when legacy notification types are removed.
+//
+//nolint:godox
 var legacyMockData = Data{
 	Entries: []*logrus.Entry{
 		{
@@ -58,6 +61,10 @@ var mockDataAllFresh = Data{
 
 // mockDataFromStates generates mock notification data with specified container states.
 // It includes legacy log entries and static data for testing purposes.
+//
+// TODO: Remove legacyMockData reference when legacy notification types are removed.
+//
+//nolint:godox
 func mockDataFromStates(states ...session.State) Data {
 	hostname := "Mock"
 	prefix := ""
@@ -141,6 +148,8 @@ updt1 (mock/updt1:latest): Updated
 		})
 	})
 
+	//nolint:godox
+	// TODO: Remove legacy template tests when legacy notification types are removed.
 	ginkgo.When("using legacy templates", func() {
 		ginkgo.When("no custom template is provided", func() {
 			ginkgo.It("should format the messages using the default template", func() {
@@ -1108,6 +1117,10 @@ func (b blockingRouter) Send(_ string, _ *types.Params) []error {
 
 // sendNotificationsWithBlockingRouter creates a notifier with a blocking router for testing.
 // It queues a message and returns the notifier and router to verify notification delays.
+//
+// TODO: Remove legacy template usage when legacy notification types are removed.
+//
+//nolint:godox
 func sendNotificationsWithBlockingRouter() (*shoutrrrTypeNotifier, *blockingRouter, error) {
 	legacy := true
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1152,6 +1165,10 @@ func sendNotificationsWithBlockingRouter() (*shoutrrrTypeNotifier, *blockingRout
 
 // createNotifierWithTemplate creates a notifier with a specified template for testing.
 // It returns the notifier and an error, falling back to a default template if parsing fails.
+//
+// TODO: Remove legacy parameter and default-legacy fallback when legacy notification types are removed.
+//
+//nolint:godox
 func createNotifierWithTemplate(tplString string, legacy bool) (*shoutrrrTypeNotifier, error) {
 	tpl, err := getShoutrrrTemplate(tplString, legacy)
 	if err != nil {
@@ -1179,6 +1196,10 @@ func createNotifierWithTemplate(tplString string, legacy bool) (*shoutrrrTypeNot
 
 // getTemplatedResult generates a templated message for testing.
 // It builds and returns the message string, expecting no errors.
+//
+// TODO: Remove legacy parameter when legacy notification types are removed.
+//
+//nolint:godox
 func getTemplatedResult(tplString string, legacy bool, data Data) string {
 	notifier, err := createNotifierWithTemplate(tplString, legacy)
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())

--- a/pkg/notifications/slack.go
+++ b/pkg/notifications/slack.go
@@ -13,11 +13,25 @@ import (
 )
 
 // slackType is the identifier for Slack notifications.
+//
+// Deprecated: Legacy slack notification type is deprecated.
+// Use --notification-url with a slack:// or discord:// URL instead.
+//
+// TODO: Remove slackType constant for the v2 release.
+//
+//nolint:godox
 const slackType = "slack"
 
 // slackTypeNotifier handles Slack notifications via webhook.
 //
 // It supports custom username, channel, and icons.
+//
+// Deprecated: Legacy slack notifier is deprecated.
+// Use --notification-url with a slack:// or discord:// URL instead.
+//
+// TODO: Remove slackTypeNotifier for the v2 release.
+//
+//nolint:godox
 type slackTypeNotifier struct {
 	HookURL   string // Slack webhook URL.
 	Username  string // Notification username.
@@ -33,6 +47,13 @@ type slackTypeNotifier struct {
 //
 // Returns:
 //   - types.ConvertibleNotifier: New Slack notifier instance.
+//
+// Deprecated: Legacy slack notifier is deprecated.
+// Use --notification-url with a slack:// or discord:// URL instead.
+//
+// TODO: Remove newSlackNotifier for the v2 release.
+//
+//nolint:godox
 func newSlackNotifier(c *cobra.Command) types.ConvertibleNotifier {
 	flags := c.Flags()
 
@@ -71,6 +92,9 @@ func newSlackNotifier(c *cobra.Command) types.ConvertibleNotifier {
 // Returns:
 //   - string: Service URL (Slack or Discord).
 //   - error: Non-nil if token parsing fails, nil on success.
+//
+// Deprecated: This method is part of the legacy slack notifier and will be removed
+// for the v2 release. Use --notification-url with a slack:// URL instead.
 func (s *slackTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 	clog := logrus.WithField("hook_url", s.HookURL)
 	clog.Debug("Generating Slack service URL")
@@ -136,6 +160,9 @@ func (s *slackTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 //
 // Returns:
 //   - []*logrus.Entry: Always nil.
+//
+// Deprecated: This method is part of the legacy slack notifier and will be removed
+// for the v2 release.
 func (s *slackTypeNotifier) GetEntries() []*logrus.Entry {
 	return nil
 }
@@ -145,6 +172,9 @@ func (s *slackTypeNotifier) GetEntries() []*logrus.Entry {
 // Parameters:
 //   - entries: Ignored.
 //   - report: Ignored.
+//
+// Deprecated: This method is part of the legacy slack notifier and will be removed
+// for the v2 release.
 func (s *slackTypeNotifier) SendFilteredEntries(_ []*logrus.Entry, _ types.Report) {
 	// Legacy notifiers do not support filtered entries.
 }

--- a/pkg/types/convertible_notifier.go
+++ b/pkg/types/convertible_notifier.go
@@ -7,6 +7,13 @@ import (
 )
 
 // ConvertibleNotifier defines a notifier that generates a shoutrrr URL.
+//
+// Deprecated: This interface is part of the legacy notification system.
+// Use --notification-url with shoutrrr URLs instead.
+//
+// TODO: Remove ConvertibleNotifier interface for the v2 release.
+//
+//nolint:godox
 type ConvertibleNotifier interface {
 	// GetURL creates a shoutrrr URL from configuration.
 	//
@@ -20,6 +27,13 @@ type ConvertibleNotifier interface {
 }
 
 // DelayNotifier defines a notifier with a delay before sending.
+//
+// Deprecated: This interface is part of the legacy notification system.
+// Use --notifications-delay instead.
+//
+// TODO: Remove DelayNotifier interface for the v2 release.
+//
+//nolint:godox
 type DelayNotifier interface {
 	// GetDelay returns the delay duration for notifications.
 	//


### PR DESCRIPTION
This PR deprecates the legacy notification service implementation in preparation for Watchtower's v2 release.

## Problem

Prior to the forking of Watchtower, it outgrew its notification implementation and the Shoutrrr notification library was split off and implemented as a more maintainable notifications service. The older configuration options were retained as legacy components in an attempt to maintain backwards compatibility; however, the prior maintainers never finished the process of deprecating and encouraging users to use the newer notification implementation.

## Solution

Updated the documentation and added TODO and deprecation directives for the respective legacy components.

Watchtower v2 is not expected to be released for several months, so this should hopefully encourage anyone using the legacy/deprecated notification service configurations to migrate to using the Shoutrrr URL's. 

The legacy-default template will be retained, as it's largely a defacto standard when not using the report-style template.

## Changes

- Mark legacy email, slack, msteams, and gotify notifiers as deprecated with `Deprecated` doc comments and TODOs for v2 removal
- Add `markFlagDeprecated` helper to flag legacy CLI flags with migration hints pointing to `--notification-url`
- Add deprecation warnings in `AppendLegacyUrls` and `GetTemplateData` when legacy types are used
- Update docs with deprecation notices, migration guidance, and a "Deprecated" column in the flags table
- Add `//nolint:godox` TODO comments in tests referencing legacy code to track removal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation notices for legacy notification types (email, Slack, Microsoft Teams, Gotify) across configuration and notification documentation.
  * Updated notification documentation with migration guides directing users to use `--notification-url` with Shoutrrr URL schemes.
  * Updated help text to reflect deprecation of legacy notification flags; warnings now display when these options are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->