### PR TITLE
add Lifecycle Hooks that are executed on the host (e.g. inside watchtower container)

### DIFF
--- a/build/docker/Dockerfile.native-binary
+++ b/build/docker/Dockerfile.native-binary
@@ -1,0 +1,46 @@
+# Dockerfile.native-binary
+#
+# Builds the Watchtower binary inside Docker and exports just the binary to the host,
+# rather than producing a runnable image. Use it with `docker build --output` to drop
+# the compiled binary onto your machine without keeping an image around.
+#
+# See README.md in this folder for usage.
+
+ARG BASE_IMAGE=golang:alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
+
+# Builder Stage
+FROM ${BASE_IMAGE} AS builder
+
+# git is required for version stamping via `git describe`.
+RUN apk add --no-cache git
+
+WORKDIR /watchtower
+
+# Download dependencies first so this layer is cached across source-only changes.
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . /watchtower
+
+# Target OS/arch. With `docker buildx --platform`, TARGETOS/TARGETARCH are populated
+# automatically; otherwise they default to the builder's platform (host architecture).
+ARG TARGETOS=linux
+ARG TARGETARCH
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+    -trimpath \
+    -ldflags "\
+    -s -w \
+    -X github.com/nicholas-fedor/watchtower/internal/meta.Version=$(git describe --tags --always) \
+    " \
+    -o /out/watchtower \
+    .
+
+# Export Stage
+#
+# A scratch image containing only the binary, so `--output type=local` writes just the
+# binary to the host destination.
+FROM scratch AS export
+
+COPY --from=builder /out/watchtower /watchtower

--- a/build/docker/README.md
+++ b/build/docker/README.md
@@ -58,6 +58,56 @@ docker buildx build . -f build/docker/Dockerfile.native-binary \
 ./bin/watchtower --run-once
 ```
 
+### Run it on a schedule with systemd
+
+Instead of running Watchtower as a long-lived daemon, you can drop the binary on the host
+and have a systemd timer invoke `--run-once` periodically. Install the binary first:
+
+```bash
+sudo install -m 0755 ./bin/watchtower /usr/local/bin/watchtower
+```
+
+`/etc/systemd/system/watchtower.service` — a `oneshot` unit that runs a single update pass:
+
+```ini
+[Unit]
+Description=Watchtower update run
+Wants=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/watchtower --run-once --cleanup
+```
+
+`/etc/systemd/system/watchtower.timer` — fires the service daily at 4 AM. This mirrors
+Watchtower's own `--schedule "0 0 4 * * *"` cron expression; `OnCalendar` is systemd's
+equivalent of that schedule:
+
+```ini
+[Unit]
+Description=Run Watchtower daily at 4 AM
+
+[Timer]
+# Equivalent to Watchtower's --schedule "0 0 4 * * *" (daily at 4 AM)
+OnCalendar=*-*-* 04:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable and start the timer (not the service — the timer pulls it in):
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now watchtower.timer
+
+# Inspect schedule and last run:
+systemctl list-timers watchtower.timer
+journalctl -u watchtower.service
+```
+
 ## Build a runnable image from local changes (`Dockerfile.self-local`)
 
 If you want a runnable image instead of a bare binary:

--- a/build/docker/README.md
+++ b/build/docker/README.md
@@ -1,0 +1,71 @@
+# Docker build files
+
+This folder holds the Dockerfiles used to build Watchtower. **All commands below must be
+run from the repository root** (the build context is the repo root, not this folder).
+
+| File                       | Produces                       | Source of code          | Typical use                           |
+|----------------------------|--------------------------------|-------------------------|---------------------------------------|
+| `Dockerfile`               | Runnable image (release)       | Pre-built binary        | Official/CI releases (GoReleaser)     |
+| `Dockerfile.self-local`    | Runnable image                 | Your local working tree | Build/run an image from local changes |
+| `Dockerfile.self-github`   | Runnable image                 | Latest `main` on GitHub | Build an image from upstream          |
+| `Dockerfile.native-binary` | **Just the binary** (no image) | Your local working tree | Get a compiled binary onto the host   |
+
+`Dockerfile` consumes a binary built beforehand (by GoReleaser). The `self-*` and
+`native-binary` files compile from source inside the container, so they need nothing but
+Docker installed.
+
+## Build the binary for local use (`Dockerfile.native-binary`)
+
+`Dockerfile.native-binary` compiles Watchtower inside Docker and exports **only the binary** to the
+host using BuildKit's `--output`. No image is added to your local image store.
+
+```bash
+docker build . \
+  -f build/docker/Dockerfile.native-binary \
+  --target export \
+  --output type=local,dest=./bin
+```
+
+Result: `./bin/watchtower` — a static (`CGO_ENABLED=0`) Linux binary with the version
+stamped in from `git describe`.
+
+### Build for a different architecture
+
+Use `buildx` and `--platform`; `TARGETOS`/`TARGETARCH` are wired through automatically:
+
+```bash
+docker buildx build . \
+  -f build/docker/Dockerfile.native-binary \
+  --platform linux/arm64 \
+  --target export \
+  --output type=local,dest=./bin
+```
+
+For multiple architectures at once, point each at its own destination:
+
+```bash
+docker buildx build . -f build/docker/Dockerfile.native-binary \
+  --platform linux/amd64 --target export --output type=local,dest=./bin/amd64
+docker buildx build . -f build/docker/Dockerfile.native-binary \
+  --platform linux/arm64 --target export --output type=local,dest=./bin/arm64
+```
+
+### Run it
+
+```bash
+./bin/watchtower --help
+# Watchtower needs the Docker socket to do anything useful:
+./bin/watchtower --run-once
+```
+
+## Build a runnable image from local changes (`Dockerfile.self-local`)
+
+If you want a runnable image instead of a bare binary:
+
+```bash
+docker build . -f build/docker/Dockerfile.self-local -t nickfedor/watchtower
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock nickfedor/watchtower --run-once
+```
+
+See the project's [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full release/dev image
+workflow (GoReleaser, multi-arch dev images, etc.).

--- a/docs/advanced-features/lifecycle-hooks/index.md
+++ b/docs/advanced-features/lifecycle-hooks/index.md
@@ -29,7 +29,7 @@ In addition to the in-container hooks above, Watchtower supports **host-side** h
 |----------------------|--------------------------------------------------------------------------------------|---------------------------------------------|
 | **Host pre-check**   | Executed on the Watchtower host for each filtered container before the update cycle  | Per container, before scanning containers   |
 | **Host pre-update**  | Executed on the Watchtower host before stopping the old container                    | Per container, immediately before stopping  |
-| **Host pre-start**   | Executed on the Watchtower host after the old container is stopped/removed but before the new one starts | Per container, between stop and start   |
+| **Host pre-start**   | Executed on the Watchtower host after the old container is stopped, but before it is removed and the new one starts | Per container, between stop and removal   |
 | **Host post-update** | Executed on the Watchtower host after starting the new container                     | Per container, immediately after starting   |
 | **Host post-check**  | Executed on the Watchtower host for each filtered container after the update cycle   | Per container, after all updates            |
 
@@ -82,7 +82,7 @@ LABEL com.centurylinklabs.watchtower.lifecycle.post-check="echo 'Update cycle co
 
 Most lifecycle hooks run *inside* the monitored container via Docker's exec API. The **host** hooks are different: their commands run on the Watchtower host itself (the process running Watchtower), using the host's `sh`. This is useful when the action you want to perform — sending a notification, touching a file, calling an external API — does not have the required tooling installed inside the monitored container.
 
-Most host hooks have an in-container counterpart, configured with a `host-` prefixed label, and fire at the same point in the update cycle as their in-container equivalent (the host hook runs first). The **host pre-start** hook is host-only — it has no in-container equivalent because it runs in the window between the old container being stopped/removed and the new container being started, when nothing is running:
+Most host hooks have an in-container counterpart, configured with a `host-` prefixed label, and fire at the same point in the update cycle as their in-container equivalent (the host hook runs first). The **host pre-start** hook is host-only — it has no in-container equivalent because it runs in the window after the old container is stopped but *before it is removed* and the new container is started. The container is stopped yet still present on the host, so the hook can resolve its configuration and mounts (e.g. via `docker inspect "$WT_CONTAINER_ID"`) while no process is writing to its data:
 
 ```dockerfile title="Host hook labels (each runs on the Watchtower host) "
 LABEL com.centurylinklabs.watchtower.lifecycle.host-pre-check="echo \"Scanning $WT_CONTAINER_NAME\" >> /var/log/watchtower-hooks.log"
@@ -98,7 +98,7 @@ Unlike the in-container pre-update hook, the host pre-update hook runs regardles
 
 ##### Exit code handling
 
-- **Host pre-check / host-pre-start / host-post-check / host-post-update**: a non-zero exit code is logged but does not stop the update cycle. (For host pre-start in particular, the old container has already been removed, so the new container is started regardless to avoid leaving it down.)
+- **Host pre-check / host-pre-start / host-post-check / host-post-update**: a non-zero exit code is logged but does not stop the update cycle. (For host pre-start in particular, the old container is removed and the new container is started regardless, to avoid leaving the service down if, for example, a backup fails.)
 - **Host pre-update**: mirrors the in-container pre-update semantics — exit code `0` continues, exit code `75` (`EX_TEMPFAIL`) skips updating that container, and any other non-zero exit aborts the update for that container.
 
 !!! Important
@@ -115,7 +115,7 @@ Host hook commands receive details about the triggering container through dedica
 
 ##### Backing Up Volumes with `host-pre-start`
 
-The `host-pre-start` hook is designed for this case: it runs on the host after the old container has been stopped and removed, but before the new container starts. At that moment nothing is writing to the container's volumes, so it is safe to snapshot or archive them. Because the command runs on the host, the backup tooling (e.g. `tar`, `restic`, `rsync`) only needs to be available on the host, not inside the monitored image.
+The `host-pre-start` hook is designed for this case: it runs on the host after the old container has been stopped but *before* it is removed, so the container still exists and nothing is writing to its volumes. Because the container is still present, the backup script can discover its mounts automatically with `docker inspect "$WT_CONTAINER_ID"` instead of hard-coding volume names. Because the command runs on the host, the backup tooling (e.g. `tar`, `restic`, `rsync`) only needs to be available where Watchtower runs, not inside the monitored image.
 
 === "Docker Compose"
 
@@ -126,12 +126,13 @@ The `host-pre-start` hook is designed for this case: it runs on the host after t
         volumes:
           - app_data:/data
         labels:
-          # Archive the named volume's contents on the host before the new container starts.
+          # Archive the container's mounted volumes on the host before it is removed.
           - "com.centurylinklabs.watchtower.lifecycle.host-pre-start=/opt/scripts/backup-volume.sh"
           # Backups can be slow, so allow up to 30 minutes (uses the pre-update timeout).
           - "com.centurylinklabs.watchtower.lifecycle.pre-update-timeout=30"
 
       watchtower:
+        # Use an image that includes the docker CLI, or install it, so the hook can run `docker inspect`.
         image: nickfedor/watchtower
         volumes:
           - /var/run/docker.sock:/var/run/docker.sock
@@ -158,16 +159,26 @@ The `host-pre-start` hook is designed for this case: it runs on the host after t
     STAMP=$(date +%Y%m%d-%H%M%S)
     DEST="/srv/backups/${NAME}-${STAMP}.tar.gz"
 
-    echo "[$WT_HOOK_TYPE] Backing up volumes for ${NAME} to ${DEST}"
+    echo "[$WT_HOOK_TYPE] Backing up volumes for ${NAME} (${WT_CONTAINER_ID}) to ${DEST}"
 
-    # The container is stopped at this point, so the data is in a consistent state.
-    tar -czf "$DEST" -C /var/lib/docker/volumes "${NAME}_app_data"
+    # The container is stopped but not yet removed, so we can inspect it to find the
+    # host paths of its named volumes. Anonymous/bind mounts can be filtered as needed.
+    SOURCES=$(docker inspect "$WT_CONTAINER_ID" \
+      --format '{{ range .Mounts }}{{ if eq .Type "volume" }}{{ .Source }}{{ "\n" }}{{ end }}{{ end }}')
+
+    if [ -z "$SOURCES" ]; then
+      echo "No named volumes to back up for ${NAME}"
+      exit 0
+    fi
+
+    # Archive each volume's contents (data is consistent because the container is stopped).
+    tar -czf "$DEST" $SOURCES
 
     echo "Backup complete: ${DEST}"
     ```
 
 !!! Note
-    A failing `host-pre-start` command is logged but does **not** abort the update — the old container has already been removed, so the new one is started regardless to avoid leaving the service down. If you need the update to stop when a backup fails, perform the backup in a `host-pre-update` hook instead and exit non-zero (which aborts the update before the container is stopped).
+    A failing `host-pre-start` command is logged but does **not** abort the update — the old container is removed and the new one started regardless, to avoid leaving the service down if a backup fails. If you instead need the update to stop when a backup fails, perform the backup in a `host-pre-update` hook and exit non-zero, which aborts the update before the container is stopped.
 
 ### Advanced Configuration
 
@@ -579,8 +590,9 @@ flowchart TD
     LOOPSTART --> PREUPDATE
     PREUPDATE[Pre-update hook]
     PREUPDATE --> STOP[Stop old container]
-    STOP --> PRESTART[Host pre-start hook<br/>host-only]
-    PRESTART --> STARTNEW[Start new container]
+    STOP --> PRESTART[Host pre-start hook<br/>host-only, container stopped]
+    PRESTART --> REMOVE[Remove old container]
+    REMOVE --> STARTNEW[Start new container]
     STARTNEW --> POSTUPDATE[Post-update hook]
     POSTUPDATE --> LOOPEND{All containers<br/>processed?}
     LOOPEND -->|No| LOOPSTART
@@ -593,7 +605,7 @@ flowchart TD
     classDef decision fill:#003343,stroke:#000,stroke-width:2px;
 
     class PRECHECK,PREUPDATE,PRESTART,POSTUPDATE,POSTCHECK hook
-    class SCAN,STOP,STARTNEW,LOOPSTART action
+    class SCAN,STOP,REMOVE,STARTNEW,LOOPSTART action
     class DECISION,LOOPEND decision
 ```
 
