### PR TITLE
fix(flags): validate notification-url secret file entries

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -47,6 +47,8 @@ var (
 	errReplaceSliceFailed = errors.New("failed to replace slice value in flag")
 	// errReadFileFailed indicates a failure to read a file's contents for secrets.
 	errReadFileFailed = errors.New("failed to read secret file")
+	// errInvalidSecretURL indicates an invalid URL was found in a secret file.
+	errInvalidSecretURL = errors.New("invalid notification URL in secret file")
 	// errSetFlagFailed indicates a failure to set a flag's value during configuration.
 	errSetFlagFailed = errors.New("failed to set flag value")
 	// errInvalidFlagName indicates an invalid flag name was provided for modification.
@@ -1222,9 +1224,15 @@ func getSecretFromFile(flags *pflag.FlagSet, secret string) error {
 				scanner := bufio.NewScanner(file)
 				for scanner.Scan() {
 					line := strings.TrimSpace(scanner.Text())
-					if line != "" {
-						values = append(values, line)
+					if line == "" || strings.HasPrefix(line, "#") {
+						continue
 					}
+
+					if secret == "notification-url" && !strings.Contains(line, "://") {
+						return fmt.Errorf("%w: %s in %s", errInvalidSecretURL, line, value)
+					}
+
+					values = append(values, line)
 				}
 
 				err = scanner.Err()

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -1228,8 +1228,17 @@ func getSecretFromFile(flags *pflag.FlagSet, secret string) error {
 						continue
 					}
 
-					if secret == "notification-url" && !strings.Contains(line, "://") {
-						return fmt.Errorf("%w: %s in %s", errInvalidSecretURL, line, value)
+					if secret == "notification-url" {
+						if !strings.Contains(line, "://") {
+							return errInvalidSecretURL
+						}
+
+						parsedURL, err := url.Parse(line)
+						if err != nil ||
+							parsedURL.Scheme == "" ||
+							(parsedURL.Opaque == "" && parsedURL.Host == "" && parsedURL.Path == "") {
+							return errInvalidSecretURL
+						}
 					}
 
 					values = append(values, line)

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -1234,10 +1234,14 @@ func getSecretFromFile(flags *pflag.FlagSet, secret string) error {
 						}
 
 						parsedURL, err := url.Parse(line)
-						if err != nil ||
-							parsedURL.Scheme == "" ||
-							(parsedURL.Opaque == "" && parsedURL.Host == "" && parsedURL.Path == "") {
+						if err != nil || parsedURL.Scheme == "" {
 							return errInvalidSecretURL
+						}
+
+						if parsedURL.Opaque == "" && parsedURL.Host == "" && parsedURL.Path == "" {
+							if parsedURL.Scheme != "logger" && parsedURL.Scheme != "mock" {
+								return errInvalidSecretURL
+							}
 						}
 					}
 

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -338,19 +338,19 @@ func TestGetSecretsFromFiles(t *testing.T) {
 		{
 			name: "slice with file",
 			files: []struct{ path, content string }{
-				{"urls.txt", "\nentry2\n\nentry3"},
+				{"urls.txt", "\ndiscord://entry2\n\ntelegram://entry3"},
 			},
 			flagName: "notification-url",
-			expected: "[entry1,entry2,entry3]",
-			args:     []string{"--notification-url", "entry1", "--notification-url", "urls.txt"},
+			expected: "[discord://entry1,discord://entry2,telegram://entry3]",
+			args:     []string{"--notification-url", "discord://entry1", "--notification-url", "urls.txt"},
 		},
 		{
 			name: "empty lines",
 			files: []struct{ path, content string }{
-				{"urls.txt", "entry1\n\nentry2\n  \nentry3"},
+				{"urls.txt", "discord://entry1\n\ntelegram://entry2\n  \nslack://entry3"},
 			},
 			flagName: "notification-url",
-			expected: "[entry1,entry2,entry3]",
+			expected: "[discord://entry1,telegram://entry2,slack://entry3]",
 			args:     []string{"--notification-url", "urls.txt"},
 		},
 		{
@@ -368,10 +368,10 @@ func TestGetSecretsFromFiles(t *testing.T) {
 		{
 			name: "special chars",
 			files: []struct{ path, content string }{
-				{"urls.txt", "smtp://user:pass@host:port\nslack://token@channel\n!@#$%^&*()"},
+				{"urls.txt", "smtp://user:pass@host:port?key=!@#$%^&*()\nslack://token@channel"},
 			},
 			flagName: "notification-url",
-			expected: "[smtp://user:pass@host:port,slack://token@channel,!@#$%^&*()]",
+			expected: "[smtp://user:pass@host:port?key=!@#$%^&*(),slack://token@channel]",
 			args:     []string{"--notification-url", "urls.txt"},
 		},
 		{
@@ -385,17 +385,17 @@ func TestGetSecretsFromFiles(t *testing.T) {
 		{
 			name: "mixed values",
 			files: []struct{ path, content string }{
-				{"urls.txt", "fileentry1\nfileentry2"},
+				{"urls.txt", "discord://fileentry1\ntelegram://fileentry2"},
 			},
 			flagName: "notification-url",
-			expected: "[direct1,fileentry1,fileentry2,direct2]",
+			expected: "[discord://direct1,discord://fileentry1,telegram://fileentry2,discord://direct2]",
 			args: []string{
 				"--notification-url",
-				"direct1",
+				"discord://direct1",
 				"--notification-url",
 				"urls.txt",
 				"--notification-url",
-				"direct2",
+				"discord://direct2",
 			},
 		},
 	}
@@ -778,6 +778,62 @@ func TestGetSecretFromFile_OpenError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to open secret file")
 }
 
+// TestGetSecretFromFile_SkipCommentsAndEmptyLines verifies that comment and empty
+// lines are skipped when reading notification URLs from a secret file.
+func TestGetSecretFromFile_SkipCommentsAndEmptyLines(t *testing.T) {
+	cmd := new(cobra.Command)
+
+	SetDefaults()
+	RegisterNotificationFlags(cmd)
+
+	file, err := os.CreateTemp(t.TempDir(), "watchtower-")
+	require.NoError(t, err)
+	_, err = file.WriteString(
+		"# This is a comment\n" +
+			"discord://token@webhookid\n" +
+			"\n" +
+			"  # indented comment\n" +
+			"telegram://token@telegram?chats=@channel\n" +
+			"# another comment\n",
+	)
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	err = cmd.ParseFlags([]string{"--notification-url", file.Name()})
+	require.NoError(t, err)
+
+	err = getSecretFromFile(cmd.PersistentFlags(), "notification-url")
+	require.NoError(t, err)
+
+	urls, err := cmd.PersistentFlags().GetStringArray("notification-url")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"discord://token@webhookid", "telegram://token@telegram?chats=@channel"}, urls)
+}
+
+// TestGetSecretFromFile_InvalidSecretURL verifies that non-URL lines in a secret
+// file are rejected with errInvalidSecretURL.
+func TestGetSecretFromFile_InvalidSecretURL(t *testing.T) {
+	cmd := new(cobra.Command)
+
+	SetDefaults()
+	RegisterNotificationFlags(cmd)
+
+	file, err := os.CreateTemp(t.TempDir(), "watchtower-")
+	require.NoError(t, err)
+	_, err = file.WriteString("discord://token@webhookid\nnot-a-url\n")
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	err = cmd.ParseFlags([]string{"--notification-url", file.Name()})
+	require.NoError(t, err)
+
+	err = getSecretFromFile(cmd.PersistentFlags(), "notification-url")
+	require.Error(t, err)
+	require.ErrorIs(t, err, errInvalidSecretURL)
+	assert.Contains(t, err.Error(), "not-a-url")
+}
+
 func TestReadFlags_Errors(t *testing.T) {
 	originalExit := logrus.StandardLogger().ExitFunc
 
@@ -822,7 +878,7 @@ func TestGetSecretFromFile_SliceReplaceError(t *testing.T) {
 	// Use a real file to ensure slice processing
 	file, err := os.CreateTemp(t.TempDir(), "watchtower-")
 	require.NoError(t, err)
-	_, err = file.WriteString("entry1\nentry2")
+	_, err = file.WriteString("discord://entry1\ntelegram://entry2")
 	require.NoError(t, err)
 
 	fileName := file.Name()

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -368,10 +368,10 @@ func TestGetSecretsFromFiles(t *testing.T) {
 		{
 			name: "special chars",
 			files: []struct{ path, content string }{
-				{"urls.txt", "smtp://user:pass@host:port?key=!@#$%^&*()\nslack://token@channel"},
+				{"urls.txt", "smtp://user:pass@host:25?key=value\nslack://token@channel"},
 			},
 			flagName: "notification-url",
-			expected: "[smtp://user:pass@host:port?key=!@#$%^&*(),slack://token@channel]",
+			expected: "[smtp://user:pass@host:25?key=value,slack://token@channel]",
 			args:     []string{"--notification-url", "urls.txt"},
 		},
 		{
@@ -821,7 +821,12 @@ func TestGetSecretFromFile_InvalidSecretURL(t *testing.T) {
 
 	file, err := os.CreateTemp(t.TempDir(), "watchtower-")
 	require.NoError(t, err)
-	_, err = file.WriteString("discord://token@webhookid\nnot-a-url\n")
+	_, err = file.WriteString(
+		"discord://token@webhookid\n" +
+			"not-a-url\n" +
+			"://missing-scheme\n" +
+			"discord://\n",
+	)
 	require.NoError(t, err)
 	require.NoError(t, file.Close())
 
@@ -831,7 +836,6 @@ func TestGetSecretFromFile_InvalidSecretURL(t *testing.T) {
 	err = getSecretFromFile(cmd.PersistentFlags(), "notification-url")
 	require.Error(t, err)
 	require.ErrorIs(t, err, errInvalidSecretURL)
-	assert.Contains(t, err.Error(), "not-a-url")
 }
 
 func TestReadFlags_Errors(t *testing.T) {

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -811,8 +811,9 @@ func TestGetSecretFromFile_SkipCommentsAndEmptyLines(t *testing.T) {
 	assert.Equal(t, []string{"discord://token@webhookid", "telegram://token@telegram?chats=@channel"}, urls)
 }
 
-// TestGetSecretFromFile_InvalidSecretURL verifies that non-URL lines in a secret
-// file are rejected with errInvalidSecretURL.
+// TestGetSecretFromFile_InvalidSecretURL verifies that non-URL lines and
+// parameterless non-logger/mock URLs in a secret file are rejected with
+// errInvalidSecretURL.
 func TestGetSecretFromFile_InvalidSecretURL(t *testing.T) {
 	cmd := new(cobra.Command)
 
@@ -836,6 +837,36 @@ func TestGetSecretFromFile_InvalidSecretURL(t *testing.T) {
 	err = getSecretFromFile(cmd.PersistentFlags(), "notification-url")
 	require.Error(t, err)
 	require.ErrorIs(t, err, errInvalidSecretURL)
+}
+
+// TestGetSecretFromFile_ParameterlessLoggerAndMockURLs verifies that
+// parameterless logger:// and mock:// URLs are accepted in a secret file.
+func TestGetSecretFromFile_ParameterlessLoggerAndMockURLs(t *testing.T) {
+	cmd := new(cobra.Command)
+
+	SetDefaults()
+	RegisterNotificationFlags(cmd)
+
+	file, err := os.CreateTemp(t.TempDir(), "watchtower-")
+	require.NoError(t, err)
+	_, err = file.WriteString(
+		"logger://\n" +
+			"mock://\n" +
+			"discord://token@webhookid\n",
+	)
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	err = cmd.ParseFlags([]string{"--notification-url", file.Name()})
+	require.NoError(t, err)
+
+	err = getSecretFromFile(cmd.PersistentFlags(), "notification-url")
+	require.NoError(t, err)
+
+	urls, err := cmd.PersistentFlags().GetStringArray("notification-url")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"logger://", "mock://", "discord://token@webhookid"}, urls)
 }
 
 func TestReadFlags_Errors(t *testing.T) {


### PR DESCRIPTION
This PR adds validation to notification-url entries read from Docker Secrets files so malformed lines are rejected early and secret values are not exposed through error messages. Blank lines and # comments are now skipped during file processing.

## Problem

When notification-url was provided via a Docker Secrets file, every non-empty line was ingested verbatim with no validation that it was actually a valid shoutrrr URL. Malformed entries only failed later at shoutrrr.NewSender startup without indicating which file or line was bad.

## Solution

The secret-file scanner in getSecretFromFile now skips blank lines and #-prefixed comments, and applies url.Parse-based validation to each notification-url entry.

## Changes

- Skip empty and #-prefixed lines in the slice-flag scanner loop
- Validate notification-url lines require ://, non-empty scheme, and non-empty endpoint component
- Return errInvalidSecretURL for invalid lines
- Update TestGetSecretsFromFiles placeholders to valid shoutrrr URLs
- Add TestGetSecretFromFile_SkipCommentsAndEmptyLines
- Add TestGetSecretFromFile_InvalidSecretURL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notification URLs loaded from secret files are now strictly validated as well-formed, scheme-qualified URLs.
  * Empty lines, whitespace-only lines, and `#`-prefixed comment lines are ignored when reading notification URL files.
  * Invalid notification URL entries now fail fast with a clear error, improving feedback.
  * `logger://` and `mock://` URL entries are accepted when present in the secret file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->