### PR TITLE
refactor(actions): parallelize staleness checks with bounded concurrency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/swag v1.16.6
 	github.com/valyala/fasthttp v1.72.0
+	golang.org/x/sync v0.22.0
 	golang.org/x/text v0.40.0
 )
 
@@ -95,7 +96,6 @@ require (
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect

--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -3,7 +3,6 @@ package actions
 import (
 	"context"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -137,7 +136,8 @@ func RunUpdatesWithNotifications(
 		updateConfig,
 	)
 	// Process update result, return metric on failure
-	if metric := handleUpdateResult(result, err, params.Notifier); metric != nil {
+	metric := handleUpdateResult(result, err, params.Notifier)
+	if metric != nil {
 		if params.EventBroadcaster != nil {
 			errMsg := "unknown error"
 			if err != nil {
@@ -250,7 +250,7 @@ func (emptyReport) All() []types.ContainerReport       { return nil }
 // Parameters:
 //   - result: The report from the update operation.
 //   - err: Any error encountered during the update.
-//   - notifier: The notification system for sending error alerts; may be nil.
+//   - notifier: The notification system for sending error alerts. It may be nil.
 //
 // Returns:
 //   - *metrics.Metric: A zero metric if an error occurred or result is nil, nil otherwise.
@@ -649,17 +649,8 @@ func sendNotifications(
 		// Check if notifications should be split by container
 		if notificationSplitByContainer {
 			sendSplitNotifications(notifier, notificationReport, result, cleanedImages)
-		} else {
-			// Send grouped notification asynchronously with proper synchronization
-			var waitGroup sync.WaitGroup
-
-			waitGroup.Go(func() {
-				if notifier.ShouldSendNotification(result) {
-					notifier.SendNotification(result)
-				}
-			})
-
-			waitGroup.Wait()
+		} else if notifier.ShouldSendNotification(result) {
+			notifier.SendNotification(result)
 		}
 	}
 }
@@ -893,7 +884,8 @@ func sendSplitNotifications(
 
 			var cdPassed bool
 
-			if cs, ok := report.(*session.ContainerStatus); ok {
+			cs, ok := report.(*session.ContainerStatus)
+			if ok {
 				cdAge = cs.CooldownAge()
 				cdDelay = cs.CooldownDelay()
 				cdPassed = cs.CooldownPassed()

--- a/internal/actions/actions_internal_test.go
+++ b/internal/actions/actions_internal_test.go
@@ -1950,7 +1950,8 @@ var _ = ginkgo.Describe("stopContainersInReversedOrder", func() {
 
 			for _, entry := range logHook.entries {
 				if entry.message == "Skipped container stop due to context cancellation" {
-					if containerName, ok := entry.fields["container"]; ok {
+					containerName, ok := entry.fields["container"]
+					if ok {
 						loggedNames[containerName.(string)] = true
 					}
 
@@ -2417,7 +2418,8 @@ var _ = ginkgo.Describe("performRollingRestart", func() {
 
 			for _, entry := range logHook.entries {
 				if entry.message == "Skipped container restart due to context cancellation" {
-					if containerName, ok := entry.fields["container"]; ok {
+					containerName, ok := entry.fields["container"]
+					if ok {
 						loggedNames[containerName.(string)] = true
 					}
 
@@ -2949,7 +2951,7 @@ var _ = ginkgo.Describe("isPinned", func() {
 	)
 
 	ginkgo.It("detects pin before parse fallback can replace the image name", func() {
-		// ImageName is a valid digest pin; even if parse were flaky, pin must win.
+		// ImageName is a valid digest pin. Even if parse were flaky, pin must win.
 		cont := mockActions.CreateMockContainer(
 			"pinned-id",
 			"/pinned-name",

--- a/internal/actions/cleanup.go
+++ b/internal/actions/cleanup.go
@@ -487,8 +487,8 @@ func getChainedContainers(
 	// Filter containers that are in the chain, present on the host, and not the effective current.
 	// Chained containers are parent containers that must be removed regardless of scope.
 	for _, c := range allContainers {
-		if _, exists := containerChainMap[string(c.ID())]; exists &&
-			c.ID() != effectiveCurrent.ID() {
+		_, exists := containerChainMap[string(c.ID())]
+		if exists && c.ID() != effectiveCurrent.ID() {
 			chainedContainers = append(chainedContainers, c)
 		}
 	}

--- a/internal/actions/ephemeral.go
+++ b/internal/actions/ephemeral.go
@@ -146,7 +146,7 @@ func EphemeralSelfUpdate(
 	logrus.Info("Starting new Watchtower container")
 
 	// Log that the orchestrator has been started. The orchestrator ID identifies
-	// the ephemeral container that will perform the replacement; the actual new
+	// the ephemeral container that will perform the replacement. The actual new
 	// container's ID is determined by the orchestrator and emitted in its own
 	// "Started new container" log entry.
 	logrus.WithFields(logrus.Fields{
@@ -469,8 +469,8 @@ func stopAndRemoveOldContainer(
 		if cerrdefs.IsNotFound(err) {
 			clog.Debug("Old container already removed")
 
-			// Container was already removed during the stop attempt;
-			// skip removal and proceed to creating the new one.
+			// Container was already removed during the stop attempt.
+			// Skip removal and proceed to creating the new one.
 			skipRemoval = true
 		} else {
 			// StopContainer failed for a reason other than NotFound.
@@ -488,10 +488,10 @@ func stopAndRemoveOldContainer(
 			}
 
 			if !freshContainer.IsRunning() {
-				// Container stopped despite the error; proceed with removal.
+				// Container stopped despite the error. Proceed with removal.
 				clog.Debug("Old container is not running after stop attempt - proceeding with removal")
 			} else {
-				// Container is still running and StopContainer failed — this is fatal.
+				// Container is still running and StopContainer failed. This is fatal.
 				clog.WithError(err).Error("Failed to stop old container")
 
 				return false, fmt.Errorf("%w: %w", errOrchestratorStopFailed, err)
@@ -592,7 +592,7 @@ func ensureContainerRunning(
 	ctr, err := client.GetContainer(ctx, containerID)
 	if err != nil {
 		clog.WithError(err).Error("Failed to inspect new container")
-		clog.Warn("Cannot verify new container is running. Old container was removed; manual recovery requires recreating the container.")
+		clog.Warn("Cannot verify new container is running. Old container was removed. Manual recovery requires recreating the container.")
 
 		return fmt.Errorf("%w: %w", errOrchestratorInspectFailed, err)
 	}
@@ -603,7 +603,7 @@ func ensureContainerRunning(
 		return nil
 	}
 
-	// Container was created but not started; start it explicitly.
+	// Container was created but not started. Start it explicitly.
 	clog.Debug("New container was created but not started, starting it now")
 
 	err = client.StartContainerByID(ctx, containerID)
@@ -618,13 +618,13 @@ func ensureContainerRunning(
 	ctr, err = client.GetContainer(ctx, containerID)
 	if err != nil {
 		clog.WithError(err).Error("Failed to inspect new container after start")
-		clog.Warn("Cannot verify new container is running. Old container was removed; manual recovery requires recreating the container.")
+		clog.Warn("Cannot verify new container is running. Old container was removed. Manual recovery requires recreating the container.")
 
 		return fmt.Errorf("%w: %w", errOrchestratorInspectFailed, err)
 	}
 
 	if !ctr.IsRunning() {
-		clog.Error("New container is not running after explicit start. Old container was removed; manual recovery requires recreating the container.")
+		clog.Error("New container is not running after explicit start. Old container was removed. Manual recovery requires recreating the container.")
 
 		return fmt.Errorf("%w: %s", errNewContainerNotRunning, containerID.ShortID())
 	}

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -303,7 +303,7 @@ func Update(
 			// Check for context cancellation to enable faster shutdown during long update cycles.
 			select {
 			case <-ctx.Done():
-				return nil
+				return ctx.Err()
 			default:
 			}
 
@@ -455,6 +455,10 @@ func Update(
 	err = checkGroup.Wait()
 	if err != nil {
 		logrus.WithError(err).Debug("Parallel staleness checks completed with error")
+
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return progress.Report(), cleanupImageInfos, fmt.Errorf("update canceled: %w", ctx.Err())
+		}
 	}
 
 	staleCheckFailed = parallelStaleCheckFailed

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -334,6 +334,10 @@ func Update(
 					sourceContainer,
 					config,
 				)
+
+				if checkErr != nil && (errors.Is(checkErr, context.Canceled) || errors.Is(checkErr, context.DeadlineExceeded)) {
+					return fmt.Errorf("staleness check canceled: %w", checkErr)
+				}
 			}
 
 			// Determine if the container should be updated based on staleness and config.
@@ -356,6 +360,12 @@ func Update(
 							"image_name":     sourceContainer.ImageName(),
 							"image_id":       sourceContainer.ImageID().ShortID(),
 						}).Debug("Failed to verify container configuration")
+				}
+
+				if verifyErr != nil &&
+					(errors.Is(verifyErr, context.Canceled) ||
+						errors.Is(verifyErr, context.DeadlineExceeded)) {
+					return fmt.Errorf("configuration verification canceled: %w", verifyErr)
 				}
 			}
 
@@ -461,9 +471,11 @@ func Update(
 		}
 	}
 
-	staleCheckFailed = parallelStaleCheckFailed
-	watchtowerPullFailed = parallelWatchtowerPullFailed
-	staleCount = parallelStaleCount
+	// Accumulate parallel results with pre-parallel sequential counts so failures
+	// from pinned-image parsing and other pre-filter checks are preserved.
+	staleCheckFailed += parallelStaleCheckFailed
+	watchtowerPullFailed = watchtowerPullFailed || parallelWatchtowerPullFailed
+	staleCount += parallelStaleCount
 
 	// Log the summary of staleness checks, including total, stale, and failed counts.
 	logrus.WithFields(

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -7,10 +7,12 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/distribution/reference"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 
 	cerrdefs "github.com/containerd/errdefs"
 	dockerContainer "github.com/moby/moby/api/types/container"
@@ -143,9 +145,9 @@ func Update(
 	// Create a progress tracker for reporting scanned, updated, and skipped containers.
 	progress := &session.Progress{}
 	// Track the number of stale containers for logging.
-	staleCount := 0
+	var staleCount int
 	// Track if Watchtower self-update pull failed to add safeguard delay.
-	watchtowerPullFailed := false
+	var watchtowerPullFailed bool
 
 	// Run pre-check lifecycle hooks if enabled to validate the environment before updates.
 	if config.LifecycleHooks {
@@ -215,6 +217,14 @@ func Update(
 	// Track containers that fail staleness checks for reporting.
 	staleCheckFailed := 0
 
+	// Prepare containers for staleness checks, skipping already-processed ones.
+	type checkTask struct {
+		index     int
+		container types.Container
+	}
+
+	var checkTasks []checkTask
+
 	// Iterate through containers to check staleness and prepare for updates or restarts.
 	for i, sourceContainer := range filteredContainers {
 		// Check for context cancellation to enable faster shutdown during long update cycles.
@@ -225,22 +235,25 @@ func Update(
 		}
 
 		// Skip containers already processed (e.g., skipped due to circular dependencies).
-		if _, exists := (*progress)[sourceContainer.ID()]; exists {
+		_, exists := (*progress)[sourceContainer.ID()]
+		if exists {
 			continue
 		}
 
 		// Set up logging fields for the current container.
-		fields := logrus.Fields{
-			"container": sourceContainer.Name(),
-			"image":     sourceContainer.ImageName(),
-		}
-		clog := logrus.WithFields(fields)
+		clog := logrus.WithFields(
+			logrus.Fields{
+				"container": sourceContainer.Name(),
+				"image":     sourceContainer.ImageName(),
+			},
+		)
 
 		// Check if the container uses a pinned (digest-based) image to skip updates.
-		isPinned, err := isPinned(sourceContainer, progress, config)
+		isPinnedVal, err := isPinned(sourceContainer, progress, config)
 		if err != nil {
 			// Log and skip containers with unparsable image references, marking as skipped.
 			clog.WithError(err).Debug("Failed to check pinned image - skipping container")
+
 			progress.AddSkipped(
 				sourceContainer,
 				fmt.Errorf("%w: %w", errParseImageReference, err),
@@ -252,137 +265,201 @@ func Update(
 			continue
 		}
 
-		if isPinned {
+		if isPinnedVal {
 			// Skip staleness checks for pinned images and mark as scanned.
 			clog.Debug("Skipping staleness check for pinned image")
 
 			continue
 		}
 
-		// Determine if the container is stale and needs updating.
-		// If the container is Watchtower and SkipSelfUpdate is enabled, skip the update
-		// by setting stale to false and using the current image. Otherwise, check staleness.
-		var (
-			stale       bool
-			newestImage types.ImageID
-		)
-
-		if sourceContainer.IsWatchtower() && config.SkipSelfUpdate {
-			stale = false
-			newestImage = sourceContainer.ImageID()
-		} else {
-			stale, newestImage, _, err = client.IsContainerStale(
-				ctx,
-				sourceContainer,
-				config,
-			)
-		}
-
-		// Determine if the container should be updated based on staleness and config.
-		shouldUpdate := shouldUpdateContainer(
-			sourceContainer,
-			stale,
-			config,
-		)
-
-		// Log when skipping Watchtower self-update in run-once mode
-		if stale && sourceContainer.IsWatchtower() && config.RunOnce {
-			clog.Info("Skipping Watchtower self-update in run-once mode")
-		}
-
-		// Track old image ID before update for cleanup notifications.
-		if shouldUpdate {
-			if c, ok := filteredContainers[i].(*container.Container); ok {
-				c.SetOldImageID(sourceContainer.ImageID())
-			}
-		}
-
-		// Verify the container's configuration if it's slated for update to
-		// ensure recreation is possible.
-		if err == nil && shouldUpdate {
-			err = sourceContainer.VerifyConfiguration()
-			if err != nil {
-				// Log configuration verification failure with detailed context.
-				logrus.WithError(err).WithFields(
-					logrus.Fields{
-						"container_name": sourceContainer.Name(),
-						"container_id":   sourceContainer.ID().ShortID(),
-						"image_name":     sourceContainer.ImageName(),
-						"image_id":       sourceContainer.ImageID().ShortID(),
-					}).Debug("Failed to verify container configuration")
-			}
-		}
-
-		// Handle staleness check results, logging skips or adding to the progress report.
-		if err != nil {
-			// Skip containers with staleness check errors, marking them as skipped.
-			clog.WithError(err).Debug("Cannot update container - skipping")
-
-			stale = false
-
-			if !errors.Is(err, container.ErrImageCooldown) {
-				staleCheckFailed++
-			}
-
-			progress.AddSkipped(sourceContainer, err, config)
-
-			// Restore rich cooldown metadata for reports/notifications (preserves the
-			// structured CooldownAge/Delay/Remaining/Passed fields that the removed
-			// high-level block used to populate via SetCooldownInfo). The rich
-			// *container.CooldownError carries the details.
-			if cooldownErr, ok := errors.AsType[*container.CooldownError](err); ok {
-				progress.SetCooldownInfo(
-					sourceContainer.ID(),
-					cooldownErr.Age,
-					cooldownErr.Delay,
-					cooldownErr.Remaining,
-					cooldownErr.EligibleAt,
-					cooldownErr.Passed,
-				)
-			} else if errors.Is(err, container.ErrImageCooldown) {
-				// Fallback for plain sentinel (keeps basic deferral visible)
-				progress.SetCooldownInfo(sourceContainer.ID(), "", "", "", time.Time{}, false)
-			}
-
-			// Track if Watchtower self-update pull failed for safeguard.
-			// Only set to true if we actually attempted a self-update
-			// (i.e., SkipSelfUpdate is false) and the error is a real
-			// failure, not a cooldown deferral.
-			if sourceContainer.IsWatchtower() &&
-				!config.SkipSelfUpdate &&
-				!errors.Is(err, container.ErrImageCooldown) {
-				watchtowerPullFailed = true
-			}
-		} else {
-			// For fresh containers, set newestImage to current image ID for proper categorization.
-			// (Cooldown decision and any layer pull now happen inside pkg/container/image.go
-			// IsOutsideCooldown + guarded PullImage, after digest staleness and before layers.)
-			if !stale {
-				newestImage = sourceContainer.ImageID()
-			}
-
-			// Log successful staleness check and add to scanned containers.
-			clog.WithFields(
-				logrus.Fields{
-					"stale":        stale,
-					"newest_image": newestImage,
-				}).Debug("Checked container staleness")
-			progress.AddScanned(
-				sourceContainer,
-				newestImage,
-				config,
-			)
-		}
-
-		// Update the container's stale status for dependency sorting.
-		// Only mark as stale if the container should actually be updated.
-		filteredContainers[i].SetStale(stale && shouldUpdate)
-
-		// Increment stale count for logging summary.
-		if stale {
-			staleCount++
-		}
+		checkTasks = append(checkTasks, checkTask{
+			index:     i,
+			container: sourceContainer,
+		})
 	}
+
+	// Check for context cancellation before launching parallel staleness checks.
+	select {
+	case <-ctx.Done():
+		return progress.Report(), cleanupImageInfos, ctx.Err()
+	default:
+	}
+
+	// Parallelize staleness checks with bounded concurrency.
+	const maxConcurrentChecks = 20
+
+	var checkGroup errgroup.Group
+	checkGroup.SetLimit(maxConcurrentChecks)
+
+	var (
+		resultMu                     sync.Mutex
+		parallelStaleCheckFailed     int
+		parallelWatchtowerPullFailed bool
+		parallelStaleCount           int
+	)
+
+	for _, task := range checkTasks {
+		checkGroup.Go(func() error {
+			// Check for context cancellation to enable faster shutdown during long update cycles.
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+			}
+
+			sourceContainer := task.container
+			clog := logrus.WithFields(
+				logrus.Fields{
+					"container": sourceContainer.Name(),
+					"image":     sourceContainer.ImageName(),
+				},
+			)
+
+			var (
+				stale       bool
+				newestImage types.ImageID
+				checkErr    error
+				verifyErr   error
+			)
+
+			// Determine if the container is stale and needs updating.
+			// If the container is Watchtower and SkipSelfUpdate is enabled, skip the update
+			// by setting stale to false and using the current image. Otherwise, check staleness.
+			if sourceContainer.IsWatchtower() && config.SkipSelfUpdate {
+				stale = false
+				newestImage = sourceContainer.ImageID()
+			} else {
+				stale, newestImage, _, checkErr = client.IsContainerStale(
+					ctx,
+					sourceContainer,
+					config,
+				)
+			}
+
+			// Determine if the container should be updated based on staleness and config.
+			shouldUpdate := shouldUpdateContainer(sourceContainer, stale, config)
+
+			// Log when skipping Watchtower self-update in run-once mode.
+			if stale && sourceContainer.IsWatchtower() && config.RunOnce {
+				clog.Info("Skipping Watchtower self-update in run-once mode")
+			}
+
+			// Verify the container's configuration if it's slated for update to
+			// ensure recreation is possible.
+			if checkErr == nil && shouldUpdate {
+				verifyErr = sourceContainer.VerifyConfiguration()
+				if verifyErr != nil {
+					logrus.WithError(verifyErr).WithFields(
+						logrus.Fields{
+							"container_name": sourceContainer.Name(),
+							"container_id":   sourceContainer.ID().ShortID(),
+							"image_name":     sourceContainer.ImageName(),
+							"image_id":       sourceContainer.ImageID().ShortID(),
+						}).Debug("Failed to verify container configuration")
+				}
+			}
+
+			resultMu.Lock()
+			defer resultMu.Unlock()
+
+			// Handle staleness check results, logging skips or adding to the progress report.
+			switch {
+			case checkErr != nil:
+				// Skip containers with staleness check errors, marking them as skipped.
+				if !errors.Is(checkErr, container.ErrImageCooldown) {
+					parallelStaleCheckFailed++
+				}
+
+				progress.AddSkipped(sourceContainer, checkErr, config)
+
+				// Restore rich cooldown metadata for reports/notifications (preserves the
+				// structured CooldownAge/Delay/Remaining/Passed fields that the removed
+				// high-level block used to populate via SetCooldownInfo). The rich
+				// *container.CooldownError carries the details.
+				cooldownErr, ok := errors.AsType[*container.CooldownError](checkErr)
+				if ok {
+					progress.SetCooldownInfo(
+						sourceContainer.ID(),
+						cooldownErr.Age,
+						cooldownErr.Delay,
+						cooldownErr.Remaining,
+						cooldownErr.EligibleAt,
+						cooldownErr.Passed,
+					)
+				} else if errors.Is(checkErr, container.ErrImageCooldown) {
+					// Fallback for plain sentinel (keeps basic deferral visible)
+					progress.SetCooldownInfo(sourceContainer.ID(), "", "", "", time.Time{}, false)
+				}
+
+				// Track if Watchtower self-update pull failed for safeguard.
+				// Only set to true if we actually attempted a self-update
+				// (i.e., SkipSelfUpdate is false) and the error is a real
+				// failure, not a cooldown deferral.
+				if sourceContainer.IsWatchtower() &&
+					!config.SkipSelfUpdate &&
+					!errors.Is(checkErr, container.ErrImageCooldown) {
+					parallelWatchtowerPullFailed = true
+				}
+			case verifyErr != nil:
+				parallelStaleCheckFailed++
+
+				progress.AddSkipped(sourceContainer, verifyErr, config)
+
+				if sourceContainer.IsWatchtower() &&
+					!config.SkipSelfUpdate &&
+					!errors.Is(verifyErr, container.ErrImageCooldown) {
+					parallelWatchtowerPullFailed = true
+				}
+			default:
+				// For fresh containers, set newestImage to current image ID for proper categorization.
+				// (Cooldown decision and any layer pull now happen inside pkg/container/image.go
+				// IsOutsideCooldown + guarded PullImage, after digest staleness and before layers.)
+				if !stale {
+					newestImage = sourceContainer.ImageID()
+				}
+
+				// Log successful staleness check and add to scanned containers.
+				clog.WithFields(
+					logrus.Fields{
+						"stale":        stale,
+						"newest_image": newestImage,
+					}).Debug("Checked container staleness")
+				progress.AddScanned(
+					sourceContainer,
+					newestImage,
+					config,
+				)
+			}
+
+			// Track old image ID before update for cleanup notifications.
+			if shouldUpdate {
+				c, ok := filteredContainers[task.index].(*container.Container)
+				if ok {
+					c.SetOldImageID(sourceContainer.ImageID())
+				}
+			}
+
+			// Update the container's stale status for dependency sorting.
+			// Only mark as stale if the container should actually be updated.
+			filteredContainers[task.index].SetStale(stale && shouldUpdate && checkErr == nil && verifyErr == nil)
+
+			// Increment stale count for logging summary.
+			if stale {
+				parallelStaleCount++
+			}
+
+			return nil
+		})
+	}
+
+	err = checkGroup.Wait()
+	if err != nil {
+		logrus.WithError(err).Debug("Parallel staleness checks completed with error")
+	}
+
+	staleCheckFailed = parallelStaleCheckFailed
+	watchtowerPullFailed = parallelWatchtowerPullFailed
+	staleCount = parallelStaleCount
 
 	// Log the summary of staleness checks, including total, stale, and failed counts.
 	logrus.WithFields(
@@ -401,7 +478,8 @@ func Update(
 	// Propagate stale status to allContainers since they are different instances.
 	for _, c := range filteredContainers {
 		if c.IsStale() {
-			if ac, ok := containerByID[c.ID()]; ok {
+			ac, ok := containerByID[c.ID()]
+			if ok {
 				ac.SetStale(true)
 			}
 		}
@@ -414,13 +492,15 @@ func Update(
 	)
 	if err != nil {
 		if errors.Is(err, sorter.ErrCircularReference) {
-			if circularErr, ok := errors.AsType[sorter.CircularReferenceError](err); ok {
+			circularErr, ok := errors.AsType[sorter.CircularReferenceError](err)
+			if ok {
 				circularName := circularErr.ContainerName
 				// Find the container and mark as skipped.
 				for _, c := range filteredContainers {
 					if c.Name() == circularName {
 						// Only add if not already skipped (e.g., from initial cycle detection)
-						if _, exists := (*progress)[c.ID()]; !exists {
+						_, exists := (*progress)[c.ID()]
+						if !exists {
 							progress.AddSkipped(
 								c,
 								errCircularDependency,
@@ -638,7 +718,8 @@ func UpdateImplicitRestart(
 		// Also index by bare name for better exact matching in mixed scenarios
 		bareName := c.Name()
 		if bareName != "" && bareName != resolvedID {
-			if _, exists := restartByIdentifier[bareName]; !exists {
+			_, exists := restartByIdentifier[bareName]
+			if !exists {
 				restartByIdentifier[bareName] = c.ToRestart()
 			}
 		}
@@ -666,12 +747,13 @@ func UpdateImplicitRestart(
 					"to_restart":           c.ToRestart(),
 				}).Debug("Checking links for container")
 
-			if link := linkedIdentifierMarkedForRestart(
+			link := linkedIdentifierMarkedForRestart(
 				links,
 				restartByIdentifier,
 				c,
 				allContainers,
-			); link != "" {
+			)
+			if link != "" {
 				logrus.WithFields(
 					logrus.Fields{
 						"container":  c.Name(),
@@ -679,7 +761,8 @@ func UpdateImplicitRestart(
 					}).Debug("Marked container as linked to restarting")
 				containers[i].SetLinkedToRestarting(true)
 
-				if allContainer, ok := byID[c.ID()]; ok {
+				allContainer, ok := byID[c.ID()]
+				if ok {
 					allContainer.SetLinkedToRestarting(true)
 					resolved := container.ResolveContainerIdentifier(allContainer)
 					restartByIdentifier[resolved] = true
@@ -804,7 +887,8 @@ func linkedIdentifierMarkedForRestart(
 	knownProjects := map[string]bool{}
 
 	for _, c := range allContainers {
-		if p := getProject(c); p != "" {
+		p := getProject(c)
+		if p != "" {
 			knownProjects[p] = true
 		}
 	}
@@ -968,7 +1052,7 @@ func linkedIdentifierMarkedForRestart(
 				}
 			}
 
-			// No same-project service match found; take the first candidate
+			// No same-project service match found. Take the first candidate
 			// after sorting for deterministic behavior.
 			sort.Strings(serviceCandidates)
 			chosen := serviceCandidates[0]
@@ -998,8 +1082,10 @@ func linkedIdentifierMarkedForRestart(
 // Returns:
 //   - string: Project name, or "" if none can be determined.
 func getProject(c types.Container) string {
-	if monitoredContainer, ok := c.(*container.Container); ok {
-		if info := monitoredContainer.ContainerInfo(); info != nil && info.Config != nil {
+	monitoredContainer, ok := c.(*container.Container)
+	if ok {
+		info := monitoredContainer.ContainerInfo()
+		if info != nil && info.Config != nil {
 			project := compose.GetProjectName(info.Config.Labels)
 			if project != "" {
 				return project
@@ -1008,7 +1094,9 @@ func getProject(c types.Container) string {
 	}
 	// Fallback to parsing from container name
 	containerName := c.Name()
-	if idx := strings.Index(containerName, "-"); idx > 0 {
+
+	idx := strings.Index(containerName, "-")
+	if idx > 0 {
 		return containerName[:idx]
 	}
 
@@ -1137,7 +1225,7 @@ func isPinned(
 		return true, nil
 	}
 
-	// Non-pinned names must still be parseable; retry with fallback when needed.
+	// Non-pinned names must still be parseable. Retry with fallback when needed.
 	err := parseReference(imageName, configImage, fallbackImage, cont)
 	if err != nil {
 		if imageName != fallbackImage {
@@ -1292,7 +1380,8 @@ func performRollingRestart(
 			} else {
 				// Set the new container ID in progress
 				if progress != nil {
-					if status, exists := (*progress)[c.ID()]; exists {
+					status, exists := (*progress)[c.ID()]
+					if exists {
 						status.SetNewContainerID(newContainerID)
 						// Mark as restarted if not stale (not updated)
 						if !c.IsStale() {
@@ -1621,7 +1710,8 @@ func restartContainersInSortedOrder(
 			} else {
 				// Set the new container ID in progress
 				if progress != nil {
-					if status, exists := (*progress)[c.ID()]; exists {
+					status, exists := (*progress)[c.ID()]
+					if exists {
 						status.SetNewContainerID(newContainerID)
 						// Mark as restarted if not stale (not updated)
 						if !c.IsStale() {
@@ -1744,8 +1834,8 @@ func restartStaleContainer(
 		// Opt-in ephemeral self-update: use a short-lived orchestrator container
 		// to perform the transition atomically. The orchestrator handles stopping
 		// the old container, creating and starting the new one, and cleanup.
-		// EphemeralSelfUpdate returns immediately after starting the orchestrator;
-		// the orchestrator completes the replacement asynchronously. The current
+		// EphemeralSelfUpdate returns immediately after starting the orchestrator.
+		// The orchestrator completes the replacement asynchronously. The current
 		// Watchtower process will be stopped by the orchestrator shortly after.
 		if config.EphemeralSelfUpdate {
 			logrus.WithFields(fields).
@@ -1815,7 +1905,8 @@ func restartStaleContainer(
 
 	// For Watchtower self-updates, accumulate container ID chain in labels.
 	if sourceContainer.IsWatchtower() {
-		if c, ok := sourceContainer.(*container.Container); ok {
+		c, ok := sourceContainer.(*container.Container)
+		if ok {
 			containerInfo := c.ContainerInfo()
 			if containerInfo != nil && containerInfo.Config != nil {
 				existingChain, _ := c.GetContainerChain()

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -466,8 +466,9 @@ func Update(
 	if err != nil {
 		logrus.WithError(err).Debug("Parallel staleness checks completed with error")
 
+		// Surface context cancellation from parallel workers as the final Update error.
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return progress.Report(), cleanupImageInfos, fmt.Errorf("update canceled: %w", ctx.Err())
+			return progress.Report(), cleanupImageInfos, fmt.Errorf("update canceled: %w", err)
 		}
 	}
 

--- a/internal/actions/update_context_test.go
+++ b/internal/actions/update_context_test.go
@@ -47,12 +47,12 @@ var _ = ginkgo.Describe("the update action", func() {
 				types.UpdateParams{Cleanup: true, CPUCopyMode: "auto"},
 			)
 
-			// Update continues but marks containers as skipped due to staleness check failure
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(report).NotTo(gomega.BeNil())
-			gomega.Expect(report.Skipped()).
-				To(gomega.HaveLen(3))
-				// All containers skipped due to error
+			// Context cancellation from IsContainerStale is propagated as the
+			// final Update error rather than being swallowed.
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("update canceled"))
+			// Workers returning context.Canceled do not add partial results to progress.
+			gomega.Expect(report.Skipped()).To(gomega.BeEmpty())
 			gomega.Expect(cleanupImageInfos).To(gomega.BeEmpty())
 		})
 
@@ -653,6 +653,55 @@ func TestUpdateAction_ContextEdgeCases(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestUpdateAction_ParallelStalenessCheckCancellationPropagation tests that context
+// cancellation during parallel staleness checks is propagated as the final Update
+// error rather than being swallowed by workers.
+func TestUpdateAction_ParallelStalenessCheckCancellationPropagation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		testData := getCommonTestData()
+		testData.Staleness = map[string]bool{
+			"test-container-01": true,
+			"test-container-02": true,
+			"test-container-03": true,
+		}
+		testData.SimulatedLatency = 10 * time.Millisecond
+
+		ctx, cancel := context.WithCancel(context.Background())
+		client := mockActions.CreateMockClientWithContext(ctx, testData, false, false)
+
+		done := make(chan struct{})
+
+		var err error
+
+		go func() {
+			defer close(done)
+
+			_, _, err = actions.Update(
+				ctx,
+				client,
+				types.UpdateParams{Cleanup: true, CPUCopyMode: "auto"},
+			)
+		}()
+
+		synctest.Wait()
+		cancel()
+
+		<-done
+
+		synctest.Wait()
+
+		if err == nil {
+			t.Fatal("expected error when context is canceled during parallel staleness checks")
+		}
+
+		if !strings.Contains(err.Error(), "update canceled") &&
+			!strings.Contains(err.Error(), "context canceled") &&
+			!strings.Contains(err.Error(), "context") {
+			t.Fatalf("expected context-related error, got: %s", err.Error())
+		}
+	})
 }
 
 // TestEarlyCancellationStopContainers tests that context cancellation is properly handled

--- a/internal/actions/update_context_test.go
+++ b/internal/actions/update_context_test.go
@@ -85,7 +85,7 @@ var _ = ginkgo.Describe("the update action", func() {
 				gomega.Expect(report).NotTo(gomega.BeNil())
 				gomega.Expect(report.Failed()).To(gomega.HaveLen(1)) // One container failed to stop
 				// Cleanup should still be attempted for successful operations.
-				// 2 of 3 containers succeeded; each gets its own entry for split notifications.
+				// 2 of 3 containers succeeded and each gets its own entry for split notifications.
 				gomega.Expect(cleanupImageInfos).To(gomega.HaveLen(2))
 			},
 		)

--- a/internal/actions/update_context_test.go
+++ b/internal/actions/update_context_test.go
@@ -2,6 +2,7 @@ package actions_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"testing/synctest"
@@ -31,7 +32,7 @@ var _ = ginkgo.Describe("the update action", func() {
 			)
 
 			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).To(gomega.ContainSubstring("update canceled"))
+			gomega.Expect(errors.Is(err, context.Canceled)).To(gomega.BeTrue())
 			gomega.Expect(report).To(gomega.BeNil())
 			gomega.Expect(cleanupImageInfos).To(gomega.BeEmpty())
 		})
@@ -50,7 +51,7 @@ var _ = ginkgo.Describe("the update action", func() {
 			// Context cancellation from IsContainerStale is propagated as the
 			// final Update error rather than being swallowed.
 			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).To(gomega.ContainSubstring("update canceled"))
+			gomega.Expect(errors.Is(err, context.Canceled)).To(gomega.BeTrue())
 			// Workers returning context.Canceled do not add partial results to progress.
 			gomega.Expect(report.Skipped()).To(gomega.BeEmpty())
 			gomega.Expect(cleanupImageInfos).To(gomega.BeEmpty())
@@ -696,10 +697,8 @@ func TestUpdateAction_ParallelStalenessCheckCancellationPropagation(t *testing.T
 			t.Fatal("expected error when context is canceled during parallel staleness checks")
 		}
 
-		if !strings.Contains(err.Error(), "update canceled") &&
-			!strings.Contains(err.Error(), "context canceled") &&
-			!strings.Contains(err.Error(), "context") {
-			t.Fatalf("expected context-related error, got: %s", err.Error())
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context canceled error, got: %s", err.Error())
 		}
 	})
 }

--- a/internal/actions/update_cooldown_test.go
+++ b/internal/actions/update_cooldown_test.go
@@ -176,7 +176,7 @@ var _ = ginkgo.Describe("the update action cooldown", func() {
 
 	ginkgo.When("CooldownDelay is set and image is older than cooldown", func() {
 		ginkgo.It("should proceed with the update normally", func() {
-			// Image was created 2 days ago; cooldown is 1 hour.
+			// Image was created 2 days ago. Cooldown is 1 hour.
 			registryServer = ghttp.NewServer()
 			registryServer.AppendHandlers(mockRegistryHandlers(time.Now().Add(-48 * time.Hour))...)
 
@@ -296,7 +296,7 @@ var _ = ginkgo.Describe("the update action cooldown", func() {
 
 	ginkgo.When("image creation time is in the future (clock skew)", func() {
 		ginkgo.It("should proceed with the update to avoid indefinite deferral", func() {
-			// Image was created 1 hour in the future; cooldown is 1 hour.
+			// Image was created 1 hour in the future. Cooldown is 1 hour.
 			// This simulates clock skew between host and registry.
 			registryServer = ghttp.NewServer()
 			registryServer.AppendHandlers(mockRegistryHandlers(time.Now().Add(1 * time.Hour))...)

--- a/internal/actions/update_dependencies_test.go
+++ b/internal/actions/update_dependencies_test.go
@@ -502,7 +502,7 @@ var _ = ginkgo.Describe("the update action", func() {
 
 		ginkgo.It("should allow replica matches for qualified links via hasExactOrReplica even without project label on dependent", func() {
 			// Dependent has no project label and a hyphenated link from compose depends_on.
-			// The restarting candidate is a replica; FindMatchingIdentifiers hits replica
+			// The restarting candidate is a replica. FindMatchingIdentifiers hits replica
 			// strategy so hasExactOrReplica is true and the qualified-link guard permits it.
 			base := mockActions.CreateMockContainerWithConfig(
 				"project-base-1",

--- a/internal/actions/update_image_test.go
+++ b/internal/actions/update_image_test.go
@@ -2,6 +2,7 @@ package actions_test
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -307,6 +308,60 @@ var _ = ginkgo.Describe("the update action", func() {
 				To(gomega.Equal(int32(0)), "RemoveImageByID should not be called")
 			gomega.Expect(client.TestData.IsContainerStaleCount.Load()).
 				To(gomega.Equal(int32(0)), "IsContainerStale should not be called")
+		})
+
+		// Verify that failures across parallel staleness checks are all counted
+		// in the final report when IsContainerStale returns an error for every container.
+		ginkgo.It("should count all parallel staleness failures in the final report", func() {
+			client = &mockActions.MockClient{
+				TestData: &mockActions.TestData{
+					Containers: []types.Container{
+						mockActions.CreateMockContainerWithImageInfoP(
+							"invalid-ref-container",
+							"/invalid-ref-container",
+							"",
+							time.Now(),
+							nil,
+						),
+						mockActions.CreateMockContainer(
+							"stale-fail-container",
+							"/stale-fail-container",
+							"image:latest",
+							time.Now(),
+						),
+						mockActions.CreateMockContainer(
+							"normal-container",
+							"/normal-container",
+							"image:latest",
+							time.Now(),
+						),
+					},
+					Staleness: map[string]bool{
+						"invalid-ref-container": true,
+						"stale-fail-container":  true,
+						"normal-container":      true,
+					},
+				},
+				Stopped: make(map[string]bool),
+			}
+			client.TestData.IsContainerStaleError = errors.New("stale check failed")
+
+			report, cleanupImageInfos, err := actions.Update(
+				context.Background(),
+				client,
+				config,
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(report.Skipped()).
+				To(gomega.HaveLen(3), "All three containers should be skipped when IsContainerStale fails")
+			gomega.Expect(report.Scanned()).
+				To(gomega.BeEmpty(), "No containers should be scanned when all fail")
+			gomega.Expect(report.Updated()).
+				To(gomega.BeEmpty(), "No containers should be updated when IsContainerStale fails")
+			gomega.Expect(cleanupImageInfos).
+				To(gomega.BeEmpty(), "No image IDs should be collected")
+			gomega.Expect(client.TestData.IsContainerStaleCount.Load()).
+				To(gomega.Equal(int32(3)), "IsContainerStale should be called for all three containers")
 		})
 	})
 })

--- a/internal/actions/validate.go
+++ b/internal/actions/validate.go
@@ -46,7 +46,8 @@ func ValidateRollingRestartDependencies(ctx context.Context, client container.Cl
 	// Check each container for links.
 	for _, c := range containers {
 		// If a container has any links, then return an error.
-		if links := c.Links(useComposeDependsOn); len(links) > 0 {
+		links := c.Links(useComposeDependsOn)
+		if len(links) > 0 {
 			logrus.WithFields(logrus.Fields{
 				"container": c.Name(),
 				"links":     links,

--- a/pkg/notifications/shoutrrr.go
+++ b/pkg/notifications/shoutrrr.go
@@ -359,11 +359,7 @@ func sendNotifications(notifier *shoutrrrTypeNotifier) {
 				"notification_type": shoutrrrType,
 			}).Trace("Calling Router.Send with message")
 
-			if !notifier.sendWithCancellation(msg) {
-				LocalLog.Debug("Context canceled during message send")
-
-				return
-			}
+			notifier.send(msg)
 		case <-notifier.stop:
 			// Shutdown mode: drain all remaining messages from the channel
 			LocalLog.Debug("Shutdown signal received, draining remaining messages without delay")
@@ -398,11 +394,7 @@ func sendNotifications(notifier *shoutrrrTypeNotifier) {
 						"notification_type": shoutrrrType,
 					}).Trace("Calling Router.Send with message during shutdown")
 
-					if !notifier.sendWithCancellation(msg) {
-						LocalLog.Debug("Context canceled during shutdown message send")
-
-						return
-					}
+					notifier.send(msg)
 				default:
 					// Channel is empty, all messages drained
 					LocalLog.Debug("All remaining messages drained during shutdown")
@@ -662,18 +654,13 @@ func (n *shoutrrrTypeNotifier) Fire(entry *logrus.Entry) error {
 	return nil
 }
 
-// sendWithCancellation sends a message with context cancellation support.
+// send sends a message via the notification router.
 //
 // Parameters:
 //   - msg: Message to send.
-//
-// Returns:
-//   - bool: True if sent successfully, false if canceled.
-func (n *shoutrrrTypeNotifier) sendWithCancellation(msg string) bool {
+func (n *shoutrrrTypeNotifier) send(msg string) {
 	errs := n.Router.Send(msg, n.params)
 	processSendErrors(n, errs)
-
-	return true
 }
 
 // buildMessage constructs a notification message from data.

--- a/pkg/notifications/shoutrrr.go
+++ b/pkg/notifications/shoutrrr.go
@@ -670,20 +670,10 @@ func (n *shoutrrrTypeNotifier) Fire(entry *logrus.Entry) error {
 // Returns:
 //   - bool: True if sent successfully, false if canceled.
 func (n *shoutrrrTypeNotifier) sendWithCancellation(msg string) bool {
-	sendCh := make(chan []error, 1)
+	errs := n.Router.Send(msg, n.params)
+	processSendErrors(n, errs)
 
-	go func() {
-		sendCh <- n.Router.Send(msg, n.params)
-	}()
-
-	select {
-	case errs := <-sendCh:
-		processSendErrors(n, errs)
-
-		return true
-	case <-n.ctx.Done():
-		return false
-	}
+	return true
 }
 
 // buildMessage constructs a notification message from data.
@@ -756,14 +746,11 @@ func (n *shoutrrrTypeNotifier) sendEntries(entries []*logrus.Entry, report types
 		Debug("Preparing to send entries")
 
 	if msg == "" {
-		// Log in go func in case we entered from Fire to avoid stalling
-		go func() { // Avoid blocking if called from Fire.
-			if err != nil {
-				LocalLog.WithError(err).Fatal("Notification template error")
-			} else if len(n.Urls) > 1 {
-				LocalLog.Info("Skipping notification due to empty message")
-			}
-		}()
+		if err != nil {
+			LocalLog.WithError(err).Fatal("Notification template error")
+		} else if len(n.Urls) > 1 {
+			LocalLog.Info("Skipping notification due to empty message")
+		}
 
 		LocalLog.Debug("Message empty, skipping send")
 

--- a/pkg/notifications/shoutrrr.go
+++ b/pkg/notifications/shoutrrr.go
@@ -734,7 +734,7 @@ func (n *shoutrrrTypeNotifier) sendEntries(entries []*logrus.Entry, report types
 
 	if msg == "" {
 		if err != nil {
-			LocalLog.WithError(err).Fatal("Notification template error")
+			LocalLog.WithError(err).Error("Notification template error")
 		} else if len(n.Urls) > 1 {
 			LocalLog.Info("Skipping notification due to empty message")
 		}

--- a/pkg/notifications/shoutrrr.go
+++ b/pkg/notifications/shoutrrr.go
@@ -659,8 +659,17 @@ func (n *shoutrrrTypeNotifier) Fire(entry *logrus.Entry) error {
 // Parameters:
 //   - msg: Message to send.
 func (n *shoutrrrTypeNotifier) send(msg string) {
-	errs := n.Router.Send(msg, n.params)
-	processSendErrors(n, errs)
+	sendCh := make(chan []error, 1)
+	go func() {
+		sendCh <- n.Router.Send(msg, n.params)
+	}()
+
+	select {
+	case errs := <-sendCh:
+		processSendErrors(n, errs)
+	case <-n.ctx.Done():
+		LocalLog.WithError(n.ctx.Err()).Debug("Notification send canceled")
+	}
 }
 
 // buildMessage constructs a notification message from data.

--- a/pkg/notifications/shoutrrr_test.go
+++ b/pkg/notifications/shoutrrr_test.go
@@ -1219,7 +1219,7 @@ func TestShutdownGracePeriodConstant(t *testing.T) {
 
 // TestCloseDoesNotHangWithBlockingRouter verifies that Close() completes without hanging
 // when the router is blocked. This tests that the context cancellation properly unblocks
-// the sendWithCancellation call.
+// the send call.
 func TestCloseDoesNotHangWithBlockingRouter(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		// Set up logging


### PR DESCRIPTION
This PR implements parallel container staleness checks.

## Problem

Watchtower checked staleness sequentially for every container, which scaled O(n) with container count.

## Solution

Run staleness checks concurrently with a bounded worker pool while preserving the existing sequential contract for progress reporting and error handling.

## Changes

- Parallelized staleness checks with bounded concurrency
- Updated cancellation test expectations and add additional integration testing
- Applied minor restructuring of the package's inline if statements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Accelerated update processing by running staleness checks in parallel with bounded concurrency.
  * Pinned-image containers are skipped from staleness checks to reduce unnecessary work.
  * Enhanced restart dependency propagation for linked containers.
* **Bug Fixes**
  * Improved notification sending reliability, including better handling for send cancellation and empty rendered messages.
  * Clarified update context-cancellation outcomes during container listing and parallel staleness checks.
* **Tests**
  * Added/updated coverage to ensure cancellation propagates correctly and staleness-failure scenarios are handled as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->