### PR TITLE
fix(notifications): suppress deprecation warning when legacy email subject tag is empty

### DIFF
--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -279,8 +279,10 @@ func GetTemplateData(c *cobra.Command) StaticData {
 		if tag == "" {
 			// Check legacy email tag.
 			tag, _ = flag.GetString("notification-email-subjecttag")
-			clog.WithField("tag", tag).
-				Warn("Using deprecated email subject tag flag: --notification-email-subjecttag. Use --notification-title-tag instead.")
+			if tag != "" {
+				clog.WithField("tag", tag).
+					Warn("Using deprecated email subject tag flag: --notification-email-subjecttag. Use --notification-title-tag instead.")
+			}
 		}
 
 		title = GetTitle(hostname, tag)


### PR DESCRIPTION
This PR suppresses a deprecation warning when the `notification-email-subjecttag` is unused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noise from deprecation warnings. The `--notification-email-subjecttag` deprecation warning now only displays when the flag is actively in use, rather than appearing unconditionally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->