### PR TITLE
fix: ensure revive-stopped configuration reaches scheduled update runs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -768,7 +768,7 @@ func runMain(cfg types.RunConfig) int {
 			Filter:                       filter,                       // Container filter determining which containers are targeted
 			Cleanup:                      params.Cleanup,               // Remove old images after container updates
 			NoRestart:                    noRestart,                    // Prevent containers from being restarted after updates
-			ReviveStopped:                reviveStopped,                // Start stopped containers after update if true
+			ReviveStopped:                params.ReviveStopped,         // Start stopped containers after update if true
 			MonitorOnly:                  params.MonitorOnly,           // Monitor containers without performing updates
 			LifecycleHooks:               lifecycleHooks,               // Enable pre- and post-update lifecycle hook commands
 			RollingRestart:               rollingRestart,               // Update containers sequentially rather than all at once

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -768,7 +768,7 @@ func runMain(cfg types.RunConfig) int {
 			Filter:                       filter,                       // Container filter determining which containers are targeted
 			Cleanup:                      params.Cleanup,               // Remove old images after container updates
 			NoRestart:                    noRestart,                    // Prevent containers from being restarted after updates
-			ReviveStopped:                params.ReviveStopped,         // Start stopped containers after update if true
+			ReviveStopped:                reviveStopped,                // Start stopped containers after update if true
 			MonitorOnly:                  params.MonitorOnly,           // Monitor containers without performing updates
 			LifecycleHooks:               lifecycleHooks,               // Enable pre- and post-update lifecycle hook commands
 			RollingRestart:               rollingRestart,               // Update containers sequentially rather than all at once

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1018,6 +1018,7 @@ func runMain(cfg types.RunConfig) int {
 		currentWatchtowerContainer,
 		startupMessageSent,
 		ephemeralSelfUpdate,
+		reviveStopped,
 	)
 	if err != nil {
 		logNotify("Scheduled upgrades failed", err)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -550,6 +550,7 @@ func TestUpdateOnStartTriggersImmediateUpdate(t *testing.T) {
 		nil,
 		false, // startupMessageSent
 		false, // ephemeralSelfUpdate
+		false, // reviveStopped
 	)
 
 	// Should not return an error (context cancellation is expected)
@@ -640,6 +641,7 @@ func TestUpdateOnStartIntegratesWithCronScheduling(t *testing.T) {
 			nil,
 			false, // startupMessageSent
 			false, // ephemeralSelfUpdate
+			false, // reviveStopped
 		)
 
 		// Should not return an error (context cancellation is expected)
@@ -734,6 +736,7 @@ func TestUpdateOnStartLockingBehavior(t *testing.T) {
 			nil,
 			false, // startupMessageSent
 			false, // ephemeralSelfUpdate
+			false, // reviveStopped
 		)
 
 		// Should not return an error
@@ -809,6 +812,7 @@ func TestUpdateOnStartSelfUpdateScenario(t *testing.T) {
 			nil,
 			false, // startupMessageSent
 			false, // ephemeralSelfUpdate
+			false, // reviveStopped
 		)
 
 		// Should not return an error
@@ -897,6 +901,7 @@ func TestUpdateOnStartMultiInstanceScenario(t *testing.T) {
 				nil,
 				false, // startupMessageSent
 				false, // ephemeralSelfUpdate
+				false, // reviveStopped
 			)
 			assert.NoError(t, err)
 			completed.Add(1)
@@ -930,6 +935,7 @@ func TestUpdateOnStartMultiInstanceScenario(t *testing.T) {
 				nil,
 				false, // startupMessageSent
 				false, // ephemeralSelfUpdate
+				false, // reviveStopped
 			)
 			assert.NoError(t, err)
 			completed.Add(1)
@@ -1130,6 +1136,7 @@ func TestRunUpgradesOnSchedule_ShutdownWaitsForRunningUpdate(t *testing.T) {
 				nil,
 				false, // startupMessageSent
 				false, // ephemeralSelfUpdate
+				false, // reviveStopped
 			)
 			assert.NoError(t, err)
 
@@ -1293,6 +1300,7 @@ func TestEphemeralSelfUpdateExercisesTruePath(t *testing.T) {
 		nil,
 		false, // startupMessageSent
 		true,  // ephemeralSelfUpdate
+		false, // reviveStopped
 	)
 
 	require.NoError(t, err)
@@ -1820,4 +1828,38 @@ func TestHTTPAPIEndpointsEnabled(t *testing.T) {
 	assert.False(t, httpAPIEndpointsEnabled(types.RunConfig{}))
 	assert.True(t, httpAPIEndpointsEnabled(types.RunConfig{EnableHealthAPI: true}))
 	assert.True(t, httpAPIEndpointsEnabled(types.RunConfig{EnableUpdateAPI: true}))
+}
+
+func TestRootCommand_ReviveStoppedFlagParsing(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected bool
+	}{
+		{
+			name:     "revive-stopped enabled",
+			args:     []string{"--revive-stopped"},
+			expected: true,
+		},
+		{
+			name:     "revive-stopped default",
+			args:     []string{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewRootCommand()
+			flags.RegisterSystemFlags(cmd)
+			cmd.SetArgs(tt.args)
+
+			err := cmd.ParseFlags(tt.args)
+			require.NoError(t, err)
+
+			value, err := cmd.PersistentFlags().GetBool("revive-stopped")
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, value)
+		})
+	}
 }

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -673,6 +673,7 @@ func TestIntegration_APIAndScheduling_ConcurrentWithUnblockHTTPAPI(t *testing.T)
 		nil,
 		true,
 		false,
+		false, // reviveStopped
 	)
 	require.NoError(t, err, "RunUpgradesOnSchedule should run concurrently after SetupAndStartAPI returns")
 }

