### PR TITLE
refactor: consolidate restart-policy updates into SetNoRestartPolicy helper

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,8 +14,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	dockerContainer "github.com/moby/moby/api/types/container"
-
 	"github.com/nicholas-fedor/watchtower/internal/actions"
 	"github.com/nicholas-fedor/watchtower/internal/api"
 	"github.com/nicholas-fedor/watchtower/internal/api/config"
@@ -30,6 +28,24 @@ import (
 	"github.com/nicholas-fedor/watchtower/pkg/filters"
 	"github.com/nicholas-fedor/watchtower/pkg/notifications"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
+)
+
+const (
+	// restartPolicyTimeout is the maximum duration allowed for restart-policy
+	// update operations.
+	//
+	// It bounds the Docker API call that sets the current Watchtower
+	// container's restart policy to "no", so a slow or unresponsive
+	// daemon cannot delay shutdown paths.
+	restartPolicyTimeout = 5 * time.Second
+
+	// containerLookupTimeout is the maximum duration allowed for current
+	// container ID lookups.
+	//
+	// It bounds the Docker API / hostname / mountinfo detection sequence,
+	// so startup cannot hang indefinitely if the daemon or container runtime
+	// metadata is unreachable.
+	containerLookupTimeout = 5 * time.Second
 )
 
 var (
@@ -242,6 +258,11 @@ var (
 	rootCmd = NewRootCommand()
 )
 
+// errInvalidAPIHost indicates http-api-host is neither empty nor a valid IP.
+var errInvalidAPIHost = errors.New(
+	"invalid http-api-host: must be empty or a valid IP address (IPv4 or IPv6)",
+)
+
 // init registers command-line flags for the root command during package initialization.
 //
 // It invokes functions from the flags package to set default values and register flags for Docker configuration
@@ -430,16 +451,37 @@ func preRun(cmd *cobra.Command, _ []string) {
 	// Check for orchestrator mode early — this is an internal mode where Watchtower
 	// runs as a one-shot orchestrator for self-update. It reads environment variables
 	// to determine the old container ID, new image, and original container name.
-	if isOrchestrator, _ := flagsSet.GetBool("self-update-orchestrator"); isOrchestrator {
+	isOrchestrator, _ := flagsSet.GetBool("self-update-orchestrator")
+	if isOrchestrator {
 		logrus.Info("Running in ephemeral self-update orchestrator mode")
 
 		actions.RunOrchestrator(context.Background(), client)
 
-		// Defensive: RunOrchestrator should always call os.Exit, but if it ever
+		// RunOrchestrator should always call os.Exit, but if it ever
 		// returns unexpectedly, ensure the process terminates to prevent the
 		// preRun flow from continuing into the main Watchtower loop.
+		//
+		// Resolve the current Watchtower container directly here, before the
+		// general lookup later in preRun, so the restart policy update targets
+		// the actual container instead of a nil reference.
+		currentWatchtowerContainer = resolveCurrentWatchtowerContainerForFallback(
+			context.Background(),
+			client,
+		)
+
+		setNoRestartPolicyCtx, cancel := context.WithTimeout(
+			context.Background(),
+			restartPolicyTimeout,
+		)
+		defer cancel()
+
+		client.SetNoRestartPolicy(
+			setNoRestartPolicyCtx,
+			currentWatchtowerContainer,
+		)
+
 		logrus.WithField("flag", "self-update-orchestrator").
-			Fatal("RunOrchestrator returned unexpectedly; exiting to prevent unintended execution")
+			Fatal("RunOrchestrator returned unexpectedly. Exiting to prevent unintended execution")
 	}
 
 	// Warn about potential redundancy in flag combinations that could result in no action.
@@ -452,7 +494,6 @@ func preRun(cmd *cobra.Command, _ []string) {
 
 	// Create a timeout-bound context for Docker API lookups to prevent hanging indefinitely.
 	// This ensures the container ID lookup fails fast if the Docker API is unresponsive.
-	const containerLookupTimeout = 5 * time.Second
 
 	ctx, cancel := context.WithTimeout(context.Background(), containerLookupTimeout)
 	defer cancel()
@@ -489,31 +530,14 @@ func preRun(cmd *cobra.Command, _ []string) {
 			"Detected invalid restart of old Watchtower container, stopping Watchtower container now",
 		)
 
-		if currentWatchtowerContainer != nil {
-			updateConfig := dockerContainer.UpdateConfig{
-				RestartPolicy: dockerContainer.RestartPolicy{
-					Name: "no",
-				},
-			}
+		ctx, cancel := context.WithTimeout(
+			context.Background(),
+			containerLookupTimeout,
+		)
+		defer cancel()
 
-			ctx, cancel := context.WithTimeout(
-				context.Background(),
-				containerLookupTimeout,
-			)
-			defer cancel()
-
-			err := client.UpdateContainer(
-				ctx,
-				currentWatchtowerContainer,
-				updateConfig,
-			)
-			if err != nil {
-				logrus.WithError(err).
-					Warn("Failed to update restart policy to 'no' for old Watchtower container")
-			} else {
-				logrus.Debug("Updated restart policy to 'no' for old Watchtower container")
-			}
-		}
+		// Update current Watchtower container's restart policy to "no" to prevent unwanted restarts
+		client.SetNoRestartPolicy(ctx, currentWatchtowerContainer)
 
 		logrus.Exit(0)
 	}
@@ -551,7 +575,8 @@ func run(command *cobra.Command, args []string) {
 		)
 	}
 
-	// Determine the effective operational scope, prioritizing explicit scope over scope derived from the container's label.
+	// Determine the effective operational scope, prioritizing explicit scope
+	// over scope derived from the container's label.
 	// This ensures scope persistence during self-updates.
 	var err error
 
@@ -733,6 +758,17 @@ func runMain(cfg types.RunConfig) int {
 
 	// Validate flag compatibility to prevent conflicting operational modes.
 	if rollingRestart && monitorOnly {
+		setNoRestartPolicyCtx, cancel := context.WithTimeout(
+			context.Background(),
+			restartPolicyTimeout,
+		)
+		defer cancel()
+
+		client.SetNoRestartPolicy(
+			setNoRestartPolicyCtx,
+			currentWatchtowerContainer,
+		)
+
 		logrus.WithFields(logrus.Fields{
 			"rolling_restart": rollingRestart,
 			"monitor_only":    monitorOnly,
@@ -797,15 +833,32 @@ func runMain(cfg types.RunConfig) int {
 	// enabling graceful shutdown of the API, scheduler, and validation operations.
 	// The stop function is returned but not needed as the context automatically
 	// handles cleanup when the program exits.
-	ctx, stop := createSignalContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx, stop := createSignalContext(
+		context.Background(),
+		os.Interrupt,
+		syscall.SIGTERM,
+	)
 	defer stop()
 
 	// If rolling restarts are enabled, validate that the containers being monitored for
 	// updates do not have linked dependencies.
 	if rollingRestart {
-		err := actions.ValidateRollingRestartDependencies(ctx, client, cfg.Filter, useComposeDependsOn)
+		err := actions.ValidateRollingRestartDependencies(
+			ctx,
+			client,
+			cfg.Filter, useComposeDependsOn,
+		)
 		if err != nil {
 			logNotify("Rolling restart compatibility validation failed", err)
+
+			// Update current Watchtower container's restart policy to "no" to prevent unwanted restarts
+			setNoRestartPolicyCtx, cancel := context.WithTimeout(
+				context.Background(),
+				restartPolicyTimeout,
+			)
+			defer cancel()
+
+			client.SetNoRestartPolicy(setNoRestartPolicyCtx, currentWatchtowerContainer)
 
 			return 1 // Exit immediately after logging failure
 		}
@@ -841,23 +894,13 @@ func runMain(cfg types.RunConfig) int {
 		notifier.Close()
 
 		// Update current Watchtower container's restart policy to "no" to prevent unwanted restarts
-		if currentWatchtowerContainer == nil {
-			logrus.Warn("Current container not available for restart policy update")
-		} else {
-			updateConfig := dockerContainer.UpdateConfig{
-				RestartPolicy: dockerContainer.RestartPolicy{
-					Name: "no",
-				},
-			}
+		setNoRestartPolicyCtx, cancel := context.WithTimeout(
+			context.Background(),
+			restartPolicyTimeout,
+		)
+		defer cancel()
 
-			err := client.UpdateContainer(ctx, currentWatchtowerContainer, updateConfig)
-			if err != nil {
-				logrus.WithError(err).
-					Warn("Failed to update restart policy to 'no' for current container")
-			} else {
-				logrus.Debug("Updated current container restart policy to 'no'")
-			}
-		}
+		client.SetNoRestartPolicy(setNoRestartPolicyCtx, currentWatchtowerContainer)
 
 		return 0 // Exit after successful execution
 	}
@@ -992,6 +1035,15 @@ func runMain(cfg types.RunConfig) int {
 	if err != nil {
 		logNotify("API setup failed", err)
 
+		// Update current Watchtower container's restart policy to "no" to prevent unwanted restarts
+		setNoRestartPolicyCtx, cancel := context.WithTimeout(
+			context.Background(),
+			restartPolicyTimeout,
+		)
+		defer cancel()
+
+		client.SetNoRestartPolicy(setNoRestartPolicyCtx, currentWatchtowerContainer)
+
 		return 1 // Exit while indicating failure.
 	}
 
@@ -1022,6 +1074,15 @@ func runMain(cfg types.RunConfig) int {
 	)
 	if err != nil {
 		logNotify("Scheduled upgrades failed", err)
+
+		// Update current Watchtower container's restart policy to "no" to prevent unwanted restarts
+		setNoRestartPolicyCtx, cancel := context.WithTimeout(
+			context.Background(),
+			restartPolicyTimeout,
+		)
+		defer cancel()
+
+		client.SetNoRestartPolicy(setNoRestartPolicyCtx, currentWatchtowerContainer)
 
 		return 1 // Exit while indicating failure.
 	}
@@ -1058,10 +1119,31 @@ func awaitDockerClient() {
 	sleepFunc(1 * time.Second)
 }
 
-// errInvalidAPIHost indicates http-api-host is neither empty nor a valid IP.
-var errInvalidAPIHost = errors.New(
-	"invalid http-api-host: must be empty or a valid IP address (IPv4 or IPv6)",
-)
+// resolveCurrentWatchtowerContainerForFallback resolves the current Watchtower container
+// for use in the orchestrator fallback path.
+//
+// It attempts to detect the current container ID and retrieve the container object,
+// returning nil if any step fails.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeouts.
+//   - c: Container client for Docker API operations.
+//
+// Returns:
+//   - types.Container: The resolved Watchtower container, or nil if detection fails.
+func resolveCurrentWatchtowerContainerForFallback(ctx context.Context, c container.Client) types.Container {
+	lookupCtx, cancel := context.WithTimeout(ctx, containerLookupTimeout)
+	defer cancel()
+
+	containerID, err := container.GetCurrentContainerID(lookupCtx, c)
+	if err == nil && containerID != "" {
+		resolvedContainer, _ := c.GetCurrentWatchtowerContainer(lookupCtx, containerID)
+
+		return resolvedContainer
+	}
+
+	return nil
+}
 
 // validateAPIHost ensures http-api-host is empty (all interfaces) or a valid IP.
 //

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1863,3 +1863,123 @@ func TestRootCommand_ReviveStoppedFlagParsing(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveCurrentWatchtowerContainerForFallback(t *testing.T) {
+	t.Run("successful resolution", func(t *testing.T) {
+		originalReadMountinfoFunc := container.ReadMountinfoFunc
+		originalReadCgroupFunc := container.ReadCgroupFunc
+		container.ReadMountinfoFunc = func(string) ([]byte, error) {
+			return nil, errors.New("mock mountinfo error")
+		}
+		container.ReadCgroupFunc = func(string) ([]byte, error) {
+			return nil, errors.New("mock cgroup error")
+		}
+
+		defer func() {
+			container.ReadMountinfoFunc = originalReadMountinfoFunc
+			container.ReadCgroupFunc = originalReadCgroupFunc
+		}()
+
+		t.Setenv("HOSTNAME", "test-hostname")
+
+		mockCnt := mockTypes.NewMockContainer(t)
+		mockClient := mockContainer.NewMockClient(t)
+
+		mockClient.EXPECT().ListContainers(mock.Anything).Return([]types.Container{mockCnt}, nil).Once()
+		mockCnt.EXPECT().ContainerInfo().Return(&dockerContainer.InspectResponse{
+			Config: &dockerContainer.Config{Hostname: "test-hostname"},
+		}).Once()
+		mockCnt.EXPECT().ID().Return(types.ContainerID("test-id")).Once()
+		mockCnt.EXPECT().IsWatchtower().Return(false).Once()
+		mockClient.EXPECT().GetCurrentWatchtowerContainer(mock.Anything, types.ContainerID("test-id")).Return(mockCnt, nil).Once()
+
+		result := resolveCurrentWatchtowerContainerForFallback(context.Background(), mockClient)
+
+		assert.Equal(t, mockCnt, result)
+	})
+
+	t.Run("GetCurrentContainerID returns error", func(t *testing.T) {
+		originalReadMountinfoFunc := container.ReadMountinfoFunc
+		originalReadCgroupFunc := container.ReadCgroupFunc
+		container.ReadMountinfoFunc = func(string) ([]byte, error) {
+			return nil, errors.New("mock mountinfo error")
+		}
+		container.ReadCgroupFunc = func(string) ([]byte, error) {
+			return nil, errors.New("mock cgroup error")
+		}
+
+		defer func() {
+			container.ReadMountinfoFunc = originalReadMountinfoFunc
+			container.ReadCgroupFunc = originalReadCgroupFunc
+		}()
+
+		t.Setenv("HOSTNAME", "test-hostname")
+
+		mockClient := mockContainer.NewMockClient(t)
+
+		mockClient.EXPECT().ListContainers(mock.Anything).Return(nil, errors.New("list failed")).Once()
+
+		result := resolveCurrentWatchtowerContainerForFallback(context.Background(), mockClient)
+
+		assert.Nil(t, result)
+	})
+
+	t.Run("GetCurrentContainerID returns empty string", func(t *testing.T) {
+		originalReadMountinfoFunc := container.ReadMountinfoFunc
+		originalReadCgroupFunc := container.ReadCgroupFunc
+		container.ReadMountinfoFunc = func(string) ([]byte, error) {
+			return nil, errors.New("mock mountinfo error")
+		}
+		container.ReadCgroupFunc = func(string) ([]byte, error) {
+			return nil, errors.New("mock cgroup error")
+		}
+
+		defer func() {
+			container.ReadMountinfoFunc = originalReadMountinfoFunc
+			container.ReadCgroupFunc = originalReadCgroupFunc
+		}()
+
+		t.Setenv("HOSTNAME", "test-hostname")
+
+		mockClient := mockContainer.NewMockClient(t)
+
+		mockClient.EXPECT().ListContainers(mock.Anything).Return([]types.Container{}, nil).Once()
+
+		result := resolveCurrentWatchtowerContainerForFallback(context.Background(), mockClient)
+
+		assert.Nil(t, result)
+	})
+
+	t.Run("GetCurrentWatchtowerContainer returns nil", func(t *testing.T) {
+		originalReadMountinfoFunc := container.ReadMountinfoFunc
+		originalReadCgroupFunc := container.ReadCgroupFunc
+		container.ReadMountinfoFunc = func(string) ([]byte, error) {
+			return nil, errors.New("mock mountinfo error")
+		}
+		container.ReadCgroupFunc = func(string) ([]byte, error) {
+			return nil, errors.New("mock cgroup error")
+		}
+
+		defer func() {
+			container.ReadMountinfoFunc = originalReadMountinfoFunc
+			container.ReadCgroupFunc = originalReadCgroupFunc
+		}()
+
+		t.Setenv("HOSTNAME", "test-hostname")
+
+		mockCnt := mockTypes.NewMockContainer(t)
+		mockClient := mockContainer.NewMockClient(t)
+
+		mockClient.EXPECT().ListContainers(mock.Anything).Return([]types.Container{mockCnt}, nil).Once()
+		mockCnt.EXPECT().ContainerInfo().Return(&dockerContainer.InspectResponse{
+			Config: &dockerContainer.Config{Hostname: "test-hostname"},
+		}).Once()
+		mockCnt.EXPECT().ID().Return(types.ContainerID("test-id")).Once()
+		mockCnt.EXPECT().IsWatchtower().Return(false).Once()
+		mockClient.EXPECT().GetCurrentWatchtowerContainer(mock.Anything, types.ContainerID("test-id")).Return(nil, nil).Once()
+
+		result := resolveCurrentWatchtowerContainerForFallback(context.Background(), mockClient)
+
+		assert.Nil(t, result)
+	})
+}

--- a/internal/actions/actions_internal_test.go
+++ b/internal/actions/actions_internal_test.go
@@ -1355,36 +1355,40 @@ type stopContainersTestCase struct {
 
 // TestDetachedContextDeadline tests the detached context creation logic in restartStaleContainer.
 // These tests verify that the detached context is created correctly based on the Timeout config value:
-// - When Timeout > 0: context has a deadline
-// - When Timeout <= 0: context has no deadline.
+// - When Timeout > 0: context has a deadline derived from Timeout
+// - When Timeout <= 0: context has a fallback deadline to prevent indefinite blocking.
 var _ = ginkgo.Describe("DetachedContext", func() {
 	// TestDetachedContextDeadlineCase represents a test case for detached context deadline behavior.
 	type TestDetachedContextDeadlineCase struct {
-		name           string
-		timeout        time.Duration
-		expectDeadline bool
-		description    string
+		name            string
+		timeout         time.Duration
+		expectDeadline  bool
+		expectedTimeout time.Duration
+		description     string
 	}
 
 	ginkgo.Describe("restartStaleContainer detached context deadline", func() {
 		testCases := []TestDetachedContextDeadlineCase{
 			{
-				name:           "positive timeout creates context with deadline",
-				timeout:        30 * time.Second,
-				expectDeadline: true,
-				description:    "When Timeout > 0, the detached context should have a deadline set",
+				name:            "positive timeout creates context with deadline",
+				timeout:         30 * time.Second,
+				expectDeadline:  true,
+				expectedTimeout: 30 * time.Second,
+				description:     "When Timeout > 0, the detached context should have a deadline set",
 			},
 			{
-				name:           "zero timeout creates context without deadline",
-				timeout:        0,
-				expectDeadline: false,
-				description:    "When Timeout is zero, the detached context should not have a deadline",
+				name:            "zero timeout creates context with fallback deadline",
+				timeout:         0,
+				expectDeadline:  true,
+				expectedTimeout: defaultRestartPolicyTimeout,
+				description:     "When Timeout is zero, the detached context should use the fallback deadline",
 			},
 			{
-				name:           "negative timeout creates context without deadline",
-				timeout:        -1 * time.Second,
-				expectDeadline: false,
-				description:    "When Timeout is negative, the detached context should not have a deadline",
+				name:            "negative timeout creates context with fallback deadline",
+				timeout:         -1 * time.Second,
+				expectDeadline:  true,
+				expectedTimeout: defaultRestartPolicyTimeout,
+				description:     "When Timeout is negative, the detached context should use the fallback deadline",
 			},
 		}
 
@@ -1447,7 +1451,7 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 					deadline, hasDeadline := client.TestData.SetNoRestartPolicyCtx.Deadline()
 					gomega.Expect(hasDeadline).To(gomega.BeTrue())
 
-					expectedDeadline := time.Now().Add(tc.timeout)
+					expectedDeadline := time.Now().Add(tc.expectedTimeout)
 					gomega.Expect(deadline).To(gomega.BeTemporally("~", expectedDeadline, time.Second))
 				} else {
 					_, hasDeadline := client.TestData.SetNoRestartPolicyCtx.Deadline()
@@ -1492,7 +1496,7 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 			)
 
 			params := types.UpdateParams{
-				Timeout: 0, // No deadline on detached context
+				Timeout: 0, // Fallback deadline applied to detached context
 				RunOnce: false,
 			}
 
@@ -1581,7 +1585,7 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 			)
 
 			params := types.UpdateParams{
-				Timeout: 0, // No deadline on detached context
+				Timeout: 0, // Fallback deadline applied to detached context
 				RunOnce: false,
 			}
 
@@ -1638,7 +1642,7 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 				false,
 			)
 
-			// Use a timeout of 0 to create a detached context without deadline.
+			// Use a timeout of 0 to create a detached context with the fallback deadline.
 			params := types.UpdateParams{
 				Timeout: 0,
 				RunOnce: false,

--- a/internal/actions/actions_internal_test.go
+++ b/internal/actions/actions_internal_test.go
@@ -327,7 +327,7 @@ var _ = ginkgo.Describe("executeUpdate", func() {
 		gomega.Expect(client.TestData.StartContainerCount.Load()).To(gomega.Equal(int32(0)))
 	})
 
-	ginkgo.It("should call UpdateContainer for Watchtower restart policy changes", func() {
+	ginkgo.It("should call SetNoRestartPolicy for Watchtower restart policy changes", func() {
 		client := mockActions.CreateMockClient(
 			&mockActions.TestData{
 				Containers: []types.Container{
@@ -362,7 +362,7 @@ var _ = ginkgo.Describe("executeUpdate", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(report).NotTo(gomega.BeNil())
 		gomega.Expect(cleanupInfos).NotTo(gomega.BeNil())
-		gomega.Expect(client.TestData.UpdateContainerCount.Load()).To(gomega.Equal(int32(1)))
+		gomega.Expect(client.TestData.SetNoRestartPolicyCount.Load()).To(gomega.Equal(int32(1)))
 	})
 })
 
@@ -1438,10 +1438,21 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 				gomega.Expect(renamed).To(gomega.BeTrue())
 				gomega.Expect(newID).NotTo(gomega.BeEmpty())
 
-				// Verify UpdateContainer was called (this uses the detached context).
+				// Verify SetNoRestartPolicy was called (this uses the detached context).
 				// The detached context is used for updating the restart policy of the
 				// renamed Watchtower container.
-				gomega.Expect(client.TestData.UpdateContainerCount.Load()).To(gomega.Equal(int32(1)))
+				gomega.Expect(client.TestData.SetNoRestartPolicyCount.Load()).To(gomega.Equal(int32(1)))
+
+				if tc.expectDeadline {
+					deadline, hasDeadline := client.TestData.SetNoRestartPolicyCtx.Deadline()
+					gomega.Expect(hasDeadline).To(gomega.BeTrue())
+
+					expectedDeadline := time.Now().Add(tc.timeout)
+					gomega.Expect(deadline).To(gomega.BeTemporally("~", expectedDeadline, time.Second))
+				} else {
+					_, hasDeadline := client.TestData.SetNoRestartPolicyCtx.Deadline()
+					gomega.Expect(hasDeadline).To(gomega.BeFalse())
+				}
 			})
 		}
 	})
@@ -1648,10 +1659,11 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 			gomega.Expect(renamed).To(gomega.BeTrue())
 			gomega.Expect(newID).NotTo(gomega.BeEmpty())
 
-			// Verify that both StartContainer and UpdateContainer were called.
-			// UpdateContainer uses the detached context for the restart policy update.
+			// Verify that both StartContainer and SetNoRestartPolicy were called.
+			// SetNoRestartPolicy uses the detached context for the restart policy update.
 			gomega.Expect(client.TestData.StartContainerCount.Load()).To(gomega.Equal(int32(1)))
-			gomega.Expect(client.TestData.UpdateContainerCount.Load()).To(gomega.Equal(int32(1)))
+			gomega.Expect(client.TestData.SetNoRestartPolicyCount.Load()).To(gomega.Equal(int32(1)))
+			gomega.Expect(client.TestData.SetNoRestartPolicyCtx).NotTo(gomega.Equal(context.Background()))
 		})
 	})
 })

--- a/internal/actions/mocks/client.go
+++ b/internal/actions/mocks/client.go
@@ -34,6 +34,7 @@ type TestData struct {
 	StartContainerCount          atomic.Int32                          // Number of times StartContainer was called.
 	CreateContainerCount         atomic.Int32                          // Number of times CreateContainer was called.
 	UpdateContainerCount         atomic.Int32                          // Number of times UpdateContainer was called.
+	SetNoRestartPolicyCount      atomic.Int32                          // Number of times SetNoRestartPolicy was called.
 	IsContainerStaleCount        atomic.Int32                          // Number of times IsContainerStale was called.
 	WaitForContainerHealthyCount atomic.Int32                          // Number of times WaitForContainerHealthy was called.
 	ListContainersCount          atomic.Int32                          // Number of times ListContainers was called.
@@ -57,6 +58,8 @@ type TestData struct {
 	SimulatedLatency             time.Duration                         // Simulated latency for operations (default 0 for fast tests, set for context cancellation tests).
 	LastContainerChain           string                                // Last container chain passed to CreateEphemeralOrchestrator.
 	LastUpdateConfig             *dockerContainer.UpdateConfig         // Last UpdateContainer config received.
+	SetNoRestartPolicyContainer  types.Container                        // Last container passed to SetNoRestartPolicy.
+	SetNoRestartPolicyCtx        context.Context                        // Last context passed to SetNoRestartPolicy.
 }
 
 // TriedToRemoveImage checks if RemoveImageByID has been invoked.
@@ -279,6 +282,14 @@ func (client MockClient) UpdateContainer(ctx context.Context, _ types.Container,
 	}
 
 	return client.TestData.UpdateContainerError
+}
+
+// SetNoRestartPolicy simulates setting a container's restart policy to "no".
+// It increments the SetNoRestartPolicyCount and records the container and context for test assertions.
+func (client MockClient) SetNoRestartPolicy(ctx context.Context, container types.Container) {
+	client.TestData.SetNoRestartPolicyCount.Add(1)
+	client.TestData.SetNoRestartPolicyContainer = container
+	client.TestData.SetNoRestartPolicyCtx = ctx
 }
 
 // RemoveImageByID increments the count of image removal attempts in TestData.

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -15,7 +15,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	cerrdefs "github.com/containerd/errdefs"
-	dockerContainer "github.com/moby/moby/api/types/container"
 
 	"github.com/nicholas-fedor/watchtower/pkg/compose"
 	"github.com/nicholas-fedor/watchtower/pkg/container"
@@ -87,17 +86,7 @@ func Update(
 					logrus.WithField("container", c.Name()).
 						Debug("Current container is an old Watchtower container, stopping self")
 
-					updateConfig := dockerContainer.UpdateConfig{
-						RestartPolicy: dockerContainer.RestartPolicy{
-							Name: "no",
-						},
-					}
-
-					err := client.UpdateContainer(ctx, c, updateConfig)
-					if err != nil {
-						logrus.WithError(err).
-							Warn("Failed to update restart policy to 'no' for old Watchtower container")
-					}
+					client.SetNoRestartPolicy(ctx, c)
 
 					return nil, nil, errOldSelfDetected
 				}
@@ -2030,25 +2019,8 @@ func restartStaleContainer(
 		logrus.WithFields(fields).
 			Debug("Updating restart policy for old Watchtower container")
 
-		// Create configuration update
-		updateConfig := dockerContainer.UpdateConfig{
-			RestartPolicy: dockerContainer.RestartPolicy{
-				Name: "no",
-			},
-		}
-		// Update the renamed Watchtower container's restart policy.
-		//
 		//nolint:contextcheck // Using detached context intentionally to survive parent cancellation
-		err := client.UpdateContainer(
-			detachedCtx,
-			sourceContainer,
-			updateConfig,
-		)
-		if err != nil {
-			logrus.WithError(err).
-				WithFields(fields).
-				Warn("Failed to update restart policy for old Watchtower container")
-		}
+		client.SetNoRestartPolicy(detachedCtx, sourceContainer)
 	}
 
 	return newContainerID, renamed, nil

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -25,11 +25,17 @@ import (
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
-// defaultPullFailureDelay defines the default delay duration for failed Watchtower self-update pulls.
-const defaultPullFailureDelay = 5 * time.Minute
+const (
+	// defaultPullFailureDelay defines the default delay duration for failed Watchtower self-update pulls.
+	defaultPullFailureDelay = 5 * time.Minute
 
-// defaultHealthCheckTimeout defines the default timeout for waiting for container health checks.
-const defaultHealthCheckTimeout = 5 * time.Minute
+	// defaultHealthCheckTimeout defines the default timeout for waiting for container health checks.
+	defaultHealthCheckTimeout = 5 * time.Minute
+
+	// defaultRestartPolicyTimeout defines the fallback timeout for restart policy
+	// updates when config.Timeout is non-positive.
+	defaultRestartPolicyTimeout = 30 * time.Second
+)
 
 // Update scans and updates containers based on parameters.
 //
@@ -86,7 +92,14 @@ func Update(
 					logrus.WithField("container", c.Name()).
 						Debug("Current container is an old Watchtower container, stopping self")
 
-					client.SetNoRestartPolicy(ctx, c)
+					setNoRestartCtx, setNoRestartCancel := context.WithTimeout(
+						context.Background(),
+						restartPolicyTimeout(config.Timeout),
+					)
+					defer setNoRestartCancel()
+
+					//nolint:contextcheck // Using bounded context to survive caller cancellation
+					client.SetNoRestartPolicy(setNoRestartCtx, c)
 
 					return nil, nil, errOldSelfDetected
 				}
@@ -1807,22 +1820,11 @@ func restartStaleContainer(
 	// Create a detached context to survive parent context cancellation.
 	// This ensures container cleanup and update operations complete even if the
 	// parent context is canceled during the restart process.
-	// If config.Timeout <= 0, use a non-deadline context; otherwise, apply the timeout.
-	var (
-		detachedCtx    context.Context
-		cancelDetached context.CancelFunc
+	// A finite fallback is applied when config.Timeout is non-positive.
+	detachedCtx, cancelDetached := context.WithTimeout(
+		context.Background(),
+		restartPolicyTimeout(config.Timeout),
 	)
-
-	if config.Timeout <= 0 {
-		detachedCtx, cancelDetached = context.WithCancel(
-			context.Background(),
-		)
-	} else {
-		detachedCtx, cancelDetached = context.WithTimeout(
-			context.Background(),
-			config.Timeout,
-		)
-	}
 
 	defer cancelDetached()
 
@@ -2050,4 +2052,15 @@ func deriveScopeFromCurrentContainer(
 		Debug("Current container not found in list")
 
 	return "", false
+}
+
+// restartPolicyTimeout returns the timeout to use for restart policy operations.
+// If the provided timeout is positive, it is returned as-is.
+// Otherwise, a finite fallback is used to prevent indefinite blocking.
+func restartPolicyTimeout(timeout time.Duration) time.Duration {
+	if timeout > 0 {
+		return timeout
+	}
+
+	return defaultRestartPolicyTimeout
 }

--- a/internal/actions/update_context_test.go
+++ b/internal/actions/update_context_test.go
@@ -158,9 +158,9 @@ var _ = ginkgo.Describe("the update action", func() {
 			)
 
 			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(client.TestData.UpdateContainerCount.Load()).To(gomega.Equal(int32(1)))
-			gomega.Expect(client.TestData.LastUpdateConfig).NotTo(gomega.BeNil())
-			gomega.Expect(client.TestData.LastUpdateConfig.RestartPolicy.Name).To(gomega.BeEquivalentTo("no"))
+			gomega.Expect(client.TestData.SetNoRestartPolicyCount.Load()).To(gomega.Equal(int32(1)))
+			gomega.Expect(client.TestData.SetNoRestartPolicyContainer).NotTo(gomega.BeNil())
+			gomega.Expect(client.TestData.SetNoRestartPolicyContainer.ID()).To(gomega.Equal(types.ContainerID("old-container-id")))
 		})
 
 		ginkgo.It("should proceed normally when current container is not old", func() {

--- a/internal/actions/update_watchtower_test.go
+++ b/internal/actions/update_watchtower_test.go
@@ -62,8 +62,8 @@ var _ = ginkgo.Describe("Watchtower container handling", func() {
 				To(gomega.Equal(int32(0)), "RemoveImageByID should not be called during Update")
 			gomega.Expect(client.TestData.RenameContainerCount.Load()).
 				To(gomega.Equal(int32(1)), "RenameContainer should be called once")
-			gomega.Expect(client.TestData.UpdateContainerCount.Load()).
-				To(gomega.Equal(int32(1)), "UpdateContainer should be called once for old Watchtower")
+			gomega.Expect(client.TestData.SetNoRestartPolicyCount.Load()).
+				To(gomega.Equal(int32(1)), "SetNoRestartPolicy should be called once for old Watchtower")
 			gomega.Expect(client.TestData.StopContainerCount.Load()).
 				To(gomega.Equal(int32(0)), "StopContainer should not be called for old Watchtower (handled by cleanup logic)")
 			gomega.Expect(client.TestData.IsContainerStaleCount.Load()).

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -306,6 +306,18 @@ type Client interface {
 	//   - error: Non-nil if update fails, nil on success.
 	UpdateContainer(ctx context.Context, container types.Container, config dockerContainer.UpdateConfig) error
 
+	// SetNoRestartPolicy updates the restart policy of a container to "no" to prevent
+	// restart loops after fatal startup failures.
+	//
+	// It is a convenience wrapper around UpdateContainer that constructs the restart
+	// policy configuration and logs a warning if the update fails, ensuring the
+	// failure does not block the exit path.
+	//
+	// Parameters:
+	//   - ctx: Context for cancellation and timeout control.
+	//   - container: Container whose restart policy should be updated.
+	SetNoRestartPolicy(ctx context.Context, container types.Container)
+
 	// RemoveContainer removes a container from the Docker host.
 	//
 	// Parameters:
@@ -843,6 +855,39 @@ func (c *client) UpdateContainer(
 	clog.Debug("Container configuration updated")
 
 	return nil
+}
+
+// SetNoRestartPolicy updates the restart policy of a container to "no" to prevent
+// restart loops after fatal startup failures.
+//
+// It is a convenience wrapper around UpdateContainer that constructs the restart
+// policy configuration and logs a warning if the update fails, ensuring the
+// failure does not block the exit path.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeout control.
+//   - container: Container whose restart policy should be updated.
+func (c *client) SetNoRestartPolicy(ctx context.Context, container types.Container) {
+	if container == nil {
+		return
+	}
+
+	clog := logrus.WithField("container_id", container.ID())
+
+	clog.Debug("Setting restart policy to 'no'")
+
+	_, err := c.api.ContainerUpdate(
+		ctx,
+		string(container.ID()),
+		dockerClient.ContainerUpdateOptions{
+			RestartPolicy: &dockerContainer.RestartPolicy{
+				Name: "no",
+			},
+		},
+	)
+	if err != nil {
+		clog.WithError(err).Warn("Failed to set restart policy to 'no'")
+	}
 }
 
 // RemoveContainer removes a container from the Docker host.

--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -2282,3 +2282,74 @@ var _ = ginkgo.Describe("isDaemonConnectionError", func() {
 			true),
 	)
 })
+
+var _ = ginkgo.Describe("SetNoRestartPolicy", func() {
+	var (
+		mockServer *ghttp.Server
+		docker     *dockerClient.Client
+	)
+
+	ginkgo.BeforeEach(func() {
+		mockServer = ghttp.NewServer()
+
+		var err error
+
+		docker, err = dockerClient.New(
+			dockerClient.WithHost(mockServer.URL()),
+			dockerClient.WithHTTPClient(mockServer.HTTPTestServer.Client()),
+		)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		mockServer.AppendHandlers(APIVersionPingHandler())
+	})
+
+	ginkgo.AfterEach(func() {
+		mockServer.Close()
+	})
+
+	ginkgo.When("the container is nil", func() {
+		ginkgo.It("should short-circuit without calling ContainerUpdate", func() {
+			c := &client{}
+
+			c.SetNoRestartPolicy(context.Background(), nil)
+		})
+	})
+
+	ginkgo.When("the container is non-nil and update succeeds", func() {
+		ginkgo.It("should send restart policy Name=no to the Docker API", func() {
+			cid := "watchtower-container-id"
+			mockedContainer := MockContainer(
+				WithID(cid),
+			)
+
+			mockServer.AppendHandlers(
+				ContainerUpdateHandler(cid, http.StatusOK, true),
+			)
+
+			c := &client{api: docker}
+
+			c.SetNoRestartPolicy(context.Background(), mockedContainer)
+		})
+	})
+
+	ginkgo.When("the container update fails", func() {
+		ginkgo.It("should log a warning and not return an error", func() {
+			resetLogrus, logbuf := captureLogrus(logrus.WarnLevel)
+			defer resetLogrus()
+
+			cid := "watchtower-container-id"
+			mockedContainer := MockContainer(
+				WithID(cid),
+			)
+
+			mockServer.AppendHandlers(
+				ContainerUpdateHandler(cid, http.StatusInternalServerError, false),
+			)
+
+			c := &client{api: docker}
+
+			c.SetNoRestartPolicy(context.Background(), mockedContainer)
+
+			gomega.Expect(logbuf).To(gbytes.Say("Failed to set restart policy to 'no'"))
+		})
+	})
+})

--- a/pkg/container/container_mock_test.go
+++ b/pkg/container/container_mock_test.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"sync/atomic"
@@ -533,6 +534,48 @@ func APIVersionPingHandler() http.HandlerFunc {
 	return ghttp.CombineHandlers(
 		ghttp.VerifyRequest("HEAD", "/_ping"),
 		ghttp.RespondWith(http.StatusOK, nil),
+	)
+}
+
+// ContainerUpdateHandler returns a handler that responds to the Docker API's
+// POST /containers/{id}/update endpoint. It optionally verifies that the request
+// body contains a restart policy with Name set to "no" when verifyRestartPolicy
+// is true.
+//
+// Parameters:
+//   - containerID: The container ID for the update endpoint.
+//   - status: HTTP status code to return (204 for success, 500 for error).
+//   - verifyRestartPolicy: When true, the handler verifies the request body
+//     contains RestartPolicy.Name == "no".
+//
+// Returns:
+//   - http.HandlerFunc: Handler for the container update endpoint.
+func ContainerUpdateHandler(
+	containerID string,
+	status int,
+	verifyRestartPolicy bool,
+) http.HandlerFunc {
+	return ghttp.CombineHandlers(
+		ghttp.VerifyRequest("POST", gomega.HaveSuffix(fmt.Sprintf("containers/%s/update", containerID))),
+		func(w http.ResponseWriter, r *http.Request) {
+			if verifyRestartPolicy {
+				var body map[string]any
+
+				err := json.NewDecoder(r.Body).Decode(&body)
+				if err != nil {
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+
+				restartPolicy, ok := body["RestartPolicy"].(map[string]any)
+				gomega.Expect(ok).To(gomega.BeTrue(), "RestartPolicy should be present in update body")
+
+				name, ok := restartPolicy["Name"].(string)
+				gomega.Expect(ok).To(gomega.BeTrue(), "RestartPolicy.Name should be a string")
+				gomega.Expect(name).To(gomega.Equal("no"), "RestartPolicy.Name should be 'no'")
+			}
+
+			ghttp.RespondWith(status, nil)(w, r)
+		},
 	)
 }
 

--- a/pkg/container/mocks/Client.go
+++ b/pkg/container/mocks/Client.go
@@ -995,6 +995,52 @@ func (_c *MockClient_RenameContainer_Call) RunAndReturn(run func(ctx context.Con
 	return _c
 }
 
+// SetNoRestartPolicy provides a mock function for the type MockClient
+func (_mock *MockClient) SetNoRestartPolicy(ctx context.Context, container types.Container) {
+	_mock.Called(ctx, container)
+	return
+}
+
+// MockClient_SetNoRestartPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetNoRestartPolicy'
+type MockClient_SetNoRestartPolicy_Call struct {
+	*mock.Call
+}
+
+// SetNoRestartPolicy is a helper method to define mock.On call
+//   - ctx context.Context
+//   - container types.Container
+func (_e *MockClient_Expecter) SetNoRestartPolicy(ctx any, container any) *MockClient_SetNoRestartPolicy_Call {
+	return &MockClient_SetNoRestartPolicy_Call{Call: _e.mock.On("SetNoRestartPolicy", ctx, container)}
+}
+
+func (_c *MockClient_SetNoRestartPolicy_Call) Run(run func(ctx context.Context, container types.Container)) *MockClient_SetNoRestartPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 types.Container
+		if args[1] != nil {
+			arg1 = args[1].(types.Container)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_SetNoRestartPolicy_Call) Return() *MockClient_SetNoRestartPolicy_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockClient_SetNoRestartPolicy_Call) RunAndReturn(run func(ctx context.Context, container types.Container)) *MockClient_SetNoRestartPolicy_Call {
+	_c.Run(run)
+	return _c
+}
+
 // StartContainer provides a mock function for the type MockClient
 func (_mock *MockClient) StartContainer(ctx context.Context, container types.Container) (types.ContainerID, error) {
 	ret := _mock.Called(ctx, container)


### PR DESCRIPTION
This PR ensures the current Watchtower container's restart policy is set to `"no"` on all fatal exit paths, preventing the container from restarting after shutdown failures, self-update orchestrator fallback, API setup failures, and incompatible flag combinations.

## Problem

Several fatal exit paths in `cmd/root.go` did not update the Watchtower container's restart policy before exiting. This left the container with its original restart policy, causing it to restart after failures that should have been terminal. Additionally, the existing restart-policy update code was duplicated inline across multiple locations without consistent timeout handling.

## Solution

Added a `SetNoRestartPolicy` helper to the container client that sends the `"no"` restart policy and logs warnings on failure. All fatal exit paths now call this helper with a bounded timeout context. This backfills missing updates on the self-update orchestrator fallback, `rollingRestart && monitorOnly` incompatibility, rolling-restart validation failure, API setup failure, and scheduled-upgrades failure paths.

## Changes

- Backfill missing restart-policy updates on all fatal exit paths in `cmd/root.go`
- Add `SetNoRestartPolicy` to the container client and replace all inline restart-policy update blocks with it
- Add bounded timeout contexts for all restart-policy updates on exit paths
- Add helper to resolve the current Watchtower container for the orchestrator fallback path
- Update tests to verify restart-policy behavior against a mock Docker API server instead of mock expectations
- Update mock test data to record `SetNoRestartPolicy` calls for detached-context assertions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced self-update orchestration with a safety fallback that disables automatic restarts if orchestration ends unexpectedly.
  - Improved recovery logic for determining the currently active Watchtower container.

- **Bug Fixes**
  - More consistent handling of startup and upgrade failures by disabling automatic restarts when they would otherwise occur.
  - Added timeout protection around restart-policy updates and container lookups to reduce the chance of hanging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->