### PR TITLE
feat(filters): add label-based container enable and disable filtering

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -128,6 +128,22 @@ var (
 	// environment variable, providing a way to blacklist specific image patterns.
 	skippedImageNamePatterns []string
 
+	// enabledContainersByLabel is a slice of "key=value" label pairs that
+	// restricts which containers are monitored.
+	//
+	// When set, only containers matching at least one pair are monitored.
+	// It is populated in preRun from the --enable-containers-by-label flag or the
+	// WATCHTOWER_ENABLE_CONTAINERS_BY_LABEL environment variable.
+	enabledContainersByLabel []string
+
+	// disabledContainersByLabel is a slice of "key=value" label pairs for
+	// containers to exclude from monitoring.
+	//
+	// Matching containers are not monitored. It is populated in preRun from the
+	// --disable-containers-by-label flag or the WATCHTOWER_DISABLE_CONTAINERS_BY_LABEL
+	// environment variable, providing a way to blacklist containers by label.
+	disabledContainersByLabel []string
+
 	// notifier is the notification system instance responsible for sending update status messages to configured channels.
 	//
 	// It is initialized in preRun with notification types specified via flags (e.g., --notifications), supporting
@@ -368,6 +384,12 @@ func preRun(cmd *cobra.Command, _ []string) {
 		skippedImageNamePatterns[i] = strings.TrimSpace(skippedImageNamePatterns[i])
 	}
 
+	// Set label key-value pairs that restrict which containers are monitored.
+	enabledContainersByLabel, _ = flagsSet.GetStringSlice("enable-containers-by-label")
+
+	// Set label key-value pairs for containers to skip during monitoring.
+	disabledContainersByLabel, _ = flagsSet.GetStringSlice("disable-containers-by-label")
+
 	// Enable/disable execution of scripts before or after updates.
 	lifecycleHooks, _ = flagsSet.GetBool("enable-lifecycle-hooks")
 
@@ -586,14 +608,29 @@ func run(command *cobra.Command, args []string) {
 	}
 
 	// Build the filter and its description based on normalized names, exclusions, and label settings.
-	filter, filterDesc := filters.BuildFilter(
+	filter, filterDesc, err := filters.BuildFilter(
 		normalizedContainerNames,
 		disableContainers,
 		monitoredImageNamePatterns,
 		skippedImageNamePatterns,
+		enabledContainersByLabel,
+		disabledContainersByLabel,
 		enableLabel,
 		scope,
 	)
+	if err != nil {
+		if currentWatchtowerContainer != nil {
+			setNoRestartPolicyCtx, cancel := context.WithTimeout(
+				context.Background(),
+				restartPolicyTimeout,
+			)
+			defer cancel()
+
+			client.SetNoRestartPolicy(setNoRestartPolicyCtx, currentWatchtowerContainer)
+		}
+
+		logrus.WithError(err).Fatal("Failed to build container filter")
+	}
 
 	// Get flags controlling execution mode.
 	runOnce, _ := command.PersistentFlags().GetBool("run-once")
@@ -737,7 +774,7 @@ func run(command *cobra.Command, args []string) {
 	// Execute core logic and exit with the returned status code (0 for success, 1 for failure).
 	if exitCode := runMain(cfg); exitCode != 0 {
 		logrus.WithField("exit_code", exitCode).Debug("Exiting with non-zero status")
-		os.Exit(exitCode)
+		logrus.Exit(exitCode)
 	}
 }
 

--- a/docs/configuration/container-selection/index.md
+++ b/docs/configuration/container-selection/index.md
@@ -67,6 +67,34 @@ Environment Variable: WATCHTOWER_DISABLE_CONTAINERS
 !!! Note
     Regex patterns are supported. See [Regex Pattern Matching](../../getting-started/container-selection/index.md#regex_pattern_matching) for details.
 
+## Enable Containers by Label
+
+Restricts monitoring to containers that have at least one of the specified label key-value pairs.
+
+```text
+            Argument: --enable-containers-by-label
+Environment Variable: WATCHTOWER_ENABLE_CONTAINERS_BY_LABEL
+                Type: Comma-separated list of key=value pairs
+             Default: None
+```
+
+!!! Note
+    Values containing commas are not supported. Use individual `key=value` pairs separated by commas.
+
+## Disable Containers by Label
+
+Excludes containers that have any of the specified label key-value pairs from monitoring.
+
+```text
+            Argument: --disable-containers-by-label
+Environment Variable: WATCHTOWER_DISABLE_CONTAINERS_BY_LABEL
+                Type: Comma-separated list of key=value pairs
+             Default: None
+```
+
+!!! Note
+    Values containing commas are not supported. Use individual `key=value` pairs separated by commas.
+
 ## Monitor Specific Images
 
 Restricts monitoring to containers whose image name matches one of the supplied image name patterns, even if other selection criteria would include them.

--- a/docs/configuration/container-selection/index.md
+++ b/docs/configuration/container-selection/index.md
@@ -79,7 +79,12 @@ Environment Variable: WATCHTOWER_ENABLE_CONTAINERS_BY_LABEL
 ```
 
 !!! Note
-    Values containing commas are not supported. Use individual `key=value` pairs separated by commas.
+    Values containing commas are not supported.
+    Use individual `key=value` pairs separated by commas.
+
+!!! Note
+    A label entry with an empty value (`key=`) performs a presence check: the label must exist on the container with any value.
+    A non-empty value requires an exact match.
 
 ## Disable Containers by Label
 
@@ -94,6 +99,9 @@ Environment Variable: WATCHTOWER_DISABLE_CONTAINERS_BY_LABEL
 
 !!! Note
     Values containing commas are not supported. Use individual `key=value` pairs separated by commas.
+
+!!! Note
+    A label entry with an empty value (`key=`) performs a presence check: the label must exist on the container with any value. A non-empty value requires an exact match.
 
 ## Monitor Specific Images
 

--- a/docs/getting-started/container-selection/index.md
+++ b/docs/getting-started/container-selection/index.md
@@ -419,21 +419,77 @@ Image name patterns match against the full `name:tag` string. Use `.*` to match 
 
 Exclude all containers starting with a prefix:
 
-```bash
-docker run -d -e WATCHTOWER_DISABLE_CONTAINERS="web-.*" nickfedor/watchtower
-```
+<!-- markdownlint-disable -->
+=== "Docker Compose"
+    ```yaml
+    services:
+        watchtower:
+            image: nickfedor/watchtower:latest
+            environment:
+                - WATCHTOWER_DISABLE_CONTAINERS=web-.*
+            volumes:
+                - /var/run/docker.sock:/var/run/docker.sock
+    ```
+=== "Docker CLI (Env Vars)"
+    ```bash
+    docker run -d \
+        -e WATCHTOWER_DISABLE_CONTAINERS="web-.*" \
+        nickfedor/watchtower
+    ```
+=== "Docker CLI (Flags)"
+    ```bash
+    docker run -d \
+        nickfedor/watchtower \
+        --disable-containers "web-.*"
+    ```
+<!-- markdownlint-restore -->
 
 Include only containers matching specific patterns:
 
-```bash
-docker run -d nickfedor/watchtower "db-.*" "cache-.*"
-```
+<!-- markdownlint-disable -->
+=== "Docker Compose"
+    ```yaml
+    services:
+        watchtower:
+            image: nickfedor/watchtower:latest
+            command: ["nickfedor/watchtower", "db-.*", "cache-.*"]
+            volumes:
+                - /var/run/docker.sock:/var/run/docker.sock
+    ```
+=== "Docker CLI"
+    ```bash
+    docker run -d \
+        nickfedor/watchtower \
+        "db-.*" "cache-.*"
+    ```
+<!-- markdownlint-restore -->
 
 Monitor only containers using nginx or redis images with any tag:
 
-```bash
-docker run -d -e WATCHTOWER_MONITOR_IMAGE_NAMES="nginx:.*,redis:.*" nickfedor/watchtower
-```
+<!-- markdownlint-disable -->
+=== "Docker Compose"
+    ```yaml
+    services:
+        watchtower:
+            image: nickfedor/watchtower:latest
+            environment:
+                - WATCHTOWER_MONITOR_IMAGE_NAMES=nginx:.*,redis:.*
+            volumes:
+                - /var/run/docker.sock:/var/run/docker.sock
+    ```
+=== "Docker CLI (Env Vars)"
+    ```bash
+    docker run -d \
+        -e WATCHTOWER_MONITOR_IMAGE_NAMES="nginx:.*,redis:.*" \
+        nickfedor/watchtower
+    ```
+=== "Docker CLI (Flags)"
+    ```bash
+    docker run -d \
+        nickfedor/watchtower \
+        --monitor-image-names "nginx:.*,redis:.*"
+    ```
+<!-- markdownlint-restore -->
 
 ## Label Precedence
 
@@ -488,81 +544,188 @@ This applies to the [`monitor-only`](../../configuration/update-behavior/index.m
 
 Run one instance for production containers and another for development:
 
-```yaml
-services:
-    watchtower-prod:
-        image: nickfedor/watchtower:latest
-        command: --scope production --interval 300
-        labels:
-            - "com.centurylinklabs.watchtower.scope=production"
-        volumes:
-            - /var/run/docker.sock:/var/run/docker.sock
+<!-- markdownlint-disable -->
+=== "Docker Compose"
+    ```yaml
+    services:
+        watchtower-prod:
+            image: nickfedor/watchtower:latest
+            command: --scope production --interval 300
+            labels:
+                - "com.centurylinklabs.watchtower.scope=production"
+            volumes:
+                - /var/run/docker.sock:/var/run/docker.sock
 
-    watchtower-dev:
-        image: nickfedor/watchtower:latest
-        command: --scope development --interval 30
-        labels:
-            - "com.centurylinklabs.watchtower.scope=development"
-        volumes:
-            - /var/run/docker.sock:/var/run/docker.sock
-```
+        watchtower-dev:
+            image: nickfedor/watchtower:latest
+            command: --scope development --interval 30
+            labels:
+                - "com.centurylinklabs.watchtower.scope=development"
+            volumes:
+                - /var/run/docker.sock:/var/run/docker.sock
+    ```
+=== "Docker CLI"
+    ```bash
+    docker run -d \
+        --name watchtower-production \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        nickfedor/watchtower \
+        --scope production --interval 300
+
+    docker run -d \
+        --name watchtower-development \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        nickfedor/watchtower \
+        --scope development --interval 30
+    ```
+<!-- markdownlint-restore -->
 
 ### Exclude System Containers
 
 Exclude Watchtower itself and other infrastructure containers:
 
-```bash
-docker run -d \
-    -e WATCHTOWER_DISABLE_CONTAINERS="watchtower,traefik,portainer" \
-    nickfedor/watchtower
-```
+<!-- markdownlint-disable -->
+=== "Docker Compose"
+    ```yaml
+    services:
+        watchtower:
+            image: nickfedor/watchtower:latest
+            environment:
+                - WATCHTOWER_DISABLE_CONTAINERS=watchtower,traefik,portainer
+            volumes:
+                - /var/run/docker.sock:/var/run/docker.sock
+    ```
+=== "Docker CLI (Env Vars)"
+    ```bash
+    docker run -d \
+        -e WATCHTOWER_DISABLE_CONTAINERS="watchtower,traefik,portainer" \
+        nickfedor/watchtower
+    ```
+=== "Docker CLI (Flags)"
+    ```bash
+    docker run -d \
+        nickfedor/watchtower \
+        --disable-containers "watchtower,traefik,portainer"
+    ```
+<!-- markdownlint-restore -->
 
 ### Exclude Containers by Label
 
 Exclude containers managed by third-party orchestrators using arbitrary labels:
 
-```bash
-docker run -d \
-    -e WATCHTOWER_DISABLE_CONTAINERS_BY_LABEL="managed-by=external" \
-    nickfedor/watchtower
-```
+<!-- markdownlint-disable -->
+=== "Docker Compose"
+    ```yaml
+    services:
+        watchtower:
+            image: nickfedor/watchtower:latest
+            environment:
+                - WATCHTOWER_DISABLE_CONTAINERS_BY_LABEL=managed-by=external
+            volumes:
+                - /var/run/docker.sock:/var/run/docker.sock
+    ```
+=== "Docker CLI (Env Vars)"
+    ```bash
+    docker run -d \
+        -e WATCHTOWER_DISABLE_CONTAINERS_BY_LABEL="managed-by=external" \
+        nickfedor/watchtower
+    ```
+=== "Docker CLI (Flags)"
+    ```bash
+    docker run -d \
+        nickfedor/watchtower \
+        --disable-containers-by-label "managed-by=external"
+    ```
+<!-- markdownlint-restore -->
 
 ### Monitor Containers by Label
 
 Only monitor containers with specific labels:
 
-```bash
-docker run -d \
-    -e WATCHTOWER_ENABLE_CONTAINERS_BY_LABEL="env=prod,team=platform" \
-    nickfedor/watchtower
-```
+<!-- markdownlint-disable -->
+=== "Docker Compose"
+    ```yaml
+    services:
+        watchtower:
+            image: nickfedor/watchtower:latest
+            environment:
+                - WATCHTOWER_ENABLE_CONTAINERS_BY_LABEL=env=prod,team=platform
+            volumes:
+                - /var/run/docker.sock:/var/run/docker.sock
+    ```
+=== "Docker CLI (Env Vars)"
+    ```bash
+    docker run -d \
+        -e WATCHTOWER_ENABLE_CONTAINERS_BY_LABEL="env=prod,team=platform" \
+        nickfedor/watchtower
+    ```
+=== "Docker CLI (Flags)"
+    ```bash
+    docker run -d \
+        nickfedor/watchtower \
+        --enable-containers-by-label "env=prod,team=platform"
+    ```
+<!-- markdownlint-restore -->
 
 ### Monitor Only Specific Image Registries
 
 Monitor only images from your private registry:
 
-```bash
-docker run -d \
-    -e WATCHTOWER_MONITOR_IMAGE_NAMES="registry.example.com/.*" \
-    nickfedor/watchtower
-```
+<!-- markdownlint-disable -->
+=== "Docker Compose"
+    ```yaml
+    services:
+        watchtower:
+            image: nickfedor/watchtower:latest
+            environment:
+                - WATCHTOWER_MONITOR_IMAGE_NAMES=registry.example.com/.*
+            volumes:
+                - /var/run/docker.sock:/var/run/docker.sock
+    ```
+=== "Docker CLI (Env Vars)"
+    ```bash
+    docker run -d \
+        -e WATCHTOWER_MONITOR_IMAGE_NAMES="registry.example.com/.*" \
+        nickfedor/watchtower
+    ```
+=== "Docker CLI (Flags)"
+    ```bash
+    docker run -d \
+        nickfedor/watchtower \
+        --monitor-image-names "registry.example.com/.*"
+    ```
+<!-- markdownlint-restore -->
 
 ### Selective Monitoring with Enable Label
 
 Use [label enable](../../configuration/container-selection/index.md#enable_label_filter) to explicitly opt containers into monitoring:
 
-```bash
-# Start Watchtower with label filtering
-docker run -d \
-    -e WATCHTOWER_LABEL_ENABLE=true \
-    nickfedor/watchtower
-```
+<!-- markdownlint-disable -->
+=== "Docker Compose"
+    ```yaml
+    services:
+        watchtower:
+            image: nickfedor/watchtower:latest
+            environment:
+                - WATCHTOWER_LABEL_ENABLE=true
+            volumes:
+                - /var/run/docker.sock:/var/run/docker.sock
 
-```yaml
-# Only this container will be monitored
-services:
-    myapp:
-        image: myapp:latest
-        labels:
-            - "com.centurylinklabs.watchtower.enable=true"
-```
+        myapp:
+            image: myapp:latest
+            labels:
+                - "com.centurylinklabs.watchtower.enable=true"
+    ```
+=== "Docker CLI"
+    ```bash
+    # Start Watchtower with label filtering
+    docker run -d \
+        -e WATCHTOWER_LABEL_ENABLE=true \
+        nickfedor/watchtower
+
+    # Only this container will be monitored
+    docker run -d \
+        --label com.centurylinklabs.watchtower.enable=true \
+        myapp:latest
+    ```
+<!-- markdownlint-restore -->

--- a/docs/getting-started/container-selection/index.md
+++ b/docs/getting-started/container-selection/index.md
@@ -8,16 +8,18 @@ This behavior can be customized through a combination of configuration options a
 Container selection works through a **filter chain**: a series of criteria applied in sequence.
 A container is monitored only if it passes every filter in the chain. The filters are evaluated in the following order:
 
-| # | Filter                                                    | Description                                                                                                                                                 |
-|---|-----------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1 | Old Watchtower container exclusion                        | Watchtower containers renamed with a `watchtower-old-` prefix during self-updates are always excluded.                                                      |
-| 2 | [Disabled label check](#enabledisable_labels)             | Containers with the Docker label `com.centurylinklabs.watchtower.enable=false` are excluded.                                                                |
-| 3 | [Scope filter](#monitoring_scopes)                        | Only containers matching the configured scope are included (default: `"none"`).                                                                             |
-| 4 | [Enable label filter](#enabledisable_labels)              | If [label enable](../../configuration/container-selection/index.md#enable_label_filter) is set, only containers with the enable label present are included. |
-| 5 | [Image skip patterns](#exclude_specific_images)           | Containers whose image matches a [skip pattern](../../configuration/container-selection/index.md#skip_specific_images) are excluded.                        |
-| 6 | [Monitored image name patterns](#monitor_specific_images) | If set, only containers whose image matches a [monitored pattern](../../configuration/container-selection/index.md#monitor_specific_images) are included.   |
-| 7 | [Disabled container names](#exclude_specific_containers)  | Containers whose name matches a [disable pattern](../../configuration/container-selection/index.md#disable_specific_containers) are excluded.               |
-| 8 | [Container name arguments](#container_name_filtering)     | If positional name arguments are provided, only containers matching at least one are included.                                                              |
+| #  | Filter                                                       | Description                                                                                                                                                   |
+|----|--------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1  | Old Watchtower container exclusion                           | Watchtower containers renamed with a `watchtower-old-` prefix during self-updates are always excluded.                                                        |
+| 2  | [Disabled label check](#enabledisable_labels)                | Containers with the Docker label `com.centurylinklabs.watchtower.enable=false` are excluded.                                                                  |
+| 3  | [Scope filter](#monitoring_scopes)                           | Only containers matching the configured scope are included (default: `"none"`).                                                                               |
+| 4  | [Enable label filter](#enabledisable_labels)                 | If [label enable](../../configuration/container-selection/index.md#enable_label_filter) is set, only containers with the enable label present are included.   |
+| 5  | [Disabled containers by label](#disable_containers_by_label) | Containers matching any [disabled label pair](../../configuration/container-selection/index.md#disable_containers_by_label) are excluded.                     |
+| 6  | [Enabled containers by label](#enable_containers_by_label)   | If set, only containers matching at least one [enabled label pair](../../configuration/container-selection/index.md#enable_containers_by_label) are included. |
+| 7  | [Image skip patterns](#exclude_specific_images)              | Containers whose image matches a [skip pattern](../../configuration/container-selection/index.md#skip_specific_images) are excluded.                          |
+| 8  | [Monitored image name patterns](#monitor_specific_images)    | If set, only containers whose image matches a [monitored pattern](../../configuration/container-selection/index.md#monitor_specific_images) are included.     |
+| 9  | [Disabled container names](#exclude_specific_containers)     | Containers whose name matches a [disable pattern](../../configuration/container-selection/index.md#disable_specific_containers) are excluded.                 |
+| 10 | [Container name arguments](#container_name_filtering)        | If positional name arguments are provided, only containers matching at least one are included.                                                                |
 
 !!! Note
     - If an image name pattern is configured, then Watchtower will exclusively manage only the respective container(s).
@@ -197,6 +199,71 @@ This supports comma- or space-separated values and regex patterns.
         --disable-containers container1,container2
     ```
 <!-- markdownlint-restore -->
+
+## Label-Based Container Filtering
+
+Watchtower can include or exclude containers based on arbitrary Docker label key-value pairs.
+
+### Enable Containers by Label
+
+Use the [enable containers by label](../../configuration/container-selection/index.md#enable_containers_by_label) option to restrict monitoring to containers that have at least one of the specified label pairs.
+
+<!-- markdownlint-disable -->
+=== "Docker Compose"
+    ```yaml
+    services:
+        watchtower:
+            image: nickfedor/watchtower:latest
+            environment:
+                - WATCHTOWER_ENABLE_CONTAINERS_BY_LABEL=env=prod,team=platform
+            volumes:
+                - /var/run/docker.sock:/var/run/docker.sock
+    ```
+=== "Docker CLI (Env Vars)"
+    ```bash
+    docker run -d \
+        -e WATCHTOWER_ENABLE_CONTAINERS_BY_LABEL="env=prod,team=platform" \
+        nickfedor/watchtower
+    ```
+=== "Docker CLI (Flags)"
+    ```bash
+    docker run -d \
+        nickfedor/watchtower \
+        --enable-containers-by-label "env=prod,team=platform"
+    ```
+<!-- markdownlint-restore -->
+
+### Disable Containers by Label
+
+Use the [disable containers by label](../../configuration/container-selection/index.md#disable_containers_by_label) option to exclude containers that have any of the specified label pairs.
+
+<!-- markdownlint-disable -->
+=== "Docker Compose"
+    ```yaml
+    services:
+        watchtower:
+            image: nickfedor/watchtower:latest
+            environment:
+                - WATCHTOWER_DISABLE_CONTAINERS_BY_LABEL=managed-by=external
+            volumes:
+                - /var/run/docker.sock:/var/run/docker.sock
+    ```
+=== "Docker CLI (Env Vars)"
+    ```bash
+    docker run -d \
+        -e WATCHTOWER_DISABLE_CONTAINERS_BY_LABEL="managed-by=external" \
+        nickfedor/watchtower
+    ```
+=== "Docker CLI (Flags)"
+    ```bash
+    docker run -d \
+        nickfedor/watchtower \
+        --disable-containers-by-label "managed-by=external"
+    ```
+<!-- markdownlint-restore -->
+
+!!! Note
+    Values containing commas are not supported. Use individual `key=value` pairs separated by commas.
 
 ## Image Name Filtering
 
@@ -383,17 +450,19 @@ This applies to the [`monitor-only`](../../configuration/update-behavior/index.m
 
 ### CLI Flags and Environment Variables
 
-| Flag                          | Environment Variable               | Type     | Default | Description                           |
-|-------------------------------|------------------------------------|----------|---------|---------------------------------------|
-| *(positional args)*           | N/A                                | []string | []      | Container names/patterns to include   |
-| `--disable-containers` / `-x` | `WATCHTOWER_DISABLE_CONTAINERS`    | []string | []      | Container names/patterns to exclude   |
-| `--monitor-image-names`       | `WATCHTOWER_MONITOR_IMAGE_NAMES`   | []string | []      | Image name patterns to monitor        |
-| `--skip-image-names`          | `WATCHTOWER_SKIP_IMAGE_NAMES`      | []string | []      | Image name patterns to exclude        |
-| `--label-enable` / `-e`       | `WATCHTOWER_LABEL_ENABLE`          | bool     | false   | Require enable label on containers    |
-| `--scope`                     | `WATCHTOWER_SCOPE`                 | string   | ""      | Monitoring scope                      |
-| `--include-stopped` / `-S`    | `WATCHTOWER_INCLUDE_STOPPED`       | bool     | false   | Include created and exited containers |
-| `--include-restarting`        | `WATCHTOWER_INCLUDE_RESTARTING`    | bool     | false   | Include restarting containers         |
-| `--label-take-precedence`     | `WATCHTOWER_LABEL_TAKE_PRECEDENCE` | bool     | false   | Labels override global flags          |
+| Flag                            | Environment Variable                     | Type     | Default | Description                           |
+|---------------------------------|------------------------------------------|----------|---------|---------------------------------------|
+| *(positional args)*             | N/A                                      | []string | []      | Container names/patterns to include   |
+| `--disable-containers` / `-x`   | `WATCHTOWER_DISABLE_CONTAINERS`          | []string | []      | Container names/patterns to exclude   |
+| `--enable-containers-by-label`  | `WATCHTOWER_ENABLE_CONTAINERS_BY_LABEL`  | []string | []      | Label key=value pairs to include      |
+| `--disable-containers-by-label` | `WATCHTOWER_DISABLE_CONTAINERS_BY_LABEL` | []string | []      | Label key=value pairs to exclude      |
+| `--monitor-image-names`         | `WATCHTOWER_MONITOR_IMAGE_NAMES`         | []string | []      | Image name patterns to monitor        |
+| `--skip-image-names`            | `WATCHTOWER_SKIP_IMAGE_NAMES`            | []string | []      | Image name patterns to exclude        |
+| `--label-enable` / `-e`         | `WATCHTOWER_LABEL_ENABLE`                | bool     | false   | Require enable label on containers    |
+| `--scope`                       | `WATCHTOWER_SCOPE`                       | string   | ""      | Monitoring scope                      |
+| `--include-stopped` / `-S`      | `WATCHTOWER_INCLUDE_STOPPED`             | bool     | false   | Include created and exited containers |
+| `--include-restarting`          | `WATCHTOWER_INCLUDE_RESTARTING`          | bool     | false   | Include restarting containers         |
+| `--label-take-precedence`       | `WATCHTOWER_LABEL_TAKE_PRECEDENCE`       | bool     | false   | Labels override global flags          |
 
 ### Container Labels
 
@@ -438,6 +507,26 @@ Exclude Watchtower itself and other infrastructure containers:
 ```bash
 docker run -d \
     -e WATCHTOWER_DISABLE_CONTAINERS="watchtower,traefik,portainer" \
+    nickfedor/watchtower
+```
+
+### Exclude Containers by Label
+
+Exclude containers managed by third-party orchestrators using arbitrary labels:
+
+```bash
+docker run -d \
+    -e WATCHTOWER_DISABLE_CONTAINERS_BY_LABEL="managed-by=external" \
+    nickfedor/watchtower
+```
+
+### Monitor Containers by Label
+
+Only monitor containers with specific labels:
+
+```bash
+docker run -d \
+    -e WATCHTOWER_ENABLE_CONTAINERS_BY_LABEL="env=prod,team=platform" \
     nickfedor/watchtower
 ```
 

--- a/docs/getting-started/container-selection/index.md
+++ b/docs/getting-started/container-selection/index.md
@@ -233,6 +233,10 @@ Use the [enable containers by label](../../configuration/container-selection/ind
     ```
 <!-- markdownlint-restore -->
 
+An empty value (`key=`) matches any container where the label key exists, regardless of its value.
+
+For example, `WATCHTOWER_ENABLE_CONTAINERS_BY_LABEL=env=` enables any container with the `env` label set to any value.
+
 ### Disable Containers by Label
 
 Use the [disable containers by label](../../configuration/container-selection/index.md#disable_containers_by_label) option to exclude containers that have any of the specified label pairs.
@@ -264,6 +268,9 @@ Use the [disable containers by label](../../configuration/container-selection/in
 
 !!! Note
     Values containing commas are not supported. Use individual `key=value` pairs separated by commas.
+
+!!! Note
+    A label entry with an empty value (`key=`) performs a presence check: the label must exist on the container with any value. A non-empty value requires an exact match.
 
 ## Image Name Filtering
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -160,6 +160,20 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		),
 		"Comma-separated list of image names to explicitly exclude from monitoring.")
 
+	flags.StringSlice(
+		"enable-containers-by-label",
+		filterEmptyStrings(
+			regexp.MustCompile(",").Split(envString("WATCHTOWER_ENABLE_CONTAINERS_BY_LABEL"), -1),
+		),
+		"Comma-separated list of key=value label pairs to restrict monitoring to matching containers.")
+
+	flags.StringSlice(
+		"disable-containers-by-label",
+		filterEmptyStrings(
+			regexp.MustCompile(",").Split(envString("WATCHTOWER_DISABLE_CONTAINERS_BY_LABEL"), -1),
+		),
+		"Comma-separated list of key=value label pairs to exclude matching containers from monitoring.")
+
 	flags.StringP(
 		"log-format",
 		"l",

--- a/pkg/container/metadata.go
+++ b/pkg/container/metadata.go
@@ -280,6 +280,21 @@ func (c *Container) Enabled() (bool, bool) {
 	return parsedBool, true
 }
 
+// GetLabel retrieves the value of an arbitrary container label.
+//
+// It returns the label value and true if the label is present, or an empty
+// string and false if the label is absent.
+//
+// Parameters:
+//   - label: Docker label key to look up.
+//
+// Returns:
+//   - string: Label value if present.
+//   - bool: True if label exists, false otherwise.
+func (c *Container) GetLabel(label string) (string, bool) {
+	return c.getLabelValue(label)
+}
+
 // IsMonitorOnly determines if the container is monitor-only.
 //
 // It uses UpdateParams.MonitorOnly and label precedence.

--- a/pkg/container/metadata.go
+++ b/pkg/container/metadata.go
@@ -249,7 +249,7 @@ func (c *Container) GetLifecycleGID() (int, bool) {
 //
 // Returns:
 //   - bool: True if enabled, false otherwise.
-//   - bool: True if label is set, false if absent/invalid.
+//   - bool: True if label is set and valid, false if absent or invalid.
 func (c *Container) Enabled() (bool, bool) {
 	clog := logrus.WithField("container", c.Name())
 	rawBool, ok := c.getLabelValue(enableLabel)

--- a/pkg/container/mocks/FilterableContainer.go
+++ b/pkg/container/mocks/FilterableContainer.go
@@ -92,3 +92,24 @@ func (_m *FilterableContainer) ImageName() string {
 
 	return result0
 }
+
+// GetLabel provides a mock function with given fields: key.
+func (_m *FilterableContainer) GetLabel(key string) (string, bool) {
+	ret := _m.Called(key)
+
+	var result0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		result0 = rf(key)
+	} else {
+		result0 = ret.Get(0).(string)
+	}
+
+	var result1 bool
+	if rf, ok := ret.Get(1).(func(string) bool); ok {
+		result1 = rf(key)
+	} else {
+		result1 = ret.Get(1).(bool)
+	}
+
+	return result0, result1
+}

--- a/pkg/filters/doc.go
+++ b/pkg/filters/doc.go
@@ -7,7 +7,10 @@
 //
 // Usage example:
 //
-//	filter, desc := filters.BuildFilter(names, disableNames, monitoredImageNamePatterns, skippedImageNamePatterns, true, "scope")
+//	filter, desc, err := filters.BuildFilter(names, disableNames, monitoredImageNamePatterns, skippedImageNamePatterns, enabledLabels, disabledLabels, true, "scope")
+//	if err != nil {
+//		return err
+//	}
 //	containers, _ := client.ListContainers(filter)
 //	logrus.Info(desc)
 //

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -444,6 +444,36 @@ func FilterByDisabledLabels(labels map[string]string, baseFilter types.Filter) t
 	}
 }
 
+// FilterByEnableLabel applies the boolean --label-enable filter.
+//
+// When enable is true, only containers whose enable label parses as true are
+// included. When enable is false, containers whose enable label parses as false
+// are excluded.
+// Absent or invalid label values follow the Enabled() defaults:
+//   - Absent is treated as not-set
+//   - Invalid text is treated as false
+//
+// Parameters:
+//   - enable: require the enable label when true, exclude false values when false.
+//   - baseFilter: base filter to chain.
+//
+// Returns:
+//   - types.Filter: filter function applying enable-label semantics and baseFilter.
+func FilterByEnableLabel(enable bool, baseFilter types.Filter) types.Filter {
+	return func(c types.FilterableContainer) bool {
+		enabled, ok := c.Enabled()
+		if ok && !enabled {
+			return false
+		}
+
+		if !ok && enable {
+			return false
+		}
+
+		return baseFilter(c)
+	}
+}
+
 // FilterByScope selects containers in a specific scope.
 //
 // Parameters:
@@ -607,12 +637,6 @@ func BuildFilter(
 		return nil, "", err
 	}
 
-	if enableLabel {
-		enabledLabelMap[enableLabelKey] = ""
-	}
-
-	disabledLabelMap[enableLabelKey] = "false"
-
 	clog := logrus.WithFields(logrus.Fields{
 		"names":                      normalizedNames,
 		"disableNames":               normalizedDisableNames,
@@ -633,6 +657,7 @@ func BuildFilter(
 	filter = FilterBySkippedImageNamePatterns(skippedImageNamePatterns, filter)
 	filter = FilterByEnabledLabels(enabledLabelMap, filter)
 	filter = FilterByDisabledLabels(disabledLabelMap, filter)
+	filter = FilterByEnableLabel(enableLabel, filter)
 
 	// Add name-based filter description.
 	if len(normalizedNames) > 0 {
@@ -690,6 +715,12 @@ func BuildFilter(
 		}
 
 		stringBuilder.WriteString(`", `)
+	}
+
+	if enableLabel {
+		stringBuilder.WriteString("with label ")
+		stringBuilder.WriteString(enableLabelKey)
+		stringBuilder.WriteString(`, `)
 	}
 
 	if len(enabledLabelMap) > 0 {

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -446,12 +446,11 @@ func FilterByDisabledLabels(labels map[string]string, baseFilter types.Filter) t
 
 // FilterByEnableLabel applies the boolean --label-enable filter.
 //
-// When enable is true, only containers whose enable label parses as true are
-// included. When enable is false, containers whose enable label parses as false
-// are excluded.
-// Absent or invalid label values follow the Enabled() defaults:
-//   - Absent is treated as not-set
-//   - Invalid text is treated as false
+// When enable is true, only containers whose enable label is present with a
+// value that parses as true are included. When enable is false, containers
+// whose enable label is present with a value that parses as false are excluded.
+// Absent labels and invalid values are both treated as unset, matching
+// Enabled() returning ok=false.
 //
 // Parameters:
 //   - enable: require the enable label when true, exclude false values when false.

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -1,6 +1,8 @@
 package filters
 
 import (
+	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -9,8 +11,42 @@ import (
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
-// noScope is the default scope value when none is specified.
-const noScope = "none"
+const (
+	// noScope is the default scope value when none is specified.
+	noScope = "none"
+
+	// Expected number of parts in a key=value label pair.
+	labelPairPartsCount = 2
+
+	// maxLabelPairBytes is the maximum combined byte length of a label key and
+	// value, consistent with containerd's label validation.
+	maxLabelPairBytes = 4096
+
+	// maxLabelPairs is the maximum number of label pairs accepted from user
+	// input, preventing memory exhaustion from unbounded slice lengths.
+	maxLabelPairs = 100
+
+	// enableLabelKey is the Docker label key used by Watchtower to control whether
+	// a container is managed.
+	enableLabelKey = "com.centurylinklabs.watchtower.enable"
+)
+
+var (
+	// errTooManyLabelPairs is returned when the number of provided label pairs
+	// exceeds the allowed maximum.
+	errTooManyLabelPairs = errors.New("too many label pairs")
+
+	// errLabelPairMissingEquals is returned when a label pair does not contain
+	// exactly one '=' separator.
+	errLabelPairMissingEquals = errors.New("label pair missing '=' separator")
+
+	// errLabelPairEmptyKey is returned when a label pair has an empty key.
+	errLabelPairEmptyKey = errors.New("label pair has empty key")
+
+	// errLabelPairTooLong is returned when a label pair exceeds the maximum
+	// combined byte length.
+	errLabelPairTooLong = errors.New("label pair exceeds maximum combined length")
+)
 
 // WatchtowerContainersFilter selects only Watchtower containers.
 //
@@ -264,49 +300,145 @@ func FilterBySkippedImageNamePatterns(namePatterns []string, baseFilter types.Fi
 	}
 }
 
-// FilterByEnableLabel selects containers with enable label set.
+// parseLabelPairs parses a slice of "key=value" strings into a map.
+//
+// Values are trimmed of surrounding whitespace for consistency with key
+// trimming. Only the first '=' separates key from value; any additional '='
+// characters are retained as part of the value. Entries without at least one
+// '=', empty keys, or pairs exceeding the maximum combined byte length are
+// rejected with an error rather than silently skipped, so callers can surface
+// malformed input to the user.
 //
 // Parameters:
+//   - pairs: Raw label pair strings from flag/env input.
+//
+// Returns:
+//   - map[string]string: Parsed label key-value pairs.
+//   - error: Non-nil if any pair is malformed or exceeds size limits.
+func parseLabelPairs(pairs []string) (map[string]string, error) {
+	if len(pairs) > maxLabelPairs {
+		return nil, fmt.Errorf("%w: %d > %d", errTooManyLabelPairs, len(pairs), maxLabelPairs)
+	}
+
+	result := make(map[string]string)
+
+	for _, pair := range pairs {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+
+		parts := strings.SplitN(pair, "=", labelPairPartsCount)
+		if len(parts) != labelPairPartsCount {
+			return nil, fmt.Errorf("%w: %q", errLabelPairMissingEquals, pair)
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		if key == "" {
+			return nil, fmt.Errorf("%w: %q", errLabelPairEmptyKey, pair)
+		}
+
+		if len(key)+len(value) > maxLabelPairBytes {
+			return nil, fmt.Errorf("%w: key=%q value=%q combined=%d bytes", errLabelPairTooLong, key, value, len(key)+len(value))
+		}
+
+		result[key] = value
+	}
+
+	return result, nil
+}
+
+// FilterByEnabledLabels restricts processing to containers that have at least
+// one of the specified label key-value pairs.
+//
+// An empty label list disables the filter entirely.
+//
+// A label entry with an empty value (key="") performs a presence check: the
+// label must exist on the container with any value. A non-empty value requires
+// an exact match.
+//
+// Parameters:
+//   - labels: Map of label key-value pairs to require.
 //   - baseFilter: Base filter to chain.
 //
 // Returns:
-//   - types.Filter: Filter function requiring enable label and applying base filter.
-func FilterByEnableLabel(baseFilter types.Filter) types.Filter {
+//   - types.Filter: Filter function matching labels and applying base filter.
+func FilterByEnabledLabels(labels map[string]string, baseFilter types.Filter) types.Filter {
+	if len(labels) == 0 {
+		return baseFilter
+	}
+
 	return func(c types.FilterableContainer) bool {
-		clog := logrus.WithField("container", c.Name())
-		_, ok := c.Enabled()
+		clog := logrus.WithFields(logrus.Fields{
+			"container": c.Name(),
+			"labels":    labels,
+		})
 
-		if !ok {
-			clog.Debug("Container excluded: enable label not set")
+		for key, expectedValue := range labels {
+			labelValue, ok := c.GetLabel(key)
+			if !ok {
+				continue
+			}
 
-			return false
+			if expectedValue != "" && labelValue != expectedValue {
+				continue
+			}
+
+			clog.WithField("matched_label", key).Debug("Container matched enabled label")
+
+			return baseFilter(c)
 		}
 
-		clog.Debug("Container included: enable label set")
+		clog.Debug("Container did not match any enabled label")
 
-		return baseFilter(c)
+		return false
 	}
 }
 
-// FilterByDisabledLabel excludes containers with enable label set to false.
+// FilterByDisabledLabels excludes containers that have any of the specified
+// label key-value pairs.
+//
+// An empty label list disables the filter entirely.
+//
+// A label entry with an empty value (key="") performs a presence check: the
+// label must exist on the container with any value. A non-empty value requires
+// an exact match.
 //
 // Parameters:
+//   - labels: Map of label key-value pairs to exclude.
 //   - baseFilter: Base filter to chain.
 //
 // Returns:
-//   - types.Filter: Filter function excluding disabled containers and applying base filter.
-func FilterByDisabledLabel(baseFilter types.Filter) types.Filter {
-	return func(c types.FilterableContainer) bool {
-		clog := logrus.WithField("container", c.Name())
-		enabledLabel, ok := c.Enabled()
+//   - types.Filter: Filter function excluding matching labels and applying base filter.
+func FilterByDisabledLabels(labels map[string]string, baseFilter types.Filter) types.Filter {
+	if len(labels) == 0 {
+		return baseFilter
+	}
 
-		if ok && !enabledLabel {
-			clog.Debug("Container excluded: enable label set to false")
+	return func(c types.FilterableContainer) bool {
+		clog := logrus.WithFields(logrus.Fields{
+			"container": c.Name(),
+			"labels":    labels,
+		})
+
+		for key, expectedValue := range labels {
+			labelValue, ok := c.GetLabel(key)
+			if !ok {
+				continue
+			}
+
+			if expectedValue != "" && labelValue != expectedValue {
+				continue
+			}
+
+			clog.WithField("matched_label", key).Debug("Container excluded by disabled label")
 
 			return false
 		}
 
-		clog.Debug("Container not excluded by disabled label")
+		clog.Debug("Container not excluded by disabled labels")
 
 		return baseFilter(c)
 	}
@@ -445,25 +577,49 @@ func matchImageAndTag(containerImage, targetImage string) bool {
 //     image matches one of these patterns are monitored.
 //   - skippedImageNamePatterns: Image name regex patterns. Containers whose image
 //     matches one of these patterns are excluded from monitoring.
+//   - enabledLabels: Label key-value pairs. When set, only containers matching at least
+//     one pair are monitored.
+//   - disabledLabels: Label key-value pairs. Containers matching any pair are excluded.
 //   - enableLabel: Require enable label if true.
 //   - scope: Scope to match.
 //
 // Returns:
 //   - types.Filter: Combined filter function.
 //   - string: Description of the filter.
+//   - error: Non-nil if any enabled or disabled label pair is malformed.
 func BuildFilter(
 	normalizedNames []string,
 	normalizedDisableNames []string,
 	monitoredImageNamePatterns []string,
 	skippedImageNamePatterns []string,
+	enabledLabels []string,
+	disabledLabels []string,
 	enableLabel bool,
 	scope string,
-) (types.Filter, string) {
+) (types.Filter, string, error) {
+	enabledLabelMap, err := parseLabelPairs(enabledLabels)
+	if err != nil {
+		return nil, "", err
+	}
+
+	disabledLabelMap, err := parseLabelPairs(disabledLabels)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if enableLabel {
+		enabledLabelMap[enableLabelKey] = ""
+	}
+
+	disabledLabelMap[enableLabelKey] = "false"
+
 	clog := logrus.WithFields(logrus.Fields{
 		"names":                      normalizedNames,
 		"disableNames":               normalizedDisableNames,
 		"monitoredImageNamePatterns": monitoredImageNamePatterns,
 		"skippedImageNamePatterns":   skippedImageNamePatterns,
+		"enabledLabels":              enabledLabelMap,
+		"disabledLabels":             disabledLabelMap,
 		"enableLabel":                enableLabel,
 		"scope":                      scope,
 	})
@@ -475,6 +631,8 @@ func BuildFilter(
 	filter = FilterByDisableNames(normalizedDisableNames, filter)
 	filter = FilterByMonitoredImageNamePatterns(monitoredImageNamePatterns, filter)
 	filter = FilterBySkippedImageNamePatterns(skippedImageNamePatterns, filter)
+	filter = FilterByEnabledLabels(enabledLabelMap, filter)
+	filter = FilterByDisabledLabels(disabledLabelMap, filter)
 
 	// Add name-based filter description.
 	if len(normalizedNames) > 0 {
@@ -534,11 +692,52 @@ func BuildFilter(
 		stringBuilder.WriteString(`", `)
 	}
 
-	// Apply enable label filter if specified.
-	if enableLabel {
-		filter = FilterByEnableLabel(filter)
+	if len(enabledLabelMap) > 0 {
+		stringBuilder.WriteString("with label ")
 
-		stringBuilder.WriteString("using enable label, ")
+		first := true
+		for key, value := range enabledLabelMap {
+			if !first {
+				stringBuilder.WriteString(" or ")
+			}
+
+			if value == "" {
+				stringBuilder.WriteString(key)
+			} else {
+				stringBuilder.WriteString(key)
+				stringBuilder.WriteString(`="`)
+				stringBuilder.WriteString(value)
+				stringBuilder.WriteString(`"`)
+			}
+
+			first = false
+		}
+
+		stringBuilder.WriteString(`, `)
+	}
+
+	if len(disabledLabelMap) > 0 {
+		stringBuilder.WriteString("without label ")
+
+		first := true
+		for key, value := range disabledLabelMap {
+			if !first {
+				stringBuilder.WriteString(" or ")
+			}
+
+			if value == "" {
+				stringBuilder.WriteString(key)
+			} else {
+				stringBuilder.WriteString(key)
+				stringBuilder.WriteString(`="`)
+				stringBuilder.WriteString(value)
+				stringBuilder.WriteString(`"`)
+			}
+
+			first = false
+		}
+
+		stringBuilder.WriteString(`, `)
 	}
 
 	if scope == noScope || scope == "" {
@@ -551,9 +750,6 @@ func BuildFilter(
 		stringBuilder.WriteString(`in scope `)
 		stringBuilder.WriteString(scope)
 	}
-
-	// Exclude explicitly disabled containers.
-	filter = FilterByDisabledLabel(filter)
 
 	// Exclude old Watchtower containers (predecessors from self-update).
 	// Applied last so it wraps the entire chain and short-circuits first.
@@ -569,5 +765,5 @@ func BuildFilter(
 
 	clog.WithField("filter_desc", filterDesc).Debug("Filter built")
 
-	return filter, filterDesc
+	return filter, filterDesc, nil
 }

--- a/pkg/filters/filters_fuzz_test.go
+++ b/pkg/filters/filters_fuzz_test.go
@@ -104,43 +104,55 @@ func FuzzMatchesImageName(f *testing.F) {
 }
 
 func FuzzFilterByEnabledLabels(f *testing.F) {
-	f.Add("app", "nginx:latest", "com.example.enabled=true")
-	f.Add("web", "redis:alpine", "com.example.env=prod")
-	f.Add("db", "postgres:15", "")
+	f.Add("app", "nginx:latest", "com.example.enabled=true", "com.example.enabled=true")
+	f.Add("web", "redis:alpine", "com.example.env=prod", "")
+	f.Add("db", "postgres:15", "com.example.env=prod", "com.example.env=staging")
+	f.Add("app", "nginx:latest", "", "com.example.enabled=true")
 
-	f.Fuzz(func(t *testing.T, containerName, imageName, labelPair string) {
-		labels, err := parseLabelPairs([]string{labelPair})
+	f.Fuzz(func(t *testing.T, containerName, imageName, filterLabelPair, containerLabelPair string) {
+		filterLabels, err := parseLabelPairs([]string{filterLabelPair})
 		if err != nil {
 			return
 		}
 
-		if len(labels) == 0 {
+		if len(filterLabels) == 0 {
 			return
 		}
 
-		c := newFuzzableContainer(containerName, imageName, true, "", false, labels)
-		filter := FilterByEnabledLabels(labels, NoFilter)
+		containerLabels, err := parseLabelPairs([]string{containerLabelPair})
+		if err != nil {
+			return
+		}
+
+		c := newFuzzableContainer(containerName, imageName, true, "", false, containerLabels)
+		filter := FilterByEnabledLabels(filterLabels, NoFilter)
 		_ = filter(c)
 	})
 }
 
 func FuzzFilterByDisabledLabels(f *testing.F) {
-	f.Add("app", "nginx:latest", "com.example.disabled=true")
-	f.Add("web", "redis:alpine", "com.example.env=prod")
-	f.Add("db", "postgres:15", "")
+	f.Add("app", "nginx:latest", "com.example.disabled=true", "com.example.disabled=true")
+	f.Add("web", "redis:alpine", "com.example.env=prod", "")
+	f.Add("db", "postgres:15", "com.example.env=prod", "com.example.env=staging")
+	f.Add("app", "nginx:latest", "", "com.example.disabled=true")
 
-	f.Fuzz(func(t *testing.T, containerName, imageName, labelPair string) {
-		labels, err := parseLabelPairs([]string{labelPair})
+	f.Fuzz(func(t *testing.T, containerName, imageName, filterLabelPair, containerLabelPair string) {
+		filterLabels, err := parseLabelPairs([]string{filterLabelPair})
 		if err != nil {
 			return
 		}
 
-		if len(labels) == 0 {
+		if len(filterLabels) == 0 {
 			return
 		}
 
-		c := newFuzzableContainer(containerName, imageName, true, "", false, labels)
-		filter := FilterByDisabledLabels(labels, NoFilter)
+		containerLabels, err := parseLabelPairs([]string{containerLabelPair})
+		if err != nil {
+			return
+		}
+
+		c := newFuzzableContainer(containerName, imageName, true, "", false, containerLabels)
+		filter := FilterByDisabledLabels(filterLabels, NoFilter)
 		_ = filter(c)
 	})
 }

--- a/pkg/filters/filters_fuzz_test.go
+++ b/pkg/filters/filters_fuzz_test.go
@@ -1,0 +1,158 @@
+package filters
+
+import (
+	"testing"
+
+	"github.com/nicholas-fedor/watchtower/pkg/types"
+)
+
+// fuzzableContainer is a minimal FilterableContainer implementation for fuzzing
+// filter functions. It stores labels in a map and returns fixed values for
+// other fields.
+type fuzzableContainer struct {
+	name       string
+	imageName  string
+	enabled    bool
+	scope      string
+	hasScope   bool
+	labels     map[string]string
+	watchtower bool
+}
+
+func newFuzzableContainer(name, imageName string, enabled bool, scope string, hasScope bool, labels map[string]string) fuzzableContainer {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	return fuzzableContainer{
+		name:       name,
+		imageName:  imageName,
+		enabled:    enabled,
+		scope:      scope,
+		hasScope:   hasScope,
+		labels:     labels,
+		watchtower: false,
+	}
+}
+
+func (c fuzzableContainer) Name() string {
+	return c.name
+}
+
+func (c fuzzableContainer) ImageName() string {
+	return c.imageName
+}
+
+func (c fuzzableContainer) Enabled() (bool, bool) {
+	return c.enabled, true
+}
+
+func (c fuzzableContainer) Scope() (string, bool) {
+	return c.scope, c.hasScope
+}
+
+func (c fuzzableContainer) GetLabel(key string) (string, bool) {
+	value, ok := c.labels[key]
+
+	return value, ok
+}
+
+func (c fuzzableContainer) IsWatchtower() bool {
+	return c.watchtower
+}
+
+var _ types.FilterableContainer = fuzzableContainer{}
+
+func FuzzParseLabelPairs(f *testing.F) {
+	f.Add("key=value")
+	f.Add("key=")
+	f.Add("  key  =  value  ")
+	f.Add("key=value=extra")
+	f.Add("nokey")
+	f.Add("=value")
+	f.Add("")
+
+	f.Fuzz(func(t *testing.T, input string) {
+		_, err := parseLabelPairs([]string{input})
+		if err != nil {
+			return
+		}
+	})
+}
+
+func FuzzMatchesName(f *testing.F) {
+	f.Add("test-container", "test")
+	f.Add("nginx-proxy-1", "nginx.*")
+	f.Add("watchtower", "watchtower")
+	f.Add("app", "^[a-z]+$")
+	f.Add("container", "")
+
+	f.Fuzz(func(t *testing.T, containerName, pattern string) {
+		_ = matchesName(containerName, pattern)
+	})
+}
+
+func FuzzMatchesImageName(f *testing.F) {
+	f.Add("nginx:latest", "nginx:.*")
+	f.Add("redis:alpine", "redis:.*")
+	f.Add("myapp:1.0", "myapp")
+	f.Add("registry:5000/app:v1", "registry:5000/app:.*")
+
+	f.Fuzz(func(t *testing.T, imageName, pattern string) {
+		_ = matchesImageName(imageName, pattern)
+	})
+}
+
+func FuzzFilterByEnabledLabels(f *testing.F) {
+	f.Add("app", "nginx:latest", "com.example.enabled=true")
+	f.Add("web", "redis:alpine", "com.example.env=prod")
+	f.Add("db", "postgres:15", "")
+
+	f.Fuzz(func(t *testing.T, containerName, imageName, labelPair string) {
+		labels, err := parseLabelPairs([]string{labelPair})
+		if err != nil {
+			return
+		}
+
+		if len(labels) == 0 {
+			return
+		}
+
+		c := newFuzzableContainer(containerName, imageName, true, "", false, labels)
+		filter := FilterByEnabledLabels(labels, NoFilter)
+		_ = filter(c)
+	})
+}
+
+func FuzzFilterByDisabledLabels(f *testing.F) {
+	f.Add("app", "nginx:latest", "com.example.disabled=true")
+	f.Add("web", "redis:alpine", "com.example.env=prod")
+	f.Add("db", "postgres:15", "")
+
+	f.Fuzz(func(t *testing.T, containerName, imageName, labelPair string) {
+		labels, err := parseLabelPairs([]string{labelPair})
+		if err != nil {
+			return
+		}
+
+		if len(labels) == 0 {
+			return
+		}
+
+		c := newFuzzableContainer(containerName, imageName, true, "", false, labels)
+		filter := FilterByDisabledLabels(labels, NoFilter)
+		_ = filter(c)
+	})
+}
+
+func FuzzMatchImageAndTag(f *testing.F) {
+	f.Add("nginx:latest", "nginx")
+	f.Add("redis:alpine", "redis:alpine")
+	f.Add("myapp:1.0", "myapp:1.0")
+	f.Add("registry:5000/app:v1", "registry:5000/app:v1")
+	f.Add("postgres:15", "postgres")
+
+	f.Fuzz(func(t *testing.T, containerImage, targetImage string) {
+		_ = matchImageAndTag(containerImage, targetImage)
+	})
+}

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -1,9 +1,12 @@
 package filters
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	mockContainer "github.com/nicholas-fedor/watchtower/pkg/container/mocks"
 )
@@ -257,27 +260,27 @@ func TestFilterByNamesRegex(t *testing.T) {
 	container.AssertExpectations(t)
 }
 
-func TestFilterByEnableLabel(t *testing.T) {
+func TestFilterByEnabledLabelsPresenceCheck(t *testing.T) {
 	t.Parallel()
 
-	filter := FilterByEnableLabel(NoFilter)
+	filter := FilterByEnabledLabels(map[string]string{enableLabelKey: ""}, NoFilter)
 	assert.NotNil(t, filter)
 
 	container := new(mockContainer.FilterableContainer)
-	container.On("Enabled").Return(true, true)
 	container.On("Name").Return("/test")
+	container.On("GetLabel", enableLabelKey).Return("true", true)
 	assert.True(t, filter(container))
 	container.AssertExpectations(t)
 
 	container = new(mockContainer.FilterableContainer)
-	container.On("Enabled").Return(false, true)
 	container.On("Name").Return("/test")
+	container.On("GetLabel", enableLabelKey).Return("false", true)
 	assert.True(t, filter(container))
 	container.AssertExpectations(t)
 
 	container = new(mockContainer.FilterableContainer)
-	container.On("Enabled").Return(false, false)
 	container.On("Name").Return("/test")
+	container.On("GetLabel", enableLabelKey).Return("", false)
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
 }
@@ -454,20 +457,23 @@ func TestFilterByNoneScope_MixedHandling(t *testing.T) {
 func TestBuildFilterNoneScope(t *testing.T) {
 	t.Parallel()
 
-	filter, desc := BuildFilter(nil, nil, nil, nil, false, "none")
+	filter, desc, err := BuildFilter(nil, nil, nil, nil, nil, nil, false, "none")
+	require.NoError(t, err)
 
 	assert.Contains(t, desc, "without a scope")
 
 	scoped := new(mockContainer.FilterableContainer)
 	scoped.On("IsWatchtower").Return(false).Maybe()
-	scoped.On("Enabled").Return(false, false)
+	scoped.On("Enabled").Return(false, false).Maybe()
 	scoped.On("Scope").Return("anyscope", true)
+	scoped.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	scoped.On("Name").Return("/scoped")
 
 	unscoped := new(mockContainer.FilterableContainer)
 	unscoped.On("IsWatchtower").Return(false).Maybe()
-	unscoped.On("Enabled").Return(false, false)
+	unscoped.On("Enabled").Return(false, false).Maybe()
 	unscoped.On("Scope").Return("", false)
+	unscoped.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	unscoped.On("Name").Return("/unscoped")
 
 	assert.False(t, filter(scoped))
@@ -484,27 +490,27 @@ func TestBuildFilterNoneScope(t *testing.T) {
 	oldNamed.AssertExpectations(t)
 }
 
-func TestFilterByDisabledLabel(t *testing.T) {
+func TestFilterByDisabledLabelsExactMatch(t *testing.T) {
 	t.Parallel()
 
-	filter := FilterByDisabledLabel(NoFilter)
+	filter := FilterByDisabledLabels(map[string]string{enableLabelKey: "false"}, NoFilter)
 	assert.NotNil(t, filter)
 
 	container := new(mockContainer.FilterableContainer)
-	container.On("Enabled").Return(true, true)
 	container.On("Name").Return("/test")
+	container.On("GetLabel", enableLabelKey).Return("true", true)
 	assert.True(t, filter(container))
 	container.AssertExpectations(t)
 
 	container = new(mockContainer.FilterableContainer)
-	container.On("Enabled").Return(false, true)
 	container.On("Name").Return("/test")
+	container.On("GetLabel", enableLabelKey).Return("false", true)
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
 
 	container = new(mockContainer.FilterableContainer)
-	container.On("Enabled").Return(false, false)
 	container.On("Name").Return("/test")
+	container.On("GetLabel", enableLabelKey).Return("", false)
 	assert.True(t, filter(container))
 	container.AssertExpectations(t)
 }
@@ -689,7 +695,8 @@ func TestBuildFilter(t *testing.T) {
 
 	names := []string{"test", "valid"}
 
-	filter, desc := BuildFilter(names, []string{}, nil, nil, false, "")
+	filter, desc, err := BuildFilter(names, []string{}, nil, nil, nil, nil, false, "")
+	require.NoError(t, err)
 	assert.Contains(t, desc, "test")
 	assert.Contains(t, desc, "or")
 	assert.Contains(t, desc, "valid")
@@ -699,6 +706,7 @@ func TestBuildFilter(t *testing.T) {
 	container.On("Name").Return("Invalid").Maybe()
 	container.On("Enabled").Return(false, false).Maybe()
 	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	container.On("Name").Return("/test").Maybe()
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
@@ -708,6 +716,7 @@ func TestBuildFilter(t *testing.T) {
 	container.On("Name").Return("test").Maybe()
 	container.On("Enabled").Return(false, false).Maybe()
 	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	container.On("Name").Return("/test").Maybe()
 	assert.True(t, filter(container))
 	container.AssertExpectations(t)
@@ -717,6 +726,7 @@ func TestBuildFilter(t *testing.T) {
 	container.On("Name").Return("Invalid").Maybe()
 	container.On("Enabled").Return(true, true).Maybe()
 	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	container.On("Name").Return("/test").Maybe()
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
@@ -726,32 +736,38 @@ func TestBuildFilter(t *testing.T) {
 	container.On("Name").Return("test").Maybe()
 	container.On("Enabled").Return(true, true).Maybe()
 	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	container.On("Name").Return("/test").Maybe()
 	assert.True(t, filter(container))
 	container.AssertExpectations(t)
 
 	container = new(mockContainer.FilterableContainer)
 	container.On("IsWatchtower").Return(false).Maybe()
-	container.On("Enabled").Return(false, true).Maybe()
+	container.On("Enabled").Return(true, true).Maybe()
 	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	container.On("Name").Return("/test").Maybe()
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
 }
 
 func TestBuildFilterEnableLabel(t *testing.T) {
-	t.Parallel()
-
+	// t.Parallel()
 	names := make([]string, 0, 1)
 	names = append(names, "test")
 
-	filter, desc := BuildFilter(names, []string{}, nil, nil, true, "")
-	assert.Contains(t, desc, "using enable label")
+	filter, desc, err := BuildFilter(names, []string{}, nil, nil, nil, nil, true, "")
+	require.NoError(t, err)
+	assert.Contains(t, desc, "with label")
+	assert.Contains(t, desc, `com.centurylinklabs.watchtower.enable`)
+	assert.Contains(t, desc, "without label")
+	assert.Contains(t, desc, `com.centurylinklabs.watchtower.enable="false"`)
 
 	container := new(mockContainer.FilterableContainer)
 	container.On("IsWatchtower").Return(false).Maybe()
-	container.On("Enabled").Return(false, false)
+	container.On("Enabled").Return(false, false).Maybe()
 	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	container.On("Name").Return("/test").Maybe()
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
@@ -761,6 +777,7 @@ func TestBuildFilterEnableLabel(t *testing.T) {
 	container.On("Name").Return("Invalid").Maybe()
 	container.On("Enabled").Return(true, true).Maybe()
 	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	container.On("Name").Return("/test").Maybe()
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
@@ -770,23 +787,27 @@ func TestBuildFilterEnableLabel(t *testing.T) {
 	container.On("Name").Return("test").Maybe()
 	container.On("Enabled").Return(true, true).Maybe()
 	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	container.On("Name").Return("/test").Maybe()
-	assert.True(t, filter(container))
+	assert.False(t, filter(container))
 	container.AssertExpectations(t)
 
 	container = new(mockContainer.FilterableContainer)
-	container.On("IsWatchtower").Return(false).Maybe()
-	container.On("Enabled").Return(false, true).Maybe()
-	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
-	container.On("Name").Return("/test").Maybe()
-	assert.False(t, filter(container))
+	container.On("IsWatchtower").Return(false).Once()
+	container.On("Enabled").Return(true, true).Maybe()
+	container.On("Scope").Return("", false).Once()
+	container.On("GetLabel", enableLabelKey).Return("true", true).Times(2)
+	container.On("Name").Return("test").Maybe()
+	result := filter(container)
+	assert.True(t, result)
 	container.AssertExpectations(t)
 }
 
 func TestBuildFilterDisableContainer(t *testing.T) {
 	t.Parallel()
 
-	filter, desc := BuildFilter([]string{}, []string{"excluded", "notfound"}, nil, nil, false, "")
+	filter, desc, err := BuildFilter([]string{}, []string{"excluded", "notfound"}, nil, nil, nil, nil, false, "")
+	require.NoError(t, err)
 	assert.Contains(t, desc, "not named")
 	assert.Contains(t, desc, "excluded")
 	assert.Contains(t, desc, "or")
@@ -797,6 +818,7 @@ func TestBuildFilterDisableContainer(t *testing.T) {
 	container.On("Name").Return("Another").Maybe()
 	container.On("Enabled").Return(false, false).Maybe()
 	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	container.On("Name").Return("/test").Maybe()
 	assert.True(t, filter(container))
 	container.AssertExpectations(t)
@@ -806,6 +828,7 @@ func TestBuildFilterDisableContainer(t *testing.T) {
 	container.On("Name").Return("AnotherOne").Maybe()
 	container.On("Enabled").Return(true, true).Maybe()
 	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	container.On("Name").Return("/test").Maybe()
 	assert.True(t, filter(container))
 	container.AssertExpectations(t)
@@ -815,6 +838,7 @@ func TestBuildFilterDisableContainer(t *testing.T) {
 	container.On("Name").Return("test").Maybe()
 	container.On("Enabled").Return(false, false).Maybe()
 	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	container.On("Name").Return("/test").Maybe()
 	assert.True(t, filter(container))
 	container.AssertExpectations(t)
@@ -824,6 +848,7 @@ func TestBuildFilterDisableContainer(t *testing.T) {
 	container.On("Name").Return("excluded").Maybe()
 	container.On("Enabled").Return(true, true).Maybe()
 	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	container.On("Name").Return("/test").Maybe()
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
@@ -833,6 +858,7 @@ func TestBuildFilterDisableContainer(t *testing.T) {
 	container.On("Name").Return("excludedAsSubstring").Maybe()
 	container.On("Enabled").Return(true, true).Maybe()
 	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	container.On("Name").Return("/test").Maybe()
 	assert.True(t, filter(container))
 	container.AssertExpectations(t)
@@ -842,6 +868,7 @@ func TestBuildFilterDisableContainer(t *testing.T) {
 	container.On("Name").Return("notfound").Maybe()
 	container.On("Enabled").Return(true, true).Maybe()
 	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	container.On("Name").Return("/test").Maybe()
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
@@ -850,8 +877,9 @@ func TestBuildFilterDisableContainer(t *testing.T) {
 	container.On("IsWatchtower").Return(false).Maybe()
 	container.On("Enabled").Return(false, true).Maybe()
 	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	container.On("Name").Return("/test").Maybe()
-	assert.False(t, filter(container))
+	assert.True(t, filter(container))
 	container.AssertExpectations(t)
 }
 
@@ -954,12 +982,14 @@ func TestFilterBySkippedImageNames(t *testing.T) {
 func TestBuildFilterImageNames(t *testing.T) {
 	t.Parallel()
 
-	filter, desc := BuildFilter(
+	filter, desc, err := BuildFilter(
 		nil, nil,
 		[]string{"nginx:.*", "redis:.*"},
 		[]string{"redis:latest"},
+		nil, nil,
 		false, "",
 	)
+	require.NoError(t, err)
 	assert.Contains(t, desc, "which image matches")
 	assert.Contains(t, desc, "nginx:.*")
 	assert.Contains(t, desc, "whose image is not one of")
@@ -972,6 +1002,7 @@ func TestBuildFilterImageNames(t *testing.T) {
 	container.On("ImageName").Return("nginx:1.25").Maybe()
 	container.On("Enabled").Return(false, false).Maybe()
 	container.On("Scope").Return("", false).Maybe()
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	assert.True(t, filter(container))
 	container.AssertExpectations(t)
 
@@ -982,6 +1013,7 @@ func TestBuildFilterImageNames(t *testing.T) {
 	container.On("ImageName").Return("api:latest").Maybe()
 	container.On("Enabled").Return(false, false).Maybe()
 	container.On("Scope").Return("", false).Maybe()
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
 
@@ -992,6 +1024,7 @@ func TestBuildFilterImageNames(t *testing.T) {
 	container.On("ImageName").Return("redis:latest").Maybe()
 	container.On("Enabled").Return(false, false).Maybe()
 	container.On("Scope").Return("", false).Maybe()
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
 
@@ -1002,6 +1035,7 @@ func TestBuildFilterImageNames(t *testing.T) {
 	container.On("ImageName").Return("redis:7").Maybe()
 	container.On("Enabled").Return(false, false).Maybe()
 	container.On("Scope").Return("", false).Maybe()
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	assert.True(t, filter(container))
 	container.AssertExpectations(t)
 }
@@ -1011,13 +1045,15 @@ func TestBuildFilterImageNamesWithContainerNames(t *testing.T) {
 
 	// When both container name and image name patterns are set,
 	// a container must match BOTH to be included.
-	filter, desc := BuildFilter(
+	filter, desc, err := BuildFilter(
 		[]string{"web"},
 		nil,
 		[]string{"nginx:.*"},
 		nil,
+		nil, nil,
 		false, "",
 	)
+	require.NoError(t, err)
 	assert.Contains(t, desc, "which name matches")
 	assert.Contains(t, desc, "which image matches")
 
@@ -1028,6 +1064,7 @@ func TestBuildFilterImageNamesWithContainerNames(t *testing.T) {
 	container.On("ImageName").Return("nginx:1.25").Maybe()
 	container.On("Enabled").Return(false, false).Maybe()
 	container.On("Scope").Return("", false).Maybe()
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	assert.True(t, filter(container))
 	container.AssertExpectations(t)
 
@@ -1038,6 +1075,7 @@ func TestBuildFilterImageNamesWithContainerNames(t *testing.T) {
 	container.On("ImageName").Return("redis:latest").Maybe()
 	container.On("Enabled").Return(false, false).Maybe()
 	container.On("Scope").Return("", false).Maybe()
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
 
@@ -1048,6 +1086,255 @@ func TestBuildFilterImageNamesWithContainerNames(t *testing.T) {
 	container.On("ImageName").Return("nginx:1.25").Maybe()
 	container.On("Enabled").Return(false, false).Maybe()
 	container.On("Scope").Return("", false).Maybe()
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
+}
+
+func TestFilterByEnabledLabels(t *testing.T) {
+	t.Parallel()
+
+	labels := map[string]string{"Service": "Pelican", "Env": "prod"}
+
+	filter := FilterByEnabledLabels(labels, NoFilter)
+	assert.NotNil(t, filter)
+
+	container := new(mockContainer.FilterableContainer)
+	container.On("Name").Return("/pelican-1")
+	container.On("GetLabel", "Service").Return("Pelican", true).Once()
+	container.On("GetLabel", "Env").Return("other", true).Maybe()
+	assert.True(t, filter(container))
+	container.AssertExpectations(t)
+
+	container = new(mockContainer.FilterableContainer)
+	container.On("Name").Return("/prod-app")
+	container.On("GetLabel", "Env").Return("prod", true).Once()
+	container.On("GetLabel", "Service").Return("other", true).Maybe()
+	assert.True(t, filter(container))
+	container.AssertExpectations(t)
+
+	container = new(mockContainer.FilterableContainer)
+	container.On("Name").Return("/other")
+	container.On("GetLabel", "Service").Return("wrong", true).Once()
+	container.On("GetLabel", "Env").Return("wrong", true).Once()
+	assert.False(t, filter(container))
+	container.AssertExpectations(t)
+
+	container = new(mockContainer.FilterableContainer)
+	container.On("Name").Return("/no-label")
+	container.On("GetLabel", "Service").Return("", false).Once()
+	container.On("GetLabel", "Env").Return("", false).Once()
+	assert.False(t, filter(container))
+	container.AssertExpectations(t)
+
+	emptyFilter := FilterByEnabledLabels(nil, NoFilter)
+	container = new(mockContainer.FilterableContainer)
+	container.On("Name").Return("/anything").Maybe()
+	assert.True(t, emptyFilter(container))
+	container.AssertExpectations(t)
+}
+
+func TestFilterByDisabledLabels(t *testing.T) {
+	t.Parallel()
+
+	labels := map[string]string{"Service": "Pelican", "Env": "dev"}
+
+	filter := FilterByDisabledLabels(labels, NoFilter)
+	assert.NotNil(t, filter)
+
+	container := new(mockContainer.FilterableContainer)
+	container.On("Name").Return("/pelican-1")
+	container.On("GetLabel", "Service").Return("Pelican", true).Once()
+	container.On("GetLabel", "Env").Return("other", true).Maybe()
+	assert.False(t, filter(container))
+	container.AssertExpectations(t)
+
+	container = new(mockContainer.FilterableContainer)
+	container.On("Name").Return("/dev-app")
+	container.On("GetLabel", "Env").Return("dev", true).Once()
+	container.On("GetLabel", "Service").Return("other", true).Maybe()
+	assert.False(t, filter(container))
+	container.AssertExpectations(t)
+
+	container = new(mockContainer.FilterableContainer)
+	container.On("Name").Return("/prod-app")
+	container.On("GetLabel", "Service").Return("prod", true).Once()
+	container.On("GetLabel", "Env").Return("prod", true).Once()
+	assert.True(t, filter(container))
+	container.AssertExpectations(t)
+
+	container = new(mockContainer.FilterableContainer)
+	container.On("Name").Return("/no-label")
+	container.On("GetLabel", "Service").Return("", false).Once()
+	container.On("GetLabel", "Env").Return("", false).Once()
+	assert.True(t, filter(container))
+	container.AssertExpectations(t)
+
+	emptyFilter := FilterByDisabledLabels(nil, NoFilter)
+	container = new(mockContainer.FilterableContainer)
+	container.On("Name").Return("/anything").Maybe()
+	assert.True(t, emptyFilter(container))
+	container.AssertExpectations(t)
+}
+
+func TestBuildFilterEnabledLabels(t *testing.T) {
+	t.Parallel()
+
+	filter, desc, err := BuildFilter(nil, nil, nil, nil, []string{"Service=Pelican"}, nil, false, "none")
+	require.NoError(t, err)
+	assert.Contains(t, desc, "with label")
+	assert.Contains(t, desc, `Service="Pelican"`)
+
+	container := new(mockContainer.FilterableContainer)
+	container.On("IsWatchtower").Return(false).Maybe()
+	container.On("Name").Return("/pelican-1").Maybe()
+	container.On("GetLabel", "Service").Return("Pelican", true)
+	container.On("Enabled").Return(false, false).Maybe()
+	container.On("Scope").Return("", false).Maybe()
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
+	assert.True(t, filter(container))
+	container.AssertExpectations(t)
+
+	container = new(mockContainer.FilterableContainer)
+	container.On("IsWatchtower").Return(false).Maybe()
+	container.On("Name").Return("/other").Maybe()
+	container.On("GetLabel", "Service").Return("Other", true)
+	container.On("Enabled").Return(false, false).Maybe()
+	container.On("Scope").Return("", false).Maybe()
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
+	assert.False(t, filter(container))
+	container.AssertExpectations(t)
+}
+
+func TestBuildFilterDisabledLabels(t *testing.T) {
+	t.Parallel()
+
+	filter, desc, err := BuildFilter(nil, nil, nil, nil, nil, []string{"Service=Pelican"}, false, "none")
+	require.NoError(t, err)
+	assert.Contains(t, desc, "without label")
+	assert.Contains(t, desc, `Service="Pelican"`)
+
+	container := new(mockContainer.FilterableContainer)
+	container.On("IsWatchtower").Return(false).Maybe()
+	container.On("Name").Return("/pelican-1").Maybe()
+	container.On("GetLabel", "Service").Return("Pelican", true)
+	container.On("Enabled").Return(false, false).Maybe()
+	container.On("Scope").Return("", false).Maybe()
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
+	assert.False(t, filter(container))
+	container.AssertExpectations(t)
+
+	container = new(mockContainer.FilterableContainer)
+	container.On("IsWatchtower").Return(false).Maybe()
+	container.On("Name").Return("/other").Maybe()
+	container.On("GetLabel", "Service").Return("Other", true)
+	container.On("Enabled").Return(false, false).Maybe()
+	container.On("Scope").Return("", false).Maybe()
+	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
+	assert.True(t, filter(container))
+	container.AssertExpectations(t)
+}
+
+func TestParseLabelPairs_Valid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    []string
+		expected map[string]string
+	}{
+		{
+			name:     "simple pair",
+			input:    []string{"key=value"},
+			expected: map[string]string{"key": "value"},
+		},
+		{
+			name:     "empty value",
+			input:    []string{"key="},
+			expected: map[string]string{"key": ""},
+		},
+		{
+			name:     "multiple pairs",
+			input:    []string{"a=1", "b=2"},
+			expected: map[string]string{"a": "1", "b": "2"},
+		},
+		{
+			name:     "value with equals",
+			input:    []string{"key=val=ue"},
+			expected: map[string]string{"key": "val=ue"},
+		},
+		{
+			name:     "whitespace trimmed from key and value",
+			input:    []string{"  key  =  value  "},
+			expected: map[string]string{"key": "value"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := parseLabelPairs(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestParseLabelPairs_TooLong(t *testing.T) {
+	t.Parallel()
+
+	longValue := strings.Repeat("a", maxLabelPairBytes-len("key")+1)
+	input := []string{"key=" + longValue}
+
+	result, err := parseLabelPairs(input)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, errLabelPairTooLong)
+}
+
+func TestParseLabelPairs_TooMany(t *testing.T) {
+	t.Parallel()
+
+	input := make([]string, maxLabelPairs+1)
+	for i := range input {
+		input[i] = fmt.Sprintf("key%d=val%d", i, i)
+	}
+
+	result, err := parseLabelPairs(input)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, errTooManyLabelPairs)
+}
+
+func TestParseLabelPairs_Malformed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     []string
+		errPrefix error
+	}{
+		{
+			name:      "missing equals",
+			input:     []string{"keyvalue"},
+			errPrefix: errLabelPairMissingEquals,
+		},
+		{
+			name:      "empty key",
+			input:     []string{"=value"},
+			errPrefix: errLabelPairEmptyKey,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := parseLabelPairs(tc.input)
+			require.Error(t, err)
+			assert.Nil(t, result)
+			assert.ErrorIs(t, err, tc.errPrefix)
+		})
+	}
 }

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -760,46 +760,64 @@ func TestBuildFilterEnableLabel(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, desc, "with label")
 	assert.Contains(t, desc, `com.centurylinklabs.watchtower.enable`)
-	assert.Contains(t, desc, "without label")
-	assert.Contains(t, desc, `com.centurylinklabs.watchtower.enable="false"`)
 
+	// Container without enable label: excluded because enableLabel requires it.
 	container := new(mockContainer.FilterableContainer)
 	container.On("IsWatchtower").Return(false).Maybe()
 	container.On("Enabled").Return(false, false).Maybe()
-	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
-	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
-	container.On("Name").Return("/test").Maybe()
-	assert.False(t, filter(container))
-	container.AssertExpectations(t)
-
-	container = new(mockContainer.FilterableContainer)
-	container.On("IsWatchtower").Return(false).Maybe()
-	container.On("Name").Return("Invalid").Maybe()
-	container.On("Enabled").Return(true, true).Maybe()
-	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
-	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
-	container.On("Name").Return("/test").Maybe()
-	assert.False(t, filter(container))
-	container.AssertExpectations(t)
-
-	container = new(mockContainer.FilterableContainer)
-	container.On("IsWatchtower").Return(false).Maybe()
+	container.On("Scope").Return("", false).Maybe()
 	container.On("Name").Return("test").Maybe()
-	container.On("Enabled").Return(true, true).Maybe()
-	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
-	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
-	container.On("Name").Return("/test").Maybe()
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
 
+	// Container with enable=false: excluded by boolean parsing.
+	container = new(mockContainer.FilterableContainer)
+	container.On("IsWatchtower").Return(false).Maybe()
+	container.On("Enabled").Return(false, true).Maybe()
+	container.On("Scope").Return("", false).Maybe()
+	container.On("Name").Return("test").Maybe()
+	assert.False(t, filter(container))
+	container.AssertExpectations(t)
+
+	// Container with enable=true: included.
 	container = new(mockContainer.FilterableContainer)
 	container.On("IsWatchtower").Return(false).Once()
 	container.On("Enabled").Return(true, true).Maybe()
 	container.On("Scope").Return("", false).Once()
-	container.On("GetLabel", enableLabelKey).Return("true", true).Times(2)
 	container.On("Name").Return("test").Maybe()
 	result := filter(container)
 	assert.True(t, result)
+	container.AssertExpectations(t)
+}
+
+// TestBuildFilterEnableLabelPreservesUserCriteria verifies that user-provided
+// enabled label criteria for the enable-label key are not silently overwritten
+// by the boolean enableLabel flag. Both filters apply independently.
+func TestBuildFilterEnableLabelPreservesUserCriteria(t *testing.T) {
+	t.Parallel()
+
+	// User requests only containers with enable=false, while enableLabel=true
+	// requires enable=true. These conflict, so a container with enable=true
+	// must be excluded by the user's exact-match criterion.
+	filter, _, err := BuildFilter(
+		[]string{"test"},
+		[]string{},
+		nil,
+		nil,
+		[]string{enableLabelKey + "=false"},
+		nil,
+		true,
+		"",
+	)
+	require.NoError(t, err)
+
+	container := new(mockContainer.FilterableContainer)
+	container.On("IsWatchtower").Return(false).Maybe()
+	container.On("Enabled").Return(true, true).Maybe()
+	container.On("GetLabel", enableLabelKey).Return("true", true).Once()
+	container.On("Scope").Return("", false).Maybe()
+	container.On("Name").Return("test").Maybe()
+	assert.False(t, filter(container))
 	container.AssertExpectations(t)
 }
 
@@ -876,10 +894,9 @@ func TestBuildFilterDisableContainer(t *testing.T) {
 	container = new(mockContainer.FilterableContainer)
 	container.On("IsWatchtower").Return(false).Maybe()
 	container.On("Enabled").Return(false, true).Maybe()
-	container.On("Scope").Return("", false).Maybe() // No scope set, defaults to "none"
-	container.On("GetLabel", enableLabelKey).Return("", false).Maybe()
+	container.On("Scope").Return("", false).Maybe()
 	container.On("Name").Return("/test").Maybe()
-	assert.True(t, filter(container))
+	assert.False(t, filter(container))
 	container.AssertExpectations(t)
 }
 

--- a/pkg/sorter/mocks/container.go
+++ b/pkg/sorter/mocks/container.go
@@ -80,6 +80,15 @@ func (c *SimpleContainer) Enabled() (bool, bool)                   { return true
 func (c *SimpleContainer) IsMonitorOnly(_ types.UpdateParams) bool { return false }
 
 func (c *SimpleContainer) Scope() (string, bool) { return "", false }
+func (c *SimpleContainer) GetLabel(key string) (string, bool) {
+	if c.ContainerInfoField != nil && c.ContainerInfoField.Config != nil && c.ContainerInfoField.Config.Labels != nil {
+		val, ok := c.ContainerInfoField.Config.Labels[key]
+
+		return val, ok
+	}
+
+	return "", false
+}
 func (c *SimpleContainer) ToRestart() bool       { return false }
 
 func (c *SimpleContainer) StopSignal() string {

--- a/pkg/types/container.go
+++ b/pkg/types/container.go
@@ -25,6 +25,7 @@ type Container interface {
 	IsMonitorOnly(params UpdateParams) bool           // Monitor-only check.
 	Scope() (string, bool)                            // Scope value and presence.
 	Links(useComposeDependsOn bool) []string          // Dependency links.
+	GetLabel(key string) (string, bool)               // Arbitrary label value lookup.
 	ToRestart() bool                                  // Needs restart check.
 	IsWatchtower() bool                               // Watchtower instance check.
 	StopSignal() string                               // Custom stop signal.

--- a/pkg/types/filterable_container.go
+++ b/pkg/types/filterable_container.go
@@ -2,9 +2,10 @@ package types
 
 // FilterableContainer defines an interface for container filtering.
 type FilterableContainer interface {
-	Name() string          // Container name.
-	IsWatchtower() bool    // Check if Watchtower instance.
-	Enabled() (bool, bool) // Enabled status and presence.
-	Scope() (string, bool) // Scope value and presence.
-	ImageName() string     // Image name with tag.
+	Name() string                       // Container name.
+	IsWatchtower() bool                 // Check if Watchtower instance.
+	Enabled() (bool, bool)              // Enabled status and presence.
+	Scope() (string, bool)              // Scope value and presence.
+	ImageName() string                  // Image name with tag.
+	GetLabel(key string) (string, bool) // Arbitrary label value lookup.
 }

--- a/pkg/types/mocks/Container.go
+++ b/pkg/types/mocks/Container.go
@@ -335,6 +335,66 @@ func (_c *MockContainer_GetCreateHostConfig_Call) RunAndReturn(run func() *conta
 	return _c
 }
 
+// GetLabel provides a mock function for the type MockContainer
+func (_mock *MockContainer) GetLabel(key string) (string, bool) {
+	ret := _mock.Called(key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLabel")
+	}
+
+	var r0 string
+	var r1 bool
+	if returnFunc, ok := ret.Get(0).(func(string) (string, bool)); ok {
+		return returnFunc(key)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) string); ok {
+		r0 = returnFunc(key)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) bool); ok {
+		r1 = returnFunc(key)
+	} else {
+		r1 = ret.Get(1).(bool)
+	}
+	return r0, r1
+}
+
+// MockContainer_GetLabel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLabel'
+type MockContainer_GetLabel_Call struct {
+	*mock.Call
+}
+
+// GetLabel is a helper method to define mock.On call
+//   - key string
+func (_e *MockContainer_Expecter) GetLabel(key any) *MockContainer_GetLabel_Call {
+	return &MockContainer_GetLabel_Call{Call: _e.mock.On("GetLabel", key)}
+}
+
+func (_c *MockContainer_GetLabel_Call) Run(run func(key string)) *MockContainer_GetLabel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockContainer_GetLabel_Call) Return(s string, b bool) *MockContainer_GetLabel_Call {
+	_c.Call.Return(s, b)
+	return _c
+}
+
+func (_c *MockContainer_GetLabel_Call) RunAndReturn(run func(key string) (string, bool)) *MockContainer_GetLabel_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLifecycleGID provides a mock function for the type MockContainer
 func (_mock *MockContainer) GetLifecycleGID() (int, bool) {
 	ret := _mock.Called()

--- a/pkg/types/mocks/FilterableContainer.go
+++ b/pkg/types/mocks/FilterableContainer.go
@@ -88,6 +88,66 @@ func (_c *MockFilterableContainer_Enabled_Call) RunAndReturn(run func() (bool, b
 	return _c
 }
 
+// GetLabel provides a mock function for the type MockFilterableContainer
+func (_mock *MockFilterableContainer) GetLabel(key string) (string, bool) {
+	ret := _mock.Called(key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLabel")
+	}
+
+	var r0 string
+	var r1 bool
+	if returnFunc, ok := ret.Get(0).(func(string) (string, bool)); ok {
+		return returnFunc(key)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) string); ok {
+		r0 = returnFunc(key)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) bool); ok {
+		r1 = returnFunc(key)
+	} else {
+		r1 = ret.Get(1).(bool)
+	}
+	return r0, r1
+}
+
+// MockFilterableContainer_GetLabel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLabel'
+type MockFilterableContainer_GetLabel_Call struct {
+	*mock.Call
+}
+
+// GetLabel is a helper method to define mock.On call
+//   - key string
+func (_e *MockFilterableContainer_Expecter) GetLabel(key any) *MockFilterableContainer_GetLabel_Call {
+	return &MockFilterableContainer_GetLabel_Call{Call: _e.mock.On("GetLabel", key)}
+}
+
+func (_c *MockFilterableContainer_GetLabel_Call) Run(run func(key string)) *MockFilterableContainer_GetLabel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockFilterableContainer_GetLabel_Call) Return(s string, b bool) *MockFilterableContainer_GetLabel_Call {
+	_c.Call.Return(s, b)
+	return _c
+}
+
+func (_c *MockFilterableContainer_GetLabel_Call) RunAndReturn(run func(key string) (string, bool)) *MockFilterableContainer_GetLabel_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ImageName provides a mock function for the type MockFilterableContainer
 func (_mock *MockFilterableContainer) ImageName() string {
 	ret := _mock.Called()


### PR DESCRIPTION
This PR adds the ability to filter containers by arbitrary Docker container labels.

## Problem

As noted in issue #1852, there are occasions where users may be unable to realistically filter containers based on the pre-existing methods, such as container or image names, or by applying Watchtower-specific labels. In such cases, it may be necessary to use arbitrary labels to apply filtering.

## Solution

Extend the filter chain with label-based inclusion and exclusion. Parse comma-separated `key=value` pairs into a map, then match container labels with optional presence-only semantics (empty value). A `GetLabel` method was added to the container interfaces so filters can query arbitrary labels without coupling to Docker-specific types.

## Changes

- Added `--enable-containers-by-label` and `--disable-containers-by-label` flags and corresponding environment variables.
- Added `GetLabel` lookup to container and filterable-container interfaces with mock implementations.
- Added `parseLabelPairs` with validation (max 100 pairs, 4096 bytes per pair, malformed-pair errors).
- Renamed and generalized `FilterByEnableLabel` / `FilterByDisabledLabel` to accept label maps.
- Updated `BuildFilter` to parse label inputs, apply label filters, return `error` on bad input, and include labels in filter descriptions.
- Added unit tests for label parsing and label filters, and fuzz tests for parsing, name/image matching, and label filtering.
- Updated documentation, including container selection and configuration information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added label-based container selection and exclusion using configurable `key=value` pairs.
  * Added command-line flags and environment variables for enabling/disabling containers by label, including label presence (`key=`) and exact value matching.
* **Bug Fixes**
  * Improved safety when label filter inputs are malformed/invalid, preventing undesired restart behavior and exiting cleanly on errors.
* **Documentation**
  * Expanded container selection docs with new sections, examples, and format/behavior limitations.
* **Tests**
  * Added fuzz coverage and updated filter tests to reflect the new label-selection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->