### PR TITLE
fix(registry): derive bearer service from realm

### DIFF
--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -616,8 +616,39 @@ func getBearerHeader(
 	registryAuth string,
 	client Client,
 ) (string, error) {
+	r, err := newBearerRequest(ctx, authURL, imageName)
+	if err != nil {
+		return "", err
+	}
 
-	// Build the token request with context.
+	addBasicAuth(r, imageName, registryAuth)
+	logrus.WithField("url", r.URL.String()).Debug("Sending bearer token request")
+
+	authResponse, err := client.Do(r)
+	if err != nil {
+		logrus.WithError(err).WithFields(logrus.Fields{
+			"image": imageName,
+			"url":   authURL.String(),
+		}).Debug("Failed to execute bearer token request")
+
+		return "", fmt.Errorf("%w: %w", errFailedExecuteBearerRequest, err)
+	}
+
+	defer authResponse.Body.Close()
+
+	token, err := readBearerToken(authResponse.Body, imageName)
+	if err != nil {
+		return "", err
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"image": imageName,
+	}).Debug("Retrieved bearer token")
+
+	return "Bearer " + token, nil
+}
+
+func newBearerRequest(ctx context.Context, authURL *url.URL, imageName string) (*http.Request, error) {
 	r, err := http.NewRequestWithContext(ctx, http.MethodGet, authURL.String(), nil)
 	if err != nil {
 		logrus.WithError(err).WithFields(logrus.Fields{
@@ -625,10 +656,13 @@ func getBearerHeader(
 			"url":   authURL.String(),
 		}).Debug("Failed to create bearer token request")
 
-		return "", fmt.Errorf("%w: %w", errFailedCreateBearerRequest, err)
+		return nil, fmt.Errorf("%w: %w", errFailedCreateBearerRequest, err)
 	}
 
-	// Add Basic auth header if credentials are provided.
+	return r, nil
+}
+
+func addBasicAuth(r *http.Request, imageName string, registryAuth string) {
 	if registryAuth != "" {
 		logrus.WithFields(logrus.Fields{
 			"image": imageName,
@@ -647,27 +681,13 @@ func getBearerHeader(
 			"image": imageName,
 		}).Debug("No credentials found")
 	}
+}
 
-	// Execute the token request.
-	logrus.WithField("url", r.URL.String()).Debug("Sending bearer token request")
-
-	authResponse, err := client.Do(r)
-	if err != nil {
-		logrus.WithError(err).WithFields(logrus.Fields{
-			"image": imageName,
-			"url":   authURL.String(),
-		}).Debug("Failed to execute bearer token request")
-
-		return "", fmt.Errorf("%w: %w", errFailedExecuteBearerRequest, err)
-	}
-
-	defer authResponse.Body.Close()
-
-	// Read and parse the response body into a token structure.
-	body, _ := io.ReadAll(authResponse.Body)
+func readBearerToken(body io.Reader, imageName string) (string, error) {
+	b, _ := io.ReadAll(body)
 	tokenResponse := &types.TokenResponse{}
 
-	err = json.Unmarshal(body, tokenResponse)
+	err := json.Unmarshal(b, tokenResponse)
 	if err != nil {
 		logrus.WithError(err).
 			WithField("image", imageName).
@@ -676,11 +696,7 @@ func getBearerHeader(
 		return "", fmt.Errorf("%w: %w", errFailedUnmarshalBearerResponse, err)
 	}
 
-	logrus.WithFields(logrus.Fields{
-		"image": imageName,
-	}).Debug("Retrieved bearer token")
-
-	return "Bearer " + tokenResponse.Token, nil
+	return tokenResponse.Token, nil
 }
 
 // GetAuthURL constructs an authentication URL from challenge instructions.

--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -489,6 +489,7 @@ func GetToken(
 // ProcessChallenge parses the WWW-Authenticate header to extract authentication details.
 //
 // It supports Bearer authentication, extracting the realm, service, and optional scope for token requests.
+// If a registry omits service, the service is derived from the realm host.
 //
 // Parameters:
 //   - wwwAuthHeader: The WWW-Authenticate header value (e.g., 'Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:linuxserver/nginx:pull"').
@@ -498,7 +499,7 @@ func GetToken(
 //   - string: The scope for the token request (e.g., "repository:linuxserver/nginx:pull"), or empty if not provided.
 //   - string: The realm URL for the token request (e.g., "https://ghcr.io/token").
 //   - string: The service identifier (e.g., "ghcr.io").
-//   - error: Non-nil if parsing fails critically (missing realm or service), nil otherwise.
+//   - error: Non-nil if parsing fails critically (missing realm or derivable service), nil otherwise.
 func ProcessChallenge(wwwAuthHeader, image string) (string, string, string, error) {
 	fields := logrus.Fields{
 		"image":     image,
@@ -524,11 +525,19 @@ func ProcessChallenge(wwwAuthHeader, image string) (string, string, string, erro
 		}
 	}
 
-	realm, realmOK := values["realm"]
-	service, serviceOK := values["service"]
+	realm := values["realm"]
+	service := values["service"]
 	scope := values["scope"] // Scope is optional
+	if service == "" && realm != "" {
+		service = extractChallengeHost(realm, fields)
+		if service != "" {
+			logrus.WithFields(fields).
+				WithField("service", service).
+				Debug("Derived challenge service from realm")
+		}
+	}
 
-	if !realmOK || !serviceOK {
+	if realm == "" || service == "" {
 		logrus.WithFields(fields).Warn("Missing required challenge header values: realm or service")
 
 		return "", "", "", fmt.Errorf(
@@ -724,6 +733,19 @@ func GetAuthURL(challenge string, imageRef reference.Named) (*url.URL, error) {
 	// 4. This ensures we always use the correct ghcr.io token endpoint for lscr.io images
 	if registryAddress == LSCRRegistry {
 		values["realm"] = "https://ghcr.io/token"
+	}
+
+	if values["service"] == "" && values["realm"] != "" {
+		values["service"] = extractChallengeHost(values["realm"], logrus.Fields{
+			"image":     imageRef.Name(),
+			"challenge": challenge,
+		})
+		if values["service"] != "" {
+			logrus.WithFields(logrus.Fields{
+				"image":   imageRef.Name(),
+				"service": values["service"],
+			}).Debug("Derived challenge service from realm")
+		}
 	}
 
 	logrus.WithFields(logrus.Fields{

--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -66,6 +66,8 @@ var (
 	errFailedExecuteChallengeRequest = errors.New("failed to execute challenge request")
 	// errFailedCreateBearerRequest indicates a failure to construct the HTTP request for a bearer token.
 	errFailedCreateBearerRequest = errors.New("failed to create bearer token request")
+	// errFailedConstructBearerAuthURL indicates a failure to construct the bearer authentication URL.
+	errFailedConstructBearerAuthURL = errors.New("failed to construct bearer auth url")
 	// errFailedExecuteBearerRequest indicates a failure to send or receive a response for the bearer token request.
 	errFailedExecuteBearerRequest = errors.New("failed to execute bearer token request")
 	// errFailedUnmarshalBearerResponse indicates a failure to parse the bearer token response JSON.
@@ -73,8 +75,7 @@ var (
 	// errFailedParseImageName indicates a failure to parse the container image name into a normalized reference.
 	errFailedParseImageName = errors.New("failed to parse image name")
 	// errFailedDecodeResponse indicates a failure to decode the token response from the registry.
-	errFailedDecodeResponse         = errors.New("failed to decode response")
-	errFailedConstructBearerAuthURL = errors.New("failed to construct bearer auth url")
+	errFailedDecodeResponse = errors.New("failed to decode response")
 	// errFailedParseImageReference indicates a failure to parse an image reference into a normalized form.
 	errFailedParseImageReference = errors.New("failed to parse image reference")
 )
@@ -516,6 +517,7 @@ func ProcessChallenge(wwwAuthHeader, image string) (string, string, string, erro
 	realm := values["realm"]
 	service := values["service"]
 	scope := values["scope"] // Scope is optional
+
 	if service == "" && realm != "" {
 		service = extractChallengeHost(realm, fields)
 		if service != "" {
@@ -663,7 +665,7 @@ func newBearerRequest(ctx context.Context, authURL *url.URL, imageName string) (
 	return r, nil
 }
 
-func addBasicAuth(r *http.Request, imageName string, registryAuth string) {
+func addBasicAuth(r *http.Request, imageName, registryAuth string) {
 	if registryAuth != "" {
 		logrus.WithFields(logrus.Fields{
 			"image": imageName,

--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -265,33 +265,6 @@ func handleBearerAuth(
 ) (string, string, bool, string, error) {
 	logrus.WithFields(fields).Debug("Entering Bearer auth path")
 
-	var challengeHost string
-
-	// Parse the WWW-Authenticate header.
-	scope, realm, service, err := ProcessChallenge(wwwAuthHeader, container.ImageName())
-	logrus.WithFields(fields).
-		WithField("realm", realm).
-		WithField("service", service).
-		WithField("scope", scope).
-		WithField("err", err).
-		Debug("Processed challenge header")
-
-	switch {
-	case err != nil:
-		logrus.WithError(err).WithFields(fields).Debug("Failed to process challenge header")
-		// Proceed with token retrieval, as challengeHost is optional.
-	case realm != "":
-		challengeHost = extractChallengeHost(realm, fields)
-		if challengeHost != "" {
-			logrus.WithFields(fields).
-				WithField("challenge_host", challengeHost).
-				Debug("Extracted challenge host")
-		}
-	default:
-		logrus.WithFields(fields).Debug("Empty realm in challenge header")
-	}
-
-	// Fetch the bearer token.
 	normalizedRef, err := reference.ParseNormalizedNamed(container.ImageName())
 	if err != nil {
 		logrus.WithError(err).WithFields(fields).Debug("Failed to parse image name")
@@ -299,10 +272,24 @@ func handleBearerAuth(
 		return "", "", redirected, redirectHost, fmt.Errorf("%w: %w", errFailedParseImageName, err)
 	}
 
-	token, err := GetBearerHeader(
+	authURL, err := GetAuthURL(strings.ToLower(wwwAuthHeader), normalizedRef)
+	if err != nil {
+		logrus.WithError(err).WithFields(fields).Debug("Failed to construct bearer auth URL")
+
+		return "", "", redirected, redirectHost, fmt.Errorf("%w: %w", errFailedDecodeResponse, err)
+	}
+
+	challengeHost := authURL.Host
+	if challengeHost != "" {
+		logrus.WithFields(fields).
+			WithField("challenge_host", challengeHost).
+			Debug("Extracted challenge host")
+	}
+
+	token, err := getBearerHeader(
 		ctx,
-		strings.ToLower(wwwAuthHeader),
-		normalizedRef,
+		authURL,
+		container.ImageName(),
 		registryAuth,
 		client,
 	)
@@ -619,11 +606,22 @@ func GetBearerHeader(
 		return "", err
 	}
 
+	return getBearerHeader(ctx, authURL, imageRef.Name(), registryAuth, client)
+}
+
+func getBearerHeader(
+	ctx context.Context,
+	authURL *url.URL,
+	imageName string,
+	registryAuth string,
+	client Client,
+) (string, error) {
+
 	// Build the token request with context.
 	r, err := http.NewRequestWithContext(ctx, http.MethodGet, authURL.String(), nil)
 	if err != nil {
 		logrus.WithError(err).WithFields(logrus.Fields{
-			"image": imageRef.Name(),
+			"image": imageName,
 			"url":   authURL.String(),
 		}).Debug("Failed to create bearer token request")
 
@@ -633,12 +631,12 @@ func GetBearerHeader(
 	// Add Basic auth header if credentials are provided.
 	if registryAuth != "" {
 		logrus.WithFields(logrus.Fields{
-			"image": imageRef.Name(),
+			"image": imageName,
 		}).Debug("Found credentials")
 
 		if logrus.GetLevel() == logrus.TraceLevel {
 			logrus.WithFields(logrus.Fields{
-				"image":        imageRef.Name(),
+				"image":        imageName,
 				"registryAuth": registryAuth,
 			}).Trace("Using credentials")
 		}
@@ -646,7 +644,7 @@ func GetBearerHeader(
 		r.Header.Add("Authorization", "Basic "+registryAuth)
 	} else {
 		logrus.WithFields(logrus.Fields{
-			"image": imageRef.Name(),
+			"image": imageName,
 		}).Debug("No credentials found")
 	}
 
@@ -656,7 +654,7 @@ func GetBearerHeader(
 	authResponse, err := client.Do(r)
 	if err != nil {
 		logrus.WithError(err).WithFields(logrus.Fields{
-			"image": imageRef.Name(),
+			"image": imageName,
 			"url":   authURL.String(),
 		}).Debug("Failed to execute bearer token request")
 
@@ -672,14 +670,14 @@ func GetBearerHeader(
 	err = json.Unmarshal(body, tokenResponse)
 	if err != nil {
 		logrus.WithError(err).
-			WithField("image", imageRef.Name()).
+			WithField("image", imageName).
 			Debug("Failed to unmarshal bearer token response")
 
 		return "", fmt.Errorf("%w: %w", errFailedUnmarshalBearerResponse, err)
 	}
 
 	logrus.WithFields(logrus.Fields{
-		"image": imageRef.Name(),
+		"image": imageName,
 	}).Debug("Retrieved bearer token")
 
 	return "Bearer " + tokenResponse.Token, nil

--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -73,7 +73,8 @@ var (
 	// errFailedParseImageName indicates a failure to parse the container image name into a normalized reference.
 	errFailedParseImageName = errors.New("failed to parse image name")
 	// errFailedDecodeResponse indicates a failure to decode the token response from the registry.
-	errFailedDecodeResponse = errors.New("failed to decode response")
+	errFailedDecodeResponse         = errors.New("failed to decode response")
+	errFailedConstructBearerAuthURL = errors.New("failed to construct bearer auth url")
 	// errFailedParseImageReference indicates a failure to parse an image reference into a normalized form.
 	errFailedParseImageReference = errors.New("failed to parse image reference")
 )
@@ -276,7 +277,7 @@ func handleBearerAuth(
 	if err != nil {
 		logrus.WithError(err).WithFields(fields).Debug("Failed to construct bearer auth URL")
 
-		return "", "", redirected, redirectHost, fmt.Errorf("%w: %w", errFailedDecodeResponse, err)
+		return "", "", redirected, redirectHost, fmt.Errorf("%w: %w", errFailedConstructBearerAuthURL, err)
 	}
 
 	challengeHost := authURL.Host

--- a/pkg/registry/auth/auth_test.go
+++ b/pkg/registry/auth/auth_test.go
@@ -991,6 +991,60 @@ var _ = ginkgo.Describe("the auth module", func() {
 			gomega.Expect(server.ReceivedRequests()).To(gomega.HaveLen(2))
 		})
 
+		ginkgo.It("should derive bearer service from realm when registry challenge omits service", func() {
+			defer ginkgo.GinkgoRecover()
+
+			server := ghttp.NewTLSServer()
+			server.RouteToHandler("GET", "/v2/", ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", "/v2/"),
+				ghttp.RespondWith(
+					http.StatusUnauthorized,
+					"",
+					http.Header{
+						"WWW-Authenticate": []string{
+							fmt.Sprintf(`Bearer realm="https://%s/token"`, server.Addr()),
+						},
+					},
+				),
+			))
+
+			server.RouteToHandler("GET", "/token", ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", "/token", "scope=repository%3Atest%2Fimage%3Apull&service="+url.QueryEscape(server.Addr())),
+				ghttp.RespondWith(http.StatusOK, `{"token": "mock-token"}`),
+			))
+			defer server.Close()
+
+			containerInstance := mockContainer{
+				id:        mockID,
+				name:      mockName,
+				imageName: server.Addr() + "/test/image:latest",
+			}
+			client := &testAuthClient{
+				client: &http.Client{
+					Transport: &http.Transport{
+						TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+					},
+				},
+			}
+
+			viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+			defer viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+
+			token, challengeHost, redirected, redirectHost, err := auth.GetToken(
+				context.Background(),
+				containerInstance,
+				"",
+				client,
+				"",
+			)
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(token).To(gomega.Equal("Bearer mock-token"))
+			gomega.Expect(challengeHost).To(gomega.Equal(server.Addr()))
+			gomega.Expect(redirected).To(gomega.BeFalse())
+			gomega.Expect(redirectHost).To(gomega.Equal(""))
+			gomega.Expect(server.ReceivedRequests()).To(gomega.HaveLen(2))
+		})
 		// Test case: Verifies that GetToken returns redirect=true when the challenge request is redirected.
 		ginkgo.It("should return redirect=true when challenge request is redirected", func() {
 			defer ginkgo.GinkgoRecover()
@@ -1354,16 +1408,25 @@ var _ = ginkgo.Describe("the auth module", func() {
 		)
 
 		ginkgo.When("given an invalid challenge header", func() {
-			// Test case: Verifies GetAuthURL returns an error when the challenge header lacks
-			// required fields (e.g., service). Ensures robust error handling for malformed inputs.
 			ginkgo.It("should return an error", func() {
-				challenge := `bearer realm="https://ghcr.io/token"`
+				challenge := `bearer service="ghcr.io"`
 				imageRef, err := reference.ParseNormalizedNamed("nicholas-fedor/watchtower")
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				URL, err := auth.GetAuthURL(challenge, imageRef)
 				gomega.Expect(err).To(gomega.HaveOccurred())
 				gomega.Expect(URL).To(gomega.BeNil())
 			})
+		})
+
+		ginkgo.It("should derive service from realm when challenge omits service", func() {
+			challenge := `bearer realm="https://asia-northeast1-docker.pkg.dev/v2/token"`
+			imageRef, err := reference.ParseNormalizedNamed("asia-northeast1-docker.pkg.dev/drawith-production-500000/drawith/artie-agent:sha-317f106")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			URL, err := auth.GetAuthURL(challenge, imageRef)
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(URL.String()).To(gomega.Equal("https://asia-northeast1-docker.pkg.dev/v2/token?scope=repository%3Adrawith-production-500000%2Fdrawith%2Fartie-agent%3Apull&service=asia-northeast1-docker.pkg.dev"))
 		})
 
 		ginkgo.When("deriving the auth scope from an image name", func() {

--- a/pkg/registry/auth/auth_test.go
+++ b/pkg/registry/auth/auth_test.go
@@ -1426,7 +1426,8 @@ var _ = ginkgo.Describe("the auth module", func() {
 			URL, err := auth.GetAuthURL(challenge, imageRef)
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(URL.String()).To(gomega.Equal("https://asia-northeast1-docker.pkg.dev/v2/token?scope=repository%3Adrawith-production-500000%2Fdrawith%2Fartie-agent%3Apull&service=asia-northeast1-docker.pkg.dev"))
+			gomega.Expect(URL.String()).
+				To(gomega.Equal("https://asia-northeast1-docker.pkg.dev/v2/token?scope=repository%3Adrawith-production-500000%2Fdrawith%2Fartie-agent%3Apull&service=asia-northeast1-docker.pkg.dev"))
 		})
 
 		ginkgo.When("deriving the auth scope from an image name", func() {

--- a/pkg/registry/auth/auth_test.go
+++ b/pkg/registry/auth/auth_test.go
@@ -1419,15 +1419,15 @@ var _ = ginkgo.Describe("the auth module", func() {
 		})
 
 		ginkgo.It("should derive service from realm when challenge omits service", func() {
-			challenge := `bearer realm="https://asia-northeast1-docker.pkg.dev/v2/token"`
-			imageRef, err := reference.ParseNormalizedNamed("asia-northeast1-docker.pkg.dev/drawith-production-500000/drawith/artie-agent:sha-317f106")
+			challenge := `bearer realm="https://registry.example.com/token"`
+			imageRef, err := reference.ParseNormalizedNamed("registry.example.com/test/image:latest")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			URL, err := auth.GetAuthURL(challenge, imageRef)
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(URL.String()).
-				To(gomega.Equal("https://asia-northeast1-docker.pkg.dev/v2/token?scope=repository%3Adrawith-production-500000%2Fdrawith%2Fartie-agent%3Apull&service=asia-northeast1-docker.pkg.dev"))
+				To(gomega.Equal("https://registry.example.com/token?scope=repository%3Atest%2Fimage%3Apull&service=registry.example.com"))
 		})
 
 		ginkgo.When("deriving the auth scope from an image name", func() {

--- a/pkg/registry/auth/auth_test.go
+++ b/pkg/registry/auth/auth_test.go
@@ -1430,6 +1430,53 @@ var _ = ginkgo.Describe("the auth module", func() {
 				To(gomega.Equal("https://registry.example.com/token?scope=repository%3Atest%2Fimage%3Apull&service=registry.example.com"))
 		})
 
+		ginkgo.It("should derive service from realm when service is explicitly empty", func() {
+			challenge := `bearer realm="https://registry.example.com/token",service=""`
+			imageRef, err := reference.ParseNormalizedNamed("registry.example.com/test/image:latest")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			URL, err := auth.GetAuthURL(challenge, imageRef)
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(URL.String()).
+				To(gomega.Equal("https://registry.example.com/token?scope=repository%3Atest%2Fimage%3Apull&service=registry.example.com"))
+		})
+
+		ginkgo.It("should derive service from realm host when realm includes a port", func() {
+			challenge := `bearer realm="http://localhost:5000/token"`
+			imageRef, err := reference.ParseNormalizedNamed("localhost:5000/test/image:latest")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			URL, err := auth.GetAuthURL(challenge, imageRef)
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(URL.String()).
+				To(gomega.Equal("http://localhost:5000/token?scope=repository%3Atest%2Fimage%3Apull&service=localhost%3A5000"))
+		})
+
+		ginkgo.It("should derive service from realm host when realm has a trailing slash", func() {
+			challenge := `bearer realm="https://registry.example.com/token/"`
+			imageRef, err := reference.ParseNormalizedNamed("registry.example.com/test/image:latest")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			URL, err := auth.GetAuthURL(challenge, imageRef)
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(URL.String()).
+				To(gomega.Equal("https://registry.example.com/token/?scope=repository%3Atest%2Fimage%3Apull&service=registry.example.com"))
+		})
+
+		ginkgo.It("should return an error when realm lacks a scheme and service is omitted", func() {
+			challenge := `bearer realm="registry.example.com/token"`
+			imageRef, err := reference.ParseNormalizedNamed("registry.example.com/test/image:latest")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			URL, err := auth.GetAuthURL(challenge, imageRef)
+
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(URL).To(gomega.BeNil())
+		})
+
 		ginkgo.When("deriving the auth scope from an image name", func() {
 			// Test case: Ensures GetAuthURL prepends "library/" to official Docker Hub images,
 			// validating correct scope derivation for standard images.


### PR DESCRIPTION
## Summary

- derive missing Bearer `service` values from the challenge `realm` host
- keep existing scope derivation for registry challenges that omit `scope`
- add regression coverage for GCP Artifact Registry's realm-only `/v2/` challenge

Fixes #1894

## Testing

- `go test ./pkg/registry/... -count=1`
- `go test ./... -count=1`
- `go test -race ./pkg/registry/... -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry Bearer authentication by normalizing the image name and deriving missing `service` from the `realm`, ensuring correct `/token` exchanges and more reliable auth URL generation.
  * Strengthened validation of Bearer `WWW-Authenticate` challenges, rejecting malformed or incomplete headers more consistently (including cases with missing scheme or unusable `realm`/`service`).

* **Tests**
  * Added and expanded coverage for Bearer challenges that omit `service`, asserting correct query parameter derivation and successful token retrieval behavior.
  * Updated error/invalid-challenge scenarios to confirm proper failures and no redirect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->