### PR TITLE
fix(registry): prefer config auth and accept identity tokens

### DIFF
--- a/pkg/registry/auth/auth_integration_test.go
+++ b/pkg/registry/auth/auth_integration_test.go
@@ -1385,7 +1385,7 @@ var _ = ginkgo.Describe("the auth module", func() {
 			gomega.Expect(result).To(gomega.Equal(inputAuth))
 		})
 
-		ginkgo.It("should handle missing username field", func() {
+		ginkgo.It("should transform password-only credentials to Basic auth", func() {
 			creds := struct {
 				Password string `json:"password"`
 			}{
@@ -1395,7 +1395,9 @@ var _ = ginkgo.Describe("the auth module", func() {
 			inputAuth := base64.StdEncoding.EncodeToString(jsonData)
 
 			result := auth.TransformAuth(inputAuth)
-			gomega.Expect(result).To(gomega.Equal(inputAuth))
+			decoded, err := base64.StdEncoding.DecodeString(result)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(string(decoded)).To(gomega.Equal(":testpass"))
 		})
 	})
 

--- a/pkg/registry/auth/credentials.go
+++ b/pkg/registry/auth/credentials.go
@@ -27,7 +27,13 @@ func TransformAuth(registryAuth string) string {
 		return ""
 	}
 
+	// EncodeCredentials uses URLEncoding; accept StdEncoding as well for
+	// compatibility with credentials produced outside Watchtower.
 	b, err := base64.StdEncoding.DecodeString(registryAuth)
+	if err != nil {
+		b, err = base64.URLEncoding.DecodeString(registryAuth)
+	}
+
 	if err != nil {
 		logrus.WithError(err).
 			Debug("Failed to decode base64 registry auth - returning original input")
@@ -45,18 +51,23 @@ func TransformAuth(registryAuth string) string {
 		return registryAuth
 	}
 
-	if credentials.Username != "" && credentials.Password != "" {
-		basicAuth := fmt.Appendf(
-			nil,
-			"%s:%s",
-			credentials.Username,
-			credentials.Password,
-		)
+	username := credentials.Username
+	password := credentials.Password
 
-		registryAuth = base64.StdEncoding.EncodeToString(basicAuth)
-
-		logrus.Debug("Transformed registry credentials to Basic auth format")
+	// Identity tokens from credential helpers are presented as the password in
+	// HTTP Basic auth when exchanging for a registry bearer token.
+	if password == "" && credentials.IdentityToken != "" {
+		password = credentials.IdentityToken
 	}
+
+	if password == "" {
+		return registryAuth
+	}
+
+	basicAuth := fmt.Appendf(nil, "%s:%s", username, password)
+	registryAuth = base64.StdEncoding.EncodeToString(basicAuth)
+
+	logrus.Debug("Transformed registry credentials to Basic auth format")
 
 	return registryAuth
 }

--- a/pkg/registry/auth/credentials_test.go
+++ b/pkg/registry/auth/credentials_test.go
@@ -1,9 +1,13 @@
 package auth
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTransformAuth(t *testing.T) {
@@ -38,9 +42,9 @@ func TestTransformAuth(t *testing.T) {
 			want:         "eyJ1c2VybmFtZSI6InVzZXIifQ==",
 		},
 		{
-			name:         "valid base64 JSON with only password returns original",
+			name:         "valid base64 JSON with only password becomes Basic auth",
 			registryAuth: "eyJwYXNzd29yZCI6InBhc3MifQ==",
-			want:         "eyJwYXNzd29yZCI6InBhc3MifQ==",
+			want:         "OnBhc3M=", // ":pass"
 		},
 		{
 			name:         "valid base64 empty JSON object returns original",
@@ -65,4 +69,52 @@ func TestTransformAuth(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestTransformAuthURLEncodedJSONCredentials(t *testing.T) {
+	// Password '?' (0x3f) yields URL-safe '-' in the JSON blob when URL-encoded,
+	// which StdEncoding alone cannot decode.
+	creds := map[string]string{
+		"username": "u",
+		"password": strings.Repeat("?", 8),
+	}
+	buf, err := json.Marshal(creds)
+	require.NoError(t, err)
+
+	urlEncoded := base64.URLEncoding.EncodeToString(buf)
+	_, stdErr := base64.StdEncoding.DecodeString(urlEncoded)
+	require.Error(t, stdErr, "fixture must fail StdEncoding so the URL path is exercised")
+
+	got := TransformAuth(urlEncoded)
+	decoded, err := base64.StdEncoding.DecodeString(got)
+	require.NoError(t, err)
+	assert.Equal(t, "u:"+strings.Repeat("?", 8), string(decoded))
+}
+
+func TestTransformAuthIdentityToken(t *testing.T) {
+	creds := map[string]string{
+		"identitytoken": "ecr-session-token",
+	}
+	buf, err := json.Marshal(creds)
+	require.NoError(t, err)
+
+	encoded := base64.StdEncoding.EncodeToString(buf)
+	got := TransformAuth(encoded)
+	decoded, err := base64.StdEncoding.DecodeString(got)
+	require.NoError(t, err)
+	assert.Equal(t, ":ecr-session-token", string(decoded))
+}
+
+func TestTransformAuthPasswordOnly(t *testing.T) {
+	creds := map[string]string{
+		"password": "ghcr-pat-token",
+	}
+	buf, err := json.Marshal(creds)
+	require.NoError(t, err)
+
+	encoded := base64.StdEncoding.EncodeToString(buf)
+	got := TransformAuth(encoded)
+	decoded, err := base64.StdEncoding.DecodeString(got)
+	require.NoError(t, err)
+	assert.Equal(t, ":ghcr-pat-token", string(decoded))
 }

--- a/pkg/registry/trust.go
+++ b/pkg/registry/trust.go
@@ -109,11 +109,11 @@ func EncodedEnvAuth() (string, error) {
 			"username": username,
 		}).Debug("Loaded auth credentials from environment")
 
-		// Log sensitive password only in trace mode.
+		// Trace only non-sensitive presence indicators; never log REPO_PASS.
 		if logrus.GetLevel() == logrus.TraceLevel {
 			logrus.WithFields(logrus.Fields{
-				"username": username,
-				"password": password,
+				"username":     username,
+				"has_password": true,
 			}).Trace("Using environment credentials")
 		}
 
@@ -185,7 +185,7 @@ func EncodedConfigCredentials(imageRef string) (string, error) {
 		return "", nil
 	}
 
-	// Log successful credential retrieval, hiding secrets unless in trace mode.
+	// Log successful credential retrieval with non-sensitive presence flags only.
 	logrus.WithFields(fields).WithFields(logrus.Fields{
 		"username":         credentials.Username,
 		"has_password":     credentials.Password != "",
@@ -194,11 +194,13 @@ func EncodedConfigCredentials(imageRef string) (string, error) {
 		"config_file":      configFile.Filename,
 	}).Debug("Loaded auth credentials from config")
 
+	// Trace only non-sensitive presence indicators; never log password or tokens.
 	if logrus.GetLevel() == logrus.TraceLevel {
 		logrus.WithFields(fields).WithFields(logrus.Fields{
-			"username": credentials.Username,
-			"password": credentials.Password,
-			"server":   server,
+			"username":         credentials.Username,
+			"has_password":     credentials.Password != "",
+			"has_identity_tok": credentials.IdentityToken != "",
+			"server":           server,
 		}).Trace("Using config credentials")
 	}
 
@@ -208,16 +210,16 @@ func EncodedConfigCredentials(imageRef string) (string, error) {
 
 // hasUsableRegistryCredentials reports whether AuthConfig carries material the
 // Docker daemon or registry HTTP clients can authenticate with.
+//
+// IdentityToken and Password are supported end to end via EncodeCredentials and
+// TransformAuth (Basic auth). RegistryToken-only entries are not accepted until
+// a Bearer-auth path is implemented for them.
 func hasUsableRegistryCredentials(credentials dockerConfig.AuthConfig) bool {
 	if credentials == (dockerConfig.AuthConfig{}) {
 		return false
 	}
 
 	if credentials.IdentityToken != "" {
-		return true
-	}
-
-	if credentials.RegistryToken != "" {
 		return true
 	}
 

--- a/pkg/registry/trust.go
+++ b/pkg/registry/trust.go
@@ -33,10 +33,13 @@ var (
 
 // EncodedAuth attempts to retrieve encoded authentication credentials for a given image name.
 //
-// It checks environment variables first, then falls back to the Docker config file if needed.
+// Per-image Docker config credentials are preferred when present so REPO_USER/REPO_PASS
+// are not sent to every registry. Environment credentials are used when the config has
+// no entry for the image's registry (or config lookup fails), preserving the common
+// single-registry REPO_USER/REPO_PASS deployment.
 //
 // Parameters:
-//   - ref: Image reference string (e.g., "docker.io/library/alpine").
+//   - imageName: Image reference string (e.g., "docker.io/library/alpine").
 //
 // Returns:
 //   - string: Base64-encoded credentials string if successful, empty if none found.
@@ -49,22 +52,38 @@ func EncodedAuth(imageName string) (string, error) {
 
 	logrus.WithFields(fields).Debug("Attempting to retrieve auth credentials")
 
-	// Try environment variables first.
+	configCredentials, configErr := EncodedConfigCredentials(imageName)
+	if configErr == nil && configCredentials != "" {
+		logrus.WithFields(fields).Debug("Successfully retrieved encoded auth credentials from config")
+
+		return configCredentials, nil
+	}
+
+	if configErr != nil {
+		logrus.WithError(configErr).
+			WithFields(fields).
+			Debug("Config auth not available, trying environment")
+	} else {
+		logrus.WithFields(fields).
+			Debug("No config credentials for registry, trying environment")
+	}
+
 	credentials, err := EncodedEnvAuth()
 	if err != nil {
-		// Fallback to config file if env vars are unavailable.
-		logrus.WithError(err).
-			WithFields(fields).
-			Debug("Environment auth not available, trying config file")
+		// Prefer surfacing a config load/address error when env is also unset.
+		if configErr != nil {
+			return "", configErr
+		}
 
-		credentials, err = EncodedConfigCredentials(imageName)
+		// No config entry and no env: empty credentials is success (anonymous pull).
+		return "", nil
 	}
 
-	if err == nil && credentials != "" {
-		logrus.WithFields(fields).Debug("Successfully retrieved encoded auth credentials")
+	if credentials != "" {
+		logrus.WithFields(fields).Debug("Successfully retrieved encoded auth credentials from environment")
 	}
 
-	return credentials, err
+	return credentials, nil
 }
 
 // EncodedEnvAuth checks for REPO_USER and REPO_PASS environment variables and encodes them.
@@ -155,11 +174,9 @@ func EncodedConfigCredentials(imageRef string) (string, error) {
 	credStore := CredentialsStore(*configFile)
 	credentials, _ := credStore.Get(server)
 
-	// Return empty string if no credentials are found or if the store returned
-	// an AuthConfig with no username/password (e.g. native store miss or empty entry).
-	if credentials == (dockerConfig.AuthConfig{}) ||
-		credentials.Username == "" ||
-		credentials.Password == "" {
+	// Accept username+password, password-only tokens, or identity tokens from
+	// credential helpers (ECR and similar). Empty AuthConfig is a miss.
+	if !hasUsableRegistryCredentials(credentials) {
 		logrus.WithFields(fields).WithFields(logrus.Fields{
 			"server":      server,
 			"config_file": configFile.Filename,
@@ -168,14 +185,15 @@ func EncodedConfigCredentials(imageRef string) (string, error) {
 		return "", nil
 	}
 
-	// Log successful credential retrieval, hiding password unless in trace mode.
+	// Log successful credential retrieval, hiding secrets unless in trace mode.
 	logrus.WithFields(fields).WithFields(logrus.Fields{
-		"username":    credentials.Username,
-		"server":      server,
-		"config_file": configFile.Filename,
+		"username":         credentials.Username,
+		"has_password":     credentials.Password != "",
+		"has_identity_tok": credentials.IdentityToken != "",
+		"server":           server,
+		"config_file":      configFile.Filename,
 	}).Debug("Loaded auth credentials from config")
 
-	// Log password only in trace mode
 	if logrus.GetLevel() == logrus.TraceLevel {
 		logrus.WithFields(fields).WithFields(logrus.Fields{
 			"username": credentials.Username,
@@ -184,8 +202,31 @@ func EncodedConfigCredentials(imageRef string) (string, error) {
 		}).Trace("Using config credentials")
 	}
 
-	// Encode and return the auth config.
+	// Encode and return the auth config (includes IdentityToken when set).
 	return EncodeCredentials(credentials)
+}
+
+// hasUsableRegistryCredentials reports whether AuthConfig carries material the
+// Docker daemon or registry HTTP clients can authenticate with.
+func hasUsableRegistryCredentials(credentials dockerConfig.AuthConfig) bool {
+	if credentials == (dockerConfig.AuthConfig{}) {
+		return false
+	}
+
+	if credentials.IdentityToken != "" {
+		return true
+	}
+
+	if credentials.RegistryToken != "" {
+		return true
+	}
+
+	// Password-only entries are used for PAT-style tokens (for example GHCR).
+	if credentials.Password != "" {
+		return true
+	}
+
+	return false
 }
 
 // CredentialsStore returns a new credentials store based on the configuration file settings.

--- a/pkg/registry/trust_test.go
+++ b/pkg/registry/trust_test.go
@@ -115,8 +115,8 @@ func TestEncodedConfigCredentials_FileStoreNoUsername(t *testing.T) {
 }
 
 // TestEncodedConfigCredentials_FileStoreUsernameOnly tests that EncodedConfigCredentials
-// returns empty string and nil error when the Docker config file's auth entry has
-// a username but no password.
+// returns empty string when the Docker config auth entry has a username but no
+// password or identity token (not usable for registry auth).
 func TestEncodedConfigCredentials_FileStoreUsernameOnly(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "watchtower-test-docker-config")
 	require.NoError(t, err)
@@ -147,6 +147,72 @@ func TestEncodedConfigCredentials_FileStoreUsernameOnly(t *testing.T) {
 	credentials, err := EncodedConfigCredentials(normalizedRef.String())
 	require.NoError(t, err)
 	assert.Empty(t, credentials)
+}
+
+// TestEncodedConfigCredentials_IdentityToken accepts ECR-style identity tokens
+// without username/password.
+func TestEncodedConfigCredentials_IdentityToken(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "watchtower-test-docker-config")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(tempDir)
+
+	configContent, err := json.Marshal(map[string]any{
+		"auths": map[string]any{
+			"123456789012.dkr.ecr.us-east-1.amazonaws.com": map[string]string{
+				"identitytoken": "eyJlY3ItdG9rZW4iOiJ0ZXN0In0=",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	configPath := filepath.Join(tempDir, "config.json")
+	require.NoError(t, os.WriteFile(configPath, configContent, 0o600))
+
+	t.Setenv("DOCKER_CONFIG", tempDir)
+	t.Setenv("HOME", tempDir)
+	dockerCliConfig.SetDir(tempDir)
+
+	credentials, err := EncodedConfigCredentials(
+		"123456789012.dkr.ecr.us-east-1.amazonaws.com/app:latest",
+	)
+	require.NoError(t, err)
+	assert.NotEmpty(t, credentials)
+
+	authConfig := decodeEncodedAuth(t, credentials)
+	assert.Equal(t, "eyJlY3ItdG9rZW4iOiJ0ZXN0In0=", authConfig["identitytoken"])
+}
+
+// TestEncodedConfigCredentials_PasswordOnly accepts password-as-token entries
+// with an empty username (common for GHCR PATs stored in config).
+func TestEncodedConfigCredentials_PasswordOnly(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "watchtower-test-docker-config")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(tempDir)
+
+	configContent, err := json.Marshal(map[string]any{
+		"auths": map[string]any{
+			"ghcr.io": map[string]string{
+				"password": "ghp_only_token",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	configPath := filepath.Join(tempDir, "config.json")
+	require.NoError(t, os.WriteFile(configPath, configContent, 0o600))
+
+	t.Setenv("DOCKER_CONFIG", tempDir)
+	t.Setenv("HOME", tempDir)
+	dockerCliConfig.SetDir(tempDir)
+
+	credentials, err := EncodedConfigCredentials("ghcr.io/org/app:latest")
+	require.NoError(t, err)
+	assert.NotEmpty(t, credentials)
+
+	authConfig := decodeEncodedAuth(t, credentials)
+	assert.Equal(t, "ghp_only_token", authConfig["password"])
 }
 
 // TestEncodedConfigCredentials_FileStoreValidCredentials tests the happy path
@@ -287,10 +353,10 @@ func TestEncodedConfigCredentials_MultipleRegistries(t *testing.T) {
 	}
 }
 
-// TestEncodedAuth_EnvVarsOverrideConfig verifies that EncodedAuth returns env
-// credentials when REPO_USER/REPO_PASS are set, even if a config file with
-// different credentials is present.
-func TestEncodedAuth_EnvVarsOverrideConfig(t *testing.T) {
+// TestEncodedAuth_ConfigPreferredOverEnv verifies that EncodedAuth returns
+// Docker config credentials for a registry when both config and REPO_USER/REPO_PASS
+// are set, so env credentials are not sent to every registry.
+func TestEncodedAuth_ConfigPreferredOverEnv(t *testing.T) {
 	writeTestDockerConfig(t, map[string]map[string]string{
 		"ghcr.io": {
 			"username": "cfg-user",
@@ -304,6 +370,30 @@ func TestEncodedAuth_EnvVarsOverrideConfig(t *testing.T) {
 	t.Setenv("REPO_PASS", "env-pass")
 
 	credentials, err := EncodedAuth("ghcr.io/test/image:latest")
+	require.NoError(t, err)
+	assert.NotEmpty(t, credentials)
+
+	authConfig := decodeEncodedAuth(t, credentials)
+	assert.Equal(t, "cfg-user", authConfig["username"])
+	assert.Equal(t, "cfg-pass", authConfig["password"])
+}
+
+// TestEncodedAuth_EnvUsedWhenConfigHasNoRegistryEntry verifies REPO_USER/REPO_PASS
+// still apply when the Docker config has no credentials for the image's registry.
+func TestEncodedAuth_EnvUsedWhenConfigHasNoRegistryEntry(t *testing.T) {
+	writeTestDockerConfig(t, map[string]map[string]string{
+		"ghcr.io": {
+			"username": "cfg-user",
+			"password": "cfg-pass",
+		},
+	})
+
+	defer os.Unsetenv("DOCKER_CONFIG")
+
+	t.Setenv("REPO_USER", "env-user")
+	t.Setenv("REPO_PASS", "env-pass")
+
+	credentials, err := EncodedAuth("quay.io/org/app:latest")
 	require.NoError(t, err)
 	assert.NotEmpty(t, credentials)
 

--- a/pkg/registry/trust_test.go
+++ b/pkg/registry/trust_test.go
@@ -5,13 +5,17 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/distribution/reference"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	dockerCliConfig "github.com/docker/cli/cli/config"
+
+	"github.com/nicholas-fedor/watchtower/pkg/registry/auth"
 )
 
 // TestEncodedEnvAuth_ReturnsCredentialsWhenSet verifies that EncodedEnvAuth
@@ -150,17 +154,19 @@ func TestEncodedConfigCredentials_FileStoreUsernameOnly(t *testing.T) {
 }
 
 // TestEncodedConfigCredentials_IdentityToken accepts ECR-style identity tokens
-// without username/password.
+// without username/password and transforms them to HTTP Basic for bearer exchange.
 func TestEncodedConfigCredentials_IdentityToken(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "watchtower-test-docker-config")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tempDir)
 
+	const identityToken = "eyJlY3ItdG9rZW4iOiJ0ZXN0In0="
+
 	configContent, err := json.Marshal(map[string]any{
 		"auths": map[string]any{
 			"123456789012.dkr.ecr.us-east-1.amazonaws.com": map[string]string{
-				"identitytoken": "eyJlY3ItdG9rZW4iOiJ0ZXN0In0=",
+				"identitytoken": identityToken,
 			},
 		},
 	})
@@ -180,7 +186,47 @@ func TestEncodedConfigCredentials_IdentityToken(t *testing.T) {
 	assert.NotEmpty(t, credentials)
 
 	authConfig := decodeEncodedAuth(t, credentials)
-	assert.Equal(t, "eyJlY3ItdG9rZW4iOiJ0ZXN0In0=", authConfig["identitytoken"])
+	assert.Equal(t, identityToken, authConfig["identitytoken"])
+
+	// End-to-end: TransformAuth must produce Basic credentials for the
+	// Authorization header used when exchanging for a registry bearer token.
+	basicEncoded := auth.TransformAuth(credentials)
+	basicDecoded, decodeErr := base64.StdEncoding.DecodeString(basicEncoded)
+	require.NoError(t, decodeErr)
+	assert.Equal(t, ":"+identityToken, string(basicDecoded))
+
+	authHeader := "Basic " + basicEncoded
+	assert.True(t, strings.HasPrefix(authHeader, "Basic "))
+	assert.NotContains(t, authHeader, "Bearer ")
+}
+
+// TestEncodedConfigCredentials_RegistryTokenOnlyRejected ensures registrytoken-only
+// entries are not treated as usable until a Bearer-auth path exists for them.
+func TestEncodedConfigCredentials_RegistryTokenOnlyRejected(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "watchtower-test-docker-config")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(tempDir)
+
+	configContent, err := json.Marshal(map[string]any{
+		"auths": map[string]any{
+			"ghcr.io": map[string]string{
+				"registrytoken": "bearer-only-token",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	configPath := filepath.Join(tempDir, "config.json")
+	require.NoError(t, os.WriteFile(configPath, configContent, 0o600))
+
+	t.Setenv("DOCKER_CONFIG", tempDir)
+	t.Setenv("HOME", tempDir)
+	dockerCliConfig.SetDir(tempDir)
+
+	credentials, err := EncodedConfigCredentials("ghcr.io/org/app:latest")
+	require.NoError(t, err)
+	assert.Empty(t, credentials)
 }
 
 // TestEncodedConfigCredentials_PasswordOnly accepts password-as-token entries
@@ -531,6 +577,84 @@ func TestEncodedAuth_EnvPartiallySetWithUnconfiguredRegistry(t *testing.T) {
 	credentials, err := EncodedAuth("ghcr.io/test/image:latest")
 	require.NoError(t, err)
 	assert.Empty(t, credentials)
+}
+
+// TestEncodedAuth_TraceLogsOmitSecrets verifies that trace-level credential logs
+// never include password or token material from config or environment sources.
+func TestEncodedAuth_TraceLogsOmitSecrets(t *testing.T) {
+	const (
+		secretPass  = "super-secret-repo-pass"
+		secretToken = "super-secret-identity-token"
+	)
+
+	var logBuf strings.Builder
+
+	origOut := logrus.StandardLogger().Out
+	origLevel := logrus.GetLevel()
+
+	logrus.SetOutput(&logBuf)
+	logrus.SetLevel(logrus.TraceLevel)
+
+	t.Cleanup(func() {
+		logrus.SetOutput(origOut)
+		logrus.SetLevel(origLevel)
+	})
+
+	t.Run("environment credentials", func(t *testing.T) {
+		logBuf.Reset()
+
+		t.Setenv("REPO_USER", "env-user")
+		t.Setenv("REPO_PASS", secretPass)
+
+		_, err := EncodedEnvAuth()
+		require.NoError(t, err)
+		assert.NotContains(t, logBuf.String(), secretPass)
+	})
+
+	t.Run("config credentials", func(t *testing.T) {
+		logBuf.Reset()
+
+		writeTestDockerConfig(t, map[string]map[string]string{
+			"ghcr.io": {
+				"username": "cfg-user",
+				"password": secretPass,
+			},
+		})
+
+		t.Setenv("REPO_USER", "")
+		t.Setenv("REPO_PASS", "")
+
+		_, err := EncodedConfigCredentials("ghcr.io/org/app:latest")
+		require.NoError(t, err)
+		assert.NotContains(t, logBuf.String(), secretPass)
+	})
+
+	t.Run("identity token credentials", func(t *testing.T) {
+		logBuf.Reset()
+
+		tempDir, err := os.MkdirTemp("", "watchtower-test-docker-config")
+		require.NoError(t, err)
+
+		defer os.RemoveAll(tempDir)
+
+		configContent, err := json.Marshal(map[string]any{
+			"auths": map[string]any{
+				"ghcr.io": map[string]string{
+					"identitytoken": secretToken,
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(tempDir, "config.json"), configContent, 0o600))
+
+		t.Setenv("DOCKER_CONFIG", tempDir)
+		t.Setenv("HOME", tempDir)
+		dockerCliConfig.SetDir(tempDir)
+
+		_, err = EncodedConfigCredentials("ghcr.io/org/app:latest")
+		require.NoError(t, err)
+		assert.NotContains(t, logBuf.String(), secretToken)
+	})
 }
 
 // TestEncodedConfigCredentials_InvalidImageRef verifies that EncodedConfigCredentials

--- a/pkg/types/registry_credentials.go
+++ b/pkg/types/registry_credentials.go
@@ -1,7 +1,11 @@
 package types
 
-// RegistryCredentials holds basic auth credentials.
+// RegistryCredentials holds registry authentication material.
+//
+// Username/Password cover classic Basic auth. IdentityToken covers cloud
+// helpers (for example ECR) that store a short-lived token without a password.
 type RegistryCredentials struct {
-	Username string `json:"username"` // Registry username.
-	Password string `json:"password"` // Registry token or password.
+	Username      string `json:"username"`                // Registry username.
+	Password      string `json:"password"`                // Registry token or password.
+	IdentityToken string `json:"identitytoken,omitempty"` // OAuth/identity token from a credential helper.
 }


### PR DESCRIPTION
This PR improves how Watchtower selects and applies registry credentials so private and helper-backed registries authenticate more reliably.

## Problem

Global environment credentials could override per-registry Docker config entries, and common credential helper outputs such as identity tokens or password-only tokens were treated as missing. Some encoded credential blobs also failed to decode during Basic auth conversion.

## Solution

Prefer Docker config credentials for the target registry when available, fall back to environment credentials only when needed, and accept identity-token and password-only auth material. Credential decoding now handles both standard and URL-safe encodings.

## Changes

- Prefer Docker config credentials over global environment credentials when both are present
- Accept identity tokens and password-only registry credentials
- Decode URL-safe base64 credential blobs for Basic auth conversion
- Expand registry auth unit coverage for the updated credential paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Supports registry authentication using identity tokens and password-only credentials.
  * Accepts both standard and URL-safe encoded credential data.
  * Prefers configured registry credentials, with environment credentials used when configuration is unavailable.
  * Supports anonymous access when no credentials are configured.
* **Improvements**
  * Enhances auth transformation to derive and re-encode credentials more reliably.
  * Ensures trace logging omits sensitive secrets (passwords/tokens).
* **Tests**
  * Expanded coverage for credential precedence, parsing, and secret redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->