@@ -603,7 +615,7 @@ flowchart TD
 |-----------------|--------------------------------------------|------------------------------------------|----------------------------------------------------------------------|------------------------------------|
 | **Pre-check**   | Per filtered container                     | Beginning of update cycle                | Command defined + hooks enabled                                      | Ignored                            |
 | **Pre-update**  | Individual containers being updated        | Immediately before stopping              | Command defined + hooks enabled + container running + not restarting | Must be running and not restarting |
-| **Host pre-start** (host-only) | Individual containers being restarted | After stop/removal, before new container starts | Command defined + hooks enabled | Stopped (not yet recreated) |
+| **Host pre-start** (host-only) | Individual containers being restarted | After stop, before removal and new container start | Command defined + hooks enabled | Stopped but not yet removed |
 | **Post-update** | Individual containers successfully updated | Immediately after starting new container | Command defined + hooks enabled + update successful                  | New container running              |
 | **Post-check**  | Per filtered container                     | End of update cycle                      | Command defined + hooks enabled                                      | Ignored                            |
 

--- a/docs/advanced-features/lifecycle-hooks/index.md
+++ b/docs/advanced-features/lifecycle-hooks/index.md
@@ -104,11 +104,12 @@ Unlike the in-container pre-update hook, the host pre-update hook runs regardles
 
 Host hook commands receive details about the triggering container through dedicated environment variables (the JSON `WT_CONTAINER` variable used by in-container hooks is **not** provided):
 
-| Variable                  | Description                       | Example          |
-|---------------------------|-----------------------------------|------------------|
-| `WT_CONTAINER_NAME`       | Container name                    | `/my-app`        |
-| `WT_CONTAINER_ID`         | Full container ID                 | `abc123def456…`  |
-| `WT_CONTAINER_IMAGE_NAME` | Container image name with tag     | `nginx:latest`   |
+| Variable                  | Description                                                      | Example          |
+|---------------------------|-----------------------------------------------------------------|------------------|
+| `WT_CONTAINER_NAME`       | Container name                                                  | `/my-app`        |
+| `WT_CONTAINER_ID`         | Full container ID                                               | `abc123def456…`  |
+| `WT_CONTAINER_IMAGE_NAME` | Container image name with tag                                   | `nginx:latest`   |
+| `WT_HOOK_TYPE`            | Lifecycle phase that triggered the command                      | `pre-check`, `post-check`, `pre-update`, `post-update` |
 
 ### Advanced Configuration
 

--- a/docs/advanced-features/lifecycle-hooks/index.md
+++ b/docs/advanced-features/lifecycle-hooks/index.md
@@ -29,6 +29,7 @@ In addition to the in-container hooks above, Watchtower supports **host-side** h
 |----------------------|--------------------------------------------------------------------------------------|---------------------------------------------|
 | **Host pre-check**   | Executed on the Watchtower host for each filtered container before the update cycle  | Per container, before scanning containers   |
 | **Host pre-update**  | Executed on the Watchtower host before stopping the old container                    | Per container, immediately before stopping  |
+| **Host pre-start**   | Executed on the Watchtower host after the old container is stopped/removed but before the new one starts | Per container, between stop and start   |
 | **Host post-update** | Executed on the Watchtower host after starting the new container                     | Per container, immediately after starting   |
 | **Host post-check**  | Executed on the Watchtower host for each filtered container after the update cycle   | Per container, after all updates            |
 
@@ -81,22 +82,23 @@ LABEL com.centurylinklabs.watchtower.lifecycle.post-check="echo 'Update cycle co
 
 Most lifecycle hooks run *inside* the monitored container via Docker's exec API. The **host** hooks are different: their commands run on the Watchtower host itself (the process running Watchtower), using the host's `sh`. This is useful when the action you want to perform — sending a notification, touching a file, calling an external API — does not have the required tooling installed inside the monitored container.
 
-Each in-container hook has a host-side counterpart, configured with a `host-` prefixed label. They fire at the same point in the update cycle as their in-container equivalent (the host hook runs first):
+Most host hooks have an in-container counterpart, configured with a `host-` prefixed label, and fire at the same point in the update cycle as their in-container equivalent (the host hook runs first). The **host pre-start** hook is host-only — it has no in-container equivalent because it runs in the window between the old container being stopped/removed and the new container being started, when nothing is running:
 
 ```dockerfile title="Host hook labels (each runs on the Watchtower host) "
 LABEL com.centurylinklabs.watchtower.lifecycle.host-pre-check="echo \"Scanning $WT_CONTAINER_NAME\" >> /var/log/watchtower-hooks.log"
 LABEL com.centurylinklabs.watchtower.lifecycle.host-pre-update="/opt/scripts/snapshot.sh"
+LABEL com.centurylinklabs.watchtower.lifecycle.host-pre-start="/opt/scripts/backup-volumes.sh"
 LABEL com.centurylinklabs.watchtower.lifecycle.host-post-update="curl -X POST -d \"$WT_CONTAINER_NAME updated\" http://notifier/local"
 LABEL com.centurylinklabs.watchtower.lifecycle.host-post-check="echo \"Cycle done\" >> /var/log/watchtower-hooks.log"
 ```
 
-The commands run as the Watchtower process's user and inherit Watchtower's environment. Host check hooks use the same fixed 1-minute timeout as their in-container counterparts; host pre/post-update hooks use the configurable `pre-update-timeout` / `post-update-timeout` values.
+The commands run as the Watchtower process's user and inherit Watchtower's environment. Host check hooks use the same fixed 1-minute timeout as their in-container counterparts; host pre-update, pre-start, and post-update hooks use the configurable `pre-update-timeout` / `post-update-timeout` values (the pre-start hook uses `pre-update-timeout`, so raise it for long-running backups).
 
 Unlike the in-container pre-update hook, the host pre-update hook runs regardless of whether the container is currently running (it executes on the host, not inside the container).
 
 ##### Exit code handling
 
-- **Host pre-check / host-post-check / host-post-update**: a non-zero exit code is logged but does not stop the update cycle.
+- **Host pre-check / host-pre-start / host-post-check / host-post-update**: a non-zero exit code is logged but does not stop the update cycle. (For host pre-start in particular, the old container has already been removed, so the new container is started regardless to avoid leaving it down.)
 - **Host pre-update**: mirrors the in-container pre-update semantics — exit code `0` continues, exit code `75` (`EX_TEMPFAIL`) skips updating that container, and any other non-zero exit aborts the update for that container.
 
 !!! Important
@@ -109,7 +111,63 @@ Host hook commands receive details about the triggering container through dedica
 | `WT_CONTAINER_NAME`       | Container name                                                  | `/my-app`        |
 | `WT_CONTAINER_ID`         | Full container ID                                               | `abc123def456…`  |
 | `WT_CONTAINER_IMAGE_NAME` | Container image name with tag                                   | `nginx:latest`   |
-| `WT_HOOK_TYPE`            | Lifecycle phase that triggered the command                      | `pre-check`, `post-check`, `pre-update`, `post-update` |
+| `WT_HOOK_TYPE`            | Lifecycle phase that triggered the command                      | `pre-check`, `post-check`, `pre-update`, `pre-start`, `post-update` |
+
+##### Backing Up Volumes with `host-pre-start`
+
+The `host-pre-start` hook is designed for this case: it runs on the host after the old container has been stopped and removed, but before the new container starts. At that moment nothing is writing to the container's volumes, so it is safe to snapshot or archive them. Because the command runs on the host, the backup tooling (e.g. `tar`, `restic`, `rsync`) only needs to be available on the host, not inside the monitored image.
+
+=== "Docker Compose"
+
+    ```yaml
+    services:
+      app:
+        image: myorg/app:latest
+        volumes:
+          - app_data:/data
+        labels:
+          # Archive the named volume's contents on the host before the new container starts.
+          - "com.centurylinklabs.watchtower.lifecycle.host-pre-start=/opt/scripts/backup-volume.sh"
+          # Backups can be slow, so allow up to 30 minutes (uses the pre-update timeout).
+          - "com.centurylinklabs.watchtower.lifecycle.pre-update-timeout=30"
+
+      watchtower:
+        image: nickfedor/watchtower
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+          # The backup script and its destination must be reachable from the Watchtower container,
+          # since "host" means the environment Watchtower itself runs in.
+          - /opt/scripts:/opt/scripts:ro
+          - /var/lib/docker/volumes:/var/lib/docker/volumes:ro
+          - /srv/backups:/srv/backups
+        environment:
+          - WATCHTOWER_LIFECYCLE_HOOKS=true
+
+    volumes:
+      app_data:
+    ```
+
+=== "Backup script (`/opt/scripts/backup-volume.sh`)"
+
+    ```bash
+    #!/bin/sh
+    set -eu
+
+    # Watchtower exposes the triggering container's details as environment variables.
+    NAME=$(echo "$WT_CONTAINER_NAME" | sed 's#^/##')
+    STAMP=$(date +%Y%m%d-%H%M%S)
+    DEST="/srv/backups/${NAME}-${STAMP}.tar.gz"
+
+    echo "[$WT_HOOK_TYPE] Backing up volumes for ${NAME} to ${DEST}"
+
+    # The container is stopped at this point, so the data is in a consistent state.
+    tar -czf "$DEST" -C /var/lib/docker/volumes "${NAME}_app_data"
+
+    echo "Backup complete: ${DEST}"
+    ```
+
+!!! Note
+    A failing `host-pre-start` command is logged but does **not** abort the update — the old container has already been removed, so the new one is started regardless to avoid leaving the service down. If you need the update to stop when a backup fails, perform the backup in a `host-pre-update` hook instead and exit non-zero (which aborts the update before the container is stopped).
 
 ### Advanced Configuration
 
@@ -521,7 +579,8 @@ flowchart TD
     LOOPSTART --> PREUPDATE
     PREUPDATE[Pre-update hook]
     PREUPDATE --> STOP[Stop old container]
-    STOP --> STARTNEW[Start new container]
+    STOP --> PRESTART[Host pre-start hook<br/>host-only]
+    PRESTART --> STARTNEW[Start new container]
     STARTNEW --> POSTUPDATE[Post-update hook]
     POSTUPDATE --> LOOPEND{All containers<br/>processed?}
     LOOPEND -->|No| LOOPSTART
@@ -533,7 +592,7 @@ flowchart TD
     classDef action fill:#003343,stroke:#000,stroke-width:2px;
     classDef decision fill:#003343,stroke:#000,stroke-width:2px;
 
-    class PRECHECK,PREUPDATE,POSTUPDATE,POSTCHECK hook
+    class PRECHECK,PREUPDATE,PRESTART,POSTUPDATE,POSTCHECK hook
     class SCAN,STOP,STARTNEW,LOOPSTART action
     class DECISION,LOOPEND decision
 ```
@@ -544,6 +603,7 @@ flowchart TD
 |-----------------|--------------------------------------------|------------------------------------------|----------------------------------------------------------------------|------------------------------------|
 | **Pre-check**   | Per filtered container                     | Beginning of update cycle                | Command defined + hooks enabled                                      | Ignored                            |
 | **Pre-update**  | Individual containers being updated        | Immediately before stopping              | Command defined + hooks enabled + container running + not restarting | Must be running and not restarting |
+| **Host pre-start** (host-only) | Individual containers being restarted | After stop/removal, before new container starts | Command defined + hooks enabled | Stopped (not yet recreated) |
 | **Post-update** | Individual containers successfully updated | Immediately after starting new container | Command defined + hooks enabled + update successful                  | New container running              |
 | **Post-check**  | Per filtered container                     | End of update cycle                      | Command defined + hooks enabled                                      | Ignored                            |
 

--- a/docs/advanced-features/lifecycle-hooks/index.md
+++ b/docs/advanced-features/lifecycle-hooks/index.md
@@ -25,9 +25,12 @@ Watchtower supports four distinct lifecycle hook types that execute at different
 
 In addition to the in-container hooks above, Watchtower supports **host-side** hooks that run on the Watchtower host (the process running Watchtower) instead of inside the monitored container:
 
-| Hook Type          | Description                                                                      | Execution Timing                          |
-|--------------------|----------------------------------------------------------------------------------|-------------------------------------------|
-| **Host pre-check** | Executed on the Watchtower host for each filtered container before the update cycle | Per container, before scanning containers |
+| Hook Type            | Description                                                                          | Execution Timing                            |
+|----------------------|--------------------------------------------------------------------------------------|---------------------------------------------|
+| **Host pre-check**   | Executed on the Watchtower host for each filtered container before the update cycle  | Per container, before scanning containers   |
+| **Host pre-update**  | Executed on the Watchtower host before stopping the old container                    | Per container, immediately before stopping  |
+| **Host post-update** | Executed on the Watchtower host after starting the new container                     | Per container, immediately after starting   |
+| **Host post-check**  | Executed on the Watchtower host for each filtered container after the update cycle   | Per container, after all updates            |
 
 ## Configuration
 
@@ -76,18 +79,30 @@ LABEL com.centurylinklabs.watchtower.lifecycle.post-check="echo 'Update cycle co
 
 #### Host-Side Hooks
 
-Most lifecycle hooks run *inside* the monitored container via Docker's exec API. The **host pre-check** hook is different: its command runs on the Watchtower host itself (the process running Watchtower), using the host's `sh`. This is useful when the action you want to perform — sending a notification, touching a file, calling an external API — does not have the required tooling installed inside the monitored container.
+Most lifecycle hooks run *inside* the monitored container via Docker's exec API. The **host** hooks are different: their commands run on the Watchtower host itself (the process running Watchtower), using the host's `sh`. This is useful when the action you want to perform — sending a notification, touching a file, calling an external API — does not have the required tooling installed inside the monitored container.
 
-```dockerfile title="Example host pre-check hook (runs on the Watchtower host) "
+Each in-container hook has a host-side counterpart, configured with a `host-` prefixed label. They fire at the same point in the update cycle as their in-container equivalent (the host hook runs first):
+
+```dockerfile title="Host hook labels (each runs on the Watchtower host) "
 LABEL com.centurylinklabs.watchtower.lifecycle.host-pre-check="echo \"Scanning $WT_CONTAINER_NAME\" >> /var/log/watchtower-hooks.log"
+LABEL com.centurylinklabs.watchtower.lifecycle.host-pre-update="/opt/scripts/snapshot.sh"
+LABEL com.centurylinklabs.watchtower.lifecycle.host-post-update="curl -X POST -d \"$WT_CONTAINER_NAME updated\" http://notifier/local"
+LABEL com.centurylinklabs.watchtower.lifecycle.host-post-check="echo \"Cycle done\" >> /var/log/watchtower-hooks.log"
 ```
 
