### PR TITLE
fix: restore correct restart order for named network dependencies

### DIFF
--- a/internal/actions/update_dependencies_test.go
+++ b/internal/actions/update_dependencies_test.go
@@ -2101,6 +2101,81 @@ var _ = ginkgo.Describe("the update action", func() {
 					To(gomega.Equal("container:download-stack-vpn-1"))
 			},
 		)
+
+		// Explicit container_name with Compose project/service labels and
+		// depends-on / network_mode targeting the peer by container name.
+		// Sort must put the network provider first so restart creates it before
+		// the dependent joins its namespace.
+		ginkgo.It(
+			"should stop and start container_name network_mode peers in dependency order",
+			func() {
+				vpn := mockActions.CreateMockContainerWithConfig(
+					"net-proxy",
+					"/net-proxy",
+					"vpn:latest",
+					true,
+					false,
+					time.Now().AddDate(0, 0, -1),
+					&dockerContainer.Config{
+						Labels: map[string]string{
+							"com.docker.compose.project":            "myproject",
+							"com.docker.compose.service":            "net-proxy",
+							"com.centurylinklabs.watchtower.enable": "true",
+						},
+						ExposedPorts: dockerNetwork.PortSet{},
+					},
+				)
+
+				web := mockActions.CreateMockContainerWithConfig(
+					"web-app",
+					"/web-app",
+					"nginx:latest",
+					true,
+					false,
+					time.Now(),
+					&dockerContainer.Config{
+						Labels: map[string]string{
+							"com.docker.compose.project":                "myproject",
+							"com.docker.compose.service":                "web",
+							"com.centurylinklabs.watchtower.enable":     "true",
+							"com.centurylinklabs.watchtower.depends-on": "net-proxy",
+						},
+						ExposedPorts: dockerNetwork.PortSet{},
+					},
+				)
+				web.ContainerInfo().HostConfig.NetworkMode = "container:net-proxy"
+
+				client := mockActions.CreateMockClient(
+					&mockActions.TestData{
+						Containers: []types.Container{web, vpn},
+						Staleness: map[string]bool{
+							"web-app":   false,
+							"net-proxy": true,
+						},
+						StopOrder:   []string{},
+						CreateOrder: []string{},
+						StartOrder:  []string{},
+					},
+					false,
+					false,
+				)
+
+				report, _, err := actions.Update(
+					context.Background(),
+					client,
+					types.UpdateParams{Cleanup: true, CPUCopyMode: "auto"},
+				)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(report.Updated()).To(gomega.HaveLen(1))
+				gomega.Expect(web.ToRestart()).To(gomega.BeTrue())
+
+				// Dependent first on stop; network provider first on create/start.
+				gomega.Expect(client.TestData.StopOrder).
+					To(gomega.Equal([]string{"web-app", "net-proxy"}))
+				gomega.Expect(client.TestData.CreateOrder).
+					To(gomega.Equal([]string{"net-proxy", "web-app"}))
+			},
+		)
 	})
 
 	ginkgo.When("handling cross-project dependencies", func() {

--- a/pkg/sorter/dependency.go
+++ b/pkg/sorter/dependency.go
@@ -189,12 +189,13 @@ func sortByDependencies(containers []types.Container, useComposeDependsOn bool) 
 // strings often differ from the canonical graph key when Compose labels are present.
 //
 // Link Matching Strategy:
-// Matching uses FindMatchingIdentifiers against the canonical keys plus unique bare Name()
-// aliases, then maps every hit back to a canonical key before recording edges. Strategies:
+// Matching uses findMatchingIdentifiersInSet against the canonical keys plus unique bare
+// Name() aliases, then maps every hit back to a canonical key before recording edges.
+// Strategies:
 //  1. Exact match on canonical identifier or bare container name
 //  2. Prefix match for Docker Compose replica suffixes (e.g., "db" matches "db-1", "db-2")
-//  3. Service-only match via ExtractServiceName on both sides (e.g., "abs-wireguard" matches
-//     "media-abs-wireguard"), only when exactly one candidate is unambiguous
+//  3. Project-qualified suffix match (id ends with "-"+link) for multi-segment links, or
+//     ExtractServiceName equality only for unhyphenated bare service names
 //
 // Parameters:
 //   - containers: List of containers to build graph for.
@@ -247,7 +248,8 @@ func buildDependencyGraph(
 	// Docs specify Watchtower depends-on and network_mode targets use container names,
 	// while Compose depends_on uses service names; aliases bridge those forms to the
 	// canonical project-service graph keys without inventing extra Kahn nodes.
-	matchIdentifiers, aliasToCanonical := buildLinkMatchIndexes(containerMap)
+	// The identifier set is built once and reused for every link in this graph.
+	matchIDSet, aliasToCanonical := buildLinkMatchIndexes(containerMap)
 
 	// Build the graph by processing container links (dependencies).
 	// Edges always use canonical identifiers so Kahn's algorithm can traverse them.
@@ -257,7 +259,7 @@ func buildDependencyGraph(
 		for _, normalizedLink := range c.Links(useComposeDependsOn) {
 			matchedKeys := resolveLinkToCanonicalKeys(
 				normalizedLink,
-				matchIdentifiers,
+				matchIDSet,
 				aliasToCanonical,
 			)
 
@@ -276,7 +278,7 @@ func buildDependencyGraph(
 	return containerMap, indegree, adjacency, normalizedMap, nil
 }
 
-// buildLinkMatchIndexes builds the identifier list and alias→canonical map used when
+// buildLinkMatchIndexes builds the identifier set and alias→canonical map used when
 // resolving dependency links against graph nodes.
 //
 // Each canonical ResolveContainerIdentifier is always included and never overwritten.
@@ -288,11 +290,11 @@ func buildDependencyGraph(
 //   - containerMap: Canonical identifier → container map from graph construction.
 //
 // Returns:
-//   - []string: Identifiers passed to FindMatchingIdentifiers (canonical keys and unique bare names).
+//   - map[string]bool: Precomputed set of matchable identifiers (canonical keys and unique bare names).
 //   - map[string]string: Maps every matchable identifier to its canonical graph key.
 func buildLinkMatchIndexes(
 	containerMap map[string]types.Container,
-) ([]string, map[string]string) {
+) (map[string]bool, map[string]string) {
 	// Capacity covers one canonical key plus one optional bare-name alias per container.
 	const aliasCapacityFactor = 2
 
@@ -342,36 +344,34 @@ func buildLinkMatchIndexes(
 		}
 	}
 
-	matchIdentifiers := make([]string, 0, len(aliasToCanonical))
+	matchIDSet := make(map[string]bool, len(aliasToCanonical))
 	for id := range aliasToCanonical {
-		matchIdentifiers = append(matchIdentifiers, id)
+		matchIDSet[id] = true
 	}
 
-	sort.Strings(matchIdentifiers)
-
-	return matchIdentifiers, aliasToCanonical
+	return matchIDSet, aliasToCanonical
 }
 
 // resolveLinkToCanonicalKeys resolves a single dependency link to sorted unique canonical
-// graph keys using FindMatchingIdentifiers and the alias index.
+// graph keys using the precomputed identifier set and alias index.
 //
 // Parameters:
 //   - link: Normalized link from Container.Links().
-//   - matchIdentifiers: Identifiers available for matching (canonical + unique bare names).
+//   - matchIDSet: Precomputed set of matchable identifiers (canonical + unique bare names).
 //   - aliasToCanonical: Maps match hits to canonical graph keys.
 //
 // Returns:
 //   - []string: Sorted unique canonical identifiers the link refers to (empty if none).
 func resolveLinkToCanonicalKeys(
 	link string,
-	matchIdentifiers []string,
+	matchIDSet map[string]bool,
 	aliasToCanonical map[string]string,
 ) []string {
 	if link == "" {
 		return nil
 	}
 
-	matches := FindMatchingIdentifiers(link, matchIdentifiers)
+	matches := findMatchingIdentifiersInSet(link, matchIDSet)
 	if len(matches) == 0 {
 		return nil
 	}
@@ -465,11 +465,11 @@ func ExtractServiceName(identifier string) string {
 //  1. Exact match.
 //  2. Replica prefix match: the identifier starts with "<link>-" and the suffix
 //     after the hyphen is a positive integer (Docker Compose replica numbering).
-//  3. Service-only / project-qualified match: ExtractServiceName equality on both
-//     sides, or identifier ends with "-"+link (full service name under a project
-//     prefix). This strategy only succeeds when exactly one candidate matches;
-//     multiple matches (e.g. the same service name in different projects) are
-//     treated as ambiguous and return no results.
+//  3. Project-qualified suffix match (identifier ends with "-"+link), and for
+//     unhyphenated links only, ExtractServiceName equality on both sides.
+//     This strategy only succeeds when exactly one candidate matches; multiple
+//     matches (e.g. the same service name in different projects) are treated as
+//     ambiguous and return no results.
 //
 // Parameters:
 //   - link: Dependency link to resolve (typically from Container.Links()).
@@ -483,10 +483,26 @@ func FindMatchingIdentifiers(link string, identifiers []string) []string {
 		return nil
 	}
 
-	// Build a temporary lookup for efficiency
 	idSet := make(map[string]bool, len(identifiers))
 	for _, id := range identifiers {
 		idSet[id] = true
+	}
+
+	return findMatchingIdentifiersInSet(link, idSet)
+}
+
+// findMatchingIdentifiersInSet returns identifiers from a precomputed set that match
+// the provided link. See FindMatchingIdentifiers for matching strategy details.
+//
+// Parameters:
+//   - link: Dependency link to resolve.
+//   - idSet: Precomputed set of known container identifiers.
+//
+// Returns:
+//   - []string: Matching identifiers, or nil/empty when none or ambiguous.
+func findMatchingIdentifiersInSet(link string, idSet map[string]bool) []string {
+	if link == "" || len(idSet) == 0 {
+		return nil
 	}
 
 	var matches []string
@@ -501,11 +517,11 @@ func FindMatchingIdentifiers(link string, identifiers []string) []string {
 	// 2. Replica prefix match (only if suffix is positive integer)
 	var replicaMatches []string
 
-	for id := range idSet {
-		if strings.HasPrefix(id, link+"-") {
-			suffix := id[len(link)+1:]
+	for identifier := range idSet {
+		if strings.HasPrefix(identifier, link+"-") {
+			suffix := identifier[len(link)+1:]
 			if IsPositiveInteger(suffix) {
-				replicaMatches = append(replicaMatches, id)
+				replicaMatches = append(replicaMatches, identifier)
 			}
 		}
 	}
@@ -517,21 +533,24 @@ func FindMatchingIdentifiers(link string, identifiers []string) []string {
 		return matches
 	}
 
-	// 3. Service-only / project-qualified match.
-	// Accept when exactly one candidate matches via either:
-	//   - ExtractServiceName equality on both sides (handles project-service keys
-	//     when the link is a bare service name, including multi-segment names
-	//     once both sides reduce to the same trailing segment), or
-	//   - the identifier ends with "-"+link (link is the full service name under
-	//     a project prefix, e.g. link "abs-wireguard" → "media-abs-wireguard").
-	// Multiple matches are ambiguous (different projects) and are discarded.
+	// 3. Project-qualified / service-only match (exactly one unambiguous candidate).
+	// Multi-segment links (containing "-") only use the precise "-"+link suffix so
+	// trailing-token ExtractServiceName equality cannot select an unrelated peer
+	// (e.g. link "net-proxy" must not match "myproject-other-proxy").
+	// Unhyphenated bare service names may still match via ExtractServiceName
+	// (e.g. link "db" → "myproject-db").
 	var serviceMatches []string
 
-	normalizedLink := ExtractServiceName(link)
-	for id := range idSet {
-		if ExtractServiceName(id) == normalizedLink ||
-			(link != "" && strings.HasSuffix(id, "-"+link)) {
-			serviceMatches = append(serviceMatches, id)
+	linkHasHyphen := strings.Contains(link, "-")
+	for identifier := range idSet {
+		if strings.HasSuffix(identifier, "-"+link) {
+			serviceMatches = append(serviceMatches, identifier)
+
+			continue
+		}
+
+		if !linkHasHyphen && ExtractServiceName(identifier) == link {
+			serviceMatches = append(serviceMatches, identifier)
 		}
 	}
 

--- a/pkg/sorter/dependency.go
+++ b/pkg/sorter/dependency.go
@@ -179,32 +179,31 @@ func sortByDependencies(containers []types.Container, useComposeDependsOn bool) 
 // buildDependencyGraph constructs the dependency graph data structures for topological sorting.
 //
 // This function builds three key data structures:
-//   - containerMap: Maps normalized container identifiers to container objects for O(1) lookup
+//   - containerMap: Maps canonical normalized identifiers to container objects for O(1) lookup
 //   - indegree: Tracks number of incoming dependencies for each container (nodes with indegree 0 have no dependencies)
-//   - adjacency: Lists containers that depend on each container (outgoing edges)
+//   - adjacency: Lists containers that depend on each container (outgoing edges; keys are canonical)
 //
-// Normalization ensures consistent handling of Docker Compose service names vs container names.
-// Container links from c.Links() are already normalized.
+// Graph nodes are always keyed by ResolveContainerIdentifier (project-service, service, or name).
+// Links from c.Links() may use Watchtower depends-on container names, Compose service names,
+// Docker links, or network_mode targets (including explicit container_name values). Those
+// strings often differ from the canonical graph key when Compose labels are present.
 //
 // Link Matching Strategy:
-// The function attempts multiple matching strategies in order of specificity:
-//  1. Exact match - direct key lookup in containerMap
-//  2. Prefix match for replicas - matches Docker Compose replica suffixes (e.g., "db" matches "db-1", "db-2")
-//  3. Service-only match - strips project prefix from identifiers (e.g., "postgresql-postgres" -> "postgres")
-//     to handle cases where watchtower labels specify only the service name without project context
-//
-// To prevent incorrect matches with similarly named containers (e.g., "db" matching "dbase" or "db-backup"),
-// the prefix matching only succeeds when the suffix after "-" is a positive integer. This ensures that
-// "watchtower-test-database" does NOT match "watchtower-test-database2", which would incorrectly
-// create a dependency relationship.
+// Matching uses FindMatchingIdentifiers against the canonical keys plus unique bare Name()
+// aliases, then maps every hit back to a canonical key before recording edges. Strategies:
+//  1. Exact match on canonical identifier or bare container name
+//  2. Prefix match for Docker Compose replica suffixes (e.g., "db" matches "db-1", "db-2")
+//  3. Service-only match via ExtractServiceName on both sides (e.g., "abs-wireguard" matches
+//     "media-abs-wireguard"), only when exactly one candidate is unambiguous
 //
 // Parameters:
 //   - containers: List of containers to build graph for.
+//   - useComposeDependsOn: Whether Links() should include Compose depends_on labels.
 //
 // Returns:
-//   - map[string]types.Container: Container lookup map
+//   - map[string]types.Container: Container lookup map (canonical keys only)
 //   - map[string]int: Indegree count for each container
-//   - map[string][]string: Adjacency list (container -> dependents)
+//   - map[string][]string: Adjacency list (canonical dependency -> dependents)
 //   - map[types.Container]string: Reverse map from container to normalized identifier
 //   - error: IdentifierCollisionError if duplicate identifiers detected, nil otherwise
 func buildDependencyGraph(
@@ -244,146 +243,139 @@ func buildDependencyGraph(
 		normalizedMap[dupContainers[0]] = identifier
 	}
 
-	// Build the graph by processing container links (dependencies)
-	// For each container, increment its indegree for each link it has to an existing container
-	// Add reverse edges in adjacency list: link target -> dependent container
+	// Lookup identifiers for link resolution: canonical keys plus unique bare names.
+	// Docs specify Watchtower depends-on and network_mode targets use container names,
+	// while Compose depends_on uses service names; aliases bridge those forms to the
+	// canonical project-service graph keys without inventing extra Kahn nodes.
+	matchIdentifiers, aliasToCanonical := buildLinkMatchIndexes(containerMap)
+
+	// Build the graph by processing container links (dependencies).
+	// Edges always use canonical identifiers so Kahn's algorithm can traverse them.
 	for _, c := range containers {
 		normalizedIdentifier := normalizedMap[c]
 		// c.Links() already returns normalized container names
 		for _, normalizedLink := range c.Links(useComposeDependsOn) {
-			// Try exact match first
-			if _, exists := containerMap[normalizedLink]; exists {
-				if normalizedLink == normalizedIdentifier {
-					// Self-reference detected: the container's Links() include itself.
-					// This can occur when:
-					//   - A container is linked to a service name that resolves to itself
-					//   - Docker Compose service dependencies create circular references
-					//   - Manual labeling creates self-referential dependencies
-					//
-					// While container.Links() filters most self-references, this guard prevents
-					// edge cases from corrupting the dependency graph. Skipping the increment
-					// ensures the container is treated as having no dependencies (indegree 0),
-					// preventing a circular dependency error for what is essentially a no-op.
-					continue
-				}
-				// This container depends on the linked container, so increment its indegree
-				indegree[normalizedIdentifier]++
-				// The linked container has this container as a dependent
-				adjacency[normalizedLink] = append(adjacency[normalizedLink], normalizedIdentifier)
-
-				continue
-			}
-
-			// 2. Try prefix match for Docker Compose replica suffixes only (e.g., "db" -> "db-1", "db-2")
-			// Only match if the suffix after "-" is a positive integer (Compose-style replica numbering).
-			// This strict matching prevents incorrectly treating "database2" as a replica of "database",
-			// or "db-backup" as a replica of "db". Only numeric suffixes like "-1", "-2" are considered
-			// valid replica indicators, which is consistent with Docker Compose's replica naming convention.
-			var matchedKeys []string
-
-			for key := range containerMap {
-				if strings.HasPrefix(key, normalizedLink+"-") {
-					// Extract the suffix after the link name and "-"
-					suffix := key[len(normalizedLink)+1:]
-					// Only match if the suffix is a positive integer (replica number).
-					// This ensures we don't match "watchtower-test-database" when looking for "watchtower-test-database2",
-					// or create false dependencies between similarly named but distinct services.
-					if IsPositiveInteger(suffix) {
-						matchedKeys = append(matchedKeys, key)
-					}
-				}
-			}
-
-			// Sort matched keys for deterministic dependency ordering
-			// This ensures that when multiple replicas match (e.g., "db-1", "db-2"),
-			// the dependencies are added in a consistent, predictable order.
-			sort.Strings(matchedKeys)
+			matchedKeys := resolveLinkToCanonicalKeys(
+				normalizedLink,
+				matchIdentifiers,
+				aliasToCanonical,
+			)
 
 			for _, key := range matchedKeys {
 				if key == normalizedIdentifier {
-					// Self-reference via prefix match: the container matched itself as a replica.
-					// This can happen when a container name follows the replica pattern
-					// (e.g., "myapp-1" linking to "myapp" would incorrectly match itself).
-					//
-					// This check prevents a container from creating a dependency on itself
-					// through the prefix matching logic. Without this guard, a container
-					// named "app-1" with a link to "app" would increment its own indegree,
-					// potentially causing incorrect dependency calculations or cycles.
-					//
-					// Note: While container.Links() should filter self-references upstream,
-					// this defensive check ensures robustness against edge cases.
+					// Self-reference: skip so the container stays indegree 0 for this link.
 					continue
 				}
-				// This container depends on the linked container, so increment its indegree
+
 				indegree[normalizedIdentifier]++
-				// The linked container has this container as a dependent
 				adjacency[key] = append(adjacency[key], normalizedIdentifier)
-			}
-
-			// If we found replica matches, skip service-only matching
-			if len(matchedKeys) > 0 {
-				continue
-			}
-
-			// 3. Try matching by service name only (strip project prefix from containerMap keys)
-			// This handles the case where watchtower labels specify only the service name
-			// (e.g., "postgres") but the containerMap key includes the project prefix
-			// (e.g., "postgresql-postgres").
-			//
-			// IMPORTANT: Only match if there's exactly ONE container with this service name
-			// to avoid ambiguous cross-project dependencies. If multiple containers from
-			// different projects have the same service name, we should NOT match any of them.
-			var serviceMatchKeys []string
-
-			for key := range containerMap {
-				serviceName := ExtractServiceName(key)
-				if serviceName == normalizedLink {
-					serviceMatchKeys = append(serviceMatchKeys, key)
-				}
-			}
-
-			// Only apply service-only matching if there's exactly ONE unambiguous match
-			if len(serviceMatchKeys) == 1 {
-				serviceMatchKey := serviceMatchKeys[0]
-
-				if serviceMatchKey == normalizedIdentifier {
-					// Self-reference via service name match.
-					// This prevents a container from creating a dependency on itself
-					// when its service name matches the link.
-					continue
-				}
-
-				// Log the service-only match for debugging
-				logrus.WithFields(logrus.Fields{
-					"link":              normalizedLink,
-					"matched_key":       serviceMatchKey,
-					"dependent":         normalizedIdentifier,
-					"match_type":        "service_only",
-					"extracted_service": ExtractServiceName(serviceMatchKey),
-				}).Debug("Matched dependency via service name fallback")
-
-				// This container depends on the linked container, so increment its indegree
-				indegree[normalizedIdentifier]++
-				// The linked container has this container as a dependent
-				adjacency[serviceMatchKey] = append(
-					adjacency[serviceMatchKey],
-					normalizedIdentifier,
-				)
-			} else if len(serviceMatchKeys) > 1 {
-				// Multiple matches found - this is ambiguous (e.g., same service name in different projects)
-				// Log this situation for debugging but don't create any dependencies
-				logrus.WithFields(logrus.Fields{
-					"link":         normalizedLink,
-					"matched_keys": serviceMatchKeys,
-					"dependent":    normalizedIdentifier,
-					"match_count":  len(serviceMatchKeys),
-					"match_type":   "service_only_ambiguous",
-				}).Debug("Skipped ambiguous service name match (multiple containers with same service name)")
 			}
 		}
 	}
 
 	return containerMap, indegree, adjacency, normalizedMap, nil
+}
+
+// buildLinkMatchIndexes builds the identifier list and alias→canonical map used when
+// resolving dependency links against graph nodes.
+//
+// Each canonical ResolveContainerIdentifier is always included. Bare container names are
+// registered as aliases only when they uniquely identify one container in the set, so
+// ambiguous names (two containers sharing a name) do not create non-deterministic edges.
+//
+// Parameters:
+//   - containerMap: Canonical identifier → container map from graph construction.
+//
+// Returns:
+//   - []string: Identifiers passed to FindMatchingIdentifiers (canonical keys and unique bare names).
+//   - map[string]string: Maps every matchable identifier to its canonical graph key.
+func buildLinkMatchIndexes(
+	containerMap map[string]types.Container,
+) ([]string, map[string]string) {
+	// Capacity covers one canonical key plus one optional bare-name alias per container.
+	const aliasCapacityFactor = 2
+
+	aliasToCanonical := make(map[string]string, len(containerMap)*aliasCapacityFactor)
+	// Track bare names claimed by more than one container so they stay unmatched.
+	ambiguousBareNames := make(map[string]bool)
+
+	for identifier, c := range containerMap {
+		aliasToCanonical[identifier] = identifier
+
+		bareName := util.NormalizeContainerName(c.Name())
+		if bareName == "" || bareName == identifier {
+			continue
+		}
+
+		if existing, exists := aliasToCanonical[bareName]; exists && existing != identifier {
+			ambiguousBareNames[bareName] = true
+
+			continue
+		}
+
+		if ambiguousBareNames[bareName] {
+			continue
+		}
+
+		aliasToCanonical[bareName] = identifier
+	}
+
+	for bareName := range ambiguousBareNames {
+		delete(aliasToCanonical, bareName)
+		logrus.WithField("bare_name", bareName).
+			Debug("Skipped ambiguous bare container name alias for dependency matching")
+	}
+
+	matchIdentifiers := make([]string, 0, len(aliasToCanonical))
+	for id := range aliasToCanonical {
+		matchIdentifiers = append(matchIdentifiers, id)
+	}
+
+	sort.Strings(matchIdentifiers)
+
+	return matchIdentifiers, aliasToCanonical
+}
+
+// resolveLinkToCanonicalKeys resolves a single dependency link to sorted unique canonical
+// graph keys using FindMatchingIdentifiers and the alias index.
+//
+// Parameters:
+//   - link: Normalized link from Container.Links().
+//   - matchIdentifiers: Identifiers available for matching (canonical + unique bare names).
+//   - aliasToCanonical: Maps match hits to canonical graph keys.
+//
+// Returns:
+//   - []string: Sorted unique canonical identifiers the link refers to (empty if none).
+func resolveLinkToCanonicalKeys(
+	link string,
+	matchIdentifiers []string,
+	aliasToCanonical map[string]string,
+) []string {
+	if link == "" {
+		return nil
+	}
+
+	matches := FindMatchingIdentifiers(link, matchIdentifiers)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]bool, len(matches))
+	canonicalKeys := make([]string, 0, len(matches))
+
+	for _, match := range matches {
+		canonical, ok := aliasToCanonical[match]
+		if !ok || canonical == "" || seen[canonical] {
+			continue
+		}
+
+		seen[canonical] = true
+		canonicalKeys = append(canonicalKeys, canonical)
+	}
+
+	sort.Strings(canonicalKeys)
+
+	return canonicalKeys
 }
 
 // IsPositiveInteger checks if a string represents a positive integer (1 or greater).
@@ -451,16 +443,17 @@ func ExtractServiceName(identifier string) string {
 }
 
 // FindMatchingIdentifiers returns the identifiers from the given list that match
-// the provided link. It applies the same three matching strategies used in
-// buildDependencyGraph:
+// the provided link. It applies the same strategies used when building the
+// dependency graph:
 //
 //  1. Exact match.
 //  2. Replica prefix match: the identifier starts with "<link>-" and the suffix
 //     after the hyphen is a positive integer (Docker Compose replica numbering).
-//  3. Service-only match using ExtractServiceName. This strategy only succeeds
-//     when exactly one candidate matches; multiple matches (e.g. the same
-//     service name in different projects) are treated as ambiguous and return
-//     no results.
+//  3. Service-only / project-qualified match: ExtractServiceName equality on both
+//     sides, or identifier ends with "-"+link (full service name under a project
+//     prefix). This strategy only succeeds when exactly one candidate matches;
+//     multiple matches (e.g. the same service name in different projects) are
+//     treated as ambiguous and return no results.
 //
 // Parameters:
 //   - link: Dependency link to resolve (typically from Container.Links()).
@@ -508,14 +501,20 @@ func FindMatchingIdentifiers(link string, identifiers []string) []string {
 		return matches
 	}
 
-	// 3. Service-only match using ExtractServiceName.
-	// Only accepted when exactly one candidate matches the service name.
+	// 3. Service-only / project-qualified match.
+	// Accept when exactly one candidate matches via either:
+	//   - ExtractServiceName equality on both sides (handles project-service keys
+	//     when the link is a bare service name, including multi-segment names
+	//     once both sides reduce to the same trailing segment), or
+	//   - the identifier ends with "-"+link (link is the full service name under
+	//     a project prefix, e.g. link "abs-wireguard" → "media-abs-wireguard").
 	// Multiple matches are ambiguous (different projects) and are discarded.
 	var serviceMatches []string
 
 	normalizedLink := ExtractServiceName(link)
 	for id := range idSet {
-		if ExtractServiceName(id) == normalizedLink {
+		if ExtractServiceName(id) == normalizedLink ||
+			(link != "" && strings.HasSuffix(id, "-"+link)) {
 			serviceMatches = append(serviceMatches, id)
 		}
 	}

--- a/pkg/sorter/dependency.go
+++ b/pkg/sorter/dependency.go
@@ -279,9 +279,10 @@ func buildDependencyGraph(
 // buildLinkMatchIndexes builds the identifier list and alias→canonical map used when
 // resolving dependency links against graph nodes.
 //
-// Each canonical ResolveContainerIdentifier is always included. Bare container names are
-// registered as aliases only when they uniquely identify one container in the set, so
-// ambiguous names (two containers sharing a name) do not create non-deterministic edges.
+// Each canonical ResolveContainerIdentifier is always included and never overwritten.
+// Bare container names are registered as aliases only when they uniquely identify one
+// container and do not collide with another container's canonical key, so ambiguous
+// names do not create non-deterministic edges.
 //
 // Parameters:
 //   - containerMap: Canonical identifier → container map from graph construction.
@@ -296,34 +297,49 @@ func buildLinkMatchIndexes(
 	const aliasCapacityFactor = 2
 
 	aliasToCanonical := make(map[string]string, len(containerMap)*aliasCapacityFactor)
-	// Track bare names claimed by more than one container so they stay unmatched.
-	ambiguousBareNames := make(map[string]bool)
+
+	// Canonical ResolveContainerIdentifier keys always map to themselves and must never
+	// be removed or overwritten by bare-name alias cleanup.
+	for identifier := range containerMap {
+		aliasToCanonical[identifier] = identifier
+	}
+
+	// bareOwners collects distinct canonical owners for each bare container name.
+	// A bare name becomes an alias only when exactly one owner claims it and the name
+	// does not collide with a different container's canonical graph key.
+	bareOwners := make(map[string]map[string]struct{})
 
 	for identifier, c := range containerMap {
-		aliasToCanonical[identifier] = identifier
-
 		bareName := util.NormalizeContainerName(c.Name())
 		if bareName == "" || bareName == identifier {
 			continue
 		}
 
-		if existing, exists := aliasToCanonical[bareName]; exists && existing != identifier {
-			ambiguousBareNames[bareName] = true
-
+		// Never use a bare name that is already another container's canonical key.
+		if _, isCanonicalKey := containerMap[bareName]; isCanonicalKey {
 			continue
 		}
 
-		if ambiguousBareNames[bareName] {
-			continue
+		owners, ok := bareOwners[bareName]
+		if !ok {
+			owners = make(map[string]struct{})
+			bareOwners[bareName] = owners
 		}
 
-		aliasToCanonical[bareName] = identifier
+		owners[identifier] = struct{}{}
 	}
 
-	for bareName := range ambiguousBareNames {
-		delete(aliasToCanonical, bareName)
-		logrus.WithField("bare_name", bareName).
-			Debug("Skipped ambiguous bare container name alias for dependency matching")
+	for bareName, owners := range bareOwners {
+		if len(owners) != 1 {
+			logrus.WithField("bare_name", bareName).
+				Debug("Skipped ambiguous bare container name alias for dependency matching")
+
+			continue
+		}
+
+		for owner := range owners {
+			aliasToCanonical[bareName] = owner
+		}
 	}
 
 	matchIdentifiers := make([]string, 0, len(aliasToCanonical))

--- a/pkg/sorter/dependency_test.go
+++ b/pkg/sorter/dependency_test.go
@@ -2000,6 +2000,26 @@ var _ = ginkgo.Describe("buildLinkMatchIndexes", func() {
 		gomega.Expect(aliasToCanonical["project1-service"]).To(gomega.Equal("project1-service"))
 		gomega.Expect(aliasToCanonical["project2-service"]).To(gomega.Equal("project2-service"))
 	})
+
+	ginkgo.It("should preserve canonical self-mapping when bare name equals another canonical key", func() {
+		// Container A is keyed by "shared"; container B's bare name is also "shared".
+		// B must not overwrite or delete A's canonical self-mapping.
+		canonicalOwner := mockTypes.NewMockContainer(ginkgo.GinkgoT())
+		canonicalOwner.EXPECT().Name().Return("shared").Maybe()
+
+		bareClaimant := mockTypes.NewMockContainer(ginkgo.GinkgoT())
+		bareClaimant.EXPECT().Name().Return("shared").Maybe()
+
+		containerMap := map[string]types.Container{
+			"shared":          canonicalOwner,
+			"project-service": bareClaimant,
+		}
+
+		ids, aliasToCanonical := buildLinkMatchIndexes(containerMap)
+		gomega.Expect(aliasToCanonical["shared"]).To(gomega.Equal("shared"))
+		gomega.Expect(aliasToCanonical["project-service"]).To(gomega.Equal("project-service"))
+		gomega.Expect(ids).To(gomega.ConsistOf("shared", "project-service"))
+	})
 })
 
 var _ = ginkgo.Describe("resolveLinkToCanonicalKeys", func() {

--- a/pkg/sorter/dependency_test.go
+++ b/pkg/sorter/dependency_test.go
@@ -1863,6 +1863,41 @@ func indexOf(names []string, target string) int {
 	return -1
 }
 
+// mockLinkedContainer builds a mock with Compose labels and fixed Links() output.
+// useComposeLinks selects Links(true) vs Links(false) for the useComposeDependsOn path.
+func mockLinkedContainer(
+	name, id, project, service string,
+	links []string,
+	useComposeLinks bool,
+) *mockTypes.MockContainer {
+	c := mockTypes.NewMockContainer(ginkgo.GinkgoT())
+	c.EXPECT().Name().Return(name).Maybe()
+	c.EXPECT().ID().Return(types.ContainerID(id)).Maybe()
+	c.EXPECT().IsWatchtower().Return(false).Maybe()
+
+	if useComposeLinks {
+		c.EXPECT().Links(true).Return(links).Maybe()
+	} else {
+		c.EXPECT().Links(false).Return(links).Maybe()
+	}
+
+	labels := map[string]string{}
+	if project != "" {
+		labels["com.docker.compose.project"] = project
+	}
+
+	if service != "" {
+		labels["com.docker.compose.service"] = service
+	}
+
+	c.EXPECT().ContainerInfo().Return(&dockerContainer.InspectResponse{
+		Name:   "/" + name,
+		Config: &dockerContainer.Config{Labels: labels},
+	}).Maybe()
+
+	return c
+}
+
 var _ = ginkgo.Describe("FindMatchingIdentifiers", func() {
 	ginkgo.It("should return exact match when present", func() {
 		identifiers := []string{"project-db", "other-db"}
@@ -1900,5 +1935,296 @@ var _ = ginkgo.Describe("FindMatchingIdentifiers", func() {
 
 		matches = FindMatchingIdentifiers("db", []string{})
 		gomega.Expect(matches).To(gomega.BeEmpty())
+	})
+
+	ginkgo.It("should match multi-segment service link against project-service identifier", func() {
+		identifiers := []string{"myproject-net-proxy", "myproject-web"}
+		matches := FindMatchingIdentifiers("net-proxy", identifiers)
+		gomega.Expect(matches).To(gomega.Equal([]string{"myproject-net-proxy"}))
+	})
+
+	ginkgo.It("should match multi-segment service link when only the project-service key exists", func() {
+		identifiers := []string{"myproject-net-proxy"}
+		matches := FindMatchingIdentifiers("net-proxy", identifiers)
+		gomega.Expect(matches).To(gomega.Equal([]string{"myproject-net-proxy"}))
+	})
+
+	ginkgo.It("should match trailing service segment via ExtractServiceName", func() {
+		matches := FindMatchingIdentifiers("proxy", []string{"myproject-net-proxy"})
+		gomega.Expect(matches).To(gomega.Equal([]string{"myproject-net-proxy"}))
+	})
+
+	ginkgo.It("should reject ambiguous multi-project service matches", func() {
+		matches := FindMatchingIdentifiers("db", []string{"project1-db", "project2-db"})
+		gomega.Expect(matches).To(gomega.BeEmpty())
+	})
+})
+
+var _ = ginkgo.Describe("buildLinkMatchIndexes", func() {
+	ginkgo.It("should map unique bare names to canonical identifiers", func() {
+		dep := mockLinkedContainer("net-proxy", "id-proxy", "myproject", "net-proxy", nil, true)
+		app := mockLinkedContainer("web-app", "id-web", "myproject", "web", nil, true)
+
+		containerMap := map[string]types.Container{
+			"myproject-net-proxy": dep,
+			"myproject-web":       app,
+		}
+
+		ids, aliasToCanonical := buildLinkMatchIndexes(containerMap)
+		gomega.Expect(aliasToCanonical["myproject-net-proxy"]).To(gomega.Equal("myproject-net-proxy"))
+		gomega.Expect(aliasToCanonical["net-proxy"]).To(gomega.Equal("myproject-net-proxy"))
+		gomega.Expect(aliasToCanonical["web-app"]).To(gomega.Equal("myproject-web"))
+		gomega.Expect(ids).To(gomega.ContainElements(
+			"myproject-net-proxy",
+			"myproject-web",
+			"net-proxy",
+			"web-app",
+		))
+	})
+
+	ginkgo.It("should omit bare name alias when it collides across containers", func() {
+		c1 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
+		c1.EXPECT().Name().Return("shared").Maybe()
+
+		c2 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
+		c2.EXPECT().Name().Return("shared").Maybe()
+
+		containerMap := map[string]types.Container{
+			"project1-service": c1,
+			"project2-service": c2,
+		}
+
+		_, aliasToCanonical := buildLinkMatchIndexes(containerMap)
+		_, hasBare := aliasToCanonical["shared"]
+		gomega.Expect(hasBare).To(gomega.BeFalse())
+		gomega.Expect(aliasToCanonical["project1-service"]).To(gomega.Equal("project1-service"))
+		gomega.Expect(aliasToCanonical["project2-service"]).To(gomega.Equal("project2-service"))
+	})
+})
+
+var _ = ginkgo.Describe("resolveLinkToCanonicalKeys", func() {
+	ginkgo.It("should resolve bare multi-segment container name to project-service key", func() {
+		ids := []string{"myproject-net-proxy", "myproject-web", "net-proxy", "web-app"}
+		alias := map[string]string{
+			"myproject-net-proxy": "myproject-net-proxy",
+			"myproject-web":       "myproject-web",
+			"net-proxy":           "myproject-net-proxy",
+			"web-app":             "myproject-web",
+		}
+
+		keys := resolveLinkToCanonicalKeys("net-proxy", ids, alias)
+		gomega.Expect(keys).To(gomega.Equal([]string{"myproject-net-proxy"}))
+	})
+
+	ginkgo.It("should resolve project-service suffix match without bare-name alias", func() {
+		ids := []string{"myproject-net-proxy"}
+		alias := map[string]string{"myproject-net-proxy": "myproject-net-proxy"}
+
+		keys := resolveLinkToCanonicalKeys("net-proxy", ids, alias)
+		gomega.Expect(keys).To(gomega.Equal([]string{"myproject-net-proxy"}))
+	})
+
+	ginkgo.It("should return nil for empty or unmatched links", func() {
+		ids := []string{"myproject-db"}
+		alias := map[string]string{"myproject-db": "myproject-db"}
+
+		gomega.Expect(resolveLinkToCanonicalKeys("", ids, alias)).To(gomega.BeNil())
+		gomega.Expect(resolveLinkToCanonicalKeys("missing", ids, alias)).To(gomega.BeNil())
+	})
+
+	ginkgo.It("should dedupe when bare alias and canonical both match", func() {
+		ids := []string{"myproject-db", "db"}
+		alias := map[string]string{
+			"myproject-db": "myproject-db",
+			"db":           "myproject-db",
+		}
+
+		keys := resolveLinkToCanonicalKeys("db", ids, alias)
+		gomega.Expect(keys).To(gomega.Equal([]string{"myproject-db"}))
+	})
+})
+
+var _ = ginkgo.Describe("dependency link form permutations", func() {
+	// Links() values from Watchtower depends-on, Compose depends_on, Docker links,
+	// and network_mode must resolve against ResolveContainerIdentifier graph keys.
+	ginkgo.DescribeTable(
+		"sorts dependency before dependent for each link form",
+		func(depName, depProject, depService, dependentName, dependentProject, dependentService string, links []string, useCompose bool) {
+			dep := mockLinkedContainer(depName, "id-dep", depProject, depService, nil, useCompose)
+			dependent := mockLinkedContainer(
+				dependentName,
+				"id-dependent",
+				dependentProject,
+				dependentService,
+				links,
+				useCompose,
+			)
+
+			containers := []types.Container{dependent, dep}
+			err := DependencySorter{}.Sort(containers, useCompose)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(containers[0].Name()).To(gomega.Equal(depName),
+				"dependency must sort before dependent")
+			gomega.Expect(containers[1].Name()).To(gomega.Equal(dependentName))
+		},
+		ginkgo.Entry(
+			"Watchtower depends-on bare container_name against project-service key",
+			"net-proxy", "myproject", "net-proxy",
+			"web-app", "myproject", "web",
+			[]string{"net-proxy"}, true,
+		),
+		ginkgo.Entry(
+			"Watchtower depends-on bare name without Compose labels",
+			"database", "", "",
+			"web", "", "",
+			[]string{"database"}, true,
+		),
+		ginkgo.Entry(
+			"Watchtower depends-on with useComposeDependsOn false",
+			"postgres", "stack", "postgres",
+			"api", "stack", "api",
+			[]string{"postgres"}, false,
+		),
+		ginkgo.Entry(
+			"Compose depends_on project-qualified service link",
+			"myproject-database", "myproject", "database",
+			"myproject-web", "myproject", "web",
+			[]string{"myproject-database"}, true,
+		),
+		ginkgo.Entry(
+			"Compose depends_on bare service name against project-service key",
+			"myproject-database", "myproject", "database",
+			"myproject-web", "myproject", "web",
+			[]string{"database"}, true,
+		),
+		ginkgo.Entry(
+			"Compose depends_on multi-segment service under project prefix",
+			"myproject-net-proxy", "myproject", "net-proxy",
+			"myproject-web", "myproject", "web",
+			[]string{"net-proxy"}, true,
+		),
+		ginkgo.Entry(
+			"network_mode HostConfig bare container name",
+			"vpn", "stack", "vpn",
+			"client", "stack", "client",
+			[]string{"vpn"}, true,
+		),
+		ginkgo.Entry(
+			"network_mode with useComposeDependsOn false",
+			"vpn", "stack", "vpn",
+			"client", "stack", "client",
+			[]string{"vpn"}, false,
+		),
+		ginkgo.Entry(
+			"legacy Docker link bare container name",
+			"db", "", "",
+			"app", "", "",
+			[]string{"db"}, true,
+		),
+		ginkgo.Entry(
+			"cross-project Watchtower depends-on by container name",
+			"app1-database", "app1", "database",
+			"app2-web", "app2", "web",
+			[]string{"app1-database"}, true,
+		),
+		ginkgo.Entry(
+			"Compose service name without container_name override",
+			"stack-cache", "stack", "cache",
+			"stack-worker", "stack", "worker",
+			[]string{"cache"}, true,
+		),
+		ginkgo.Entry(
+			"normalized bare service name after Links processing",
+			"redis", "cache", "redis",
+			"app", "cache", "app",
+			[]string{"redis"}, true,
+		),
+	)
+
+	ginkgo.It("should order multiple dependents after a shared network provider", func() {
+		vpn := mockLinkedContainer("vpn", "id-vpn", "stack", "vpn", nil, true)
+		clientA := mockLinkedContainer("client-a", "id-a", "stack", "client-a", []string{"vpn"}, true)
+		clientB := mockLinkedContainer("client-b", "id-b", "stack", "client-b", []string{"vpn"}, true)
+
+		containers := []types.Container{clientA, clientB, vpn}
+		err := DependencySorter{}.Sort(containers, true)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(containers[0].Name()).To(gomega.Equal("vpn"))
+		names := []string{containers[1].Name(), containers[2].Name()}
+		gomega.Expect(names).To(gomega.ConsistOf("client-a", "client-b"))
+	})
+
+	ginkgo.It("should order when dependent has multiple dependencies", func() {
+		db := mockLinkedContainer("db", "id-db", "app", "db", nil, true)
+		cache := mockLinkedContainer("cache", "id-cache", "app", "cache", nil, true)
+		web := mockLinkedContainer("web", "id-web", "app", "web", []string{"db", "cache"}, true)
+
+		containers := []types.Container{web, db, cache}
+		err := DependencySorter{}.Sort(containers, true)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(containers[2].Name()).To(gomega.Equal("web"))
+
+		ordered := []string{containers[0].Name(), containers[1].Name(), containers[2].Name()}
+		assertOrderBefore(ordered, "db", "web")
+		assertOrderBefore(ordered, "cache", "web")
+	})
+
+	ginkgo.It("should match Compose replica identifiers from a service link", func() {
+		db1 := mockLinkedContainer("myproject-db-1", "id-db1", "myproject", "db", nil, true)
+		db2 := mockLinkedContainer("myproject-db-2", "id-db2", "myproject", "db", nil, true)
+		app := mockLinkedContainer("myproject-app", "id-app", "myproject", "app", []string{"myproject-db"}, true)
+
+		containers := []types.Container{app, db1, db2}
+		err := DependencySorter{}.Sort(containers, true)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(containers[2].Name()).To(gomega.Equal("myproject-app"))
+		gomega.Expect([]string{containers[0].Name(), containers[1].Name()}).
+			To(gomega.ConsistOf("myproject-db-1", "myproject-db-2"))
+	})
+
+	ginkgo.It("should not create edges for ambiguous same service name across projects", func() {
+		db1 := mockLinkedContainer("project1-db", "id-1", "project1", "db", nil, true)
+		db2 := mockLinkedContainer("project2-db", "id-2", "project2", "db", nil, true)
+		app := mockLinkedContainer("project3-app", "id-3", "project3", "app", []string{"db"}, true)
+
+		containers := []types.Container{app, db1, db2}
+		err := DependencySorter{}.Sort(containers, true)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		names := []string{containers[0].Name(), containers[1].Name(), containers[2].Name()}
+		gomega.Expect(names).To(gomega.ConsistOf("project1-db", "project2-db", "project3-app"))
+	})
+
+	ginkgo.It("should ignore missing dependency targets without failing sort", func() {
+		app := mockLinkedContainer("app", "id-app", "myproject", "app", []string{"missing-dep"}, true)
+		standalone := mockLinkedContainer("other", "id-other", "myproject", "other", nil, true)
+
+		containers := []types.Container{app, standalone}
+		err := DependencySorter{}.Sort(containers, true)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect([]string{containers[0].Name(), containers[1].Name()}).
+			To(gomega.ConsistOf("app", "other"))
+	})
+
+	ginkgo.It("should keep Watchtower last when linked non-Watchtower containers sort first", func() {
+		db := mockLinkedContainer("db", "id-db", "myproject", "db", nil, true)
+		web := mockLinkedContainer("web", "id-web", "myproject", "web", []string{"db"}, true)
+
+		wt := mockTypes.NewMockContainer(ginkgo.GinkgoT())
+		wt.EXPECT().Name().Return("watchtower").Maybe()
+		wt.EXPECT().ID().Return(types.ContainerID("id-wt")).Maybe()
+		wt.EXPECT().IsWatchtower().Return(true).Maybe()
+		wt.EXPECT().Links(true).Return(nil).Maybe()
+		wt.EXPECT().ContainerInfo().Return(&dockerContainer.InspectResponse{
+			Name:   "/watchtower",
+			Config: &dockerContainer.Config{Labels: map[string]string{}},
+		}).Maybe()
+
+		containers := []types.Container{wt, web, db}
+		err := DependencySorter{}.Sort(containers, true)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(containers[0].Name()).To(gomega.Equal("db"))
+		gomega.Expect(containers[1].Name()).To(gomega.Equal("web"))
+		gomega.Expect(containers[2].Name()).To(gomega.Equal("watchtower"))
 	})
 })

--- a/pkg/sorter/dependency_test.go
+++ b/pkg/sorter/dependency_test.go
@@ -1899,66 +1899,88 @@ func mockLinkedContainer(
 }
 
 var _ = ginkgo.Describe("FindMatchingIdentifiers", func() {
-	ginkgo.It("should return exact match when present", func() {
-		identifiers := []string{"project-db", "other-db"}
-		matches := FindMatchingIdentifiers("project-db", identifiers)
-		gomega.Expect(matches).To(gomega.Equal([]string{"project-db"}))
-	})
+	// Exhaustive link × identifier permutations across Compose stacks, multi-segment
+	// services, replicas, bare container names, and ambiguous cross-project cases.
+	ginkgo.DescribeTable(
+		"matches identifiers for each link form",
+		func(link string, identifiers, expected []string) {
+			matches := FindMatchingIdentifiers(link, identifiers)
+			if expected == nil {
+				gomega.Expect(matches).To(gomega.BeEmpty())
 
-	ginkgo.It("should match replica suffix when link has no replica", func() {
-		identifiers := []string{"project-db-1", "project-db-2", "other"}
-		matches := FindMatchingIdentifiers("project-db", identifiers)
-		gomega.Expect(matches).To(gomega.ConsistOf("project-db-1", "project-db-2"))
-	})
+				return
+			}
 
-	ginkgo.It("should not match replica when suffix is not a positive integer", func() {
-		identifiers := []string{"project-db-backup"}
-		matches := FindMatchingIdentifiers("project-db", identifiers)
-		gomega.Expect(matches).To(gomega.BeEmpty())
-	})
-
-	ginkgo.It("should return service-only match when exactly one candidate exists", func() {
-		identifiers := []string{"project1-db"}
-		matches := FindMatchingIdentifiers("db", identifiers)
-		gomega.Expect(matches).To(gomega.Equal([]string{"project1-db"}))
-	})
-
-	ginkgo.It("should return no matches for ambiguous service name across projects", func() {
-		identifiers := []string{"project1-db", "project2-db"}
-		matches := FindMatchingIdentifiers("db", identifiers)
-		gomega.Expect(matches).To(gomega.BeEmpty())
-	})
-
-	ginkgo.It("should return empty for empty input", func() {
-		matches := FindMatchingIdentifiers("", []string{"db"})
-		gomega.Expect(matches).To(gomega.BeEmpty())
-
-		matches = FindMatchingIdentifiers("db", []string{})
-		gomega.Expect(matches).To(gomega.BeEmpty())
-	})
-
-	ginkgo.It("should match multi-segment service link against project-service identifier", func() {
-		identifiers := []string{"myproject-net-proxy", "myproject-web"}
-		matches := FindMatchingIdentifiers("net-proxy", identifiers)
-		gomega.Expect(matches).To(gomega.Equal([]string{"myproject-net-proxy"}))
-	})
-
-	ginkgo.It("should match multi-segment service link when only the project-service key exists", func() {
-		identifiers := []string{"myproject-net-proxy"}
-		matches := FindMatchingIdentifiers("net-proxy", identifiers)
-		gomega.Expect(matches).To(gomega.Equal([]string{"myproject-net-proxy"}))
-	})
-
-	ginkgo.It("should match trailing service segment via ExtractServiceName", func() {
-		matches := FindMatchingIdentifiers("proxy", []string{"myproject-net-proxy"})
-		gomega.Expect(matches).To(gomega.Equal([]string{"myproject-net-proxy"}))
-	})
-
-	ginkgo.It("should reject ambiguous multi-project service matches", func() {
-		matches := FindMatchingIdentifiers("db", []string{"project1-db", "project2-db"})
-		gomega.Expect(matches).To(gomega.BeEmpty())
-	})
+			gomega.Expect(matches).To(gomega.Equal(expected))
+		},
+		// Exact
+		ginkgo.Entry("exact project-service key",
+			"project-db", []string{"project-db", "other-db"}, []string{"project-db"}),
+		ginkgo.Entry("exact bare container name",
+			"net-proxy", []string{"net-proxy", "web-app"}, []string{"net-proxy"}),
+		// Replicas
+		ginkgo.Entry("replica suffixes from project-service link",
+			"project-db", []string{"project-db-1", "project-db-2", "other"},
+			[]string{"project-db-1", "project-db-2"}),
+		ginkgo.Entry("non-numeric hyphen suffix is not a replica",
+			"project-db", []string{"project-db-backup"}, nil),
+		ginkgo.Entry("numeric-looking middle segment is not a replica of shorter prefix",
+			"project", []string{"project-db-1"}, nil),
+		// Unhyphenated service-only (ExtractServiceName)
+		ginkgo.Entry("unhyphenated service against single project-service key",
+			"db", []string{"project1-db"}, []string{"project1-db"}),
+		ginkgo.Entry("unhyphenated service against multi-segment project-service key",
+			"proxy", []string{"myproject-net-proxy"}, []string{"myproject-net-proxy"}),
+		ginkgo.Entry("unhyphenated service ambiguous across two projects",
+			"db", []string{"project1-db", "project2-db"}, nil),
+		ginkgo.Entry("unhyphenated service with three projects still ambiguous",
+			"cache", []string{"a-cache", "b-cache", "c-cache"}, nil),
+		// Multi-segment link → project-service suffix
+		ginkgo.Entry("multi-segment link against project-service key",
+			"net-proxy", []string{"myproject-net-proxy", "myproject-web"},
+			[]string{"myproject-net-proxy"}),
+		ginkgo.Entry("multi-segment link sole candidate",
+			"net-proxy", []string{"myproject-net-proxy"}, []string{"myproject-net-proxy"}),
+		ginkgo.Entry("multi-segment link must not match trailing-token-only peer",
+			"net-proxy", []string{"myproject-other-proxy"}, nil),
+		ginkgo.Entry("multi-segment link must not match substring service",
+			"net-proxy", []string{"myproject-net"}, nil),
+		ginkgo.Entry("multi-segment link must not match longer multi-segment sibling",
+			"net-proxy", []string{"myproject-net-proxy-extra"}, nil),
+		ginkgo.Entry("multi-segment link ambiguous across two projects",
+			"net-proxy", []string{"stack-a-net-proxy", "stack-b-net-proxy"}, nil),
+		ginkgo.Entry("multi-segment link prefers exact over suffix when both present",
+			"net-proxy", []string{"net-proxy", "myproject-net-proxy"}, []string{"net-proxy"}),
+		// Mixed multi-stack identifier pools
+		ginkgo.Entry("unhyphenated db among multi-stack unrelated services",
+			"db", []string{"frontend-web", "backend-api", "data-db"}, []string{"data-db"}),
+		ginkgo.Entry("hyphenated link among multi-stack noise",
+			"net-proxy",
+			[]string{"frontend-web", "backend-api", "infra-net-proxy", "infra-other-proxy"},
+			[]string{"infra-net-proxy"}),
+		ginkgo.Entry("hyphenated link with same trailing token in another stack",
+			"auth-gateway",
+			[]string{"stack-a-auth-gateway", "stack-b-edge-gateway"},
+			[]string{"stack-a-auth-gateway"}),
+		// Empty / edge
+		ginkgo.Entry("empty link",
+			"", []string{"db"}, nil),
+		ginkgo.Entry("empty identifiers",
+			"db", []string{}, nil),
+		ginkgo.Entry("no candidates at all",
+			"missing", []string{"a", "b"}, nil),
+	)
 })
+
+// identifierSet builds a bool set from identifier strings for resolveLinkToCanonicalKeys tests.
+func identifierSet(ids ...string) map[string]bool {
+	set := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		set[id] = true
+	}
+
+	return set
+}
 
 var _ = ginkgo.Describe("buildLinkMatchIndexes", func() {
 	ginkgo.It("should map unique bare names to canonical identifiers", func() {
@@ -1970,16 +1992,14 @@ var _ = ginkgo.Describe("buildLinkMatchIndexes", func() {
 			"myproject-web":       app,
 		}
 
-		ids, aliasToCanonical := buildLinkMatchIndexes(containerMap)
+		idSet, aliasToCanonical := buildLinkMatchIndexes(containerMap)
 		gomega.Expect(aliasToCanonical["myproject-net-proxy"]).To(gomega.Equal("myproject-net-proxy"))
 		gomega.Expect(aliasToCanonical["net-proxy"]).To(gomega.Equal("myproject-net-proxy"))
 		gomega.Expect(aliasToCanonical["web-app"]).To(gomega.Equal("myproject-web"))
-		gomega.Expect(ids).To(gomega.ContainElements(
-			"myproject-net-proxy",
-			"myproject-web",
-			"net-proxy",
-			"web-app",
-		))
+		gomega.Expect(idSet).To(gomega.HaveKey("myproject-net-proxy"))
+		gomega.Expect(idSet).To(gomega.HaveKey("myproject-web"))
+		gomega.Expect(idSet).To(gomega.HaveKey("net-proxy"))
+		gomega.Expect(idSet).To(gomega.HaveKey("web-app"))
 	})
 
 	ginkgo.It("should omit bare name alias when it collides across containers", func() {
@@ -2015,16 +2035,18 @@ var _ = ginkgo.Describe("buildLinkMatchIndexes", func() {
 			"project-service": bareClaimant,
 		}
 
-		ids, aliasToCanonical := buildLinkMatchIndexes(containerMap)
+		idSet, aliasToCanonical := buildLinkMatchIndexes(containerMap)
 		gomega.Expect(aliasToCanonical["shared"]).To(gomega.Equal("shared"))
 		gomega.Expect(aliasToCanonical["project-service"]).To(gomega.Equal("project-service"))
-		gomega.Expect(ids).To(gomega.ConsistOf("shared", "project-service"))
+		gomega.Expect(idSet).To(gomega.HaveKey("shared"))
+		gomega.Expect(idSet).To(gomega.HaveKey("project-service"))
+		gomega.Expect(idSet).To(gomega.HaveLen(2))
 	})
 })
 
 var _ = ginkgo.Describe("resolveLinkToCanonicalKeys", func() {
 	ginkgo.It("should resolve bare multi-segment container name to project-service key", func() {
-		ids := []string{"myproject-net-proxy", "myproject-web", "net-proxy", "web-app"}
+		idSet := identifierSet("myproject-net-proxy", "myproject-web", "net-proxy", "web-app")
 		alias := map[string]string{
 			"myproject-net-proxy": "myproject-net-proxy",
 			"myproject-web":       "myproject-web",
@@ -2032,34 +2054,34 @@ var _ = ginkgo.Describe("resolveLinkToCanonicalKeys", func() {
 			"web-app":             "myproject-web",
 		}
 
-		keys := resolveLinkToCanonicalKeys("net-proxy", ids, alias)
+		keys := resolveLinkToCanonicalKeys("net-proxy", idSet, alias)
 		gomega.Expect(keys).To(gomega.Equal([]string{"myproject-net-proxy"}))
 	})
 
 	ginkgo.It("should resolve project-service suffix match without bare-name alias", func() {
-		ids := []string{"myproject-net-proxy"}
+		idSet := identifierSet("myproject-net-proxy")
 		alias := map[string]string{"myproject-net-proxy": "myproject-net-proxy"}
 
-		keys := resolveLinkToCanonicalKeys("net-proxy", ids, alias)
+		keys := resolveLinkToCanonicalKeys("net-proxy", idSet, alias)
 		gomega.Expect(keys).To(gomega.Equal([]string{"myproject-net-proxy"}))
 	})
 
 	ginkgo.It("should return nil for empty or unmatched links", func() {
-		ids := []string{"myproject-db"}
+		idSet := identifierSet("myproject-db")
 		alias := map[string]string{"myproject-db": "myproject-db"}
 
-		gomega.Expect(resolveLinkToCanonicalKeys("", ids, alias)).To(gomega.BeNil())
-		gomega.Expect(resolveLinkToCanonicalKeys("missing", ids, alias)).To(gomega.BeNil())
+		gomega.Expect(resolveLinkToCanonicalKeys("", idSet, alias)).To(gomega.BeNil())
+		gomega.Expect(resolveLinkToCanonicalKeys("missing", idSet, alias)).To(gomega.BeNil())
 	})
 
 	ginkgo.It("should dedupe when bare alias and canonical both match", func() {
-		ids := []string{"myproject-db", "db"}
+		idSet := identifierSet("myproject-db", "db")
 		alias := map[string]string{
 			"myproject-db": "myproject-db",
 			"db":           "myproject-db",
 		}
 
-		keys := resolveLinkToCanonicalKeys("db", ids, alias)
+		keys := resolveLinkToCanonicalKeys("db", idSet, alias)
 		gomega.Expect(keys).To(gomega.Equal([]string{"myproject-db"}))
 	})
 })
@@ -2246,5 +2268,159 @@ var _ = ginkgo.Describe("dependency link form permutations", func() {
 		gomega.Expect(containers[0].Name()).To(gomega.Equal("db"))
 		gomega.Expect(containers[1].Name()).To(gomega.Equal("web"))
 		gomega.Expect(containers[2].Name()).To(gomega.Equal("watchtower"))
+	})
+
+	ginkgo.It("should order independent stacks without cross-linking same service names", func() {
+		// Two Compose projects each have db→web. Bare link "db" is ambiguous and
+		// must not couple stacks; each web only orders relative to its own db when
+		// links use project-qualified or unique names.
+		dbA := mockLinkedContainer("stack-a-db", "id-da", "stack-a", "db", nil, true)
+		webA := mockLinkedContainer(
+			"stack-a-web", "id-wa", "stack-a", "web", []string{"stack-a-db"}, true,
+		)
+		dbB := mockLinkedContainer("stack-b-db", "id-db", "stack-b", "db", nil, true)
+		webB := mockLinkedContainer(
+			"stack-b-web", "id-wb", "stack-b", "web", []string{"stack-b-db"}, true,
+		)
+
+		containers := []types.Container{webA, webB, dbA, dbB}
+		err := DependencySorter{}.Sort(containers, true)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		ordered := make([]string, len(containers))
+		for i, c := range containers {
+			ordered[i] = c.Name()
+		}
+
+		assertOrderBefore(ordered, "stack-a-db", "stack-a-web")
+		assertOrderBefore(ordered, "stack-b-db", "stack-b-web")
+	})
+
+	ginkgo.It("should order cross-stack Watchtower depends-on by foreign container_name", func() {
+		// Provider stack owns the named network peer; consumer stack depends on it
+		// via Watchtower depends-on / network_mode container name.
+		provider := mockLinkedContainer(
+			"shared-net-proxy", "id-prov", "infra", "net-proxy", nil, true,
+		)
+		consumer := mockLinkedContainer(
+			"app-web", "id-cons", "app", "web", []string{"shared-net-proxy"}, true,
+		)
+		unrelated := mockLinkedContainer(
+			"other-db", "id-other", "other", "db", nil, true,
+		)
+
+		containers := []types.Container{consumer, unrelated, provider}
+		err := DependencySorter{}.Sort(containers, true)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		ordered := make([]string, len(containers))
+		for i, c := range containers {
+			ordered[i] = c.Name()
+		}
+
+		assertOrderBefore(ordered, "shared-net-proxy", "app-web")
+		gomega.Expect(ordered).To(gomega.ConsistOf("shared-net-proxy", "app-web", "other-db"))
+	})
+
+	ginkgo.It("should not couple stacks when multi-segment services share a trailing token", func() {
+		// stack-a has service net-proxy; stack-b has service other-proxy. A dependent
+		// linking to net-proxy must only wait on stack-a's peer, not other-proxy.
+		proxyA := mockLinkedContainer(
+			"stack-a-net-proxy", "id-pa", "stack-a", "net-proxy", nil, true,
+		)
+		proxyB := mockLinkedContainer(
+			"stack-b-other-proxy", "id-pb", "stack-b", "other-proxy", nil, true,
+		)
+		client := mockLinkedContainer(
+			"stack-a-client", "id-cl", "stack-a", "client", []string{"net-proxy"}, true,
+		)
+
+		containers := []types.Container{client, proxyB, proxyA}
+		err := DependencySorter{}.Sort(containers, true)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		ordered := make([]string, len(containers))
+		for i, c := range containers {
+			ordered[i] = c.Name()
+		}
+
+		assertOrderBefore(ordered, "stack-a-net-proxy", "stack-a-client")
+		// other-proxy must not become a dependency of client (no edge).
+		// If wrongly linked, client would have indegree 2 and sort after both proxies
+		// with a fixed relative order; assert client is not forced after proxyB only
+		// when proxyA is already before client.
+		gomega.Expect(indexOf(ordered, "stack-a-client")).
+			To(gomega.BeNumerically(">", indexOf(ordered, "stack-a-net-proxy")))
+	})
+
+	ginkgo.It("should order multi-segment container_name dependency among multi-stack peers", func() {
+		// Explicit container_name equals multi-segment service; Compose keys differ.
+		provider := mockLinkedContainer(
+			"net-proxy", "id-np", "media", "net-proxy", nil, true,
+		)
+		dependent := mockLinkedContainer(
+			"web-app", "id-wa", "media", "web", []string{"net-proxy"}, true,
+		)
+		foreign := mockLinkedContainer(
+			"net-proxy-other", "id-fo", "other", "net-proxy-other", nil, true,
+		)
+		// Same trailing token in another stack must not steal the edge.
+		decoy := mockLinkedContainer(
+			"edge-proxy", "id-de", "edge", "edge-proxy", nil, true,
+		)
+
+		containers := []types.Container{dependent, foreign, decoy, provider}
+		err := DependencySorter{}.Sort(containers, true)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		ordered := make([]string, len(containers))
+		for i, c := range containers {
+			ordered[i] = c.Name()
+		}
+
+		assertOrderBefore(ordered, "net-proxy", "web-app")
+	})
+
+	ginkgo.It("should order chain across three stacks with mixed link forms", func() {
+		// data.db ← (compose service) app.worker ← (watchtower container_name) edge.client
+		db := mockLinkedContainer("data-db", "id-db", "data", "db", nil, true)
+		worker := mockLinkedContainer(
+			"app-worker", "id-wk", "app", "worker", []string{"db"}, true,
+		)
+		// Watchtower depends-on uses worker's container_name.
+		client := mockLinkedContainer(
+			"edge-client", "id-cl", "edge", "client", []string{"app-worker"}, true,
+		)
+
+		containers := []types.Container{client, worker, db}
+		err := DependencySorter{}.Sort(containers, true)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		ordered := make([]string, len(containers))
+		for i, c := range containers {
+			ordered[i] = c.Name()
+		}
+
+		assertOrderBefore(ordered, "data-db", "app-worker")
+		assertOrderBefore(ordered, "app-worker", "edge-client")
+		assertOrderBefore(ordered, "data-db", "edge-client")
+	})
+
+	ginkgo.It("should not create edge for hyphenated link against trailing-token-only peer", func() {
+		// Regression: ExtractServiceName("net-proxy") and ExtractServiceName("other-proxy")
+		// both yield "proxy"; matching must not treat them as the same dependency.
+		decoy := mockLinkedContainer(
+			"other-proxy", "id-decoy", "other", "other-proxy", nil, true,
+		)
+		dependent := mockLinkedContainer(
+			"web", "id-web", "app", "web", []string{"net-proxy"}, true,
+		)
+
+		containers := []types.Container{dependent, decoy}
+		err := DependencySorter{}.Sort(containers, true)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		// No dependency edge: both indegree 0. Order is reverse-alpha among keys.
+		gomega.Expect([]string{containers[0].Name(), containers[1].Name()}).
+			To(gomega.ConsistOf("web", "other-proxy"))
 	})
 })


### PR DESCRIPTION
This PR fixes dependency sorting when containers use explicit names alongside Compose labels. Dependents that share a network namespace or declare depends-on by container name again stop and start in the correct order.

## Problem

When Compose project and service labels are present, dependency graph keys often differ from the bare container names used by Watchtower depends-on labels and network mode. Those links failed to resolve, so peers could restart out of order and dependents could fail to join a missing network namespace.

## Solution

Resolve dependency links against both canonical graph identifiers and unique bare container names, without letting bare-name aliases overwrite or remove canonical entries. Multi-segment service names and the usual Watchtower, Compose, Docker link, and network mode link forms are covered.

## Changes

- Improve dependency link matching so container names and Compose identifiers sort in the expected order
- Expand unit coverage for dependency sorting and stop or recreate ordering across common link configurations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dependency-aware container ordering for Compose labels, `network_mode: container:<peer>`, `depends_on`, and legacy Docker links.
  - Ensured dependent containers are stopped before their required network providers, and that providers are created/started before dependents.
  - Enhanced service/replica/alias and project-qualified name matching, including clearer handling of multi-segment links and self-references.
  - Fixed edge cases around shared dependencies, cross-stack monitoring containers, and ambiguous or missing dependency targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->