### PR TITLE
feat: filter containers by image name

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -92,17 +92,22 @@ var (
 	// allowing users to blacklist specific containers from Watchtower's operations.
 	disableContainers []string
 
-	// imageNames is a slice of image names (regex supported) to include in watching.
+	// monitoredImageNamePatterns is a slice of image name patterns that
+	// restricts which containers are monitored.
 	//
-	// It is populated in preRun from the --image-names flag or the WATCHTOWER_IMAGE_NAMES environment variable,
-	// restricting updates to containers whose image matches one of the patterns.
-	imageNames []string
+	// When set, only containers whose image matches one of these patterns are monitored.
+	// It is populated in preRun from the --monitored-image-name-patterns flag or the
+	// WATCHTOWER_MONITORED_IMAGE_NAME_PATTERNS environment variable, allowing users to
+	// configure specific image patterns for Watchtower's monitoring scope.
+	monitoredImageNamePatterns []string
 
-	// disableImageNames is a slice of image names (regex supported) explicitly excluded from watching.
+	// skippedImageNamePatterns is a slice of image name patterns for
+	// containers to exclude from monitoring.
 	//
-	// It is populated in preRun from the --disable-image-names flag or the WATCHTOWER_DISABLE_IMAGE_NAMES environment variable,
-	// allowing users to blacklist containers by image name from Watchtower's operations.
-	disableImageNames []string
+	// Matching containers are not monitored. It is populated in preRun from the
+	// --skipped-image-name-patterns flag or the WATCHTOWER_SKIPPED_IMAGE_NAME_PATTERNS
+	// environment variable, providing a way to blacklist specific image patterns.
+	skippedImageNamePatterns []string
 
 	// notifier is the notification system instance responsible for sending update status messages to configured channels.
 	//
@@ -315,15 +320,16 @@ func preRun(cmd *cobra.Command, _ []string) {
 		disableContainers[i] = util.NormalizeContainerName(disableContainers[i])
 	}
 
-	// Set image names included in or excluded from Watchtower's handling.
-	imageNames, _ = flagsSet.GetStringSlice("image-names")
-	for i := range imageNames {
-		imageNames[i] = strings.TrimSpace(imageNames[i])
+	// Set image name patterns to define which respective containers are monitored.
+	monitoredImageNamePatterns, _ = flagsSet.GetStringSlice("monitor-image-names")
+	for i := range monitoredImageNamePatterns {
+		monitoredImageNamePatterns[i] = strings.TrimSpace(monitoredImageNamePatterns[i])
 	}
 
-	disableImageNames, _ = flagsSet.GetStringSlice("disable-image-names")
-	for i := range disableImageNames {
-		disableImageNames[i] = strings.TrimSpace(disableImageNames[i])
+	// Set image name patterns for respective containers to skip during monitoring.
+	skippedImageNamePatterns, _ = flagsSet.GetStringSlice("skip-image-names")
+	for i := range skippedImageNamePatterns {
+		skippedImageNamePatterns[i] = strings.TrimSpace(skippedImageNamePatterns[i])
 	}
 
 	// Enable/disable execution of scripts before or after updates.
@@ -538,9 +544,9 @@ func run(command *cobra.Command, args []string) {
 	// Build the filter and its description based on normalized names, exclusions, and label settings.
 	filter, filterDesc := filters.BuildFilter(
 		normalizedContainerNames,
-		disableContainers, // Normalized container names
-		imageNames,
-		disableImageNames,
+		disableContainers,
+		monitoredImageNamePatterns,
+		skippedImageNamePatterns,
 		enableLabel,
 		scope,
 	)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -90,6 +91,18 @@ var (
 	// It is populated in preRun from the --disable-containers flag or the WATCHTOWER_DISABLE_CONTAINERS environment variable,
 	// allowing users to blacklist specific containers from Watchtower's operations.
 	disableContainers []string
+
+	// imageNames is a slice of image names (regex supported) to include in watching.
+	//
+	// It is populated in preRun from the --image-names flag or the WATCHTOWER_IMAGE_NAMES environment variable,
+	// restricting updates to containers whose image matches one of the patterns.
+	imageNames []string
+
+	// disableImageNames is a slice of image names (regex supported) explicitly excluded from watching.
+	//
+	// It is populated in preRun from the --disable-image-names flag or the WATCHTOWER_DISABLE_IMAGE_NAMES environment variable,
+	// allowing users to blacklist containers by image name from Watchtower's operations.
+	disableImageNames []string
 
 	// notifier is the notification system instance responsible for sending update status messages to configured channels.
 	//
@@ -300,6 +313,17 @@ func preRun(cmd *cobra.Command, _ []string) {
 	disableContainers, _ = flagsSet.GetStringSlice("disable-containers")
 	for i := range disableContainers {
 		disableContainers[i] = util.NormalizeContainerName(disableContainers[i])
+	}
+
+	// Set image names included in or excluded from Watchtower's handling.
+	imageNames, _ = flagsSet.GetStringSlice("image-names")
+	for i := range imageNames {
+		imageNames[i] = strings.TrimSpace(imageNames[i])
+	}
+
+	disableImageNames, _ = flagsSet.GetStringSlice("disable-image-names")
+	for i := range disableImageNames {
+		disableImageNames[i] = strings.TrimSpace(disableImageNames[i])
 	}
 
 	// Enable/disable execution of scripts before or after updates.
@@ -515,6 +539,8 @@ func run(command *cobra.Command, args []string) {
 	filter, filterDesc := filters.BuildFilter(
 		normalizedContainerNames,
 		disableContainers, // Normalized container names
+		imageNames,
+		disableImageNames,
 		enableLabel,
 		scope,
 	)

--- a/docs/configuration/arguments/index.md
+++ b/docs/configuration/arguments/index.md
@@ -430,7 +430,43 @@ Environment Variable: WATCHTOWER_DISABLE_CONTAINERS
 ```
 
 !!! Note
-    Regex patterns are supported. See [Regex Pattern Matching](../container-selection/index.md#regex-pattern-matching) for details.
+    Regex patterns are supported. See [Regex Pattern Matching](../container-selection/index.md#regex_pattern_matching) for details.
+
+### Include Specific Images
+
+Restricts monitoring to containers whose image name matches one of the supplied
+values, even if other selection criteria would include them.
+
+```text
+            Argument: --image-names
+Environment Variable: WATCHTOWER_IMAGE_NAMES
+                Type: Comma- or space-separated string list
+             Default: None
+```
+
+!!! Note
+    Image names include the tag (for example `nginx:latest`). Regex patterns are
+    supported and anchored to the **full** image name. See
+    [Regex Pattern Matching](../container-selection/index.md#regex_pattern_matching)
+    for details.
+
+### Disable Specific Images
+
+Excludes containers by image name from monitoring, even if they have the enable
+label set to `true`.
+
+```text
+            Argument: --disable-image-names
+Environment Variable: WATCHTOWER_DISABLE_IMAGE_NAMES
+                Type: Comma- or space-separated string list
+             Default: None
+```
+
+!!! Note
+    Image names include the tag (for example `nginx:latest`). Regex patterns are
+    supported and anchored to the **full** image name. See
+    [Regex Pattern Matching](../container-selection/index.md#regex_pattern_matching)
+    for details.
 
 ### Scope Filter
 

--- a/docs/configuration/arguments/index.md
+++ b/docs/configuration/arguments/index.md
@@ -452,7 +452,7 @@ Environment Variable: WATCHTOWER_MONITOR_IMAGE_NAMES
 
 ### Skip Specific Images
 
-Excludes containers by image name pattern from monitoring , even if they have the enable
+Excludes containers by image name pattern from monitoring, even if they have the enable
 label set to `true`.
 
 ```text

--- a/docs/configuration/arguments/index.md
+++ b/docs/configuration/arguments/index.md
@@ -420,7 +420,7 @@ Environment Variable: WATCHTOWER_LABEL_ENABLE
 
 ### Disable Specific Containers
 
-Excludes containers by name from monitoring, even if they have the enable label set to `true`.
+Excludes containers by container name from monitoring, even if they have the enable label set to `true`.
 
 ```text
             Argument: --disable-containers, -x
@@ -432,40 +432,40 @@ Environment Variable: WATCHTOWER_DISABLE_CONTAINERS
 !!! Note
     Regex patterns are supported. See [Regex Pattern Matching](../container-selection/index.md#regex_pattern_matching) for details.
 
-### Include Specific Images
+### Monitor Specific Images
 
 Restricts monitoring to containers whose image name matches one of the supplied
-values, even if other selection criteria would include them.
+image name patterns, even if other selection criteria would include them.
 
 ```text
-            Argument: --image-names
-Environment Variable: WATCHTOWER_IMAGE_NAMES
-                Type: Comma- or space-separated string list
+            Argument: --monitor-image-names
+Environment Variable: WATCHTOWER_MONITOR_IMAGE_NAMES
+                Type: Comma or space-separated string list
              Default: None
 ```
 
 !!! Note
-    Image names include the tag (for example `nginx:latest`). Regex patterns are
-    supported and anchored to the **full** image name. See
-    [Regex Pattern Matching](../container-selection/index.md#regex_pattern_matching)
+    Image name patterns include the tag (for example `nginx:latest`).
+    Regex patterns are supported and anchored to the **full** image name.
+    See [Regex Pattern Matching](../container-selection/index.md#regex_pattern_matching)
     for details.
 
-### Disable Specific Images
+### Skip Specific Images
 
-Excludes containers by image name from monitoring, even if they have the enable
+Excludes containers by image name pattern from monitoring , even if they have the enable
 label set to `true`.
 
 ```text
-            Argument: --disable-image-names
-Environment Variable: WATCHTOWER_DISABLE_IMAGE_NAMES
-                Type: Comma- or space-separated string list
+            Argument: --skip-image-names
+Environment Variable: WATCHTOWER_SKIP_IMAGE_NAMES
+                Type: Comma or space-separated string list
              Default: None
 ```
 
 !!! Note
-    Image names include the tag (for example `nginx:latest`). Regex patterns are
-    supported and anchored to the **full** image name. See
-    [Regex Pattern Matching](../container-selection/index.md#regex_pattern_matching)
+    Image name patterns include the tag (for example `nginx:latest`).
+    Regex patterns are supported and anchored to the **full** image name.
+    See [Regex Pattern Matching](../container-selection/index.md#regex_pattern_matching)
     for details.
 
 ### Scope Filter

--- a/docs/configuration/container-selection/index.md
+++ b/docs/configuration/container-selection/index.md
@@ -13,10 +13,10 @@ A container is monitored only if it passes every filter in the chain. The filter
 | 1 | Old Watchtower container exclusion                        | Watchtower containers renamed with a `watchtower-old-` prefix during self-updates are always excluded.                           |
 | 2 | [Disabled label check](#enabledisable_labels)             | Containers with the Docker label `com.centurylinklabs.watchtower.enable=false` are excluded.                                     |
 | 3 | [Scope filter](#monitoring_scopes)                        | Only containers matching the configured scope are included (default: `"none"`).                                                  |
-| 4 | [Image skip patterns](#exclude_specific_images)           | Containers whose image matches a [skip pattern](../arguments/index.md#skip_specific_images) are excluded.                        |
-| 5 | [Monitored image name patterns](#include_specific_images) | If set, only containers whose image matches a [monitored pattern](../arguments/index.md#monitor_specific_images) are included.   |
-| 6 | [Disabled container names](#exclude_specific_containers)  | Containers whose name matches a [disable pattern](../arguments/index.md#disable_specific_containers) are excluded.               |
-| 7 | [Enable label filter](#enabledisable_labels)              | If [label enable](../arguments/index.md#enable_label_filter) is set, only containers with the enable label present are included. |
+| 4 | [Enable label filter](#enabledisable_labels)              | If [label enable](../arguments/index.md#enable_label_filter) is set, only containers with the enable label present are included. |
+| 5 | [Image skip patterns](#exclude_specific_images)           | Containers whose image matches a [skip pattern](../arguments/index.md#skip_specific_images) are excluded.                        |
+| 6 | [Monitored image name patterns](#monitor_specific_images) | If set, only containers whose image matches a [monitored pattern](../arguments/index.md#monitor_specific_images) are included.   |
+| 7 | [Disabled container names](#exclude_specific_containers)  | Containers whose name matches a [disable pattern](../arguments/index.md#disable_specific_containers) are excluded.               |
 | 8 | [Container name arguments](#container_name_filtering)     | If positional name arguments are provided, only containers matching at least one are included.                                   |
 
 !!! Note
@@ -51,7 +51,7 @@ Two configuration options extend this to include additional states:
 
 The `com.centurylinklabs.watchtower.enable` label controls whether Watchtower manages a container.
 
-!!!Note "This label is set on the container you want to manage, not on the Watchtower instance."
+!!! Note "This label is set on the container you want to manage, not on the Watchtower instance."
 
 ### Default Behavior
 
@@ -200,7 +200,7 @@ Watchtower can filter containers based on their image name using [Go regex patte
 
 Image name patterns match against the **full image name including its tag** (e.g., `nginx:latest`, `docker.io/library/nginx:1.25`).
 
-!!!Note "If no tag is specified in the image reference, `:latest` is assumed."
+!!! Note "If no tag is specified in the image reference, `:latest` is assumed."
 
 ### Monitor Specific Images
 
@@ -354,7 +354,7 @@ docker run -d nickfedor/watchtower "db-.*" "cache-.*"
 Monitor only containers using nginx or redis images with any tag:
 
 ```bash
-docker run -d -e WATCHTOWER_IMAGE_NAMES="nginx:.*,redis:.*" nickfedor/watchtower
+docker run -d -e WATCHTOWER_MONITOR_IMAGE_NAMES="nginx:.*,redis:.*" nickfedor/watchtower
 ```
 
 ## Label Precedence
@@ -383,8 +383,8 @@ This applies to the `monitor-only` and `no-pull` settings.
 |-------------------------------|------------------------------------|----------|---------|---------------------------------------|
 | *(positional args)*           | N/A                                | []string | []      | Container names/patterns to include   |
 | `--disable-containers` / `-x` | `WATCHTOWER_DISABLE_CONTAINERS`    | []string | []      | Container names/patterns to exclude   |
-| `--image-names`               | `WATCHTOWER_IMAGE_NAMES`           | []string | []      | Image name patterns to include        |
-| `--disable-image-names`       | `WATCHTOWER_DISABLE_IMAGE_NAMES`   | []string | []      | Image name patterns to exclude        |
+| `--monitor-image-names`       | `WATCHTOWER_MONITOR_IMAGE_NAMES`   | []string | []      | Image name patterns to monitor        |
+| `--skip-image-names`          | `WATCHTOWER_SKIP_IMAGE_NAMES`      | []string | []      | Image name patterns to exclude        |
 | `--label-enable` / `-e`       | `WATCHTOWER_LABEL_ENABLE`          | bool     | false   | Require enable label on containers    |
 | `--scope`                     | `WATCHTOWER_SCOPE`                 | string   | ""      | Monitoring scope                      |
 | `--include-stopped` / `-S`    | `WATCHTOWER_INCLUDE_STOPPED`       | bool     | false   | Include created and exited containers |
@@ -443,7 +443,7 @@ Monitor only images from your private registry:
 
 ```bash
 docker run -d \
-  -e WATCHTOWER_IMAGE_NAMES="registry.example.com/.*" \
+  -e WATCHTOWER_MONITOR_IMAGE_NAMES="registry.example.com/.*" \
   nickfedor/watchtower
 ```
 

--- a/docs/configuration/container-selection/index.md
+++ b/docs/configuration/container-selection/index.md
@@ -90,6 +90,8 @@ When the label is specified on a container, Watchtower treats that container exa
 
 Both container inclusion (positional arguments) and exclusion  ([`--disable-containers`/`WATCHTOWER_DISABLE_CONTAINERS`](../arguments/index.md#disable_specific_containers)) support regular expression patterns for matching container names.
 
+Image-name selection ([`--image-names`/`WATCHTOWER_IMAGE_NAMES`](../arguments/index.md#include_specific_images) and [`--disable-image-names`/`WATCHTOWER_DISABLE_IMAGE_NAMES`](../arguments/index.md#disable_specific_images)) supports the same regex syntax, matching against the **full image name including its tag** (for example `nginx:latest`). To match every tag of an image, use a pattern such as `nginx:.*`.
+
 !!! Note "Patterns are anchored to match the **full container name**"
     Use `.*` (period + asterisk) for wildcards instead of just an `*` (asterisk)
 

--- a/docs/configuration/container-selection/index.md
+++ b/docs/configuration/container-selection/index.md
@@ -1,124 +1,468 @@
 # Container Selection
 
-By default, Watchtower will watch all containers. However, sometimes only some containers should be updated.
+## Overview
 
-There are two options:
+By default, Watchtower monitors and updates all running containers on the connected Docker daemon.
+This behavior can be customized through a combination of configuration options and container labels to control exactly which containers are managed and how.
 
-- **Fully exclude**: You can choose to exclude containers entirely from being watched by Watchtower.
-- **Monitor only**: In this mode, Watchtower checks for container updates, sends notifications and invokes the [pre-check/post-check hooks](../../advanced-features/lifecycle-hooks/index.md) on the containers but does **not** perform the update.
+Container selection works through a **filter chain**: a series of criteria applied in sequence.
+A container is monitored only if it passes every filter in the chain. The filters are evaluated in the following order:
 
-## Full Exclude
+| # | Filter                                                    | Description                                                                                                                      |
+|---|-----------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| 1 | Old Watchtower container exclusion                        | Watchtower containers renamed with a `watchtower-old-` prefix during self-updates are always excluded.                           |
+| 2 | [Disabled label check](#enabledisable_labels)             | Containers with the Docker label `com.centurylinklabs.watchtower.enable=false` are excluded.                                     |
+| 3 | [Scope filter](#monitoring_scopes)                        | Only containers matching the configured scope are included (default: `"none"`).                                                  |
+| 4 | [Image skip patterns](#exclude_specific_images)           | Containers whose image matches a [skip pattern](../arguments/index.md#skip_specific_images) are excluded.                        |
+| 5 | [Monitored image name patterns](#include_specific_images) | If set, only containers whose image matches a [monitored pattern](../arguments/index.md#monitor_specific_images) are included.   |
+| 6 | [Disabled container names](#exclude_specific_containers)  | Containers whose name matches a [disable pattern](../arguments/index.md#disable_specific_containers) are excluded.               |
+| 7 | [Enable label filter](#enabledisable_labels)              | If [label enable](../arguments/index.md#enable_label_filter) is set, only containers with the enable label present are included. |
+| 8 | [Container name arguments](#container_name_filtering)     | If positional name arguments are provided, only containers matching at least one are included.                                   |
 
-If you need to exclude some containers, set the _com.centurylinklabs.watchtower.enable_ label to `false`.
-For clarity this should be set **on the container(s)** you wish to be ignored, this is not set on Watchtower.
+!!! Note
+    - If an image name pattern is configured, then Watchtower will exclusively manage only the respective container(s).
+    - If a container name is provided as an argument, then Watchtower will exclusively manage only the specified container(s).
+
+!!! Note "All criteria must be satisfied"
+    A container must pass **every** filter in the chain to be monitored. If any single filter rejects it, the container is excluded.
+
+## Management Modes
+
+Watchtower supports two management modes for containers:
+
+- **Full Management** (default): Watchtower checks for updates, pulls new images, recreates containers, and runs lifecycle hooks.
+- [**Monitor Only Mode**](../arguments/index.md#monitor_only): Watchtower checks for updates, sends notifications, and runs lifecycle hooks, but does **not** recreate containers.
+
+## Container State Filtering
+
+By default, Watchtower only processes containers in the `running` state.
+
+Two configuration options extend this to include additional states:
+
+| Option                                                                               | Environment Variable            | Effect                                        |
+|--------------------------------------------------------------------------------------|---------------------------------|-----------------------------------------------|
+| [Include Stopped Containers](../arguments/index.md#include_stopped_containers)       | `WATCHTOWER_INCLUDE_STOPPED`    | Include `created` and `exited` containers     |
+| [Include Restarting Containers](../arguments/index.md#include_restarting_containers) | `WATCHTOWER_INCLUDE_RESTARTING` | Include `restarting` containers (Docker only) |
+
+!!! Note "Podman compatibility"
+    The `restarting` state is not available on Podman and is automatically excluded when Podman is detected.
+
+## Enable/Disable Labels
+
+The `com.centurylinklabs.watchtower.enable` label controls whether Watchtower manages a container.
+
+!!!Note "This label is set on the container you want to manage, not on the Watchtower instance."
+
+### Default Behavior
+
+When [label enable](../arguments/index.md#enable_label_filter) is **not** set:
+
+- Containers **without** the label are **monitored**
+- Containers with `enable=true` are **monitored**
+- Containers with `enable=false` are **excluded**
+
+### With Label Enable
+
+When [label enable](../arguments/index.md#enable_label_filter) is set:
+
+- Containers with `enable=true` are **monitored**
+- Containers with `enable=false` are **excluded**
+- Containers **without** the label are **excluded**
+
 <!-- markdownlint-disable -->
-=== "dockerfile"
-
-    ```docker
-    LABEL com.centurylinklabs.watchtower.enable="false"
-    ```
-=== "docker run"
-
-    ```bash
-    docker run -d --label=com.centurylinklabs.watchtower.enable=false someimage
-    ```
-
-=== "docker-compose"
-
-    ``` yaml
-    version: "3"
+=== "Docker Compose"
+    ```yaml
     services:
       someimage:
-        container_name: someimage
-        labels:
-          - "com.centurylinklabs.watchtower.enable=false"
-    ```
-<!-- markdownlint-restore -->
-If instead you want to [only include containers with the enable label](../arguments/index.md#enable_label_filter), pass the `--label-enable` flag or the `WATCHTOWER_LABEL_ENABLE` environment variable on startup for Watchtower and set the _com.centurylinklabs.watchtower.enable_ label with a value of `true` on the containers you want to watch.
-<!-- markdownlint-disable -->
-=== "dockerfile"
-
-    ```docker
-    LABEL com.centurylinklabs.watchtower.enable="true"
-    ```
-=== "docker run"
-
-    ```bash
-    docker run -d --label=com.centurylinklabs.watchtower.enable=true someimage
-    ```
-
-=== "docker-compose"
-
-    ``` yaml
-    version: "3"
-    services:
-      someimage:
-        container_name: someimage
         labels:
           - "com.centurylinklabs.watchtower.enable=true"
     ```
+=== "Docker CLI"
+    ```bash
+    docker run -d --label=com.centurylinklabs.watchtower.enable=true someimage
+    ```
+=== "Dockerfile"
+    ```dockerfile
+    LABEL com.centurylinklabs.watchtower.enable="true"
+    ```
 <!-- markdownlint-restore -->
-If you wish to create a monitoring scope, you will need to [run multiple instances and set a scope for each of them](../../advanced-features/running-multiple-instances/index.md).
 
-Watchtower filters running containers by testing them against each configured criteria.
-A container is monitored if all criteria are met.
+To exclude a container, set the label to `false`:
 
-For example:
+<!-- markdownlint-disable -->
+=== "Docker Compose"
+    ```yaml
+    services:
+      someimage:
+        labels:
+          - "com.centurylinklabs.watchtower.enable=false"
+    ```
+=== "Docker CLI"
+    ```bash
+    docker run -d --label=com.centurylinklabs.watchtower.enable=false someimage
+    ```
+=== "Dockerfile"
+    ```dockerfile
+    LABEL com.centurylinklabs.watchtower.enable="false"
+    ```
+<!-- markdownlint-restore -->
 
-- If a container's name is on the monitoring name list (not empty `--name` argument), but it is not enabled (_centurylinklabs.watchtower.enable=false_), then it won't be monitored.
-- If a container's name is not on the monitoring name list (not empty `--name` argument), even if it is enabled (_centurylinklabs.watchtower.enable=true_ and `--label-enable` flag is set), then it won't be monitored.
+## Monitor-Only Mode
 
-## Monitor Only
+Individual containers can be set to [monitor-only mode](../arguments/index.md#monitor_only), where Watchtower checks for updates and sends notifications but does not recreate the container.
 
-Individual containers can be marked to only be monitored and will not be updated by Watchtower.
+Set the `com.centurylinklabs.watchtower.monitor-only` label to `true` on the container:
 
-To do so, set the _com.centurylinklabs.watchtower.monitor-only_ label to `true` on that container:
+<!-- markdownlint-disable -->
+=== "Docker Compose"
+    ```yaml
+    services:
+      someimage:
+        labels:
+          - "com.centurylinklabs.watchtower.monitor-only=true"
+    ```
+=== "Docker CLI"
+    ```bash
+    docker run -d --label=com.centurylinklabs.watchtower.monitor-only=true someimage
+    ```
+=== "Dockerfile"
+    ```dockerfile
+    LABEL com.centurylinklabs.watchtower.monitor-only="true"
+    ```
+<!-- markdownlint-restore -->
 
-```docker
-LABEL com.centurylinklabs.watchtower.monitor-only="true"
-```
+!!! Note
+    The per-container label has the same effect as the global [monitor-only](../arguments/index.md#monitor_only) option, but applies only to that specific container.
 
-Or, it can be specified as part of the `docker run` command line:
+    When combined with [label precedence](../arguments/index.md#label_precedence), the container label overrides the global option. Without label precedence, the container is monitor-only if **either** the label or the global option is set.
 
-```bash
-docker run -d --label=com.centurylinklabs.watchtower.monitor-only=true someimage
-```
+## Container Name Filtering
 
-When the label is specified on a container, Watchtower treats that container exactly as if [`WATCHTOWER_MONITOR_ONLY`](../arguments/index.md#monitor_only) was set, but the effect is limited to the individual container.
+Watchtower can filter containers based on their container name using [Go regex pattern matching](#regex_pattern_matching).
+
+### Include Specific Containers
+
+Pass container names as positional arguments to Watchtower.
+When provided, only containers matching at least one name are monitored.
+
+<!-- markdownlint-disable -->
+=== "Docker Compose"
+    ```yaml
+    services:
+      watchtower:
+        image: nickfedor/watchtower:latest
+        command: nginx redis
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+    ```
+=== "Docker CLI"
+    ```bash
+    docker run -d \
+      --name watchtower \
+      -v /var/run/docker.sock:/var/run/docker.sock \
+      nickfedor/watchtower \
+      nginx redis
+    ```
+<!-- markdownlint-restore -->
+
+### Exclude Specific Containers
+
+Use the [disable containers](../arguments/index.md#disable_specific_containers) option to exclude containers by name. This supports comma- or space-separated values and regex patterns.
+
+<!-- markdownlint-disable -->
+=== "Docker Compose"
+    ```yaml
+    services:
+      watchtower:
+        image: nickfedor/watchtower:latest
+        environment:
+          - WATCHTOWER_DISABLE_CONTAINERS=container1,container2
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+    ```
+=== "Docker CLI (Env Vars)"
+    ```bash
+    docker run -d \
+      -e WATCHTOWER_DISABLE_CONTAINERS="container1,container2" \
+      nickfedor/watchtower
+    ```
+=== "Docker CLI (Flags)"
+    ```bash
+    docker run -d \
+      nickfedor/watchtower \
+      --disable-containers container1,container2
+    ```
+<!-- markdownlint-restore -->
+
+## Image Name Filtering
+
+Watchtower can filter containers based on their image name using [Go regex pattern matching](#regex_pattern_matching).
+
+Image name patterns match against the **full image name including its tag** (e.g., `nginx:latest`, `docker.io/library/nginx:1.25`).
+
+!!!Note "If no tag is specified in the image reference, `:latest` is assumed."
+
+### Monitor Specific Images
+
+Use the [monitor image names](../arguments/index.md#monitor_specific_images) option to restrict monitoring to containers whose image matches at least one pattern.
+
+<!-- markdownlint-disable -->
+=== "Docker Compose"
+    ```yaml
+    services:
+      watchtower:
+        image: nickfedor/watchtower:latest
+        environment:
+          - WATCHTOWER_MONITOR_IMAGE_NAMES=nginx:.*,redis:7.*
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+    ```
+=== "Docker CLI (Env Vars)"
+    ```bash
+    docker run -d \
+      -e WATCHTOWER_MONITOR_IMAGE_NAMES="nginx:.*,redis:7.*" \
+      nickfedor/watchtower
+    ```
+=== "Docker CLI (Flags)"
+    ```bash
+    docker run -d \
+      nickfedor/watchtower \
+      --monitor-image-names "nginx:.*,redis:7.*"
+    ```
+<!-- markdownlint-restore -->
+
+### Exclude Specific Images
+
+Use the [skip image names](../arguments/index.md#skip_specific_images) option to exclude containers whose image matches at least one pattern.
+
+<!-- markdownlint-disable -->
+=== "Docker Compose"
+    ```yaml
+    services:
+      watchtower:
+        image: nickfedor/watchtower:latest
+        environment:
+          - WATCHTOWER_SKIP_IMAGE_NAMES=postgres:.*,mcr.microsoft.com/*
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+    ```
+=== "Docker CLI (Env Vars)"
+    ```bash
+    docker run -d \
+      -e WATCHTOWER_SKIP_IMAGE_NAMES="postgres:.*,mcr.microsoft.com/*" \
+      nickfedor/watchtower
+    ```
+=== "Docker CLI (Flags)"
+    ```bash
+    docker run -d \
+      nickfedor/watchtower \
+      --skip-image-names "postgres:.*,mcr.microsoft.com/*"
+    ```
+<!-- markdownlint-restore -->
+
+## Monitoring Scopes
+
+Scopes allow multiple Watchtower instances to run on the same Docker host without interfering with each other.
+Each instance manages only the containers within its scope.
+
+1. Use the [scope filter](../arguments/index.md#scope_filter) option to define a scope.
+2. Then, use the `com.centurylinklabs.watchtower.scope` label on containers to assign them to that scope.
+
+<!-- markdownlint-disable -->
+=== "Docker Compose"
+    ```yaml
+    services:
+      # Scoped Application
+      app-production:
+        image: myapp:latest
+        labels:
+          - "com.centurylinklabs.watchtower.scope=production"
+
+      # Scoped Watchtower watching "production" scope
+      watchtower-production:
+        image: nickfedor/watchtower:latest
+        environment:
+          - WATCHTOWER_SCOPE=production
+        labels:
+          - "com.centurylinklabs.watchtower.scope=production"
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+    ```
+=== "Docker CLI"
+    ```bash
+    docker run -d \
+      --name watchtower-production \
+      -v /var/run/docker.sock:/var/run/docker.sock \
+      nickfedor/watchtower \
+      --scope production
+    ```
+<!-- markdownlint-restore -->
+
+!!! Note
+    - Without a [scope filter](../arguments/index.md#scope_filter), Watchtower defaults to scope `"none"` and manages only **unscoped** containers (those without a `com.centurylinklabs.watchtower.scope` label, or with it set to `"none"` or `""`).
+    - Containers with a non-empty scope label (e.g., `scope=production`) are **not** monitored by an unscoped Watchtower instance.
+    - Set the scope filter to `none` to explicitly manage only unscoped containers (same as the default behavior).
+    - Two instances cannot share the same scope.
+    - An unscoped instance coexists with scoped instances.
+
+    See [Running Multiple Instances](../../advanced-features/running-multiple-instances/index.md) for a complete guide.
 
 ## Regex Pattern Matching
 
-Both container inclusion (positional arguments) and exclusion  ([`--disable-containers`/`WATCHTOWER_DISABLE_CONTAINERS`](../arguments/index.md#disable_specific_containers)) support regular expression patterns for matching container names.
+Container name and image name filters support regular expressions using [Go regex syntax](https://pkg.go.dev/regexp/syntax){target="_blank" rel="noopener noreferrer"}.
 
-Image-name selection ([`--image-names`/`WATCHTOWER_IMAGE_NAMES`](../arguments/index.md#include_specific_images) and [`--disable-image-names`/`WATCHTOWER_DISABLE_IMAGE_NAMES`](../arguments/index.md#disable_specific_images)) supports the same regex syntax, matching against the **full image name including its tag** (for example `nginx:latest`). To match every tag of an image, use a pattern such as `nginx:.*`.
+!!! Important "Patterns are anchored to match the **full** name"
+    Patterns are automatically anchored with `^...$`, meaning they must match the entire container or image name. Use `.*` for wildcard matching instead of bare `*`.
 
-!!! Note "Patterns are anchored to match the **full container name**"
-    Use `.*` (period + asterisk) for wildcards instead of just an `*` (asterisk)
+### Container Name Patterns
 
-### Syntax
+Container names are normalized before matching (the leading `/` stripped). Both positional arguments and the [disable containers](../arguments/index.md#disable_specific_containers) option support regex.
 
-- Patterns use [Go regex syntax](https://pkg.go.dev/regexp/syntax)
-- Patterns are anchored to match the **entire** container name
-- Invalid regex patterns fall back to literal string matching
+| Pattern           | Matches                                  |
+|-------------------|------------------------------------------|
+| `container.*`     | "container1", "container-abc"            |
+| `.*-dev`          | "web-dev", "api-dev", "db-dev"           |
+| `.*`              | Any container name                       |
+| `nginx\|redis`    | Either "nginx" or "redis"                |
+| `db-.*\|cache-.*` | Any name starting with "db-" or "cache-" |
+
+### Image Name Patterns
+
+Image name patterns match against the full `name:tag` string. Use `.*` to match any tag.
+
+| Pattern                 | Matches                            |
+|-------------------------|------------------------------------|
+| `nginx:latest`          | Only `nginx:latest`                |
+| `nginx:.*`              | `nginx` with any tag               |
+| `docker\.io/library/.*` | Any official Docker Hub image      |
+| `.*\.azurecr\.io/.*`    | Any Azure Container Registry image |
 
 ### Examples
 
-| Pattern | Matches |
-|---------|---------|
-| `container.*` | "container1", "container-abc", "mycontainer" |
-| `.*-dev` | "web-dev", "api-dev", "db-dev" |
-| `.*` | Any container name |
-| `nginx|redis` | Either "nginx" or "redis" |
-| `^web-.*$` | All containers starting with "web-" |
-
-- Exclude all containers starting with a specific prefix:
+Exclude all containers starting with a prefix:
 
 ```bash
 docker run -d -e WATCHTOWER_DISABLE_CONTAINERS="web-.*" nickfedor/watchtower
 ```
 
-- Include only containers matching a pattern:
+Include only containers matching specific patterns:
 
 ```bash
-watchtower "db-.*" "cache-.*"
+docker run -d nickfedor/watchtower "db-.*" "cache-.*"
+```
+
+Monitor only containers using nginx or redis images with any tag:
+
+```bash
+docker run -d -e WATCHTOWER_IMAGE_NAMES="nginx:.*,redis:.*" nickfedor/watchtower
+```
+
+## Label Precedence
+
+By default, when a container-level label (e.g., `com.centurylinklabs.watchtower.monitor-only`) and a global option (e.g., [monitor-only](../arguments/index.md#monitor_only)) are both set, the container uses the **combined** effect (either triggers the behavior).
+
+With [label precedence](../arguments/index.md#label_precedence), container labels **override** the global options. This allows per-container control even when global options are set.
+
+| [Label Precedence](../arguments/index.md#label_precedence) | Container Label | Global Option | Result            |
+|------------------------------------------------------------|-----------------|---------------|-------------------|
+| false (default)                                            | not set         | false         | false             |
+| false (default)                                            | not set         | true          | true              |
+| false (default)                                            | true            | false         | true              |
+| false (default)                                            | true            | true          | true              |
+| true                                                       | not set         | any           | global flag value |
+| true                                                       | true            | false         | true              |
+| true                                                       | false           | true          | false             |
+
+This applies to the `monitor-only` and `no-pull` settings.
+
+## Complete Configuration Reference
+
+### CLI Flags and Environment Variables
+
+| Flag                          | Environment Variable               | Type     | Default | Description                           |
+|-------------------------------|------------------------------------|----------|---------|---------------------------------------|
+| *(positional args)*           | N/A                                | []string | []      | Container names/patterns to include   |
+| `--disable-containers` / `-x` | `WATCHTOWER_DISABLE_CONTAINERS`    | []string | []      | Container names/patterns to exclude   |
+| `--image-names`               | `WATCHTOWER_IMAGE_NAMES`           | []string | []      | Image name patterns to include        |
+| `--disable-image-names`       | `WATCHTOWER_DISABLE_IMAGE_NAMES`   | []string | []      | Image name patterns to exclude        |
+| `--label-enable` / `-e`       | `WATCHTOWER_LABEL_ENABLE`          | bool     | false   | Require enable label on containers    |
+| `--scope`                     | `WATCHTOWER_SCOPE`                 | string   | ""      | Monitoring scope                      |
+| `--include-stopped` / `-S`    | `WATCHTOWER_INCLUDE_STOPPED`       | bool     | false   | Include created and exited containers |
+| `--include-restarting`        | `WATCHTOWER_INCLUDE_RESTARTING`    | bool     | false   | Include restarting containers         |
+| `--label-take-precedence`     | `WATCHTOWER_LABEL_TAKE_PRECEDENCE` | bool     | false   | Labels override global flags          |
+
+### Container Labels
+
+| Label                                           | Values                | Effect                            |
+|-------------------------------------------------|-----------------------|-----------------------------------|
+| `com.centurylinklabs.watchtower.enable`         | true / false          | Enable or disable management      |
+| `com.centurylinklabs.watchtower.monitor-only`   | true / false          | Monitor without updating          |
+| `com.centurylinklabs.watchtower.no-pull`        | true / false          | Skip image pulls                  |
+| `com.centurylinklabs.watchtower.scope`          | any string            | Assign to a monitoring scope      |
+| `com.centurylinklabs.watchtower.depends-on`     | comma-separated names | Declare container dependencies    |
+| `com.centurylinklabs.watchtower.cooldown-delay` | duration string       | Minimum image age before updating |
+
+## Common Patterns
+
+### Run Multiple Watchtower Instances
+
+Run one instance for production containers and another for development:
+
+```yaml
+services:
+  watchtower-prod:
+    image: nickfedor/watchtower:latest
+    command: --scope production --interval 300
+    labels:
+      - "com.centurylinklabs.watchtower.scope=production"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  watchtower-dev:
+    image: nickfedor/watchtower:latest
+    command: --scope development --interval 30
+    labels:
+      - "com.centurylinklabs.watchtower.scope=development"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+```
+
+### Exclude System Containers
+
+Exclude Watchtower itself and other infrastructure containers:
+
+```bash
+docker run -d \
+  -e WATCHTOWER_DISABLE_CONTAINERS="watchtower,traefik,portainer" \
+  nickfedor/watchtower
+```
+
+### Monitor Only Specific Image Registries
+
+Monitor only images from your private registry:
+
+```bash
+docker run -d \
+  -e WATCHTOWER_IMAGE_NAMES="registry.example.com/.*" \
+  nickfedor/watchtower
+```
+
+### Selective Monitoring with Enable Label
+
+Use [label enable](../arguments/index.md#enable_label_filter) to explicitly opt containers into management:
+
+```bash
+# Start Watchtower with label filtering
+docker run -d \
+  -e WATCHTOWER_LABEL_ENABLE=true \
+  nickfedor/watchtower
+```
+
+```yaml
+# Only this container will be monitored
+services:
+  myapp:
+    image: myapp:latest
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
 ```

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -147,18 +147,18 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		"Comma-separated list of containers to explicitly exclude from watching.")
 
 	flags.StringSlice(
-		"image-names",
+		"monitor-image-names",
 		filterEmptyStrings(
-			regexp.MustCompile("[, ]+").Split(envString("WATCHTOWER_IMAGE_NAMES"), -1),
+			regexp.MustCompile("[, ]+").Split(envString("WATCHTOWER_MONITOR_IMAGE_NAMES"), -1),
 		),
-		"Comma-separated list of image names (regex supported) to include in watching.")
+		"Comma-separated list of image names to monitor.")
 
 	flags.StringSlice(
-		"disable-image-names",
+		"skip-image-names",
 		filterEmptyStrings(
-			regexp.MustCompile("[, ]+").Split(envString("WATCHTOWER_DISABLE_IMAGE_NAMES"), -1),
+			regexp.MustCompile("[, ]+").Split(envString("WATCHTOWER_SKIP_IMAGE_NAMES"), -1),
 		),
-		"Comma-separated list of image names (regex supported) to explicitly exclude from watching.")
+		"Comma-separated list of image names to explicitly exclude from monitoring.")
 
 	flags.StringP(
 		"log-format",

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -146,6 +146,20 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		),
 		"Comma-separated list of containers to explicitly exclude from watching.")
 
+	flags.StringSlice(
+		"image-names",
+		filterEmptyStrings(
+			regexp.MustCompile("[, ]+").Split(envString("WATCHTOWER_IMAGE_NAMES"), -1),
+		),
+		"Comma-separated list of image names (regex supported) to include in watching.")
+
+	flags.StringSlice(
+		"disable-image-names",
+		filterEmptyStrings(
+			regexp.MustCompile("[, ]+").Split(envString("WATCHTOWER_DISABLE_IMAGE_NAMES"), -1),
+		),
+		"Comma-separated list of image names (regex supported) to explicitly exclude from watching.")
+
 	flags.StringP(
 		"log-format",
 		"l",

--- a/pkg/filters/doc.go
+++ b/pkg/filters/doc.go
@@ -7,7 +7,7 @@
 //
 // Usage example:
 //
-//	filter, desc := filters.BuildFilter(names, disableNames, true, "scope")
+//	filter, desc := filters.BuildFilter(names, disableNames, imageNames, disableImageNames, true, "scope")
 //	containers, _ := client.ListContainers(filter)
 //	logrus.Info(desc)
 //

--- a/pkg/filters/doc.go
+++ b/pkg/filters/doc.go
@@ -1,5 +1,5 @@
 // Package filters provides filtering logic for Watchtower containers.
-// It defines functions to select containers by names, labels, scopes, and images.
+// It defines functions to select containers by container names, image names, labels, and scopes.
 //
 // Key components:
 //   - Filter Functions: Select containers (e.g., FilterByNames, FilterByScope).
@@ -7,7 +7,7 @@
 //
 // Usage example:
 //
-//	filter, desc := filters.BuildFilter(names, disableNames, imageNames, disableImageNames, true, "scope")
+//	filter, desc := filters.BuildFilter(names, disableNames, monitoredImageNamePatterns, skippedImageNamePatterns, true, "scope")
 //	containers, _ := client.ListContainers(filter)
 //	logrus.Info(desc)
 //

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -190,6 +190,76 @@ func FilterByDisableNames(normalizedDisableNames []string, baseFilter types.Filt
 	}
 }
 
+// FilterByImageNames selects containers whose image matches specified names.
+//
+// Parameters:
+//   - imageNames: List of image names or regex patterns to match.
+//   - baseFilter: Base filter to chain.
+//
+// Returns:
+//   - types.Filter: Filter function combining image name check with base filter.
+func FilterByImageNames(imageNames []string, baseFilter types.Filter) types.Filter {
+	if len(imageNames) == 0 {
+		return baseFilter
+	}
+
+	return func(c types.FilterableContainer) bool {
+		imageName := c.ImageName()
+		clog := logrus.WithFields(logrus.Fields{
+			"container":  c.Name(),
+			"image":      imageName,
+			"imageNames": imageNames,
+		})
+
+		for _, pattern := range imageNames {
+			if matchesName(imageName, pattern) {
+				clog.Debug("Matched container by image name/pattern")
+
+				return baseFilter(c)
+			}
+		}
+
+		clog.Debug("Container image did not match any filter")
+
+		return false
+	}
+}
+
+// FilterByDisableImageNames excludes containers whose image matches specified names.
+//
+// Parameters:
+//   - disableImageNames: Image names or regex patterns to exclude.
+//   - baseFilter: Base filter to chain.
+//
+// Returns:
+//   - types.Filter: Filter function excluding image names and applying base filter.
+func FilterByDisableImageNames(disableImageNames []string, baseFilter types.Filter) types.Filter {
+	if len(disableImageNames) == 0 {
+		return baseFilter
+	}
+
+	return func(c types.FilterableContainer) bool {
+		imageName := c.ImageName()
+		clog := logrus.WithFields(logrus.Fields{
+			"container":         c.Name(),
+			"image":             imageName,
+			"disableImageNames": disableImageNames,
+		})
+
+		for _, pattern := range disableImageNames {
+			if matchesName(imageName, pattern) {
+				clog.Debug("Container excluded by disable image name/pattern")
+
+				return false
+			}
+		}
+
+		clog.Debug("Container not excluded by disable image names")
+
+		return baseFilter(c)
+	}
+}
+
 // FilterByEnableLabel selects containers with enable label set.
 //
 // Parameters:
@@ -353,7 +423,9 @@ func matchImageAndTag(containerImage, targetImage string) bool {
 //
 // Parameters:
 //   - normalizedNames: Normalized names or regex patterns to include.
-//   - disableNames: Normalized names or regex patterns to exclude.
+//   - normalizedDisableNames: Normalized names or regex patterns to exclude.
+//   - imageNames: Image names or regex patterns to include.
+//   - disableImageNames: Image names or regex patterns to exclude.
 //   - enableLabel: Require enable label if true.
 //   - scope: Scope to match.
 //
@@ -363,14 +435,18 @@ func matchImageAndTag(containerImage, targetImage string) bool {
 func BuildFilter(
 	normalizedNames []string,
 	normalizedDisableNames []string,
+	imageNames []string,
+	disableImageNames []string,
 	enableLabel bool,
 	scope string,
 ) (types.Filter, string) {
 	clog := logrus.WithFields(logrus.Fields{
-		"names":        normalizedNames,
-		"disableNames": normalizedDisableNames,
-		"enableLabel":  enableLabel,
-		"scope":        scope,
+		"names":             normalizedNames,
+		"disableNames":      normalizedDisableNames,
+		"imageNames":        imageNames,
+		"disableImageNames": disableImageNames,
+		"enableLabel":       enableLabel,
+		"scope":             scope,
 	})
 	clog.Debug("Building container filter")
 
@@ -379,6 +455,8 @@ func BuildFilter(
 	filter := NoFilter
 	filter = FilterByNames(normalizedNames, filter)
 	filter = FilterByDisableNames(normalizedDisableNames, filter)
+	filter = FilterByImageNames(imageNames, filter)
+	filter = FilterByDisableImageNames(disableImageNames, filter)
 
 	// Add name-based filter description.
 	if len(normalizedNames) > 0 {
@@ -403,6 +481,36 @@ func BuildFilter(
 			stringBuilder.WriteString(n)
 
 			if i < len(normalizedDisableNames)-1 {
+				stringBuilder.WriteString(`" or "`)
+			}
+		}
+
+		stringBuilder.WriteString(`", `)
+	}
+
+	// Add image-name-based filter description.
+	if len(imageNames) > 0 {
+		stringBuilder.WriteString("which image matches \"")
+
+		for i, n := range imageNames {
+			stringBuilder.WriteString(n)
+
+			if i < len(imageNames)-1 {
+				stringBuilder.WriteString(`" or "`)
+			}
+		}
+
+		stringBuilder.WriteString(`", `)
+	}
+
+	// Add disable-image-name-based filter description.
+	if len(disableImageNames) > 0 {
+		stringBuilder.WriteString("whose image is not one of \"")
+
+		for i, n := range disableImageNames {
+			stringBuilder.WriteString(n)
+
+			if i < len(disableImageNames)-1 {
 				stringBuilder.WriteString(`" or "`)
 			}
 		}

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -190,71 +190,75 @@ func FilterByDisableNames(normalizedDisableNames []string, baseFilter types.Filt
 	}
 }
 
-// FilterByImageNames selects containers whose image matches specified names.
+// FilterByMonitoredImageNamePatterns restricts monitoring to containers whose image name
+// matches specified patterns. When set, only matching containers are monitored.
 //
 // Parameters:
-//   - imageNames: List of image names or regex patterns to match.
+//   - namePatterns: Image name regex patterns.
 //   - baseFilter: Base filter to chain.
 //
 // Returns:
-//   - types.Filter: Filter function combining image name check with base filter.
-func FilterByImageNames(imageNames []string, baseFilter types.Filter) types.Filter {
-	if len(imageNames) == 0 {
+//   - types.Filter: Filter function restricting to matching image names, then
+//     applying base filter.
+func FilterByMonitoredImageNamePatterns(namePatterns []string, baseFilter types.Filter) types.Filter {
+	if len(namePatterns) == 0 {
 		return baseFilter
 	}
 
 	return func(c types.FilterableContainer) bool {
 		imageName := c.ImageName()
 		clog := logrus.WithFields(logrus.Fields{
-			"container":  c.Name(),
-			"image":      imageName,
-			"imageNames": imageNames,
+			"container":    c.Name(),
+			"image":        imageName,
+			"namePatterns": namePatterns,
 		})
 
-		for _, pattern := range imageNames {
-			if matchesName(imageName, pattern) {
-				clog.Debug("Matched container by image name/pattern")
+		for _, pattern := range namePatterns {
+			if matchesImageName(imageName, pattern) {
+				clog.Debug("Container image matched pattern")
 
 				return baseFilter(c)
 			}
 		}
 
-		clog.Debug("Container image did not match any filter")
+		clog.Debug("Container image did not match any pattern")
 
 		return false
 	}
 }
 
-// FilterByDisableImageNames excludes containers whose image matches specified names.
+// FilterBySkippedImageNamePatterns prevents monitoring of containers whose image name
+// matches specified patterns. Matching containers are excluded from monitoring.
 //
 // Parameters:
-//   - disableImageNames: Image names or regex patterns to exclude.
+//   - namePatterns: Image name regex patterns.
 //   - baseFilter: Base filter to chain.
 //
 // Returns:
-//   - types.Filter: Filter function excluding image names and applying base filter.
-func FilterByDisableImageNames(disableImageNames []string, baseFilter types.Filter) types.Filter {
-	if len(disableImageNames) == 0 {
+//   - types.Filter: Filter function excluding matching image names, then applying
+//     base filter.
+func FilterBySkippedImageNamePatterns(namePatterns []string, baseFilter types.Filter) types.Filter {
+	if len(namePatterns) == 0 {
 		return baseFilter
 	}
 
 	return func(c types.FilterableContainer) bool {
 		imageName := c.ImageName()
 		clog := logrus.WithFields(logrus.Fields{
-			"container":         c.Name(),
-			"image":             imageName,
-			"disableImageNames": disableImageNames,
+			"container":    c.Name(),
+			"image":        imageName,
+			"namePatterns": namePatterns,
 		})
 
-		for _, pattern := range disableImageNames {
-			if matchesName(imageName, pattern) {
-				clog.Debug("Container excluded by disable image name/pattern")
+		for _, pattern := range namePatterns {
+			if matchesImageName(imageName, pattern) {
+				clog.Debug("Container image matched skip pattern")
 
 				return false
 			}
 		}
 
-		clog.Debug("Container not excluded by disable image names")
+		clog.Debug("Container not skipped by image name patterns")
 
 		return baseFilter(c)
 	}
@@ -373,23 +377,34 @@ func FilterByImage(images []string, baseFilter types.Filter) types.Filter {
 	}
 }
 
+// matchesImageName checks if a container's image name matches a given pattern (exact or regex).
+// Returns true if it matches, false otherwise.
+// Invalid regex patterns are treated as literal strings for exact matching.
+func matchesImageName(imageName, pattern string) bool {
+	if pattern == imageName {
+		return true
+	}
+
+	regex, err := regexp.Compile("^" + pattern + "$")
+	if err != nil {
+		return false
+	}
+
+	return regex.MatchString(imageName)
+}
+
 // matchesName checks if a container name matches a given pattern (exact or regex).
 // Returns true if it matches, false otherwise.
 // Invalid regex patterns are treated as literal strings for exact matching.
 func matchesName(containerName, pattern string) bool {
-	// Normalize the pattern by trimming leading slash.
-	// This is retained to ensure robust handling, despite existing input normalization.
 	pattern = strings.TrimPrefix(pattern, "/")
 
-	// Exact match first.
 	if pattern == containerName {
 		return true
 	}
 
-	// Try regex match (anchored to match whole string).
 	regex, err := regexp.Compile("^" + pattern + "$")
 	if err != nil {
-		// Treat invalid regex as literal string (exact match already checked above).
 		return false
 	}
 
@@ -422,10 +437,14 @@ func matchImageAndTag(containerImage, targetImage string) bool {
 // BuildFilter constructs a composite filter for containers.
 //
 // Parameters:
-//   - normalizedNames: Normalized names or regex patterns to include.
-//   - normalizedDisableNames: Normalized names or regex patterns to exclude.
-//   - imageNames: Image names or regex patterns to include.
-//   - disableImageNames: Image names or regex patterns to exclude.
+//   - normalizedNames: Normalized container names or regex patterns. When set, only
+//     containers matching these patterns are monitored.
+//   - normalizedDisableNames: Container names or regex patterns to skip. Matching
+//     containers are excluded from monitoring.
+//   - monitoredImageNamePatterns: Image name regex patterns. When set, only containers whose
+//     image matches one of these patterns are monitored.
+//   - skippedImageNamePatterns: Image name regex patterns. Containers whose image
+//     matches one of these patterns are excluded from monitoring.
 //   - enableLabel: Require enable label if true.
 //   - scope: Scope to match.
 //
@@ -435,28 +454,27 @@ func matchImageAndTag(containerImage, targetImage string) bool {
 func BuildFilter(
 	normalizedNames []string,
 	normalizedDisableNames []string,
-	imageNames []string,
-	disableImageNames []string,
+	monitoredImageNamePatterns []string,
+	skippedImageNamePatterns []string,
 	enableLabel bool,
 	scope string,
 ) (types.Filter, string) {
 	clog := logrus.WithFields(logrus.Fields{
-		"names":             normalizedNames,
-		"disableNames":      normalizedDisableNames,
-		"imageNames":        imageNames,
-		"disableImageNames": disableImageNames,
-		"enableLabel":       enableLabel,
-		"scope":             scope,
+		"names":                      normalizedNames,
+		"disableNames":               normalizedDisableNames,
+		"monitoredImageNamePatterns": monitoredImageNamePatterns,
+		"skippedImageNamePatterns":   skippedImageNamePatterns,
+		"enableLabel":                enableLabel,
+		"scope":                      scope,
 	})
 	clog.Debug("Building container filter")
 
-	// Start with no filter and chain additional filters.
 	stringBuilder := strings.Builder{}
 	filter := NoFilter
 	filter = FilterByNames(normalizedNames, filter)
 	filter = FilterByDisableNames(normalizedDisableNames, filter)
-	filter = FilterByImageNames(imageNames, filter)
-	filter = FilterByDisableImageNames(disableImageNames, filter)
+	filter = FilterByMonitoredImageNamePatterns(monitoredImageNamePatterns, filter)
+	filter = FilterBySkippedImageNamePatterns(skippedImageNamePatterns, filter)
 
 	// Add name-based filter description.
 	if len(normalizedNames) > 0 {
@@ -488,14 +506,13 @@ func BuildFilter(
 		stringBuilder.WriteString(`", `)
 	}
 
-	// Add image-name-based filter description.
-	if len(imageNames) > 0 {
+	if len(monitoredImageNamePatterns) > 0 {
 		stringBuilder.WriteString("which image matches \"")
 
-		for i, n := range imageNames {
+		for i, n := range monitoredImageNamePatterns {
 			stringBuilder.WriteString(n)
 
-			if i < len(imageNames)-1 {
+			if i < len(monitoredImageNamePatterns)-1 {
 				stringBuilder.WriteString(`" or "`)
 			}
 		}
@@ -503,14 +520,13 @@ func BuildFilter(
 		stringBuilder.WriteString(`", `)
 	}
 
-	// Add disable-image-name-based filter description.
-	if len(disableImageNames) > 0 {
+	if len(skippedImageNamePatterns) > 0 {
 		stringBuilder.WriteString("whose image is not one of \"")
 
-		for i, n := range disableImageNames {
+		for i, n := range skippedImageNamePatterns {
 			stringBuilder.WriteString(n)
 
-			if i < len(disableImageNames)-1 {
+			if i < len(skippedImageNamePatterns)-1 {
 				stringBuilder.WriteString(`" or "`)
 			}
 		}
@@ -525,8 +541,7 @@ func BuildFilter(
 		stringBuilder.WriteString("using enable label, ")
 	}
 
-	// Apply scope filter based on value.
-	if scope == noScope || scope == "" { // "none" or empty (unscoped)
+	if scope == noScope || scope == "" {
 		filter = FilterByScope(noScope, filter)
 
 		stringBuilder.WriteString(`without a scope`)

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -454,7 +454,7 @@ func TestFilterByNoneScope_MixedHandling(t *testing.T) {
 func TestBuildFilterNoneScope(t *testing.T) {
 	t.Parallel()
 
-	filter, desc := BuildFilter(nil, nil, false, "none")
+	filter, desc := BuildFilter(nil, nil, nil, nil, false, "none")
 
 	assert.Contains(t, desc, "without a scope")
 
@@ -689,7 +689,7 @@ func TestBuildFilter(t *testing.T) {
 
 	names := []string{"test", "valid"}
 
-	filter, desc := BuildFilter(names, []string{}, false, "")
+	filter, desc := BuildFilter(names, []string{}, nil, nil, false, "")
 	assert.Contains(t, desc, "test")
 	assert.Contains(t, desc, "or")
 	assert.Contains(t, desc, "valid")
@@ -745,7 +745,7 @@ func TestBuildFilterEnableLabel(t *testing.T) {
 	names := make([]string, 0, 1)
 	names = append(names, "test")
 
-	filter, desc := BuildFilter(names, []string{}, true, "")
+	filter, desc := BuildFilter(names, []string{}, nil, nil, true, "")
 	assert.Contains(t, desc, "using enable label")
 
 	container := new(mockContainer.FilterableContainer)
@@ -786,7 +786,7 @@ func TestBuildFilterEnableLabel(t *testing.T) {
 func TestBuildFilterDisableContainer(t *testing.T) {
 	t.Parallel()
 
-	filter, desc := BuildFilter([]string{}, []string{"excluded", "notfound"}, false, "")
+	filter, desc := BuildFilter([]string{}, []string{"excluded", "notfound"}, nil, nil, false, "")
 	assert.Contains(t, desc, "not named")
 	assert.Contains(t, desc, "excluded")
 	assert.Contains(t, desc, "or")
@@ -852,5 +852,135 @@ func TestBuildFilterDisableContainer(t *testing.T) {
 	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
 	container.On("Name").Return("/test").Maybe()
 	assert.False(t, filter(container))
+	container.AssertExpectations(t)
+}
+
+func TestFilterByImageNames(t *testing.T) {
+	t.Parallel()
+
+	imageNames := make([]string, 0, 1)
+
+	filter := FilterByImageNames(imageNames, nil)
+	assert.Nil(t, filter)
+
+	imageNames = append(imageNames, "nginx:latest")
+	filter = FilterByImageNames(imageNames, NoFilter)
+	assert.NotNil(t, filter)
+
+	// Image matches -> kept.
+	container := new(mockContainer.FilterableContainer)
+	container.On("Name").Return("web")
+	container.On("ImageName").Return("nginx:latest")
+	assert.True(t, filter(container))
+	container.AssertExpectations(t)
+
+	// Image does not match -> excluded.
+	container = new(mockContainer.FilterableContainer)
+	container.On("Name").Return("cache")
+	container.On("ImageName").Return("redis:latest")
+	assert.False(t, filter(container))
+	container.AssertExpectations(t)
+}
+
+func TestFilterByImageNamesRegex(t *testing.T) {
+	t.Parallel()
+
+	filter := FilterByImageNames([]string{"nginx:.*"}, NoFilter)
+	assert.NotNil(t, filter)
+
+	// Anchored regex matches any nginx tag.
+	container := new(mockContainer.FilterableContainer)
+	container.On("Name").Return("web")
+	container.On("ImageName").Return("nginx:1.25")
+	assert.True(t, filter(container))
+	container.AssertExpectations(t)
+
+	// Anchored regex does not match a different image name.
+	container = new(mockContainer.FilterableContainer)
+	container.On("Name").Return("web")
+	container.On("ImageName").Return("nginxx:1.25")
+	assert.False(t, filter(container))
+	container.AssertExpectations(t)
+}
+
+func TestFilterByDisableImageNames(t *testing.T) {
+	t.Parallel()
+
+	disableImageNames := make([]string, 0, 1)
+
+	filter := FilterByDisableImageNames(disableImageNames, nil)
+	assert.Nil(t, filter)
+
+	disableImageNames = append(disableImageNames, "nginx:latest")
+	filter = FilterByDisableImageNames(disableImageNames, NoFilter)
+	assert.NotNil(t, filter)
+
+	// Excluded image.
+	container := new(mockContainer.FilterableContainer)
+	container.On("Name").Return("web")
+	container.On("ImageName").Return("nginx:latest")
+	assert.False(t, filter(container))
+	container.AssertExpectations(t)
+
+	// Non-excluded image passes through baseFilter.
+	container = new(mockContainer.FilterableContainer)
+	container.On("Name").Return("cache")
+	container.On("ImageName").Return("redis:latest")
+	assert.True(t, filter(container))
+	container.AssertExpectations(t)
+}
+
+func TestBuildFilterImageNames(t *testing.T) {
+	t.Parallel()
+
+	filter, desc := BuildFilter(
+		nil, nil,
+		[]string{"nginx:.*", "redis:.*"},
+		[]string{"redis:latest"},
+		false, "",
+	)
+	assert.Contains(t, desc, "which image matches")
+	assert.Contains(t, desc, "nginx:.*")
+	assert.Contains(t, desc, "whose image is not one of")
+	assert.Contains(t, desc, "redis:latest")
+
+	// Image matches an include pattern and is not disabled -> kept.
+	container := new(mockContainer.FilterableContainer)
+	container.On("IsWatchtower").Return(false).Maybe()
+	container.On("Name").Return("/web").Maybe()
+	container.On("ImageName").Return("nginx:1.25").Maybe()
+	container.On("Enabled").Return(false, false).Maybe()
+	container.On("Scope").Return("", false).Maybe()
+	assert.True(t, filter(container))
+	container.AssertExpectations(t)
+
+	// Image matches no include pattern -> excluded.
+	container = new(mockContainer.FilterableContainer)
+	container.On("IsWatchtower").Return(false).Maybe()
+	container.On("Name").Return("/api").Maybe()
+	container.On("ImageName").Return("api:latest").Maybe()
+	container.On("Enabled").Return(false, false).Maybe()
+	container.On("Scope").Return("", false).Maybe()
+	assert.False(t, filter(container))
+	container.AssertExpectations(t)
+
+	// Image matches an include pattern but is explicitly disabled -> excluded.
+	container = new(mockContainer.FilterableContainer)
+	container.On("IsWatchtower").Return(false).Maybe()
+	container.On("Name").Return("/cache").Maybe()
+	container.On("ImageName").Return("redis:latest").Maybe()
+	container.On("Enabled").Return(false, false).Maybe()
+	container.On("Scope").Return("", false).Maybe()
+	assert.False(t, filter(container))
+	container.AssertExpectations(t)
+
+	// Image matches include pattern and disable pattern does not match -> kept.
+	container = new(mockContainer.FilterableContainer)
+	container.On("IsWatchtower").Return(false).Maybe()
+	container.On("Name").Return("/cache2").Maybe()
+	container.On("ImageName").Return("redis:7").Maybe()
+	container.On("Enabled").Return(false, false).Maybe()
+	container.On("Scope").Return("", false).Maybe()
+	assert.True(t, filter(container))
 	container.AssertExpectations(t)
 }

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -858,13 +858,13 @@ func TestBuildFilterDisableContainer(t *testing.T) {
 func TestFilterByImageNames(t *testing.T) {
 	t.Parallel()
 
-	imageNames := make([]string, 0, 1)
+	patterns := make([]string, 0, 1)
 
-	filter := FilterByImageNames(imageNames, nil)
+	filter := FilterByMonitoredImageNamePatterns(patterns, nil)
 	assert.Nil(t, filter)
 
-	imageNames = append(imageNames, "nginx:latest")
-	filter = FilterByImageNames(imageNames, NoFilter)
+	patterns = append(patterns, "nginx:latest")
+	filter = FilterByMonitoredImageNamePatterns(patterns, NoFilter)
 	assert.NotNil(t, filter)
 
 	// Image matches -> kept.
@@ -885,7 +885,7 @@ func TestFilterByImageNames(t *testing.T) {
 func TestFilterByImageNamesRegex(t *testing.T) {
 	t.Parallel()
 
-	filter := FilterByImageNames([]string{"nginx:.*"}, NoFilter)
+	filter := FilterByMonitoredImageNamePatterns([]string{"nginx:.*"}, NoFilter)
 	assert.NotNil(t, filter)
 
 	// Anchored regex matches any nginx tag.
@@ -903,26 +903,47 @@ func TestFilterByImageNamesRegex(t *testing.T) {
 	container.AssertExpectations(t)
 }
 
-func TestFilterByDisableImageNames(t *testing.T) {
+func TestFilterByImageNamesRegistryPath(t *testing.T) {
 	t.Parallel()
 
-	disableImageNames := make([]string, 0, 1)
-
-	filter := FilterByDisableImageNames(disableImageNames, nil)
-	assert.Nil(t, filter)
-
-	disableImageNames = append(disableImageNames, "nginx:latest")
-	filter = FilterByDisableImageNames(disableImageNames, NoFilter)
+	filter := FilterByMonitoredImageNamePatterns([]string{"docker.io/library/nginx:.*"}, NoFilter)
 	assert.NotNil(t, filter)
 
-	// Excluded image.
+	// Registry path with slashes matches.
+	container := new(mockContainer.FilterableContainer)
+	container.On("Name").Return("web")
+	container.On("ImageName").Return("docker.io/library/nginx:1.25")
+	assert.True(t, filter(container))
+	container.AssertExpectations(t)
+
+	// Different registry does not match.
+	container = new(mockContainer.FilterableContainer)
+	container.On("Name").Return("web")
+	container.On("ImageName").Return("ghcr.io/org/nginx:1.25")
+	assert.False(t, filter(container))
+	container.AssertExpectations(t)
+}
+
+func TestFilterBySkippedImageNames(t *testing.T) {
+	t.Parallel()
+
+	patterns := make([]string, 0, 1)
+
+	filter := FilterBySkippedImageNamePatterns(patterns, nil)
+	assert.Nil(t, filter)
+
+	patterns = append(patterns, "nginx:latest")
+	filter = FilterBySkippedImageNamePatterns(patterns, NoFilter)
+	assert.NotNil(t, filter)
+
+	// Skipped image.
 	container := new(mockContainer.FilterableContainer)
 	container.On("Name").Return("web")
 	container.On("ImageName").Return("nginx:latest")
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
 
-	// Non-excluded image passes through baseFilter.
+	// Non-skipped image passes through baseFilter.
 	container = new(mockContainer.FilterableContainer)
 	container.On("Name").Return("cache")
 	container.On("ImageName").Return("redis:latest")
@@ -944,7 +965,7 @@ func TestBuildFilterImageNames(t *testing.T) {
 	assert.Contains(t, desc, "whose image is not one of")
 	assert.Contains(t, desc, "redis:latest")
 
-	// Image matches an include pattern and is not disabled -> kept.
+	// Image matches a pattern and is not skipped -> kept.
 	container := new(mockContainer.FilterableContainer)
 	container.On("IsWatchtower").Return(false).Maybe()
 	container.On("Name").Return("/web").Maybe()
@@ -954,7 +975,7 @@ func TestBuildFilterImageNames(t *testing.T) {
 	assert.True(t, filter(container))
 	container.AssertExpectations(t)
 
-	// Image matches no include pattern -> excluded.
+	// Image matches no pattern -> excluded.
 	container = new(mockContainer.FilterableContainer)
 	container.On("IsWatchtower").Return(false).Maybe()
 	container.On("Name").Return("/api").Maybe()
@@ -964,7 +985,7 @@ func TestBuildFilterImageNames(t *testing.T) {
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
 
-	// Image matches an include pattern but is explicitly disabled -> excluded.
+	// Image matches a pattern but is explicitly skipped -> excluded.
 	container = new(mockContainer.FilterableContainer)
 	container.On("IsWatchtower").Return(false).Maybe()
 	container.On("Name").Return("/cache").Maybe()
@@ -974,7 +995,7 @@ func TestBuildFilterImageNames(t *testing.T) {
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
 
-	// Image matches include pattern and disable pattern does not match -> kept.
+	// Image matches pattern and skip pattern does not match -> kept.
 	container = new(mockContainer.FilterableContainer)
 	container.On("IsWatchtower").Return(false).Maybe()
 	container.On("Name").Return("/cache2").Maybe()
@@ -982,5 +1003,51 @@ func TestBuildFilterImageNames(t *testing.T) {
 	container.On("Enabled").Return(false, false).Maybe()
 	container.On("Scope").Return("", false).Maybe()
 	assert.True(t, filter(container))
+	container.AssertExpectations(t)
+}
+
+func TestBuildFilterImageNamesWithContainerNames(t *testing.T) {
+	t.Parallel()
+
+	// When both container name and image name patterns are set,
+	// a container must match BOTH to be included.
+	filter, desc := BuildFilter(
+		[]string{"web"},
+		nil,
+		[]string{"nginx:.*"},
+		nil,
+		false, "",
+	)
+	assert.Contains(t, desc, "which name matches")
+	assert.Contains(t, desc, "which image matches")
+
+	// Matches both container name and image name -> kept.
+	container := new(mockContainer.FilterableContainer)
+	container.On("IsWatchtower").Return(false).Maybe()
+	container.On("Name").Return("web").Maybe()
+	container.On("ImageName").Return("nginx:1.25").Maybe()
+	container.On("Enabled").Return(false, false).Maybe()
+	container.On("Scope").Return("", false).Maybe()
+	assert.True(t, filter(container))
+	container.AssertExpectations(t)
+
+	// Matches container name but not image name -> excluded.
+	container = new(mockContainer.FilterableContainer)
+	container.On("IsWatchtower").Return(false).Maybe()
+	container.On("Name").Return("web").Maybe()
+	container.On("ImageName").Return("redis:latest").Maybe()
+	container.On("Enabled").Return(false, false).Maybe()
+	container.On("Scope").Return("", false).Maybe()
+	assert.False(t, filter(container))
+	container.AssertExpectations(t)
+
+	// Matches image name but not container name -> excluded.
+	container = new(mockContainer.FilterableContainer)
+	container.On("IsWatchtower").Return(false).Maybe()
+	container.On("Name").Return("api").Maybe()
+	container.On("ImageName").Return("nginx:1.25").Maybe()
+	container.On("Enabled").Return(false, false).Maybe()
+	container.On("Scope").Return("", false).Maybe()
+	assert.False(t, filter(container))
 	container.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary

Adds the ability to include or exclude containers from Watchtower's update checks based on their **image name**, mirroring the existing container-**name** selection.

- New flags:
  - `--image-names` / `WATCHTOWER_IMAGE_NAMES` — only watch containers whose image matches one of the patterns.
  - `--disable-image-names` / `WATCHTOWER_DISABLE_IMAGE_NAMES` — exclude containers whose image matches one of the patterns.
- Matching reuses the existing anchored-regex helper (`^pattern$`) and runs against the **full image name including the tag** (e.g. `nginx:latest`). Use a pattern like `nginx:.*` to match every tag of an image.
- New `FilterByImageNames` / `FilterByDisableImageNames` filters are chained into `BuildFilter` right after the name filters; **exclusion takes precedence over inclusion**.
- Docs updated (`configuration/arguments` and `configuration/container-selection`).

Implemented to mirror the existing `--disable-containers` feature for consistency (same regex semantics, flag/env style, and filter composition).

## Test Plan

- [x] `make test` — unit tests for both new filters (exact + regex) and an integration test through `BuildFilter` (include-match kept, no-match excluded, disabled excluded, disable-non-match kept).
- [x] `make lint` — golangci-lint clean.
- [x] Manual: `--image-names nginx:.*` restricts updates to nginx images; `--disable-image-names redis:latest` excludes that image even when its enable label is `true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image-name filtering to include or skip containers via `--monitor-image-names` / `--skip-image-names` ( `WATCHTOWER_MONITOR_IMAGE_NAMES` / `WATCHTOWER_SKIP_IMAGE_NAMES` ).
  * Supports regex matching against the full image name (including tag, e.g., `nginx:latest`), with whitespace-trimmed list entries.

* **Documentation**
  * Updated configuration and container-selection docs with the new image filtering sections, examples, and updated anchor/linking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->