--- a/internal/scheduling/scheduling.go
+++ b/internal/scheduling/scheduling.go
@@ -78,6 +78,7 @@ func WaitForRunningUpdate(ctx context.Context, lock chan bool) {
 //   - currentWatchtowerContainer: The current Watchtower container for parent checking.
 //   - startupMessageSent: Whether the startup message was already sent (e.g., by the HTTP API in blocking mode).
 //   - ephemeralSelfUpdate: Whether the self-update uses ephemeral mode (removes old container before creating new one).
+//   - reviveStopped: Whether to start stopped containers after update.
 //
 // Returns:
 //   - error: An error if scheduling fails (e.g., invalid cron spec), nil on successful shutdown.
@@ -101,6 +102,7 @@ func RunUpgradesOnSchedule(
 	currentWatchtowerContainer types.Container,
 	startupMessageSent bool,
 	ephemeralSelfUpdate bool,
+	reviveStopped bool,
 ) error {
 	// Initialize lock if not provided, ensuring single-update concurrency.
 	if lock == nil {
@@ -184,6 +186,7 @@ func RunUpgradesOnSchedule(
 			RunOnce:        false,
 			MonitorOnly:    monitorOnly,
 			SkipSelfUpdate: skipWatchtowerSelfUpdate,
+			ReviveStopped:  reviveStopped,
 		}
 
 		metric := runUpdatesWithNotifications(ctx, filter, params)

--- a/internal/scheduling/scheduling_test.go
+++ b/internal/scheduling/scheduling_test.go
@@ -144,6 +144,7 @@ func TestRunUpgradesOnSchedule_EmptySchedule(t *testing.T) {
 		nil,   // currentWatchtowerContainer
 		false, // startupMessageSent
 		false, // ephemeralSelfUpdate
+		false, // reviveStopped
 	)
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
@@ -193,6 +194,7 @@ func TestRunUpgradesOnSchedule_StartupMessageSuppressed(t *testing.T) {
 		nil,   // currentWatchtowerContainer
 		true,  // startupMessageSent - suppress the startup message
 		false, // ephemeralSelfUpdate
+		false, // reviveStopped
 	)
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
@@ -246,6 +248,7 @@ func TestRunUpgradesOnSchedule_UpdateOnStart(t *testing.T) {
 		nil,   // currentWatchtowerContainer
 		false, // startupMessageSent
 		false, // ephemeralSelfUpdate
+		false, // reviveStopped
 	)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -305,6 +308,7 @@ func TestRunUpgradesOnSchedule_InvalidCronSpec(t *testing.T) {
 		nil,   // currentWatchtowerContainer
 		false, // startupMessageSent
 		false, // ephemeralSelfUpdate
+		false, // reviveStopped
 	)
 	if err == nil {
 		t.Error("expected error")
@@ -385,10 +389,11 @@ func TestRunUpgradesOnSchedule_QuotedScheduleSpec(t *testing.T) {
 				"v1.0.0",
 				false, // monitorOnly
 				false, // updateOnStart
-				false, // skipFirstRun
+				true,  // skipFirstRun - should skip Watchtower self-update on first run
 				nil,   // currentWatchtowerContainer
 				false, // startupMessageSent
 				false, // ephemeralSelfUpdate
+				false, // reviveStopped
 			)
 
 			if tt.expectError {
@@ -440,6 +445,7 @@ func TestRunUpgradesOnSchedule_ContextCancellation(t *testing.T) {
 		nil,   // currentWatchtowerContainer
 		false, // startupMessageSent
 		false, // ephemeralSelfUpdate
+		false, // reviveStopped
 	)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -505,6 +511,7 @@ func TestRunUpgradesOnSchedule_MonitorOnlyParameter(t *testing.T) {
 				nil,            // currentWatchtowerContainer
 				false,          // startupMessageSent
 				false,          // ephemeralSelfUpdate
+				false,          // reviveStopped
 			)
 			if err != nil {
 				t.Errorf("expected no error, got %v", err)
@@ -639,6 +646,7 @@ func TestRunUpgradesOnSchedule_CronWithSeconds(t *testing.T) {
 		nil,   // currentWatchtowerContainer
 		false, // startupMessageSent
 		false, // ephemeralSelfUpdate
+		false, // reviveStopped
 	)
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
@@ -694,6 +702,7 @@ func TestRunUpgradesOnSchedule_SkipFirstRun_True(t *testing.T) {
 		nil,   // currentWatchtowerContainer
 		false, // startupMessageSent
 		false, // ephemeralSelfUpdate
+		false, // reviveStopped
 	)
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
@@ -761,6 +770,7 @@ func TestRunUpgradesOnSchedule_WatchtowerParent_Skipping(t *testing.T) {
 		parentContainer, // currentWatchtowerContainer - should skip updates
 		false,           // startupMessageSent
 		false,           // ephemeralSelfUpdate
+		false,           // reviveStopped
 	)
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
@@ -821,6 +831,7 @@ func TestRunUpgradesOnSchedule_ScheduledRuns_Execution(t *testing.T) {
 		nil,   // currentWatchtowerContainer
 		false, // startupMessageSent
 		false, // ephemeralSelfUpdate
+		false, // reviveStopped
 	)
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
@@ -886,7 +897,7 @@ func TestRunUpgradesOnSchedule_EphemeralSelfUpdateWithExposedPorts(t *testing.T)
 		cmd,
 		filters.NoFilter,
 		"test filter",
-		nil,   // lock (auto-created)
+		nil,   // no lock
 		false, // cleanup
 		"",    // empty schedule
 		writeStartupMessage,
@@ -895,12 +906,13 @@ func TestRunUpgradesOnSchedule_EphemeralSelfUpdateWithExposedPorts(t *testing.T)
 		"",  // scope
 		nil, // no notifier
 		"v1.0.0",
-		false,              // monitorOnly
-		true,               // updateOnStart - triggers immediate update
-		false,              // skipFirstRun
-		containerWithPorts, // currentWatchtowerContainer with exposed ports
-		false,              // startupMessageSent
-		true,               // ephemeralSelfUpdate - bypasses port-conflict guard
+		false, // monitorOnly
+		false, // updateOnStart
+		false, // skipFirstRun
+		nil,   // currentWatchtowerContainer
+		false, // startupMessageSent
+		false, // ephemeralSelfUpdate
+		false, // reviveStopped
 	)
 	require.NoError(t, err)
 
@@ -964,6 +976,7 @@ func TestRunUpgradesOnSchedule_PortConflictGuard_SkipsSelfUpdate(t *testing.T) {
 		containerWithPorts, // currentWatchtowerContainer with exposed ports
 		false,              // startupMessageSent
 		false,              // ephemeralSelfUpdate - port-conflict guard is active
+		false,              // reviveStopped
 	)
 	require.NoError(t, err)
 
@@ -1042,6 +1055,7 @@ func TestRunUpgradesOnSchedule_NoExposedPorts_AllowsSelfUpdate(t *testing.T) {
 				containerNoPorts, // currentWatchtowerContainer without exposed ports
 				false,            // startupMessageSent
 				tt.ephemeralSelfUpdate,
+				false, // reviveStopped
 			)
 			require.NoError(t, err)
 
@@ -1050,6 +1064,78 @@ func TestRunUpgradesOnSchedule_NoExposedPorts_AllowsSelfUpdate(t *testing.T) {
 			assert.False(t, capturedParams.SkipSelfUpdate,
 				"self-update should NOT be skipped when container has no exposed ports",
 			)
+		})
+	}
+}
+
+// TestRunUpgradesOnSchedule_ReviveStoppedPropagation verifies that RunUpgradesOnSchedule
+// passes the ReviveStopped flag through UpdateParams to the update function.
+func TestRunUpgradesOnSchedule_ReviveStoppedPropagation(t *testing.T) {
+	tests := []struct {
+		name           string
+		reviveStopped  bool
+		expectSelected bool
+	}{
+		{
+			name:           "reviveStopped=true",
+			reviveStopped:  true,
+			expectSelected: true,
+		},
+		{
+			name:           "reviveStopped=false",
+			reviveStopped:  false,
+			expectSelected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
+
+			ctx := t.Context()
+
+			var capturedParams types.UpdateParams
+
+			runUpdatesWithNotifications := func(_ context.Context, _ types.Filter, params types.UpdateParams) *metrics.Metric {
+				capturedParams = params
+
+				return &metrics.Metric{Scanned: 1, Updated: 0, Failed: 0}
+			}
+
+			writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {}
+
+			cmd.PersistentFlags().Bool("update-on-start", true, "")
+
+			timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
+			defer timeoutCancel()
+
+			err := scheduling.RunUpgradesOnSchedule(
+				timeoutCtx,
+				cmd,
+				filters.NoFilter,
+				"test filter",
+				nil,   // lock (auto-created)
+				false, // cleanup
+				"",    // empty schedule
+				writeStartupMessage,
+				runUpdatesWithNotifications,
+				client,
+				"",  // scope
+				nil, // no notifier
+				"v1.0.0",
+				false,            // monitorOnly
+				true,             // updateOnStart - triggers immediate update
+				false,            // skipFirstRun
+				nil,              // currentWatchtowerContainer
+				false,            // startupMessageSent
+				false,            // ephemeralSelfUpdate
+				tt.reviveStopped, // reviveStopped
+			)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectSelected, capturedParams.ReviveStopped,
+				"ReviveStopped should be %v in UpdateParams", tt.expectSelected)
 		})
 	}
 }

