### PR TITLE
fix: handle local-only images and clarify self-update port messages

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -910,15 +910,21 @@ func runMain(cfg types.RunConfig) int {
 		logrus.Debug("Disabled update-on-start due to cleanup of old Watchtower containers")
 	}
 
-	// Configure and start the HTTP API, handling any startup errors.
+	// Determine whether self-update should be skipped because the running
+	// Watchtower container has published host ports. Docker cannot rebind
+	// an occupied port during container replacement. Ephemeral self-updates
+	// are exempt, because they remove the old container before creating the new
+	// one, so no port conflict occurs.
 	//
-	// Determine if self-update should be skipped due to host-bound port conflicts.
-	// Ephemeral self-updates are exempt because they remove the old container before
-	// creating the new one, avoiding port conflicts.
-	// This flag is passed to the API so the warning is emitted near the HTTP server startup message.
+	// Perform this check here rather than inside SetupAndStartAPI so the
+	// warning always appears, even when no HTTP API endpoints are enabled
+	// and SetupAndStartAPI returns early.
 	skipSelfUpdate := currentWatchtowerContainer != nil &&
 		currentWatchtowerContainer.HasExposedPorts() &&
 		!ephemeralSelfUpdate
+	if skipSelfUpdate {
+		logrus.Warn("Published port detected - self-updates disabled.")
+	}
 
 	err = api.SetupAndStartAPI(
 		ctx,

--- a/internal/api/lifecycle.go
+++ b/internal/api/lifecycle.go
@@ -118,7 +118,7 @@ func SetupAndStartAPI(ctx context.Context, opts config.Options) error {
 
 	if opts.SkipSelfUpdate {
 		logrus.WithField("notify", "no").
-			Warn("Skipping self-update to prevent port conflict: Watchtower container has host-bound ports")
+			Warn("Published port detected - self-updates disabled.")
 	}
 
 	tlsCertPath, tlsKeyPath := opts.TLSCertPath, opts.TLSKeyPath

--- a/internal/api/lifecycle.go
+++ b/internal/api/lifecycle.go
@@ -116,11 +116,6 @@ func SetupAndStartAPI(ctx context.Context, opts config.Options) error {
 		return fmt.Errorf("route registration failed: %w", err)
 	}
 
-	if opts.SkipSelfUpdate {
-		logrus.WithField("notify", "no").
-			Warn("Published port detected - self-updates disabled.")
-	}
-
 	tlsCertPath, tlsKeyPath := opts.TLSCertPath, opts.TLSKeyPath
 
 	if (tlsCertPath == "") != (tlsKeyPath == "") {

--- a/internal/scheduling/scheduling.go
+++ b/internal/scheduling/scheduling.go
@@ -140,7 +140,7 @@ func RunUpgradesOnSchedule(
 		if skipSelfUpdateForPorts {
 			skipWatchtowerSelfUpdate = true
 
-			logrus.Debug("Skipping self-update to prevent port conflict")
+			logrus.Debug("Published ports detected - self-update skipped.")
 		}
 
 		// Skip update if this is a Watchtower parent container (from self-update chain)

--- a/pkg/container/cooldown_test.go
+++ b/pkg/container/cooldown_test.go
@@ -271,9 +271,11 @@ var _ = ginkgo.Describe("PullImage cooldown gate", func() {
 			)
 
 			i := newImageClient(mockClient)
+			// Use an explicit registry host so local-only 404 handling does not apply.
+			// Digest failure must fall through to the cooldown gate.
 			c := MockContainer(
-				WithImageName("test:latest"),
-				WithRepoDigests([]string{"test@sha256:12345"}),
+				WithImageName("registry.example.com/test:latest"),
+				WithRepoDigests([]string{"registry.example.com/test@sha256:12345"}),
 			)
 
 			err := i.PullImage(context.Background(), c, WarnAuto, types.UpdateParams{

--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -121,6 +121,12 @@ func (c imageClient) IsContainerStale(
 			return false, sourceContainer.ImageID(), "", err
 		}
 
+		if errors.Is(err, ErrPullImageNotFound) {
+			clog.WithError(err).Debug("Image not found in any registry - treating as up-to-date")
+
+			return false, sourceContainer.ImageID(), "", nil
+		}
+
 		clog.WithError(err).Debug("Failed to pull image")
 
 		return false, sourceContainer.ImageID(), "", err
@@ -381,7 +387,7 @@ func (c imageClient) PullImage(
 		clog.Debug("Authentication credentials loaded")
 	}
 
-	// Skip the pull if the digest matches the current image.
+	// Skip the pull if the digest matches the current image (or local-only).
 	if c.shouldSkipPull(ctx, sourceContainer, opts.RegistryAuth, warnOnHeadFailed, fields) {
 		return nil
 	}
@@ -548,6 +554,7 @@ func (c imageClient) shouldSkipPull(
 	endpoints := c.buildMirrorEndpoints(mirrorInfo)
 
 	// Compare current and remote digests, trying each endpoint.
+	// Local-only images are handled inside CompareDigest (match=true, err=nil).
 	match, err := digest.CompareDigest(ctx, sourceContainer, registryAuth, endpoints...)
 	if err != nil {
 		clog.WithFields(logrus.Fields{
@@ -560,7 +567,7 @@ func (c imageClient) shouldSkipPull(
 
 	switch {
 	case err != nil:
-		// Digest retrieval failed; log based on warning strategy and proceed with pull.
+		// Digest retrieval failed. Log based on warning strategy and proceed with pull.
 		headLevel := logrus.DebugLevel
 		if warn {
 			headLevel = logrus.WarnLevel
@@ -571,12 +578,12 @@ func (c imageClient) shouldSkipPull(
 
 		return false
 	case match:
-		// Digests match; no pull needed.
+		// Digests match (or local-only image treated as up-to-date). No pull needed.
 		clog.Debug("Digest match, skipping pull")
 
 		return true
 	default:
-		// Digests differ; proceed with pull.
+		// Digests differ. Proceed with pull.
 		clog.Debug("Digest mismatch, proceeding with pull")
 
 		return false

--- a/pkg/container/image_test.go
+++ b/pkg/container/image_test.go
@@ -141,14 +141,14 @@ var _ = ginkgo.Describe("the client", func() {
 			mockServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("POST", gomega.MatchRegexp("/images/create")),
-					ghttp.RespondWith(http.StatusNotFound, `{"message":"manifest for nonexistent:latest not found"}`),
+					ghttp.RespondWith(http.StatusNotFound, `{"message":"manifest for registry.example.com/nonexistent:latest not found"}`),
 				),
 			)
 
 			i := newImageClient(mockClient)
 			pullContainer := MockContainer(
-				WithImageName("nonexistent:latest"),
-				WithRepoDigests([]string{"nonexistent@sha256:def"}),
+				WithImageName("registry.example.com/nonexistent:latest"),
+				WithRepoDigests([]string{"registry.example.com/nonexistent@sha256:def"}),
 			)
 
 			resetLogrus, logbuf := captureLogrus(logrus.DebugLevel)
@@ -174,8 +174,8 @@ var _ = ginkgo.Describe("the client", func() {
 
 			i := newImageClient(mockClient)
 			pullContainer := MockContainer(
-				WithImageName("app:latest"),
-				WithRepoDigests([]string{"app@sha256:ghi"}),
+				WithImageName("registry.example.com/app:latest"),
+				WithRepoDigests([]string{"registry.example.com/app@sha256:ghi"}),
 			)
 
 			resetLogrus, logbuf := captureLogrus(logrus.DebugLevel)
@@ -685,6 +685,57 @@ var _ = ginkgo.Describe("the client", func() {
 				gomega.Expect(stale).To(gomega.BeTrue())
 				gomega.Expect(string(latestID)).To(gomega.Equal(newImageID))
 				gomega.Expect(latestDigest).To(gomega.Equal(newDigest))
+			})
+		})
+		ginkgo.When("the image is not found in any registry", func() {
+			ginkgo.It("should treat the container as up-to-date without error", func() {
+				currentImageID := "sha256:" + util.GenerateRandomSHA256()
+				container := MockContainer(
+					WithImageName("atlas-badgerdb:latest"),
+					WithRepoDigests([]string{"atlas-badgerdb@sha256:80f07677bee57274a48929d0688bf0cfabe5e83f06f2f152dab4076445d6ab35"}),
+					func(container *dockerContainer.InspectResponse, image *dockerImage.InspectResponse) {
+						container.Image = currentImageID
+						image.ID = currentImageID
+					},
+				)
+
+				// Domain-less Config.Image + registry 404 is handled inside CompareDigest
+				// as match=true; PullImage skips without ImagePull. HasNewImage still runs
+				// and inspects the local image by name.
+				mockServer.AllowUnhandledRequests = true
+				mockServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", gomega.MatchRegexp(`/images/.+/json`)),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, dockerImage.InspectResponse{
+							ID: currentImageID,
+							RepoDigests: []string{
+								"atlas-badgerdb@sha256:80f07677bee57274a48929d0688bf0cfabe5e83f06f2f152dab4076445d6ab35",
+							},
+						}),
+					),
+				)
+
+				c := &client{api: mockClient}
+
+				resetLogrus, logbuf := captureLogrus(logrus.DebugLevel)
+				defer resetLogrus()
+
+				stale, latestID, latestDigest, err := c.IsContainerStale(
+					context.Background(),
+					container,
+					types.UpdateParams{},
+				)
+				gomega.Expect(err).To(gomega.Succeed())
+				gomega.Expect(stale).To(gomega.BeFalse())
+				gomega.Expect(latestID).To(gomega.Equal(types.ImageID(currentImageID)))
+				gomega.Expect(latestDigest).To(gomega.Equal(
+					"sha256:80f07677bee57274a48929d0688bf0cfabe5e83f06f2f152dab4076445d6ab35",
+				))
+				gomega.Eventually(logbuf).Should(gbytes.Say(`Digest match, skipping pull`))
+
+				for _, req := range mockServer.ReceivedRequests() {
+					gomega.Expect(req.URL.Path).ToNot(gomega.ContainSubstring("/images/create"))
+				}
 			})
 		})
 	})

--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -174,9 +174,18 @@ func isLocalImageNotFound(container types.Container, err error) bool {
 		return false
 	}
 
+	// Evaluate only the repository name so tags/digests (e.g. my-app:1.0) do not
+	// make a domain-less image look registry-qualified via "." in a semver tag.
 	originalImage := container.ContainerInfo().Config.Image
+	namePart, _, _ := strings.Cut(originalImage, "@")
 
-	return !strings.ContainsAny(originalImage, "./")
+	if i := strings.LastIndex(namePart, ":"); i >= 0 {
+		if j := strings.LastIndex(namePart, "/"); j < i {
+			namePart = namePart[:i]
+		}
+	}
+
+	return !strings.ContainsAny(namePart, "./")
 }
 
 // CompareDigestWithRemote checks whether a container's current image digest matches

--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/distribution/reference"
 	"github.com/sirupsen/logrus"
@@ -36,6 +37,8 @@ var (
 	errMissingImageInfo = errors.New("container image info missing")
 	// errInvalidRegistryResponse indicates the registry's HEAD response lacks a digest or is malformed.
 	errInvalidRegistryResponse = errors.New("registry responded with invalid HEAD request")
+	// ErrManifestNotFound indicates the registry returned 404 for the manifest request.
+	ErrManifestNotFound = errors.New("manifest not found")
 	// errFailedGetToken indicates a failure to obtain an authentication token from the registry.
 	errFailedGetToken = errors.New("failed to get token")
 	// errFailedBuildManifestURL indicates a failure to construct the manifest URL for the registry.
@@ -45,6 +48,47 @@ var (
 	// errFailedExecuteRequest indicates a failure to execute an HTTP request to the registry.
 	errFailedExecuteRequest = errors.New("failed to execute request")
 )
+
+// localOnlyImageCache records image name+ID pairs previously confirmed as local-only
+// (domain-less Config.Image with a registry 404). Subsequent checks skip remote
+// probes, avoiding Docker Hub rate-limit pressure that can starve concurrent
+// staleness checks for other containers in the same update cycle.
+//
+// Keyed by "imageName|imageID". Entries live for process lifetime; a rebuild
+// (new image ID) forces a fresh probe.
+var localOnlyImageCache sync.Map
+
+// localOnlyCacheKey builds a cache key for a container's image identity.
+func localOnlyCacheKey(container types.Container) string {
+	if !container.HasImageInfo() {
+		return container.ImageName() + "|"
+	}
+
+	return container.ImageName() + "|" + container.ImageInfo().ID
+}
+
+// rememberLocalOnlyImage records that the container's image was confirmed local-only.
+func rememberLocalOnlyImage(container types.Container) {
+	localOnlyImageCache.Store(localOnlyCacheKey(container), true)
+}
+
+// isCachedLocalOnlyImage reports whether the container's image was previously
+// confirmed local-only for this process.
+func isCachedLocalOnlyImage(container types.Container) bool {
+	_, ok := localOnlyImageCache.Load(localOnlyCacheKey(container))
+
+	return ok
+}
+
+// ClearLocalOnlyImageCache removes all cached local-only image entries.
+// Intended for tests.
+func ClearLocalOnlyImageCache() {
+	localOnlyImageCache.Range(func(key, _ any) bool {
+		localOnlyImageCache.Delete(key)
+
+		return true
+	})
+}
 
 // NormalizeDigest standardizes a digest string for consistent comparison.
 //
@@ -107,6 +151,34 @@ func CompareDigest(
 	return match, err
 }
 
+// isLocalImageNotFound reports whether the digest fetch failed because the
+// registry returned 404 for a manifest request and the container's image name
+// does not explicitly specify a registry domain. That pattern indicates a
+// locally built image that has never been pushed, so there is no remote
+// manifest to compare against.
+//
+// Parameters:
+//   - container: Container whose image name is inspected.
+//   - err: Error returned from digest fetch.
+//
+// Returns:
+//   - bool: True if the image should be treated as local-only, false otherwise.
+func isLocalImageNotFound(container types.Container, err error) bool {
+	if !errors.Is(err, ErrManifestNotFound) {
+		return false
+	}
+
+	if !container.HasImageInfo() ||
+		container.ContainerInfo() == nil ||
+		container.ContainerInfo().Config == nil {
+		return false
+	}
+
+	originalImage := container.ContainerInfo().Config.Image
+
+	return !strings.ContainsAny(originalImage, "./")
+}
+
 // CompareDigestWithRemote checks whether a container's current image digest matches
 // the latest from its registry and returns the remote digest used for comparison.
 //
@@ -154,11 +226,21 @@ func CompareDigestWithRemote(
 	// We check container.ImageInfo().RepoDigests rather than inspecting via the
 	// Docker daemon because:
 	// 1. The container was already populated with image info during initialization
-	// 2. For locally built images, RepoDigests is always empty
+	// 2. For locally built images, RepoDigests are either empty or registry-less
 	// 3. This avoids an extra Docker daemon call
 	if len(container.ImageInfo().RepoDigests) == 0 {
 		logrus.WithFields(fields).
 			Debug("Image with no registry reference detected (empty RepoDigests) - skipping digest comparison")
+
+		return true, "", nil
+	}
+
+	// Skip registry probes for images previously confirmed local-only (same name+ID).
+	// This prevents repeated Docker Hub 404 traffic that can rate-limit concurrent
+	// checks for other containers in the same update session.
+	if isCachedLocalOnlyImage(container) {
+		logrus.WithFields(fields).
+			Debug("Cached local-only image - skipping digest comparison")
 
 		return true, "", nil
 	}
@@ -172,6 +254,16 @@ func CompareDigestWithRemote(
 		endpoints...,
 	)
 	if err != nil {
+		// Domain-less image names that 404 are local-only builds; treat as up-to-date
+		// with no error so callers skip the pull without logging a warning.
+		if isLocalImageNotFound(container, err) {
+			rememberLocalOnlyImage(container)
+			logrus.WithFields(fields).
+				Debug("Image not found in registry - treating as local image")
+
+			return true, "", nil
+		}
+
 		return false, "", err
 	}
 
@@ -707,7 +799,8 @@ func HandleManifestResponse(
 				Debug("Response status not successful")
 
 			return "", "", false, fmt.Errorf(
-				"%w: status %s",
+				"%w: %w: status %s",
+				ErrManifestNotFound,
 				errInvalidRegistryResponse,
 				resp.Status,
 			)

--- a/pkg/registry/digest/digest_test.go
+++ b/pkg/registry/digest/digest_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	dockerContainer "github.com/moby/moby/api/types/container"
 	dockerImage "github.com/moby/moby/api/types/image"
 
 	mockAuth "github.com/nicholas-fedor/watchtower/pkg/registry/auth/mocks"
@@ -204,6 +205,175 @@ func TestCompareDigestWithRemote(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, match)
 	assert.Equal(t, "sha256:"+remoteHash, remoteDigest)
+}
+
+// TestCompareDigestWithRemote_LocalOnly404 is a regression test for locally built
+// images (e.g. atlas-badgerdb) that have non-empty registry-less RepoDigests.
+// A HEAD 404 must be treated as up-to-date with no error so callers skip the pull
+// without logging "Digest retrieval failed, falling back to full pull".
+func TestCompareDigestWithRemote_LocalOnly404(t *testing.T) {
+	ClearLocalOnlyImageCache()
+	t.Cleanup(ClearLocalOnlyImageCache)
+
+	viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+	t.Cleanup(func() {
+		viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+	})
+
+	mc := mockTypes.NewMockContainer(t)
+	mc.On("Name").Return("atlas-badgerdb-1")
+	mc.On("ImageName").Return("atlas-badgerdb:latest")
+	mc.On("HasImageInfo").Return(true)
+	mc.On("ImageInfo").Return(&dockerImage.InspectResponse{
+		RepoDigests: []string{
+			"atlas-badgerdb@sha256:80f07677bee57274a48929d0688bf0cfabe5e83f06f2f152dab4076445d6ab35",
+		},
+	})
+	mc.On("ContainerInfo").Return(&dockerContainer.InspectResponse{
+		Config: &dockerContainer.Config{
+			Image: "atlas-badgerdb",
+		},
+	})
+
+	var headManifestCalls int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Auth probe may GET /v2/; only manifest GET would indicate unwanted fallback.
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/manifests/") {
+			t.Errorf("unexpected GET to %s; local-only 404 must not fall back to GET", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+
+			return
+		}
+
+		if r.Method == http.MethodHead && strings.Contains(r.URL.Path, "/manifests/") {
+			headManifestCalls++
+
+			w.WriteHeader(http.StatusNotFound)
+
+			return
+		}
+
+		// Unauthenticated registry probe.
+		if r.Method == http.MethodGet && (r.URL.Path == "/v2/" || r.URL.Path == "/v2") {
+			w.WriteHeader(http.StatusOK)
+
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	parts := strings.SplitN(server.URL, "://", 2)
+	host := parts[len(parts)-1]
+
+	match, remoteDigest, err := CompareDigestWithRemote(
+		context.Background(),
+		mc,
+		"",
+		host,
+	)
+	require.NoError(t, err)
+	assert.True(t, match)
+	assert.Empty(t, remoteDigest)
+	assert.GreaterOrEqual(t, headManifestCalls, 1)
+}
+
+// TestIsLocalImageNotFound verifies domain-less Config.Image + ErrManifestNotFound
+// identity matching (a prior dual-sentinel bug broke errors.Is).
+func TestIsLocalImageNotFound(t *testing.T) {
+	t.Run("true for domain-less Config.Image with wrapped ErrManifestNotFound", func(t *testing.T) {
+		mc := mockTypes.NewMockContainer(t)
+		mc.On("HasImageInfo").Return(true)
+		mc.On("ContainerInfo").Return(&dockerContainer.InspectResponse{
+			Config: &dockerContainer.Config{Image: "atlas-badgerdb"},
+		})
+
+		err := fmt.Errorf("%w: %w: status 404 Not Found", ErrManifestNotFound, errInvalidRegistryResponse)
+		assert.True(t, isLocalImageNotFound(mc, err))
+	})
+
+	t.Run("false for domain-ful Config.Image", func(t *testing.T) {
+		mc := mockTypes.NewMockContainer(t)
+		mc.On("HasImageInfo").Return(true)
+		mc.On("ContainerInfo").Return(&dockerContainer.InspectResponse{
+			Config: &dockerContainer.Config{Image: "registry.example.com/app:latest"},
+		})
+
+		err := fmt.Errorf("%w: status 404 Not Found", ErrManifestNotFound)
+		assert.False(t, isLocalImageNotFound(mc, err))
+	})
+
+	t.Run("false for non-manifest errors", func(t *testing.T) {
+		mc := mockTypes.NewMockContainer(t)
+		err := fmt.Errorf("%w: status 500", errInvalidRegistryResponse)
+		assert.False(t, isLocalImageNotFound(mc, err))
+	})
+}
+
+// TestLocalOnlyImageCache ensures a confirmed local-only image skips subsequent
+// registry probes for the same image name+ID.
+func TestLocalOnlyImageCache(t *testing.T) {
+	ClearLocalOnlyImageCache()
+	t.Cleanup(ClearLocalOnlyImageCache)
+
+	viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+	t.Cleanup(func() {
+		viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+	})
+
+	const imageID = "sha256:80f07677bee57274a48929d0688bf0cfabe5e83f06f2f152dab4076445d6ab35"
+
+	mc := mockTypes.NewMockContainer(t)
+	mc.On("Name").Return("atlas-badgerdb-1")
+	mc.On("ImageName").Return("atlas-badgerdb:latest")
+	mc.On("HasImageInfo").Return(true)
+	mc.On("ImageInfo").Return(&dockerImage.InspectResponse{
+		ID: imageID,
+		RepoDigests: []string{
+			"atlas-badgerdb@sha256:80f07677bee57274a48929d0688bf0cfabe5e83f06f2f152dab4076445d6ab35",
+		},
+	})
+	mc.On("ContainerInfo").Return(&dockerContainer.InspectResponse{
+		Config: &dockerContainer.Config{Image: "atlas-badgerdb"},
+	})
+
+	var headManifestCalls int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead && strings.Contains(r.URL.Path, "/manifests/") {
+			headManifestCalls++
+
+			w.WriteHeader(http.StatusNotFound)
+
+			return
+		}
+
+		if r.Method == http.MethodGet && (r.URL.Path == "/v2/" || r.URL.Path == "/v2") {
+			w.WriteHeader(http.StatusOK)
+
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	parts := strings.SplitN(server.URL, "://", 2)
+	host := parts[len(parts)-1]
+
+	// First call: probe registry, cache local-only.
+	match, _, err := CompareDigestWithRemote(context.Background(), mc, "", host)
+	require.NoError(t, err)
+	assert.True(t, match)
+	assert.Equal(t, 1, headManifestCalls)
+
+	// Second call: cache hit, no additional HEAD.
+	match, _, err = CompareDigestWithRemote(context.Background(), mc, "", host)
+	require.NoError(t, err)
+	assert.True(t, match)
+	assert.Equal(t, 1, headManifestCalls, "cached local-only image must not re-probe registry")
 }
 
 func TestCompareDigest(t *testing.T) {

--- a/pkg/registry/digest/digest_test.go
+++ b/pkg/registry/digest/digest_test.go
@@ -294,6 +294,17 @@ func TestIsLocalImageNotFound(t *testing.T) {
 		assert.True(t, isLocalImageNotFound(mc, err))
 	})
 
+	t.Run("true for domain-less image with version tag containing dots", func(t *testing.T) {
+		mc := mockTypes.NewMockContainer(t)
+		mc.On("HasImageInfo").Return(true)
+		mc.On("ContainerInfo").Return(&dockerContainer.InspectResponse{
+			Config: &dockerContainer.Config{Image: "my-app:1.0"},
+		})
+
+		err := fmt.Errorf("%w: status 404 Not Found", ErrManifestNotFound)
+		assert.True(t, isLocalImageNotFound(mc, err))
+	})
+
 	t.Run("false for domain-ful Config.Image", func(t *testing.T) {
 		mc := mockTypes.NewMockContainer(t)
 		mc.On("HasImageInfo").Return(true)


### PR DESCRIPTION
Skip registry digest checks and pulls for images that have no remote counterpart (domain-less name with a registry 404), and simplify self-update skip logs when host-published ports block in-place self-updates.

## Problem

Locally built images often have non-empty, but registry-less `RepoDigests`. Watchtower still probed Docker Hub, logged digest failures, and fell back to full pulls even though no remote image exists to update from.

Separately, self-update skip messaging for host-published ports was verbose and inconsistent between API startup and scheduled runs.

## Solution

When a manifest HEAD returns 404 and `Config.Image` has no registry domain (no `.` or `/`), treat the image as having **no remote update source**: skip remote digest comparison and pull without recording a failed check. Cache confirmed local-only `imageName|imageID` pairs for the process lifetime so later cycles do not re-probe Hub.

This is not the same as `no-pull`. `no-pull` is an explicit policy that never pulls and can still detect newer **local** image IDs. Local-only handling only skips **remote** work when the registry has nothing for that name. It does not claim a rebuilt local tag is current if the running container still uses an older image ID.

Also shorten self-update port skip messages: warn once at API startup, debug on each schedule tick.

## Changes

- Add `ErrManifestNotFound`, `isLocalImageNotFound`, and process-local local-only image cache in `pkg/registry/digest`
- On domain-less image + registry 404, skip remote digest comparison and pull without error
- Treat pull-not-found as no remote update in `IsContainerStale`
- Add regression tests for local-only 404 handling, error identity, and cache reuse
- Adjust container/cooldown tests to use registry-qualified names where real pull failures are expected
- Warn: `Published port detected - self-updates disabled.`
- Debug: `Published ports detected - self-update skipped.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of locally built images that aren’t present in remote registries by treating them as up-to-date when appropriate.
  * Avoided unnecessary remote digest/manifest checks by caching “local-only” results for the process lifetime.
  * Treated image pull “not found” as up-to-date to prevent avoidable pull failures.
  * Clarified the self-update warning behavior when published ports force self-updates to be skipped.
* **Tests**
  * Updated mocks to use fully qualified registry hostnames.
  * Added/expanded coverage for local-only 404 handling, cache reuse, and “not found” scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->