-The command is run as the Watchtower process's user and inherits Watchtower's environment. It uses the same fixed 1-minute timeout as the in-container check hooks. As with the in-container pre-check, a non-zero exit code is logged but does not stop the update cycle.
+The commands run as the Watchtower process's user and inherit Watchtower's environment. Host check hooks use the same fixed 1-minute timeout as their in-container counterparts; host pre/post-update hooks use the configurable `pre-update-timeout` / `post-update-timeout` values.
+
+Unlike the in-container pre-update hook, the host pre-update hook runs regardless of whether the container is currently running (it executes on the host, not inside the container).
+
+##### Exit code handling
+
+- **Host pre-check / host-post-check / host-post-update**: a non-zero exit code is logged but does not stop the update cycle.
+- **Host pre-update**: mirrors the in-container pre-update semantics — exit code `0` continues, exit code `75` (`EX_TEMPFAIL`) skips updating that container, and any other non-zero exit aborts the update for that container.
 
 !!! Important
-    Because host pre-check commands execute on the Watchtower host, ensure any tooling they invoke is available there. If Watchtower itself runs in a container, "host" refers to that Watchtower container's environment, not the underlying Docker host.
+    Because host hooks execute on the Watchtower host, ensure any tooling they invoke is available there. If Watchtower itself runs in a container, "host" refers to that Watchtower container's environment, not the underlying Docker host.
 
-Host pre-check commands receive details about the triggering container through dedicated environment variables (the JSON `WT_CONTAINER` variable used by in-container hooks is **not** provided):
+Host hook commands receive details about the triggering container through dedicated environment variables (the JSON `WT_CONTAINER` variable used by in-container hooks is **not** provided):
 
 | Variable                  | Description                       | Example          |
 |---------------------------|-----------------------------------|------------------|

--- a/docs/advanced-features/lifecycle-hooks/index.md
+++ b/docs/advanced-features/lifecycle-hooks/index.md
@@ -23,6 +23,12 @@ Watchtower supports four distinct lifecycle hook types that execute at different
 | **Post-update** | Executed after starting the new container                             | Per container, immediately after starting  |
 | **Post-check**  | Executed for each filtered container after the update cycle completes | Per container, after all updates           |
 
+In addition to the in-container hooks above, Watchtower supports **host-side** hooks that run on the Watchtower host (the process running Watchtower) instead of inside the monitored container:
+
+| Hook Type          | Description                                                                      | Execution Timing                          |
+|--------------------|----------------------------------------------------------------------------------|-------------------------------------------|
+| **Host pre-check** | Executed on the Watchtower host for each filtered container before the update cycle | Per container, before scanning containers |
+
 ## Configuration
 
 ### Enabling Lifecycle Hooks
@@ -67,6 +73,27 @@ LABEL com.centurylinklabs.watchtower.lifecycle.post-check="echo 'Update cycle co
 
 !!! Note
     If the container is not running, lifecycle hooks (including pre-update hooks) cannot run, as the stop phase is skipped, and the update proceeds directly to removal (if applicable) or completion.
+
+#### Host-Side Hooks
+
+Most lifecycle hooks run *inside* the monitored container via Docker's exec API. The **host pre-check** hook is different: its command runs on the Watchtower host itself (the process running Watchtower), using the host's `sh`. This is useful when the action you want to perform — sending a notification, touching a file, calling an external API — does not have the required tooling installed inside the monitored container.
+
+```dockerfile title="Example host pre-check hook (runs on the Watchtower host) "
+LABEL com.centurylinklabs.watchtower.lifecycle.host-pre-check="echo \"Scanning $WT_CONTAINER_NAME\" >> /var/log/watchtower-hooks.log"
+```
+
+The command is run as the Watchtower process's user and inherits Watchtower's environment. It uses the same fixed 1-minute timeout as the in-container check hooks. As with the in-container pre-check, a non-zero exit code is logged but does not stop the update cycle.
+
+!!! Important
+    Because host pre-check commands execute on the Watchtower host, ensure any tooling they invoke is available there. If Watchtower itself runs in a container, "host" refers to that Watchtower container's environment, not the underlying Docker host.
+
+Host pre-check commands receive details about the triggering container through dedicated environment variables (the JSON `WT_CONTAINER` variable used by in-container hooks is **not** provided):
+
+| Variable                  | Description                       | Example          |
+|---------------------------|-----------------------------------|------------------|
+| `WT_CONTAINER_NAME`       | Container name                    | `/my-app`        |
+| `WT_CONTAINER_ID`         | Full container ID                 | `abc123def456…`  |
+| `WT_CONTAINER_IMAGE_NAME` | Container image name with tag     | `nginx:latest`   |
 
 ### Advanced Configuration
 

--- a/docs/advanced-features/lifecycle-hooks/index.md
+++ b/docs/advanced-features/lifecycle-hooks/index.md
@@ -162,12 +162,16 @@ The `host-pre-start` hook is designed for this case: it runs on the host after t
     echo "[$WT_HOOK_TYPE] Backing up volumes for ${NAME} (${WT_CONTAINER_ID}) to ${DEST}"
 
     # The container is stopped but not yet removed, so we can inspect it to find the
-    # host paths of its named volumes. Anonymous/bind mounts can be filtered as needed.
+    # host paths of its mounts. This matches both named volumes (host path lives under
+    # /var/lib/docker/volumes) and bind mounts (.Source is an arbitrary host path).
+    # NOTE: every path emitted here must also be reachable from the Watchtower container
+    # for `tar` to read it — see the compose volumes above. Adjust the filter (e.g. drop
+    # "bind", or skip read-only mounts) to match what you actually want backed up.
     SOURCES=$(docker inspect "$WT_CONTAINER_ID" \
-      --format '{{ range .Mounts }}{{ if eq .Type "volume" }}{{ .Source }}{{ "\n" }}{{ end }}{{ end }}')
+      --format '{{ range .Mounts }}{{ if or (eq .Type "volume") (eq .Type "bind") }}{{ .Source }}{{ "\n" }}{{ end }}{{ end }}')
 
     if [ -z "$SOURCES" ]; then
-      echo "No named volumes to back up for ${NAME}"
+      echo "No volumes or bind mounts to back up for ${NAME}"
       exit 0
     fi
 

--- a/internal/actions/mocks/client.go
+++ b/internal/actions/mocks/client.go
@@ -413,6 +413,12 @@ func (client MockClient) RemoveContainer(ctx context.Context, _ types.Container)
 	return nil
 }
 
+// RemoveStoppedContainer simulates removing an already-stopped container.
+// It delegates to RemoveContainer to mirror the production removal behavior.
+func (client MockClient) RemoveStoppedContainer(ctx context.Context, c types.Container) error {
+	return client.RemoveContainer(ctx, c)
+}
+
 // CreateEphemeralOrchestrator simulates creating an ephemeral orchestrator container.
 // It records the container chain parameter for test verification and returns a mock
 // container ID for the orchestrator and nil error to indicate success.

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -1449,6 +1449,23 @@ func stopStaleContainer(
 
 	// Execute pre-update lifecycle hooks if enabled, checking for skip conditions.
 	if config.LifecycleHooks {
+		// Host pre-update runs on the Watchtower host before the in-container hook.
+		hostSkipUpdate, err := lifecycle.ExecuteHostPreUpdateCommand(ctx, container)
+		if err != nil {
+			logrus.WithFields(fields).
+				WithError(err).
+				Debug("Host pre-update command execution failed")
+
+			return fmt.Errorf("%w: %w", errPreUpdateFailed, err)
+		}
+
+		if hostSkipUpdate {
+			logrus.WithFields(fields).
+				Debug("Skipping container due to host pre-update exit code 75")
+
+			return errSkipUpdate
+		}
+
 		skipUpdate, err := lifecycle.ExecutePreUpdateCommand(
 			ctx,
 			client,
@@ -1883,6 +1900,15 @@ func restartStaleContainer(
 
 		// Run post-update lifecycle hooks for restarting containers if enabled.
 		if sourceContainer.ToRestart() && config.LifecycleHooks {
+			logrus.WithFields(fields).
+				Debug("Executing host post-update command")
+			//nolint:contextcheck // Using detached context intentionally to survive parent cancellation
+			lifecycle.ExecuteHostPostUpdateCommand(
+				detachedCtx,
+				client,
+				newContainerID,
+			)
+
 			logrus.WithFields(fields).
 				Debug("Executing post-update command")
 			//nolint:contextcheck // Using detached context intentionally to survive parent cancellation

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -1835,6 +1835,16 @@ func restartStaleContainer(
 		}
 	}
 
+	// Run host pre-start lifecycle hook if enabled, after the old container has been
+	// stopped and removed but before the new container is created and started. This
+	// host-only window (the container is not running) is suited to backing up volumes.
+	if config.LifecycleHooks {
+		logrus.WithFields(fields).
+			Debug("Executing host pre-start command")
+		//nolint:contextcheck // Using detached context intentionally to survive parent cancellation
+		lifecycle.ExecuteHostPreStartCommand(detachedCtx, sourceContainer)
+	}
+
 	// Create the new container with updated configuration.
 	//nolint:contextcheck // Using detached context intentionally to survive parent cancellation
 	newContainerID, err := client.CreateContainer(detachedCtx, sourceContainer)

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -1489,7 +1489,15 @@ func stopStaleContainer(
 		}
 	}
 
-	// Stop the container with the configured timeout.
+	// When a host pre-start hook is configured, split the stop and removal so the hook
+	// can run while the old container is stopped but still present on the host (e.g. so a
+	// backup script can resolve its volumes via `docker inspect`). Otherwise, stop and
+	// remove in a single operation.
+	if config.LifecycleHooks && container.GetLifecycleHostPreStartCommand() != "" {
+		return stopRemoveWithHostPreStart(ctx, container, client, config, fields)
+	}
+
+	// Stop and remove the container with the configured timeout.
 	err := client.StopAndRemoveContainer(
 		ctx,
 		container,
@@ -1509,6 +1517,70 @@ func stopStaleContainer(
 		logrus.WithFields(fields).
 			WithError(err).
 			Error("Failed to stop container")
+
+		return fmt.Errorf("%w: %w", errStopContainerFailed, err)
+	}
+
+	return nil
+}
+
+// stopRemoveWithHostPreStart stops a container, runs the host pre-start lifecycle hook
+// while the container is stopped but not yet removed, then removes it.
+//
+// This ordering lets host pre-start hooks inspect the still-present container (for
+// example, to discover its mounts/volumes via `docker inspect`) before backing them up.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeout control.
+//   - container: Container to stop and remove.
+//   - client: Container client for Docker operations.
+//   - config: Update options controlling stop/removal behavior.
+//   - fields: Pre-populated log fields for the container.
+//
+// Returns:
+//   - error: Non-nil if stopping or removing the container fails, nil on success.
+func stopRemoveWithHostPreStart(
+	ctx context.Context,
+	container types.Container,
+	client container.Client,
+	config types.UpdateParams,
+	fields logrus.Fields,
+) error {
+	// Stop the container without removing it.
+	if err := client.StopContainer(ctx, container, config.Timeout); err != nil {
+		if cerrdefs.IsNotFound(err) {
+			logrus.WithFields(fields).
+				WithError(err).
+				Debug("Container not found, treating as already stopped")
+
+			return nil
+		}
+
+		logrus.WithFields(fields).
+			WithError(err).
+			Error("Failed to stop container")
+
+		return fmt.Errorf("%w: %w", errStopContainerFailed, err)
+	}
+
+	// Run the host pre-start hook while the container is stopped but still present.
+	logrus.WithFields(fields).
+		Debug("Executing host pre-start command")
+	lifecycle.ExecuteHostPreStartCommand(ctx, container)
+
+	// Remove the now-stopped container, honoring volume/AutoRemove configuration.
+	if err := client.RemoveStoppedContainer(ctx, container); err != nil {
+		if cerrdefs.IsNotFound(err) {
+			logrus.WithFields(fields).
+				WithError(err).
+				Debug("Container not found, treating as already removed")
+
+			return nil
+		}
+
+		logrus.WithFields(fields).
+			WithError(err).
+			Error("Failed to remove container")
 
 		return fmt.Errorf("%w: %w", errStopContainerFailed, err)
 	}
@@ -1833,16 +1905,6 @@ func restartStaleContainer(
 					Debug("Updated container chain label for Watchtower self-update")
 			}
 		}
-	}
-
-	// Run host pre-start lifecycle hook if enabled, after the old container has been
-	// stopped and removed but before the new container is created and started. This
-	// host-only window (the container is not running) is suited to backing up volumes.
-	if config.LifecycleHooks {
-		logrus.WithFields(fields).
-			Debug("Executing host pre-start command")
-		//nolint:contextcheck // Using detached context intentionally to survive parent cancellation
-		lifecycle.ExecuteHostPreStartCommand(detachedCtx, sourceContainer)
 	}
 
 	// Create the new container with updated configuration.

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -133,6 +133,19 @@ type Client interface {
 	//   - error: Non-nil if stop/removal fails, nil on success.
 	StopAndRemoveContainer(ctx context.Context, container types.Container, timeout time.Duration) error
 
+	// RemoveStoppedContainer removes an already-stopped container, honoring the
+	// configured volume-removal and AutoRemove behavior. It is the removal half of
+	// StopAndRemoveContainer, exposed so callers can act (e.g. run host lifecycle hooks)
+	// while the container is stopped but still present on the host.
+	//
+	// Parameters:
+	//   - ctx: Context for cancellation and timeout control.
+	//   - container: Container to remove (expected to already be stopped).
+	//
+	// Returns:
+	//   - error: Non-nil if removal fails, nil on success.
+	RemoveStoppedContainer(ctx context.Context, container types.Container) error
+
 	// CreateContainer creates a new container based on the provided
 	// container's configuration, but does not start it.
 	//
@@ -627,6 +640,34 @@ func (c *client) StopAndRemoveContainer(ctx context.Context, container types.Con
 		"container": container.Name(),
 		"image":     container.ImageName(),
 	}).Debug("Stopped and removed container")
+
+	return nil
+}
+
+// RemoveStoppedContainer removes an already-stopped container, honoring the configured
+// volume-removal and AutoRemove behavior.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeout control.
+//   - container: Container to remove (expected to already be stopped).
+//
+// Returns:
+//   - error: Non-nil if removal fails, nil on success.
+func (c *client) RemoveStoppedContainer(ctx context.Context, container types.Container) error {
+	err := RemoveSourceContainer(ctx, c.api, container, c.RemoveVolumes)
+	if err != nil {
+		logrus.WithError(err).WithFields(logrus.Fields{
+			"container": container.Name(),
+			"image":     container.ImageName(),
+		}).Debug("Failed to remove stopped container")
+
+		return err
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"container": container.Name(),
+		"image":     container.ImageName(),
+	}).Debug("Removed stopped container")
 
 	return nil
 }

