### PR TITLE
fix(notifications): correct deprecation notice url

### DIFF
--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -113,25 +113,25 @@ func AppendLegacyUrls(urls []string, cmd *cobra.Command) ([]string, time.Duratio
 		switch notificationType {
 		case emailType:
 			clog.Warn(
-				"Legacy email notification type is deprecated; use --notification-url with an smtp:// URL instead. See https://docs.nickfedor.com/watchtower/notifications/ for migration guidance.",
+				"Legacy email notification type is deprecated; use --notification-url with an smtp:// URL instead. See https://watchtower.nickfedor.com/latest/notifications/overview/ for migration guidance.",
 			)
 
 			legacyNotifier = newEmailNotifier(cmd)
 		case slackType:
 			clog.Warn(
-				"Legacy slack notification type is deprecated; use --notification-url with a slack:// or discord:// URL instead. See https://docs.nickfedor.com/watchtower/notifications/ for migration guidance.",
+				"Legacy slack notification type is deprecated; use --notification-url with a slack:// or discord:// URL instead. See https://watchtower.nickfedor.com/latest/notifications/overview/ for migration guidance.",
 			)
 
 			legacyNotifier = newSlackNotifier(cmd)
 		case msTeamsType:
 			clog.Warn(
-				"Legacy msteams notification type is deprecated; use --notification-url with a teams:// URL instead. See https://docs.nickfedor.com/watchtower/notifications/ for migration guidance.",
+				"Legacy msteams notification type is deprecated; use --notification-url with a teams:// URL instead. See https://watchtower.nickfedor.com/latest/notifications/overview/ for migration guidance.",
 			)
 
 			legacyNotifier = newMsTeamsNotifier(cmd)
 		case gotifyType:
 			clog.Warn(
-				"Legacy gotify notification type is deprecated; use --notification-url with a gotify:// URL instead. See https://docs.nickfedor.com/watchtower/notifications/ for migration guidance.",
+				"Legacy gotify notification type is deprecated; use --notification-url with a gotify:// URL instead. See https://watchtower.nickfedor.com/latest/notifications/overview/ for migration guidance.",
 			)
 
 			legacyNotifier = newGotifyNotifier(cmd)


### PR DESCRIPTION
This PR corrects the URL referenced in the notifications deprecation warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deprecation warning messages for legacy notification types (email, Slack, Microsoft Teams, Gotify) to direct users to migration guidance resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->