### PR TITLE
docs: remove yaml array recommendation and restructure notifications documentation

### DIFF
--- a/docs/configuration/http-api/index.md
+++ b/docs/configuration/http-api/index.md
@@ -109,7 +109,7 @@ Valid names (case-insensitive):
 !!! Note "Flag and environment value usage"
     - The CLI flag can be specified multiple times.
     - Defining the environment variable multiple times will not work (only the last value is used).
-    - For environment variables, use a single comma- or space-separated value, or a YAML array.
+    - For environment variables use comma or space-separated values.
 
 ## HTTP API Rate Limit
 

--- a/docs/configuration/notifications/index.md
+++ b/docs/configuration/notifications/index.md
@@ -25,7 +25,6 @@ Configures the notification service URL(s).
 
     - Use comma-separated URLs: `--notification-url="discord://xxx,telegram://yyy"`
     - Specify the flag multiple times: `--notification-url=discord://xxx --notification-url=telegram://yyy`
-    - Use YAML arrays in Docker Compose (recommended)
 
     See [Configuring Multiple Notification URLs](../../notifications/introduction/index.md#using_multiple_notification_services) for detailed examples.
 
@@ -33,8 +32,7 @@ Configures the notification service URL(s).
     The CLI flag can be called multiple times as CLI arguments; however, defining the environment variable multiple times will NOT work and only the last value will be used.
 
     This is because CLI flags use a StringArray type that supports multiple invocations,  while environment variables are simple key-value pairs that get overwritten when defined multiple times.
-
-    For environment variables, use comma-separated values or YAML arrays instead.
+    For environment variables, use comma-separated or space-separated values.
 
 ## Notification Split by Container
 

--- a/docs/configuration/notifications/index.md
+++ b/docs/configuration/notifications/index.md
@@ -14,7 +14,7 @@ Configures the notification service URL(s).
 ```text
              Argument: --notification-url
  Environment Variable: WATCHTOWER_NOTIFICATION_URL
-                  Type: String (comma-separated or multiple flags)
+                   Type: String (comma-separated or space-separated)
                Default: None
 ```
 

--- a/docs/notifications/introduction/index.md
+++ b/docs/notifications/introduction/index.md
@@ -20,80 +20,71 @@ The [`NOTIFICATION URL`](../../configuration/notifications/index.md#notification
 
 ### Using Multiple Notification Services
 
-Watchtower supports sending notifications to multiple services simultaneously.
-The preferred method is to use multiple Shoutrrr URL's.
-
-For most Watchtower deployments via Docker Compose, this is best achieved via using either a comma-separated list or YAML array for the [`WATCHTOWER_NOTIFICATION_URL`](../../configuration/notifications/index.md#notification_url) environment variable.
-When running Watchtower via the Docker CLI, the [`--notification-url`](../../configuration/notifications/index.md#notification_url) CLI flag can be used multiple times, or use a comma-separated list.
-
-!!! Note "Environment Variable Format"
-    - `WATCHTOWER_NOTIFICATION_URL` supports comma-separated and space-separated values.
-    - Commas within URLs (e.g., in query parameters) are preserved.
-    - For Docker Compose, the YAML array syntax is the recommended approach.
-
-=== "Docker CLI"
-
-    === "Environment Variable"
-
-        ```bash
-        docker run -d \
-        --name watchtower \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        -e WATCHTOWER_NOTIFICATION_URL="discord://token@webhookid,telegram://token@telegram?chats=@channel" \
-        nickfedor/watchtower
-        ```
-
-    === "Flags"
-
-        ```bash
-        docker run -d \
-        --name watchtower \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        nickfedor/watchtower \
-        --notification-url "discord://token@webhookid" \
-        --notification-url "telegram://token@telegram?chats=@channel"
-        ```
+Watchtower supports using multiple Shoutrrr URLs to send notifications to multiple notification services.
 
 === "Docker Compose"
 
-    === "YAML Array"
+    === "Docker Secrets"
+
+        This is the recommended method for providing Shoutrrr URLs, as they typically contain security-sensitive values.
+
+        ```text
+        # Watchtower Notification URLs
+        # Path: ./secrets/notification_urls.txt
+        # Only place one URL per line
+        # ---
+
+        discord://token@webhookid
+        telegram://token@telegram?chats=@channel
+        ```
 
         ```yaml
+        secrets:
+            notification_urls:
+                file: ./secrets/notification_urls.txt
+
         services:
-        watchtower:
-            image: nickfedor/watchtower:latest
-            environment:
-            WATCHTOWER_NOTIFICATION_URL:
-                - "discord://token@webhookid"
-                - "telegram://token@telegram?chats=@channel"
-            volumes:
-            - /var/run/docker.sock:/var/run/docker.sock
+            watchtower:
+                image: nickfedor/watchtower:latest
+                volumes:
+                    - /var/run/docker.sock:/var/run/docker.sock
+                secrets:
+                    - notification_urls
+                environment:
+                    - WATCHTOWER_NOTIFICATION_URL=/run/secrets/notification_urls
+                restart: unless-stopped
         ```
 
     === "Single-line"
 
+        Comma or space-separated lists can also be provided to the [`WATCHTOWER_NOTIFICATION_URL`](../../configuration/notifications/index.md#notification_url) environment variable.
+
         ```yaml
         services:
-          watchtower:
-            image: nickfedor/watchtower:latest
-            environment:
-              WATCHTOWER_NOTIFICATION_URL: "discord://token@webhookid,telegram://token@telegram?chats=@channel"
-            volumes:
-              - /var/run/docker.sock:/var/run/docker.sock
+            watchtower:
+                image: nickfedor/watchtower:latest
+                environment:
+                    WATCHTOWER_NOTIFICATION_URL: "discord://token@webhookid,telegram://token@telegram?chats=@channel"
+                volumes:
+                    - /var/run/docker.sock:/var/run/docker.sock
+                restart: unless-stopped
         ```
 
     === "Multi-line"
 
+        Comma or space-separated lists can also be provided to the [`WATCHTOWER_NOTIFICATION_URL`](../../configuration/notifications/index.md#notification_url) environment variable.
+
         ```yaml
         services:
-        watchtower:
-            image: nickfedor/watchtower:latest
-            environment:
-            WATCHTOWER_NOTIFICATION_URL: >
-                discord://token@webhookid,
-                telegram://token@telegram?chats=@channel
-            volumes:
-            - /var/run/docker.sock:/var/run/docker.sock
+            watchtower:
+                image: nickfedor/watchtower:latest
+                environment:
+                    WATCHTOWER_NOTIFICATION_URL: >
+                        discord://token@webhookid,
+                        telegram://token@telegram?chats=@channel
+                volumes:
+                    - /var/run/docker.sock:/var/run/docker.sock
+                restart: unless-stopped
         ```
 
     !!! Warning "Do NOT define the variable multiple times"
@@ -107,12 +98,39 @@ When running Watchtower via the Docker CLI, the [`--notification-url`](../../con
         - WATCHTOWER_NOTIFICATION_URL=telegram://xxx
         ```
 
+=== "Docker CLI"
+
+    === "Environment Variable"
+
+        When using the Docker CLI, the [`--notification-url`](../../configuration/notifications/index.md#notification_url) environment variable can accept a comma or space-separated list.
+
+        ```bash
+        docker run -d \
+            --name watchtower \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -e WATCHTOWER_NOTIFICATION_URL="discord://token@webhookid,telegram://token@telegram?chats=@channel" \
+            nickfedor/watchtower
+        ```
+
+    === "Flags"
+
+        When using the Docker CLI, the [`--notification-url`](../../configuration/notifications/index.md#notification_url) CLI flag can be used multiple times.
+
+        ```bash
+        docker run -d \
+            --name watchtower \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            nickfedor/watchtower \
+            --notification-url "discord://token@webhookid" \
+            --notification-url "telegram://token@telegram?chats=@channel"
+        ```
+
 !!! Note "CLI Flags vs Environment Variables"
     The CLI flag can be called multiple times as CLI arguments; however, defining the environment variable multiple times will NOT work and only the last value will be used.
 
     This is because CLI flags use a StringArray type that supports multiple invocations,  while environment variables are simple key-value pairs that get overwritten when defined multiple times.
 
-    For environment variables, use comma-separated values or YAML arrays instead.
+    For environment variables, use comma-separated or space-separated values.
 
 #### Verifying Multiple Notifications
 

--- a/docs/notifications/introduction/index.md
+++ b/docs/notifications/introduction/index.md
@@ -29,11 +29,6 @@ Watchtower supports using multiple Shoutrrr URLs to send notifications to multip
         This is the recommended method for providing Shoutrrr URLs, as they typically contain security-sensitive values.
 
         ```text
-        # Watchtower Notification URLs
-        # Path: ./secrets/notification_urls.txt
-        # Only place one URL per line
-        # ---
-
         discord://token@webhookid
         telegram://token@telegram?chats=@channel
         ```


### PR DESCRIPTION
This PR corrects the recommendation of using YAML arrays in the documentation. Docker Secrets are the recommended method for Shoutrrr URLs, because they typically contain sensitive information, such as tokens and passwords. It also restructures the notification documentation to inline information with the examples.

## Problem

A prior update to the documentation included the addition of YAML arrays as the recommended method for configuring notification services using Shoutrrr URLs. This is not supported by the Compose spec and doesn't recommend the best method for handling sensitive configuration information.

## Solution

Updated the documentation by replacing the recommendation with an example of using Docker Secrets. Relevant information was also in-lined with the examples to help reduce visual clutter.

## Changes

- Restructure multiple notification services guide to recommend Docker Secrets
- Remove YAML array recommendations for notification URLs
- Simplify environment variable formatting instructions
- Update Docker CLI and Docker Compose examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated HTTP API docs to specify that environment variable values should be comma- or space-separated.
  * Refreshed notification URL configuration to use comma- or space-separated environment variable values.
  * Removed outdated Docker Compose examples that suggested YAML array formatting for notification URLs.
  * Reworked “Using Multiple Notification Services” with clearer Compose examples (including Docker Secrets) and updated single-line/multi-line formats.
  * Clarified that re-defining the same environment variable only uses the last value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->