--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -1768,6 +1768,48 @@ func TestStopAndRemoveContainer_ContainerDoesNotExistAfterStopping(t *testing.T)
 	})
 }
 
+func TestRemoveStoppedContainer_RemovesContainer(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		removed := false
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/containers/") {
+				removed = true
+
+				w.WriteHeader(http.StatusNoContent)
+
+				return
+			}
+			// A stop must not be issued: the container is expected to already be stopped.
+			if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/stop") {
+				t.Errorf("unexpected stop call in RemoveStoppedContainer")
+			}
+		}))
+		defer server.Close()
+
+		docker, _ := dockerClient.New(
+			dockerClient.WithHost(server.URL),
+			dockerClient.WithHTTPClient(server.Client()),
+		)
+
+		// Container already stopped.
+		mockedContainer := MockContainer(
+			WithContainerState(dockerContainer.State{Running: false}),
+		)
+
+		err := (&client{api: docker}).RemoveStoppedContainer(
+			context.Background(),
+			mockedContainer,
+		)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if !removed {
+			t.Errorf("expected container to be removed")
+		}
+	})
+}
+
 func TestStopContainer_StoppingFailsWithUnexpectedError(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/container/container_source.go
+++ b/pkg/container/container_source.go
@@ -330,16 +330,42 @@ func StopAndRemoveSourceContainer(
 	timeout time.Duration,
 	removeVolumes bool,
 ) error {
-	clog := logrus.WithFields(logrus.Fields{
-		"container": sourceContainer.Name(),
-		"id":        sourceContainer.ID().ShortID(),
-	})
-
 	// Stop the container first
 	err := StopSourceContainer(ctx, api, sourceContainer, timeout)
 	if err != nil {
 		return err
 	}
+
+	// Remove the now-stopped container, honoring AutoRemove and volume options.
+	return RemoveSourceContainer(ctx, api, sourceContainer, removeVolumes)
+}
+
+// RemoveSourceContainer removes an already-stopped container using the Docker API.
+//
+// It honors the container's AutoRemove configuration (skipping explicit removal when
+// Docker already removes the container automatically) and optionally removes associated
+// volumes. This is the removal half of StopAndRemoveSourceContainer, exposed separately
+// so callers can run logic (such as host lifecycle hooks) while the container is stopped
+// but still present.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeout control.
+//   - api: Docker API client for interacting with the Docker daemon.
+//   - sourceContainer: Container object to remove, containing metadata like name and ID.
+//   - removeVolumes: Boolean indicating whether to remove associated volumes during removal.
+//
+// Returns:
+//   - error: Non-nil if removing the container fails, nil on successful completion.
+func RemoveSourceContainer(
+	ctx context.Context,
+	api dockerClient.APIClient,
+	sourceContainer types.Container,
+	removeVolumes bool,
+) error {
+	clog := logrus.WithFields(logrus.Fields{
+		"container": sourceContainer.Name(),
+		"id":        sourceContainer.ID().ShortID(),
+	})
 
 	// Check if the container has AutoRemove enabled in its HostConfig, which automatically removes
 	// the container after stopping, eliminating the need for an explicit removal call.
@@ -359,7 +385,7 @@ func StopAndRemoveSourceContainer(
 
 	// Call the Docker API's ContainerRemove to delete the container, forcing termination of any
 	// lingering processes (via SIGKILL if needed) and removing volumes if specified.
-	_, err = api.ContainerRemove(ctx, string(sourceContainer.ID()), dockerClient.ContainerRemoveOptions{
+	_, err := api.ContainerRemove(ctx, string(sourceContainer.ID()), dockerClient.ContainerRemoveOptions{
 		Force:         true,          // Ensure any lingering processes are terminated before removal.
 		RemoveVolumes: removeVolumes, // Remove associated volumes if the parameter is true.
 	})

--- a/pkg/container/metadata.go
+++ b/pkg/container/metadata.go
@@ -57,8 +57,9 @@ const (
 	// inside the container) before updating the container.
 	hostPreUpdateLabel = "com.centurylinklabs.watchtower.lifecycle.host-pre-update"
 	// hostPreStartLabel specifies a command to run on the Watchtower host after the old
-	// container has been stopped and removed but before the new container is started.
-	// This host-only phase (the container is not running) is useful for backing up volumes.
+	// container has been stopped but before it is removed and the new container is started.
+	// The container is stopped yet still present, so this host-only phase can inspect it
+	// (e.g. to resolve volumes) and is useful for backing up volumes.
 	hostPreStartLabel = "com.centurylinklabs.watchtower.lifecycle.host-pre-start"
 	// postUpdateLabel specifies a command to run after updating the container.
 	postUpdateLabel = "com.centurylinklabs.watchtower.lifecycle.post-update"
@@ -135,8 +136,8 @@ func (c *Container) GetLifecycleHostPreUpdateCommand() string {
 // GetLifecycleHostPreStartCommand returns the host pre-start command from labels.
 //
 // This command is intended to be executed on the Watchtower host (the process running
-// Watchtower) after the old container has been stopped and removed but before the new
-// container is started. It has no in-container counterpart, as the container is not
+// Watchtower) after the old container has been stopped but before it is removed and the
+// new container is started. It has no in-container counterpart, as the container is not
 // running at this point.
 //
 // Returns:

--- a/pkg/container/metadata.go
+++ b/pkg/container/metadata.go
@@ -56,6 +56,10 @@ const (
 	// hostPreUpdateLabel specifies a command to run on the Watchtower host (rather than
 	// inside the container) before updating the container.
 	hostPreUpdateLabel = "com.centurylinklabs.watchtower.lifecycle.host-pre-update"
+	// hostPreStartLabel specifies a command to run on the Watchtower host after the old
+	// container has been stopped and removed but before the new container is started.
+	// This host-only phase (the container is not running) is useful for backing up volumes.
+	hostPreStartLabel = "com.centurylinklabs.watchtower.lifecycle.host-pre-start"
 	// postUpdateLabel specifies a command to run after updating the container.
 	postUpdateLabel = "com.centurylinklabs.watchtower.lifecycle.post-update"
 	// hostPostUpdateLabel specifies a command to run on the Watchtower host (rather than
@@ -126,6 +130,19 @@ func (c *Container) GetLifecyclePreUpdateCommand() string {
 //   - string: Host pre-update command or empty if unset.
 func (c *Container) GetLifecycleHostPreUpdateCommand() string {
 	return c.getLabelValueOrEmpty(hostPreUpdateLabel)
+}
+
+// GetLifecycleHostPreStartCommand returns the host pre-start command from labels.
+//
+// This command is intended to be executed on the Watchtower host (the process running
+// Watchtower) after the old container has been stopped and removed but before the new
+// container is started. It has no in-container counterpart, as the container is not
+// running at this point.
+//
+// Returns:
+//   - string: Host pre-start command or empty if unset.
+func (c *Container) GetLifecycleHostPreStartCommand() string {
+	return c.getLabelValueOrEmpty(hostPreStartLabel)
 }
 
 // GetLifecyclePostUpdateCommand returns the post-update command from labels.

--- a/pkg/container/metadata.go
+++ b/pkg/container/metadata.go
@@ -48,10 +48,19 @@ const (
 	hostPreCheckLabel = "com.centurylinklabs.watchtower.lifecycle.host-pre-check"
 	// postCheckLabel specifies a command to run after checking for updates.
 	postCheckLabel = "com.centurylinklabs.watchtower.lifecycle.post-check"
+	// hostPostCheckLabel specifies a command to run on the Watchtower host (rather than
+	// inside the container) after checking for updates.
+	hostPostCheckLabel = "com.centurylinklabs.watchtower.lifecycle.host-post-check"
 	// preUpdateLabel specifies a command to run before updating the container.
 	preUpdateLabel = "com.centurylinklabs.watchtower.lifecycle.pre-update"
+	// hostPreUpdateLabel specifies a command to run on the Watchtower host (rather than
+	// inside the container) before updating the container.
+	hostPreUpdateLabel = "com.centurylinklabs.watchtower.lifecycle.host-pre-update"
 	// postUpdateLabel specifies a command to run after updating the container.
 	postUpdateLabel = "com.centurylinklabs.watchtower.lifecycle.post-update"
+	// hostPostUpdateLabel specifies a command to run on the Watchtower host (rather than
+	// inside the container) after updating the container.
+	hostPostUpdateLabel = "com.centurylinklabs.watchtower.lifecycle.host-post-update"
 	// preUpdateTimeoutLabel sets the timeout (in minutes) for the pre-update command.
 	preUpdateTimeoutLabel = "com.centurylinklabs.watchtower.lifecycle.pre-update-timeout"
 	// postUpdateTimeoutLabel sets the timeout (in minutes) for the post-update command.
@@ -89,6 +98,17 @@ func (c *Container) GetLifecyclePostCheckCommand() string {
 	return c.getLabelValueOrEmpty(postCheckLabel)
 }
 
+// GetLifecycleHostPostCheckCommand returns the host post-check command from labels.
+//
+// Unlike the post-check command, this command is intended to be executed on the
+// Watchtower host (the process running Watchtower) rather than inside the container.
+//
+// Returns:
+//   - string: Host post-check command or empty if unset.
+func (c *Container) GetLifecycleHostPostCheckCommand() string {
+	return c.getLabelValueOrEmpty(hostPostCheckLabel)
+}
+
 // GetLifecyclePreUpdateCommand returns the pre-update command from labels.
 //
 // Returns:
@@ -97,12 +117,34 @@ func (c *Container) GetLifecyclePreUpdateCommand() string {
 	return c.getLabelValueOrEmpty(preUpdateLabel)
 }
 
+// GetLifecycleHostPreUpdateCommand returns the host pre-update command from labels.
+//
+// Unlike the pre-update command, this command is intended to be executed on the
+// Watchtower host (the process running Watchtower) rather than inside the container.
+//
+// Returns:
+//   - string: Host pre-update command or empty if unset.
+func (c *Container) GetLifecycleHostPreUpdateCommand() string {
+	return c.getLabelValueOrEmpty(hostPreUpdateLabel)
+}
+
 // GetLifecyclePostUpdateCommand returns the post-update command from labels.
 //
 // Returns:
 //   - string: Post-update command or empty if unset.
 func (c *Container) GetLifecyclePostUpdateCommand() string {
 	return c.getLabelValueOrEmpty(postUpdateLabel)
+}
+
+// GetLifecycleHostPostUpdateCommand returns the host post-update command from labels.
+//
+// Unlike the post-update command, this command is intended to be executed on the
+// Watchtower host (the process running Watchtower) rather than inside the container.
+//
+// Returns:
+//   - string: Host post-update command or empty if unset.
+func (c *Container) GetLifecycleHostPostUpdateCommand() string {
+	return c.getLabelValueOrEmpty(hostPostUpdateLabel)
 }
 
 // PreUpdateTimeout returns the pre-update command timeout in minutes.

--- a/pkg/container/metadata.go
+++ b/pkg/container/metadata.go
@@ -43,6 +43,9 @@ const (
 const (
 	// preCheckLabel specifies a command to run before checking for updates.
 	preCheckLabel = "com.centurylinklabs.watchtower.lifecycle.pre-check"
+	// hostPreCheckLabel specifies a command to run on the Watchtower host (rather than
+	// inside the container) before checking for updates.
+	hostPreCheckLabel = "com.centurylinklabs.watchtower.lifecycle.host-pre-check"
 	// postCheckLabel specifies a command to run after checking for updates.
 	postCheckLabel = "com.centurylinklabs.watchtower.lifecycle.post-check"
 	// preUpdateLabel specifies a command to run before updating the container.
@@ -65,6 +68,17 @@ const (
 //   - string: Pre-check command or empty if unset.
 func (c *Container) GetLifecyclePreCheckCommand() string {
 	return c.getLabelValueOrEmpty(preCheckLabel)
+}
+
+// GetLifecycleHostPreCheckCommand returns the host pre-check command from labels.
+//
+// Unlike the pre-check command, this command is intended to be executed on the
+// Watchtower host (the process running Watchtower) rather than inside the container.
+//
+// Returns:
+//   - string: Host pre-check command or empty if unset.
+func (c *Container) GetLifecycleHostPreCheckCommand() string {
+	return c.getLabelValueOrEmpty(hostPreCheckLabel)
 }
 
 // GetLifecyclePostCheckCommand returns the post-check command from labels.

--- a/pkg/container/metadata_test.go
+++ b/pkg/container/metadata_test.go
@@ -54,6 +54,48 @@ func TestContainer_GetLifecyclePreCheckCommand(t *testing.T) {
 	}
 }
 
+func TestContainer_GetLifecycleHostPreCheckCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		c    *Container
+		want string
+	}{
+		{
+			name: "HostPreCheckLabelSet",
+			c: &Container{
+				containerInfo: &dockerContainer.InspectResponse{
+					Name: "/test-container",
+					Config: &dockerContainer.Config{
+						Labels: map[string]string{
+							hostPreCheckLabel: "echo host-pre-check",
+						},
+					},
+				},
+			},
+			want: "echo host-pre-check",
+		},
+		{
+			name: "HostPreCheckLabelNotSet",
+			c: &Container{
+				containerInfo: &dockerContainer.InspectResponse{
+					Name: "/test-container",
+					Config: &dockerContainer.Config{
+						Labels: map[string]string{},
+					},
+				},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.c.GetLifecycleHostPreCheckCommand()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestContainer_GetLifecyclePostCheckCommand(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/container/metadata_test.go
+++ b/pkg/container/metadata_test.go
@@ -306,6 +306,48 @@ func TestContainer_GetLifecycleHostPreUpdateCommand(t *testing.T) {
 	}
 }
 
+func TestContainer_GetLifecycleHostPreStartCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		c    *Container
+		want string
+	}{
+		{
+			name: "HostPreStartLabelSet",
+			c: &Container{
+				containerInfo: &dockerContainer.InspectResponse{
+					Name: "/test-container",
+					Config: &dockerContainer.Config{
+						Labels: map[string]string{
+							hostPreStartLabel: "echo host-pre-start",
+						},
+					},
+				},
+			},
+			want: "echo host-pre-start",
+		},
+		{
+			name: "HostPreStartLabelNotSet",
+			c: &Container{
+				containerInfo: &dockerContainer.InspectResponse{
+					Name: "/test-container",
+					Config: &dockerContainer.Config{
+						Labels: map[string]string{},
+					},
+				},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.c.GetLifecycleHostPreStartCommand()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestContainer_GetLifecycleHostPostUpdateCommand(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/container/metadata_test.go
+++ b/pkg/container/metadata_test.go
@@ -222,6 +222,132 @@ func TestContainer_GetLifecyclePostUpdateCommand(t *testing.T) {
 	}
 }
 
+func TestContainer_GetLifecycleHostPostCheckCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		c    *Container
+		want string
+	}{
+		{
+			name: "HostPostCheckLabelSet",
+			c: &Container{
+				containerInfo: &dockerContainer.InspectResponse{
+					Name: "/test-container",
+					Config: &dockerContainer.Config{
+						Labels: map[string]string{
+							hostPostCheckLabel: "echo host-post-check",
+						},
+					},
+				},
+			},
+			want: "echo host-post-check",
+		},
+		{
+			name: "HostPostCheckLabelNotSet",
+			c: &Container{
+				containerInfo: &dockerContainer.InspectResponse{
+					Name: "/test-container",
+					Config: &dockerContainer.Config{
+						Labels: map[string]string{},
+					},
+				},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.c.GetLifecycleHostPostCheckCommand()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestContainer_GetLifecycleHostPreUpdateCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		c    *Container
+		want string
+	}{
+		{
+			name: "HostPreUpdateLabelSet",
+			c: &Container{
+				containerInfo: &dockerContainer.InspectResponse{
+					Name: "/test-container",
+					Config: &dockerContainer.Config{
+						Labels: map[string]string{
+							hostPreUpdateLabel: "echo host-pre-update",
+						},
+					},
+				},
+			},
+			want: "echo host-pre-update",
+		},
+		{
+			name: "HostPreUpdateLabelNotSet",
+			c: &Container{
+				containerInfo: &dockerContainer.InspectResponse{
+					Name: "/test-container",
+					Config: &dockerContainer.Config{
+						Labels: map[string]string{},
+					},
+				},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.c.GetLifecycleHostPreUpdateCommand()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestContainer_GetLifecycleHostPostUpdateCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		c    *Container
+		want string
+	}{
+		{
+			name: "HostPostUpdateLabelSet",
+			c: &Container{
+				containerInfo: &dockerContainer.InspectResponse{
+					Name: "/test-container",
+					Config: &dockerContainer.Config{
+						Labels: map[string]string{
+							hostPostUpdateLabel: "echo host-post-update",
+						},
+					},
+				},
+			},
+			want: "echo host-post-update",
+		},
+		{
+			name: "HostPostUpdateLabelNotSet",
+			c: &Container{
+				containerInfo: &dockerContainer.InspectResponse{
+					Name: "/test-container",
+					Config: &dockerContainer.Config{
+						Labels: map[string]string{},
+					},
+				},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.c.GetLifecycleHostPostUpdateCommand()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestContainer_PreUpdateTimeout(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/container/mocks/Client.go
+++ b/pkg/container/mocks/Client.go
@@ -1040,6 +1040,63 @@ func (_c *MockClient_StopAndRemoveContainer_Call) RunAndReturn(run func(ctx cont
 	return _c
 }
 
+// RemoveStoppedContainer provides a mock function for the type MockClient
+func (_mock *MockClient) RemoveStoppedContainer(ctx context.Context, container types.Container) error {
+	ret := _mock.Called(ctx, container)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveStoppedContainer")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, types.Container) error); ok {
+		r0 = returnFunc(ctx, container)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockClient_RemoveStoppedContainer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveStoppedContainer'
+type MockClient_RemoveStoppedContainer_Call struct {
+	*mock.Call
+}
+
+// RemoveStoppedContainer is a helper method to define mock.On call
+//   - ctx context.Context
+//   - container types.Container
+func (_e *MockClient_Expecter) RemoveStoppedContainer(ctx interface{}, container interface{}) *MockClient_RemoveStoppedContainer_Call {
+	return &MockClient_RemoveStoppedContainer_Call{Call: _e.mock.On("RemoveStoppedContainer", ctx, container)}
+}
+
+func (_c *MockClient_RemoveStoppedContainer_Call) Run(run func(ctx context.Context, container types.Container)) *MockClient_RemoveStoppedContainer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 types.Container
+		if args[1] != nil {
+			arg1 = args[1].(types.Container)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_RemoveStoppedContainer_Call) Return(err error) *MockClient_RemoveStoppedContainer_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockClient_RemoveStoppedContainer_Call) RunAndReturn(run func(ctx context.Context, container types.Container) error) *MockClient_RemoveStoppedContainer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // StopContainer provides a mock function for the type MockClient
 func (_mock *MockClient) StopContainer(ctx context.Context, container types.Container, timeout time.Duration) error {
 	ret := _mock.Called(ctx, container, timeout)

--- a/pkg/lifecycle/doc.go
+++ b/pkg/lifecycle/doc.go
@@ -1,5 +1,7 @@
 // Package lifecycle manages execution of lifecycle hooks for Watchtower containers.
-// It runs pre-check, post-check, pre-update, and post-update commands during updates.
+// It runs pre-check, post-check, pre-update, and post-update commands during updates,
+// as well as host-side hooks (e.g. host-pre-check) that execute on the Watchtower host
+// rather than inside the monitored container.
 //
 // Key components:
 //   - Execute Functions: Handle lifecycle hook execution (e.g., ExecutePreUpdateCommand).

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -20,7 +20,13 @@ const checkCommandTimeout = 1
 var (
 	// errPreUpdateFailed indicates a failure in executing the pre-update command.
 	errPreUpdateFailed = errors.New("pre-update command execution failed")
+	// errHostCommandFailed indicates a host lifecycle command exited non-zero.
+	errHostCommandFailed = errors.New("host command execution failed")
 )
+
+// exTempFail is the exit code (EX_TEMPFAIL) a host pre-update command can return to
+// signal that this container's update should be skipped without aborting the cycle.
+const exTempFail = 75
 
 // ExecutePreChecks runs pre-check lifecycle hooks for filtered containers.
 //
@@ -76,6 +82,7 @@ func ExecutePostChecks(ctx context.Context, client container.Client, params type
 	clog.WithField("count", len(containers)).Debug("Found containers for post-checks")
 
 	for _, currentContainer := range containers {
+		ExecuteHostPostCheckCommand(ctx, currentContainer)
 		ExecutePostCheckCommand(ctx, client, currentContainer, uid, gid)
 	}
 }
@@ -146,14 +153,26 @@ func ExecuteHostPreCheckCommand(ctx context.Context, container types.Container) 
 	// as in-container check commands (1 minute).
 	clog.WithField("command", command).Debug("Executing host pre-check command")
 
-	env := []string{
+	if _, err := executeHostCommand(ctx, command, checkCommandTimeout, hostCommandEnv(container)); err != nil {
+		clog.WithError(err).Debug("Host pre-check command failed")
+	}
+}
+
+// hostCommandEnv builds the environment variables exposed to host lifecycle commands.
+//
+// These mirror the fields of the in-container WT_CONTAINER metadata that are
+// meaningful on the host, exposed as discrete variables.
+//
+// Parameters:
+//   - container: Container the command is being run for.
+//
+// Returns:
+//   - []string: Environment variables in "KEY=value" form.
+func hostCommandEnv(container types.Container) []string {
+	return []string{
 		"WT_CONTAINER_NAME=" + container.Name(),
 		"WT_CONTAINER_ID=" + string(container.ID()),
 		"WT_CONTAINER_IMAGE_NAME=" + container.ImageName(),
-	}
-
-	if err := executeHostCommand(ctx, command, checkCommandTimeout, env); err != nil {
-		clog.WithError(err).Debug("Host pre-check command failed")
 	}
 }
 
@@ -166,8 +185,10 @@ func ExecuteHostPreCheckCommand(ctx context.Context, container types.Container) 
 //   - env: Additional environment variables (appended to the host environment).
 //
 // Returns:
-//   - error: Non-nil if the command fails or times out, nil on success.
-func executeHostCommand(ctx context.Context, command string, timeout int, env []string) error {
+//   - bool: True if the command signalled a skip via exit code 75 (EX_TEMPFAIL).
+//   - error: Non-nil if the command exits non-zero (other than 75), fails to start,
+//     or times out; nil on success.
+func executeHostCommand(ctx context.Context, command string, timeout int, env []string) (bool, error) {
 	// Apply a timeout when configured, otherwise inherit the parent context.
 	if timeout > 0 {
 		var cancel context.CancelFunc
@@ -184,11 +205,27 @@ func executeHostCommand(ctx context.Context, command string, timeout int, env []
 		logrus.WithField("output", string(output)).Debug("Host command output")
 	}
 
-	if err != nil {
-		return fmt.Errorf("host command execution failed: %w", err)
+	if err == nil {
+		return false, nil
 	}
 
-	return nil
+	// Inspect the exit code when the command ran but exited non-zero.
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if exitErr.ExitCode() == exTempFail {
+			return true, nil // Skip update on temporary failure.
+		}
+
+		return false, fmt.Errorf(
+			"%w with exit code %d: %s",
+			errHostCommandFailed,
+			exitErr.ExitCode(),
+			string(output),
+		)
+	}
+
+	// Command failed to start or the context was cancelled/timed out.
+	return false, fmt.Errorf("%w: %w", errHostCommandFailed, err)
 }
 
 // ExecutePostCheckCommand executes the post-check hook for a container.
@@ -229,6 +266,36 @@ func ExecutePostCheckCommand(ctx context.Context, client container.Client, conta
 	_, err := client.ExecuteCommand(ctx, container, command, checkCommandTimeout, effectiveUID, effectiveGID)
 	if err != nil {
 		clog.WithError(err).Debug("Post-check command failed")
+	}
+}
+
+// ExecuteHostPostCheckCommand executes the host post-check hook for a container.
+//
+// Unlike ExecutePostCheckCommand, the command runs on the Watchtower host (the
+// process running Watchtower) instead of inside the container. The triggering
+// container's name, ID, and image are exposed to the command via environment
+// variables (WT_CONTAINER_NAME, WT_CONTAINER_ID, WT_CONTAINER_IMAGE_NAME).
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeout.
+//   - container: Container to process.
+func ExecuteHostPostCheckCommand(ctx context.Context, container types.Container) {
+	clog := logrus.WithField("container", container.Name())
+	command := container.GetLifecycleHostPostCheckCommand()
+
+	// Skip if no command is set.
+	if len(command) == 0 {
+		clog.Debug("No host post-check command supplied. Skipping")
+
+		return
+	}
+
+	// Host check commands are lightweight and use the same fixed short timeout
+	// as in-container check commands (1 minute).
+	clog.WithField("command", command).Debug("Executing host post-check command")
+
+	if _, err := executeHostCommand(ctx, command, checkCommandTimeout, hostCommandEnv(container)); err != nil {
+		clog.WithError(err).Debug("Host post-check command failed")
 	}
 }
 
@@ -305,6 +372,59 @@ func ExecutePreUpdateCommand(
 	return success, nil
 }
 
+// ExecuteHostPreUpdateCommand executes the host pre-update hook for a container.
+//
+// Unlike ExecutePreUpdateCommand, the command runs on the Watchtower host (the
+// process running Watchtower) instead of inside the container, so it executes
+// regardless of whether the container is currently running. It honours the same
+// exit-code semantics as the in-container pre-update hook: exit code 75
+// (EX_TEMPFAIL) requests skipping this container's update, while any other
+// non-zero exit aborts the update. The triggering container's name, ID, and
+// image are exposed via WT_CONTAINER_NAME, WT_CONTAINER_ID, and
+// WT_CONTAINER_IMAGE_NAME environment variables.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeout.
+//   - container: Container to process.
+//
+// Returns:
+//   - bool: True if the update should be skipped (exit code 75).
+//   - error: Non-nil if execution fails, nil otherwise.
+func ExecuteHostPreUpdateCommand(ctx context.Context, container types.Container) (bool, error) {
+	timeout := container.PreUpdateTimeout()
+	command := container.GetLifecycleHostPreUpdateCommand()
+	clog := logrus.WithFields(logrus.Fields{
+		"container": container.Name(),
+		"timeout":   timeout,
+	})
+
+	// Skip if no command is set.
+	if len(command) == 0 {
+		clog.Debug("No host pre-update command supplied. Skipping")
+
+		return false, nil
+	}
+
+	// Execute command with configured timeout.
+	clog.WithField("command", command).Debug("Executing host pre-update command")
+
+	skipUpdate, err := executeHostCommand(ctx, command, timeout, hostCommandEnv(container))
+	if err != nil {
+		clog.WithError(err).Debug("Host pre-update command failed")
+
+		return false, fmt.Errorf(
+			"%w for container %s: %w",
+			errPreUpdateFailed,
+			container.Name(),
+			err,
+		)
+	}
+
+	clog.WithField("skip_update", skipUpdate).Debug("Host pre-update command executed")
+
+	return skipUpdate, nil
+}
+
 // ExecutePostUpdateCommand executes the post-update hook for a container.
 //
 // Parameters:
@@ -364,5 +484,55 @@ func ExecutePostUpdateCommand(
 		clog.WithError(err).WithFields(logrus.Fields{
 			"container_id": newContainerID.ShortID(),
 		}).Debug("Post-update command failed")
+	}
+}
+
+// ExecuteHostPostUpdateCommand executes the host post-update hook for a container.
+//
+// Unlike ExecutePostUpdateCommand, the command runs on the Watchtower host (the
+// process running Watchtower) instead of inside the updated container. The updated
+// container's name, ID, and image are exposed to the command via environment
+// variables (WT_CONTAINER_NAME, WT_CONTAINER_ID, WT_CONTAINER_IMAGE_NAME).
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeout.
+//   - client: Container client used to resolve the updated container.
+//   - newContainerID: ID of the updated container.
+func ExecuteHostPostUpdateCommand(
+	ctx context.Context,
+	client container.Client,
+	newContainerID types.ContainerID,
+) {
+	clog := logrus.WithField("container_id", newContainerID.ShortID())
+	clog.Debug("Retrieving container for host post-update")
+
+	// Retrieve container by ID.
+	newContainer, err := client.GetContainer(ctx, newContainerID)
+	if err != nil {
+		clog.WithError(err).Debug("Failed to get container for host post-update")
+
+		return
+	}
+
+	timeout := newContainer.PostUpdateTimeout()
+	clog = logrus.WithFields(logrus.Fields{
+		"container": newContainer.Name(),
+		"timeout":   timeout,
+	})
+	command := newContainer.GetLifecycleHostPostUpdateCommand()
+
+	// Skip if no command is set.
+	if len(command) == 0 {
+		clog.Debug("No host post-update command supplied. Skipping")
+
+		return
+	}
+
+	// Execute command with configured timeout.
+	clog.WithField("command", command).Debug("Executing host post-update command")
+
+	if _, err := executeHostCommand(ctx, command, timeout, hostCommandEnv(newContainer)); err != nil {
+		clog.WithError(err).WithField("container_id", newContainerID.ShortID()).
+			Debug("Host post-update command failed")
 	}
 }

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -22,6 +22,7 @@ const (
 	hookTypePreCheck   = "pre-check"
 	hookTypePostCheck  = "post-check"
 	hookTypePreUpdate  = "pre-update"
+	hookTypePreStart   = "pre-start"
 	hookTypePostUpdate = "post-update"
 )
 
@@ -435,6 +436,45 @@ func ExecuteHostPreUpdateCommand(ctx context.Context, container types.Container)
 	clog.WithField("skip_update", skipUpdate).Debug("Host pre-update command executed")
 
 	return skipUpdate, nil
+}
+
+// ExecuteHostPreStartCommand executes the host pre-start hook for a container.
+//
+// The command runs on the Watchtower host (the process running Watchtower) after the
+// old container has been stopped and removed but before the new container is started.
+// Because the container is not running at this point, this hook is host-only and has
+// no in-container counterpart; it is well suited to backing up volumes while they are
+// idle. The triggering container's name, ID, and image are exposed via
+// WT_CONTAINER_NAME, WT_CONTAINER_ID, and WT_CONTAINER_IMAGE_NAME environment
+// variables.
+//
+// A non-zero exit code is logged but does not abort the restart, since the old
+// container is already gone and should not be left stopped.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeout.
+//   - container: Container to process.
+func ExecuteHostPreStartCommand(ctx context.Context, container types.Container) {
+	timeout := container.PreUpdateTimeout()
+	command := container.GetLifecycleHostPreStartCommand()
+	clog := logrus.WithFields(logrus.Fields{
+		"container": container.Name(),
+		"timeout":   timeout,
+	})
+
+	// Skip if no command is set.
+	if len(command) == 0 {
+		clog.Debug("No host pre-start command supplied. Skipping")
+
+		return
+	}
+
+	// Execute command with the pre-update timeout, as backups may be long-running.
+	clog.WithField("command", command).Debug("Executing host pre-start command")
+
+	if _, err := executeHostCommand(ctx, command, timeout, hostCommandEnv(container, hookTypePreStart)); err != nil {
+		clog.WithError(err).Debug("Host pre-start command failed")
+	}
 }
 
 // ExecutePostUpdateCommand executes the post-update hook for a container.

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -441,15 +441,16 @@ func ExecuteHostPreUpdateCommand(ctx context.Context, container types.Container)
 // ExecuteHostPreStartCommand executes the host pre-start hook for a container.
 //
 // The command runs on the Watchtower host (the process running Watchtower) after the
-// old container has been stopped and removed but before the new container is started.
-// Because the container is not running at this point, this hook is host-only and has
-// no in-container counterpart; it is well suited to backing up volumes while they are
-// idle. The triggering container's name, ID, and image are exposed via
-// WT_CONTAINER_NAME, WT_CONTAINER_ID, and WT_CONTAINER_IMAGE_NAME environment
-// variables.
+// old container has been stopped but before it is removed and the new container is
+// started. Because the container is stopped yet still present at this point, the hook
+// can inspect it (e.g. `docker inspect` to resolve volumes) while no process is writing
+// to its data — making it well suited to backing up volumes. This hook is host-only and
+// has no in-container counterpart, as the container is not running. The triggering
+// container's name, ID, and image are exposed via WT_CONTAINER_NAME, WT_CONTAINER_ID,
+// and WT_CONTAINER_IMAGE_NAME environment variables.
 //
-// A non-zero exit code is logged but does not abort the restart, since the old
-// container is already gone and should not be left stopped.
+// A non-zero exit code is logged but does not abort the restart, to avoid leaving the
+// service down because, for example, a backup failed.
 //
 // Parameters:
 //   - ctx: Context for cancellation and timeout.

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os/exec"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -46,6 +48,7 @@ func ExecutePreChecks(ctx context.Context, client container.Client, params types
 	clog.WithField("count", len(containers)).Debug("Found containers for pre-checks")
 
 	for _, currentContainer := range containers {
+		ExecuteHostPreCheckCommand(ctx, currentContainer)
 		ExecutePreCheckCommand(ctx, client, currentContainer, uid, gid)
 	}
 }
@@ -116,6 +119,76 @@ func ExecutePreCheckCommand(ctx context.Context, client container.Client, contai
 	if err != nil {
 		clog.WithError(err).Debug("Pre-check command failed")
 	}
+}
+
+// ExecuteHostPreCheckCommand executes the host pre-check hook for a container.
+//
+// Unlike ExecutePreCheckCommand, the command runs on the Watchtower host (the
+// process running Watchtower) instead of inside the container. The triggering
+// container's name, ID, and image are exposed to the command via environment
+// variables (WT_CONTAINER_NAME, WT_CONTAINER_ID, WT_CONTAINER_IMAGE_NAME).
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeout.
+//   - container: Container to process.
+func ExecuteHostPreCheckCommand(ctx context.Context, container types.Container) {
+	clog := logrus.WithField("container", container.Name())
+	command := container.GetLifecycleHostPreCheckCommand()
+
+	// Skip if no command is set.
+	if len(command) == 0 {
+		clog.Debug("No host pre-check command supplied. Skipping")
+
+		return
+	}
+
+	// Host check commands are lightweight and use the same fixed short timeout
+	// as in-container check commands (1 minute).
+	clog.WithField("command", command).Debug("Executing host pre-check command")
+
+	env := []string{
+		"WT_CONTAINER_NAME=" + container.Name(),
+		"WT_CONTAINER_ID=" + string(container.ID()),
+		"WT_CONTAINER_IMAGE_NAME=" + container.ImageName(),
+	}
+
+	if err := executeHostCommand(ctx, command, checkCommandTimeout, env); err != nil {
+		clog.WithError(err).Debug("Host pre-check command failed")
+	}
+}
+
+// executeHostCommand runs a shell command on the Watchtower host.
+//
+// Parameters:
+//   - ctx: Context for cancellation.
+//   - command: Command to execute via "sh -c".
+//   - timeout: Minutes to wait before timeout (0 for no timeout).
+//   - env: Additional environment variables (appended to the host environment).
+//
+// Returns:
+//   - error: Non-nil if the command fails or times out, nil on success.
+func executeHostCommand(ctx context.Context, command string, timeout int, env []string) error {
+	// Apply a timeout when configured, otherwise inherit the parent context.
+	if timeout > 0 {
+		var cancel context.CancelFunc
+
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Minute)
+		defer cancel()
+	}
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	cmd.Env = append(cmd.Environ(), env...)
+
+	output, err := cmd.CombinedOutput()
+	if len(output) > 0 {
+		logrus.WithField("output", string(output)).Debug("Host command output")
+	}
+
+	if err != nil {
+		return fmt.Errorf("host command execution failed: %w", err)
+	}
+
+	return nil
 }
 
 // ExecutePostCheckCommand executes the post-check hook for a container.

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -16,6 +16,15 @@ import (
 // checkCommandTimeout is the timeout in minutes for check commands (pre/post check hooks).
 const checkCommandTimeout = 1
 
+// Hook type identifiers exposed to host commands via the WT_HOOK_TYPE environment
+// variable, allowing a single script to branch on the phase that triggered it.
+const (
+	hookTypePreCheck   = "pre-check"
+	hookTypePostCheck  = "post-check"
+	hookTypePreUpdate  = "pre-update"
+	hookTypePostUpdate = "post-update"
+)
+
 // Errors for lifecycle hook execution.
 var (
 	// errPreUpdateFailed indicates a failure in executing the pre-update command.
@@ -153,7 +162,7 @@ func ExecuteHostPreCheckCommand(ctx context.Context, container types.Container) 
 	// as in-container check commands (1 minute).
 	clog.WithField("command", command).Debug("Executing host pre-check command")
 
-	if _, err := executeHostCommand(ctx, command, checkCommandTimeout, hostCommandEnv(container)); err != nil {
+	if _, err := executeHostCommand(ctx, command, checkCommandTimeout, hostCommandEnv(container, hookTypePreCheck)); err != nil {
 		clog.WithError(err).Debug("Host pre-check command failed")
 	}
 }
@@ -161,18 +170,21 @@ func ExecuteHostPreCheckCommand(ctx context.Context, container types.Container) 
 // hostCommandEnv builds the environment variables exposed to host lifecycle commands.
 //
 // These mirror the fields of the in-container WT_CONTAINER metadata that are
-// meaningful on the host, exposed as discrete variables.
+// meaningful on the host, exposed as discrete variables, plus WT_HOOK_TYPE
+// identifying the lifecycle phase that triggered the command.
 //
 // Parameters:
 //   - container: Container the command is being run for.
+//   - hookType: Lifecycle phase identifier (e.g. "pre-check", "post-update").
 //
 // Returns:
 //   - []string: Environment variables in "KEY=value" form.
-func hostCommandEnv(container types.Container) []string {
+func hostCommandEnv(container types.Container, hookType string) []string {
 	return []string{
 		"WT_CONTAINER_NAME=" + container.Name(),
 		"WT_CONTAINER_ID=" + string(container.ID()),
 		"WT_CONTAINER_IMAGE_NAME=" + container.ImageName(),
+		"WT_HOOK_TYPE=" + hookType,
 	}
 }
 
@@ -294,7 +306,7 @@ func ExecuteHostPostCheckCommand(ctx context.Context, container types.Container)
 	// as in-container check commands (1 minute).
 	clog.WithField("command", command).Debug("Executing host post-check command")
 
-	if _, err := executeHostCommand(ctx, command, checkCommandTimeout, hostCommandEnv(container)); err != nil {
+	if _, err := executeHostCommand(ctx, command, checkCommandTimeout, hostCommandEnv(container, hookTypePostCheck)); err != nil {
 		clog.WithError(err).Debug("Host post-check command failed")
 	}
 }
@@ -408,7 +420,7 @@ func ExecuteHostPreUpdateCommand(ctx context.Context, container types.Container)
 	// Execute command with configured timeout.
 	clog.WithField("command", command).Debug("Executing host pre-update command")
 
-	skipUpdate, err := executeHostCommand(ctx, command, timeout, hostCommandEnv(container))
+	skipUpdate, err := executeHostCommand(ctx, command, timeout, hostCommandEnv(container, hookTypePreUpdate))
 	if err != nil {
 		clog.WithError(err).Debug("Host pre-update command failed")
 
@@ -531,7 +543,7 @@ func ExecuteHostPostUpdateCommand(
 	// Execute command with configured timeout.
 	clog.WithField("command", command).Debug("Executing host post-update command")
 
-	if _, err := executeHostCommand(ctx, command, timeout, hostCommandEnv(newContainer)); err != nil {
+	if _, err := executeHostCommand(ctx, command, timeout, hostCommandEnv(newContainer, hookTypePostUpdate)); err != nil {
 		clog.WithError(err).WithField("container_id", newContainerID.ShortID()).
 			Debug("Host post-update command failed")
 	}

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -81,7 +82,7 @@ func TestExecutePreChecks(t *testing.T) {
 				c.On("ExecuteCommand", mock.Anything, mock.Anything, "pre-check", 1, 0, 0).
 					Return(true, nil)
 			},
-			expectedLogs:   13, // Listing, Found, UID not found x2, UID not set x2, GID not found x2, GID not set x2, Execute, Label not found, Skip
+			expectedLogs:   17, // Listing, Found, host-pre-check label not found x2 + skip x2, UID not found x2, UID not set x2, GID not found x2, GID not set x2, Execute, Label not found, Skip
 			expectedLogMsg: "Listing containers for pre-checks",
 		},
 		{
@@ -278,6 +279,60 @@ func TestExecutePreCheckCommand(t *testing.T) {
 					tt.expectedLogMsg,
 				)
 			}
+
+			hook.Reset()
+		})
+	}
+}
+
+// TestExecuteHostPreCheckCommand tests the ExecuteHostPreCheckCommand function.
+func TestExecuteHostPreCheckCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		container      types.Container
+		expectedLogMsg string
+	}{
+		{
+			name:           "no command",
+			container:      mockedContainer(),
+			expectedLogMsg: "No host pre-check command supplied",
+		},
+		{
+			name: "command succeeds",
+			container: mockedContainer(withLabels(map[string]string{
+				"com.centurylinklabs.watchtower.lifecycle.host-pre-check": "true",
+			})),
+			expectedLogMsg: "Executing host pre-check command",
+		},
+		{
+			name: "command fails",
+			container: mockedContainer(withLabels(map[string]string{
+				"com.centurylinklabs.watchtower.lifecycle.host-pre-check": "exit 1",
+			})),
+			expectedLogMsg: "Host pre-check command failed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := test.NewGlobal()
+
+			logrus.SetLevel(logrus.DebugLevel)
+			hook.Reset()
+
+			ExecuteHostPreCheckCommand(context.Background(), tt.container)
+
+			require.NotEmpty(t, hook.Entries, "expected at least one log entry")
+
+			found := false
+			for _, entry := range hook.Entries {
+				if strings.Contains(entry.Message, tt.expectedLogMsg) {
+					found = true
+
+					break
+				}
+			}
+
+			assert.True(t, found, "expected a log entry containing %q", tt.expectedLogMsg)
 
 			hook.Reset()
 		})

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -457,6 +457,49 @@ func TestExecuteHostPreUpdateCommand(t *testing.T) {
 	}
 }
 
+// TestExecuteHostPreStartCommand tests the ExecuteHostPreStartCommand function.
+func TestExecuteHostPreStartCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		container      types.Container
+		expectedLogMsg string
+	}{
+		{
+			name:           "no command",
+			container:      mockedContainer(),
+			expectedLogMsg: "No host pre-start command supplied",
+		},
+		{
+			name: "command succeeds",
+			container: mockedContainer(withLabels(map[string]string{
+				"com.centurylinklabs.watchtower.lifecycle.host-pre-start": "true",
+			})),
+			expectedLogMsg: "Executing host pre-start command",
+		},
+		{
+			name: "command fails",
+			container: mockedContainer(withLabels(map[string]string{
+				"com.centurylinklabs.watchtower.lifecycle.host-pre-start": "exit 1",
+			})),
+			expectedLogMsg: "Host pre-start command failed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := test.NewGlobal()
+
+			logrus.SetLevel(logrus.DebugLevel)
+			hook.Reset()
+
+			ExecuteHostPreStartCommand(context.Background(), tt.container)
+
+			assertLogContains(t, hook.Entries, tt.expectedLogMsg)
+
+			hook.Reset()
+		})
+	}
+}
+
 // TestExecuteHostPostUpdateCommand tests the ExecuteHostPostUpdateCommand function.
 func TestExecuteHostPostUpdateCommand(t *testing.T) {
 	tests := []struct {

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -56,6 +56,21 @@ func withContainerState(state dockerContainer.State) func(*container.Container) 
 	}
 }
 
+// assertLogContains asserts that at least one log entry contains the given message.
+func assertLogContains(t *testing.T, entries []logrus.Entry, msg string) {
+	t.Helper()
+
+	require.NotEmpty(t, entries, "expected at least one log entry")
+
+	for _, entry := range entries {
+		if strings.Contains(entry.Message, msg) {
+			return
+		}
+	}
+
+	t.Errorf("expected a log entry containing %q", msg)
+}
+
 var (
 	errListingFailed = errors.New("listing failed")
 	errExecFailed    = errors.New("exec failed")
@@ -153,7 +168,7 @@ func TestExecutePostChecks(t *testing.T) {
 				c.On("ExecuteCommand", mock.Anything, mock.Anything, "post-check", 1, 0, 0).
 					Return(true, nil)
 			},
-			expectedLogs:   13, // Listing, Found, UID not found x2, UID not set x2, GID not found x2, GID not set x2, Execute, Label not found, Skip
+			expectedLogs:   17, // Listing, Found, host-post-check label not found x2 + skip x2, UID not found x2, UID not set x2, GID not found x2, GID not set x2, Execute, Label not found, Skip
 			expectedLogMsg: "Listing containers for post-checks",
 		},
 		{
@@ -321,18 +336,172 @@ func TestExecuteHostPreCheckCommand(t *testing.T) {
 
 			ExecuteHostPreCheckCommand(context.Background(), tt.container)
 
-			require.NotEmpty(t, hook.Entries, "expected at least one log entry")
+			assertLogContains(t, hook.Entries, tt.expectedLogMsg)
 
-			found := false
-			for _, entry := range hook.Entries {
-				if strings.Contains(entry.Message, tt.expectedLogMsg) {
-					found = true
+			hook.Reset()
+		})
+	}
+}
 
-					break
-				}
+// TestExecuteHostPostCheckCommand tests the ExecuteHostPostCheckCommand function.
+func TestExecuteHostPostCheckCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		container      types.Container
+		expectedLogMsg string
+	}{
+		{
+			name:           "no command",
+			container:      mockedContainer(),
+			expectedLogMsg: "No host post-check command supplied",
+		},
+		{
+			name: "command succeeds",
+			container: mockedContainer(withLabels(map[string]string{
+				"com.centurylinklabs.watchtower.lifecycle.host-post-check": "true",
+			})),
+			expectedLogMsg: "Executing host post-check command",
+		},
+		{
+			name: "command fails",
+			container: mockedContainer(withLabels(map[string]string{
+				"com.centurylinklabs.watchtower.lifecycle.host-post-check": "exit 1",
+			})),
+			expectedLogMsg: "Host post-check command failed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := test.NewGlobal()
+
+			logrus.SetLevel(logrus.DebugLevel)
+			hook.Reset()
+
+			ExecuteHostPostCheckCommand(context.Background(), tt.container)
+
+			assertLogContains(t, hook.Entries, tt.expectedLogMsg)
+
+			hook.Reset()
+		})
+	}
+}
+
+// TestExecuteHostPreUpdateCommand tests the ExecuteHostPreUpdateCommand function.
+func TestExecuteHostPreUpdateCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		container      types.Container
+		expectedSkip   bool
+		expectError    bool
+		expectedLogMsg string
+	}{
+		{
+			name:           "no command",
+			container:      mockedContainer(),
+			expectedLogMsg: "No host pre-update command supplied",
+		},
+		{
+			name: "command succeeds",
+			container: mockedContainer(withLabels(map[string]string{
+				"com.centurylinklabs.watchtower.lifecycle.host-pre-update": "true",
+			})),
+			expectedLogMsg: "Host pre-update command executed",
+		},
+		{
+			name: "exit code 75 requests skip",
+			container: mockedContainer(withLabels(map[string]string{
+				"com.centurylinklabs.watchtower.lifecycle.host-pre-update": "exit 75",
+			})),
+			expectedSkip:   true,
+			expectedLogMsg: "Host pre-update command executed",
+		},
+		{
+			name: "command fails",
+			container: mockedContainer(withLabels(map[string]string{
+				"com.centurylinklabs.watchtower.lifecycle.host-pre-update": "exit 1",
+			})),
+			expectError:    true,
+			expectedLogMsg: "Host pre-update command failed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := test.NewGlobal()
+
+			logrus.SetLevel(logrus.DebugLevel)
+			hook.Reset()
+
+			skip, err := ExecuteHostPreUpdateCommand(context.Background(), tt.container)
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 
-			assert.True(t, found, "expected a log entry containing %q", tt.expectedLogMsg)
+			assert.Equal(t, tt.expectedSkip, skip)
+			assertLogContains(t, hook.Entries, tt.expectedLogMsg)
+
+			hook.Reset()
+		})
+	}
+}
+
+// TestExecuteHostPostUpdateCommand tests the ExecuteHostPostUpdateCommand function.
+func TestExecuteHostPostUpdateCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupClient    func(*mockContainer.MockClient)
+		expectedLogMsg string
+	}{
+		{
+			name: "command succeeds",
+			setupClient: func(c *mockContainer.MockClient) {
+				c.On("GetContainer", mock.Anything, types.ContainerID("test")).
+					Return(mockedContainer(withLabels(map[string]string{
+						"com.centurylinklabs.watchtower.lifecycle.host-post-update": "true",
+					})), nil)
+			},
+			expectedLogMsg: "Executing host post-update command",
+		},
+		{
+			name: "no command",
+			setupClient: func(c *mockContainer.MockClient) {
+				c.On("GetContainer", mock.Anything, types.ContainerID("test")).Return(mockedContainer(), nil)
+			},
+			expectedLogMsg: "No host post-update command supplied",
+		},
+		{
+			name: "container retrieval error",
+			setupClient: func(c *mockContainer.MockClient) {
+				c.On("GetContainer", mock.Anything, types.ContainerID("test")).Return(nil, errNotFound)
+			},
+			expectedLogMsg: "Failed to get container for host post-update",
+		},
+		{
+			name: "command fails",
+			setupClient: func(c *mockContainer.MockClient) {
+				c.On("GetContainer", mock.Anything, types.ContainerID("test")).
+					Return(mockedContainer(withLabels(map[string]string{
+						"com.centurylinklabs.watchtower.lifecycle.host-post-update": "exit 1",
+					})), nil)
+			},
+			expectedLogMsg: "Host post-update command failed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := test.NewGlobal()
+
+			logrus.SetLevel(logrus.DebugLevel)
+
+			client := mockContainer.NewMockClient(t)
+			tt.setupClient(client)
+			hook.Reset()
+
+			ExecuteHostPostUpdateCommand(context.Background(), client, types.ContainerID("test"))
+
+			assertLogContains(t, hook.Entries, tt.expectedLogMsg)
 
 			hook.Reset()
 		})

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -300,6 +300,16 @@ func TestExecutePreCheckCommand(t *testing.T) {
 	}
 }
 
+// TestHostCommandEnv verifies the environment variables exposed to host hooks,
+// including the WT_HOOK_TYPE phase identifier.
+func TestHostCommandEnv(t *testing.T) {
+	env := hostCommandEnv(mockedContainer(), hookTypePreUpdate)
+
+	assert.Contains(t, env, "WT_CONTAINER_NAME=test-container")
+	assert.Contains(t, env, "WT_CONTAINER_ID=container_id")
+	assert.Contains(t, env, "WT_HOOK_TYPE=pre-update")
+}
+
 // TestExecuteHostPreCheckCommand tests the ExecuteHostPreCheckCommand function.
 func TestExecuteHostPreCheckCommand(t *testing.T) {
 	tests := []struct {

--- a/pkg/registry/auth/auth_test.go
+++ b/pkg/registry/auth/auth_test.go
@@ -126,6 +126,14 @@ func (m mockContainer) GetLifecyclePreCheckCommand() string {
 	return "" // Minimal stub, not used in these tests
 }
 
+// GetLifecycleHostPreCheckCommand returns a string representing the command to run
+// on the Watchtower host before a lifecycle check. This method satisfies the
+// types.Container interface, returning an empty string as a minimal stub since the auth
+// package does not rely on this functionality in these authentication-focused tests.
+func (m mockContainer) GetLifecycleHostPreCheckCommand() string {
+	return "" // Minimal stub, not used in these tests
+}
+
 // GetLifecyclePostCheckCommand returns a string representing the command to run
 // after a lifecycle check (e.g., post-update verification). This method satisfies the
 // types.Container interface, returning an empty string as a minimal stub since the auth

--- a/pkg/registry/auth/auth_test.go
+++ b/pkg/registry/auth/auth_test.go
@@ -166,6 +166,15 @@ func (m mockContainer) GetLifecycleHostPreUpdateCommand() string {
 	return "" // Minimal stub, not used in these tests
 }
 
+// GetLifecycleHostPreStartCommand returns a string representing the command to run
+// on the Watchtower host between stopping the old container and starting the new one.
+// This method satisfies the types.Container interface, returning an empty string as a
+// minimal stub since the auth package does not rely on this functionality in these
+// authentication-focused tests.
+func (m mockContainer) GetLifecycleHostPreStartCommand() string {
+	return "" // Minimal stub, not used in these tests
+}
+
 // GetLifecyclePostUpdateCommand returns a string representing the command to run
 // after a lifecycle update (e.g., post-update actions). This method satisfies the
 // types.Container interface, returning an empty string as a minimal stub since the auth

--- a/pkg/registry/auth/auth_test.go
+++ b/pkg/registry/auth/auth_test.go
@@ -142,6 +142,14 @@ func (m mockContainer) GetLifecyclePostCheckCommand() string {
 	return "" // Minimal stub, not used in these tests
 }
 
+// GetLifecycleHostPostCheckCommand returns a string representing the command to run
+// on the Watchtower host after a lifecycle check. This method satisfies the
+// types.Container interface, returning an empty string as a minimal stub since the auth
+// package does not rely on this functionality in these authentication-focused tests.
+func (m mockContainer) GetLifecycleHostPostCheckCommand() string {
+	return "" // Minimal stub, not used in these tests
+}
+
 // GetLifecyclePreUpdateCommand returns a string representing the command to run
 // before a lifecycle update (e.g., pre-update actions). This method satisfies the
 // types.Container interface, returning an empty string as a minimal stub since the auth
@@ -150,11 +158,27 @@ func (m mockContainer) GetLifecyclePreUpdateCommand() string {
 	return "" // Minimal stub, not used in these tests
 }
 
+// GetLifecycleHostPreUpdateCommand returns a string representing the command to run
+// on the Watchtower host before a lifecycle update. This method satisfies the
+// types.Container interface, returning an empty string as a minimal stub since the auth
+// package does not rely on this functionality in these authentication-focused tests.
+func (m mockContainer) GetLifecycleHostPreUpdateCommand() string {
+	return "" // Minimal stub, not used in these tests
+}
+
 // GetLifecyclePostUpdateCommand returns a string representing the command to run
 // after a lifecycle update (e.g., post-update actions). This method satisfies the
 // types.Container interface, returning an empty string as a minimal stub since the auth
 // package does not rely on this functionality in these authentication-focused tests.
 func (m mockContainer) GetLifecyclePostUpdateCommand() string {
+	return "" // Minimal stub, not used in these tests
+}
+
+// GetLifecycleHostPostUpdateCommand returns a string representing the command to run
+// on the Watchtower host after a lifecycle update. This method satisfies the
+// types.Container interface, returning an empty string as a minimal stub since the auth
+// package does not rely on this functionality in these authentication-focused tests.
+func (m mockContainer) GetLifecycleHostPostUpdateCommand() string {
 	return "" // Minimal stub, not used in these tests
 }
 

--- a/pkg/sorter/mocks/container.go
+++ b/pkg/sorter/mocks/container.go
@@ -104,8 +104,11 @@ func (c *SimpleContainer) ImageInfo() *dockerImage.InspectResponse          { re
 func (c *SimpleContainer) GetLifecyclePreCheckCommand() string              { return "" }
 func (c *SimpleContainer) GetLifecycleHostPreCheckCommand() string          { return "" }
 func (c *SimpleContainer) GetLifecyclePostCheckCommand() string             { return "" }
+func (c *SimpleContainer) GetLifecycleHostPostCheckCommand() string         { return "" }
 func (c *SimpleContainer) GetLifecyclePreUpdateCommand() string             { return "" }
+func (c *SimpleContainer) GetLifecycleHostPreUpdateCommand() string         { return "" }
 func (c *SimpleContainer) GetLifecyclePostUpdateCommand() string            { return "" }
+func (c *SimpleContainer) GetLifecycleHostPostUpdateCommand() string        { return "" }
 func (c *SimpleContainer) GetLifecycleUID() (int, bool)                     { return 0, false }
 func (c *SimpleContainer) GetLifecycleGID() (int, bool)                     { return 0, false }
 func (c *SimpleContainer) GetContainerChain() (string, bool)                { return "", false }

--- a/pkg/sorter/mocks/container.go
+++ b/pkg/sorter/mocks/container.go
@@ -102,6 +102,7 @@ func (c *SimpleContainer) StopTimeout() *int {
 func (c *SimpleContainer) HasImageInfo() bool                               { return false }
 func (c *SimpleContainer) ImageInfo() *dockerImage.InspectResponse          { return nil }
 func (c *SimpleContainer) GetLifecyclePreCheckCommand() string              { return "" }
+func (c *SimpleContainer) GetLifecycleHostPreCheckCommand() string          { return "" }
 func (c *SimpleContainer) GetLifecyclePostCheckCommand() string             { return "" }
 func (c *SimpleContainer) GetLifecyclePreUpdateCommand() string             { return "" }
 func (c *SimpleContainer) GetLifecyclePostUpdateCommand() string            { return "" }

--- a/pkg/sorter/mocks/container.go
+++ b/pkg/sorter/mocks/container.go
@@ -107,6 +107,7 @@ func (c *SimpleContainer) GetLifecyclePostCheckCommand() string             { re
 func (c *SimpleContainer) GetLifecycleHostPostCheckCommand() string         { return "" }
 func (c *SimpleContainer) GetLifecyclePreUpdateCommand() string             { return "" }
 func (c *SimpleContainer) GetLifecycleHostPreUpdateCommand() string         { return "" }
+func (c *SimpleContainer) GetLifecycleHostPreStartCommand() string          { return "" }
 func (c *SimpleContainer) GetLifecyclePostUpdateCommand() string            { return "" }
 func (c *SimpleContainer) GetLifecycleHostPostUpdateCommand() string        { return "" }
 func (c *SimpleContainer) GetLifecycleUID() (int, bool)                     { return 0, false }

--- a/pkg/types/container.go
+++ b/pkg/types/container.go
@@ -34,8 +34,11 @@ type Container interface {
 	GetLifecyclePreCheckCommand() string              // Pre-check command.
 	GetLifecycleHostPreCheckCommand() string          // Host pre-check command (runs on the host).
 	GetLifecyclePostCheckCommand() string             // Post-check command.
+	GetLifecycleHostPostCheckCommand() string         // Host post-check command (runs on the host).
 	GetLifecyclePreUpdateCommand() string             // Pre-update command.
+	GetLifecycleHostPreUpdateCommand() string         // Host pre-update command (runs on the host).
 	GetLifecyclePostUpdateCommand() string            // Post-update command.
+	GetLifecycleHostPostUpdateCommand() string        // Host post-update command (runs on the host).
 	GetLifecycleUID() (int, bool)                     // UID for lifecycle hooks, with presence.
 	GetLifecycleGID() (int, bool)                     // GID for lifecycle hooks, with presence.
 	VerifyConfiguration() error                       // Config validation.

--- a/pkg/types/container.go
+++ b/pkg/types/container.go
@@ -37,6 +37,7 @@ type Container interface {
 	GetLifecycleHostPostCheckCommand() string         // Host post-check command (runs on the host).
 	GetLifecyclePreUpdateCommand() string             // Pre-update command.
 	GetLifecycleHostPreUpdateCommand() string         // Host pre-update command (runs on the host).
+	GetLifecycleHostPreStartCommand() string          // Host pre-start command (runs on the host between stop and start).
 	GetLifecyclePostUpdateCommand() string            // Post-update command.
 	GetLifecycleHostPostUpdateCommand() string        // Host post-update command (runs on the host).
 	GetLifecycleUID() (int, bool)                     // UID for lifecycle hooks, with presence.

--- a/pkg/types/container.go
+++ b/pkg/types/container.go
@@ -32,6 +32,7 @@ type Container interface {
 	HasImageInfo() bool                               // Image metadata presence.
 	ImageInfo() *dockerImage.InspectResponse          // Image metadata.
 	GetLifecyclePreCheckCommand() string              // Pre-check command.
+	GetLifecycleHostPreCheckCommand() string          // Host pre-check command (runs on the host).
 	GetLifecyclePostCheckCommand() string             // Post-check command.
 	GetLifecyclePreUpdateCommand() string             // Pre-update command.
 	GetLifecyclePostUpdateCommand() string            // Post-update command.

--- a/pkg/types/mocks/Container.go
+++ b/pkg/types/mocks/Container.go
@@ -564,6 +564,138 @@ func (_c *MockContainer_GetLifecycleHostPreCheckCommand_Call) RunAndReturn(run f
 	return _c
 }
 
+// GetLifecycleHostPostCheckCommand provides a mock function for the type MockContainer
+func (_mock *MockContainer) GetLifecycleHostPostCheckCommand() string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLifecycleHostPostCheckCommand")
+	}
+
+	var r0 string
+	if returnFunc, ok := ret.Get(0).(func() string); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	return r0
+}
+
+// MockContainer_GetLifecycleHostPostCheckCommand_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLifecycleHostPostCheckCommand'
+type MockContainer_GetLifecycleHostPostCheckCommand_Call struct {
+	*mock.Call
+}
+
+// GetLifecycleHostPostCheckCommand is a helper method to define mock.On call
+func (_e *MockContainer_Expecter) GetLifecycleHostPostCheckCommand() *MockContainer_GetLifecycleHostPostCheckCommand_Call {
+	return &MockContainer_GetLifecycleHostPostCheckCommand_Call{Call: _e.mock.On("GetLifecycleHostPostCheckCommand")}
+}
+
+func (_c *MockContainer_GetLifecycleHostPostCheckCommand_Call) Run(run func()) *MockContainer_GetLifecycleHostPostCheckCommand_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockContainer_GetLifecycleHostPostCheckCommand_Call) Return(s string) *MockContainer_GetLifecycleHostPostCheckCommand_Call {
+	_c.Call.Return(s)
+	return _c
+}
+
+func (_c *MockContainer_GetLifecycleHostPostCheckCommand_Call) RunAndReturn(run func() string) *MockContainer_GetLifecycleHostPostCheckCommand_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetLifecycleHostPreUpdateCommand provides a mock function for the type MockContainer
+func (_mock *MockContainer) GetLifecycleHostPreUpdateCommand() string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLifecycleHostPreUpdateCommand")
+	}
+
+	var r0 string
+	if returnFunc, ok := ret.Get(0).(func() string); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	return r0
+}
+
+// MockContainer_GetLifecycleHostPreUpdateCommand_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLifecycleHostPreUpdateCommand'
+type MockContainer_GetLifecycleHostPreUpdateCommand_Call struct {
+	*mock.Call
+}
+
+// GetLifecycleHostPreUpdateCommand is a helper method to define mock.On call
+func (_e *MockContainer_Expecter) GetLifecycleHostPreUpdateCommand() *MockContainer_GetLifecycleHostPreUpdateCommand_Call {
+	return &MockContainer_GetLifecycleHostPreUpdateCommand_Call{Call: _e.mock.On("GetLifecycleHostPreUpdateCommand")}
+}
+
+func (_c *MockContainer_GetLifecycleHostPreUpdateCommand_Call) Run(run func()) *MockContainer_GetLifecycleHostPreUpdateCommand_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockContainer_GetLifecycleHostPreUpdateCommand_Call) Return(s string) *MockContainer_GetLifecycleHostPreUpdateCommand_Call {
+	_c.Call.Return(s)
+	return _c
+}
+
+func (_c *MockContainer_GetLifecycleHostPreUpdateCommand_Call) RunAndReturn(run func() string) *MockContainer_GetLifecycleHostPreUpdateCommand_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetLifecycleHostPostUpdateCommand provides a mock function for the type MockContainer
+func (_mock *MockContainer) GetLifecycleHostPostUpdateCommand() string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLifecycleHostPostUpdateCommand")
+	}
+
+	var r0 string
+	if returnFunc, ok := ret.Get(0).(func() string); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	return r0
+}
+
+// MockContainer_GetLifecycleHostPostUpdateCommand_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLifecycleHostPostUpdateCommand'
+type MockContainer_GetLifecycleHostPostUpdateCommand_Call struct {
+	*mock.Call
+}
+
+// GetLifecycleHostPostUpdateCommand is a helper method to define mock.On call
+func (_e *MockContainer_Expecter) GetLifecycleHostPostUpdateCommand() *MockContainer_GetLifecycleHostPostUpdateCommand_Call {
+	return &MockContainer_GetLifecycleHostPostUpdateCommand_Call{Call: _e.mock.On("GetLifecycleHostPostUpdateCommand")}
+}
+
+func (_c *MockContainer_GetLifecycleHostPostUpdateCommand_Call) Run(run func()) *MockContainer_GetLifecycleHostPostUpdateCommand_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockContainer_GetLifecycleHostPostUpdateCommand_Call) Return(s string) *MockContainer_GetLifecycleHostPostUpdateCommand_Call {
+	_c.Call.Return(s)
+	return _c
+}
+
+func (_c *MockContainer_GetLifecycleHostPostUpdateCommand_Call) RunAndReturn(run func() string) *MockContainer_GetLifecycleHostPostUpdateCommand_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLifecyclePreUpdateCommand provides a mock function for the type MockContainer
 func (_mock *MockContainer) GetLifecyclePreUpdateCommand() string {
 	ret := _mock.Called()

--- a/pkg/types/mocks/Container.go
+++ b/pkg/types/mocks/Container.go
@@ -520,6 +520,50 @@ func (_c *MockContainer_GetLifecyclePreCheckCommand_Call) RunAndReturn(run func(
 	return _c
 }
 
+// GetLifecycleHostPreCheckCommand provides a mock function for the type MockContainer
+func (_mock *MockContainer) GetLifecycleHostPreCheckCommand() string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLifecycleHostPreCheckCommand")
+	}
+
+	var r0 string
+	if returnFunc, ok := ret.Get(0).(func() string); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	return r0
+}
+
+// MockContainer_GetLifecycleHostPreCheckCommand_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLifecycleHostPreCheckCommand'
+type MockContainer_GetLifecycleHostPreCheckCommand_Call struct {
+	*mock.Call
+}
+
+// GetLifecycleHostPreCheckCommand is a helper method to define mock.On call
+func (_e *MockContainer_Expecter) GetLifecycleHostPreCheckCommand() *MockContainer_GetLifecycleHostPreCheckCommand_Call {
+	return &MockContainer_GetLifecycleHostPreCheckCommand_Call{Call: _e.mock.On("GetLifecycleHostPreCheckCommand")}
+}
+
+func (_c *MockContainer_GetLifecycleHostPreCheckCommand_Call) Run(run func()) *MockContainer_GetLifecycleHostPreCheckCommand_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockContainer_GetLifecycleHostPreCheckCommand_Call) Return(s string) *MockContainer_GetLifecycleHostPreCheckCommand_Call {
+	_c.Call.Return(s)
+	return _c
+}
+
+func (_c *MockContainer_GetLifecycleHostPreCheckCommand_Call) RunAndReturn(run func() string) *MockContainer_GetLifecycleHostPreCheckCommand_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLifecyclePreUpdateCommand provides a mock function for the type MockContainer
 func (_mock *MockContainer) GetLifecyclePreUpdateCommand() string {
 	ret := _mock.Called()

--- a/pkg/types/mocks/Container.go
+++ b/pkg/types/mocks/Container.go
@@ -652,6 +652,50 @@ func (_c *MockContainer_GetLifecycleHostPreUpdateCommand_Call) RunAndReturn(run 
 	return _c
 }
 
+// GetLifecycleHostPreStartCommand provides a mock function for the type MockContainer
+func (_mock *MockContainer) GetLifecycleHostPreStartCommand() string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLifecycleHostPreStartCommand")
+	}
+
+	var r0 string
+	if returnFunc, ok := ret.Get(0).(func() string); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	return r0
+}
+
+// MockContainer_GetLifecycleHostPreStartCommand_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLifecycleHostPreStartCommand'
+type MockContainer_GetLifecycleHostPreStartCommand_Call struct {
+	*mock.Call
+}
+
+// GetLifecycleHostPreStartCommand is a helper method to define mock.On call
+func (_e *MockContainer_Expecter) GetLifecycleHostPreStartCommand() *MockContainer_GetLifecycleHostPreStartCommand_Call {
+	return &MockContainer_GetLifecycleHostPreStartCommand_Call{Call: _e.mock.On("GetLifecycleHostPreStartCommand")}
+}
+
+func (_c *MockContainer_GetLifecycleHostPreStartCommand_Call) Run(run func()) *MockContainer_GetLifecycleHostPreStartCommand_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockContainer_GetLifecycleHostPreStartCommand_Call) Return(s string) *MockContainer_GetLifecycleHostPreStartCommand_Call {
+	_c.Call.Return(s)
+	return _c
+}
+
+func (_c *MockContainer_GetLifecycleHostPreStartCommand_Call) RunAndReturn(run func() string) *MockContainer_GetLifecycleHostPreStartCommand_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLifecycleHostPostUpdateCommand provides a mock function for the type MockContainer
 func (_mock *MockContainer) GetLifecycleHostPostUpdateCommand() string {
 	ret := _mock.Called()


### PR DESCRIPTION
Allows 
```
docker run -dt --name alpinetest --restart always \
  --label com.centurylinklabs.watchtower.lifecycle.host-pre-update="/script/on/host/fs.sh" \
  alpine
```

Edits are quite straightforward till `bc54c887`, which is a bigger change to allow the possibility of `host-pre-start` hook to run between stopping the old container and removing it, so that a script could still inspect it (I'm using this to just backup all used volume paths).

I'm testing this right now with a systemd script (`watchtower` binary runs directly on host system). Use case is to allow for backups before starting a new container and potentially destroying persistent data by a failed update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for host-side lifecycle hooks that run on the Watchtower host instead of inside containers (pre-check, post-check, pre-update, pre-start, post-update phases).
  * Added Docker native binary export capability via `Dockerfile.native-binary`.

* **Documentation**
  * Added Docker build setup guide with instructions for building, exporting, and running Watchtower.
  * Updated lifecycle hooks documentation with host-side hook details and timing diagrams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->