--- a/internal/scheduling/scheduling_test.go
+++ b/internal/scheduling/scheduling_test.go
@@ -906,13 +906,13 @@ func TestRunUpgradesOnSchedule_EphemeralSelfUpdateWithExposedPorts(t *testing.T)
 		"",  // scope
 		nil, // no notifier
 		"v1.0.0",
-		false, // monitorOnly
-		false, // updateOnStart
-		false, // skipFirstRun
-		nil,   // currentWatchtowerContainer
-		false, // startupMessageSent
-		false, // ephemeralSelfUpdate
-		false, // reviveStopped
+		false,              // monitorOnly
+		true,               // updateOnStart - triggers immediate update
+		false,              // skipFirstRun
+		containerWithPorts, // currentWatchtowerContainer with exposed ports
+		false,              // startupMessageSent
+		true,               // ephemeralSelfUpdate - bypasses port-conflict guard
+		false,              // reviveStopped
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR fixes a regression where the `revive-stopped` configuration was silently dropped when Watchtower executed updates on a schedule. As a result, stopped containers were recreated but never started, remaining in a "Created" state despite the user explicitly enabling revive behavior.

## Problem

The `runUpdatesWithNotifications` closure in `cmd/root.go` read `params.ReviveStopped` from a zero-value `types.UpdateParams` constructed by the scheduler. In addition, `RunUpgradesOnSchedule` did not accept or forward the flag at all. Together these caused the revive-stopped setting to be lost before reaching the update layer.

## Solution

Thread `reviveStopped` through the scheduling API and correct the closure to use the outer-scope flag variable, matching how `noRestart`, `rollingRestart`, and `timeout` are already handled.

## Changes

- `cmd/root.go`: closure uses `reviveStopped` instead of `params.ReviveStopped`; call site passes `reviveStopped` into `scheduling.RunUpgradesOnSchedule`
- `internal/scheduling/scheduling.go`: `RunUpgradesOnSchedule` accepts `reviveStopped bool` and forwards it into `types.UpdateParams`
- Test updates across `cmd/root_test.go`, `internal/scheduling/scheduling_test.go`, and `internal/api/api_integration_test.go` to match the new signature and add propagation coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent support for the `--revive-stopped` setting across both manual and scheduled update runs.
  * When enabled, stopped containers can be started after updates.

* **Bug Fixes**
  * Scheduled updates now honor the same stopped-container recovery configuration as other update flows.
  * Added coverage to verify `--revive-stopped` flag default/behavior and correct propagation during scheduled upgrade execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->