### PR TITLE
fix: tighten image filter matching and local-only detection

### DIFF
--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/distribution/reference"
 	"github.com/sirupsen/logrus"
 
 	"github.com/nicholas-fedor/watchtower/pkg/types"
@@ -574,6 +575,12 @@ func matchesName(containerName, pattern string) bool {
 
 // matchImageAndTag checks if a container's image matches a target image, including optional tag.
 //
+// Image references are parsed with distribution/reference so host:port registries
+// (for example localhost:5000/nginx:alpine) are not split on the port colon.
+// When the target omits a tag, any tag on the container image is accepted.
+// When the target includes a tag, both name and tag must match. Digest-only
+// references compare the familiar name without requiring a matching tag.
+//
 // Parameters:
 //   - containerImage: The container's image name (e.g., "registry:develop").
 //   - targetImage: The target image name or image:tag to match (e.g., "registry").
@@ -581,18 +588,41 @@ func matchesName(containerName, pattern string) bool {
 // Returns:
 //   - bool: True if the image (and tag, if specified) matches, false otherwise.
 func matchImageAndTag(containerImage, targetImage string) bool {
-	containerParts := strings.Split(containerImage, ":") // Split into name and tag.
-	targetParts := strings.Split(targetImage, ":")       // Split target into name and tag.
-
-	if containerParts[0] != targetParts[0] { // Compare image names.
-		return false // Image names don't match.
+	containerRef, err := reference.ParseAnyReference(containerImage)
+	if err != nil {
+		return false
 	}
 
-	if len(targetParts) > 1 && len(containerParts) > 1 { // Both have tags.
-		return containerParts[1] == targetParts[1] // Compare tags.
+	targetRef, err := reference.ParseAnyReference(targetImage)
+	if err != nil {
+		return false
 	}
 
-	return true // No tag in target or container, name match sufficient.
+	containerNamed, ok := containerRef.(reference.Named)
+	if !ok {
+		return false
+	}
+
+	targetNamed, ok := targetRef.(reference.Named)
+	if !ok {
+		return false
+	}
+
+	if reference.FamiliarName(containerNamed) != reference.FamiliarName(targetNamed) {
+		return false
+	}
+
+	targetTagged, targetHasTag := targetRef.(reference.NamedTagged)
+	if !targetHasTag {
+		return true
+	}
+
+	containerTagged, containerHasTag := containerRef.(reference.NamedTagged)
+	if !containerHasTag {
+		return false
+	}
+
+	return containerTagged.Tag() == targetTagged.Tag()
 }
 
 // BuildFilter constructs a composite filter for containers.

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -690,6 +690,40 @@ func TestFilterByImageMalformed(t *testing.T) {
 	container.AssertExpectations(t)
 }
 
+func TestMatchImageAndTagHostPortRegistry(t *testing.T) {
+	t.Parallel()
+
+	// host:port must not be treated as image:tag; different tags must not match.
+	assert.False(t, matchImageAndTag("localhost:5000/nginx:alpine", "localhost:5000/nginx:latest"))
+	assert.True(t, matchImageAndTag("localhost:5000/nginx:alpine", "localhost:5000/nginx:alpine"))
+	assert.True(t, matchImageAndTag("localhost:5000/nginx:alpine", "localhost:5000/nginx"))
+	assert.False(t, matchImageAndTag("my.reg:443/a/b:1", "my.reg:443/a/b:2"))
+	assert.True(t, matchImageAndTag("my.reg:443/a/b:1", "my.reg:443/a/b:1"))
+
+	// Standard image:tag matching still works.
+	assert.False(t, matchImageAndTag("nginx:latest", "nginx:develop"))
+	assert.True(t, matchImageAndTag("nginx:latest", "nginx:latest"))
+	assert.True(t, matchImageAndTag("nginx:latest", "nginx"))
+}
+
+func TestFilterByImageHostPortRegistry(t *testing.T) {
+	t.Parallel()
+
+	filterTagged := FilterByImage([]string{"localhost:5000/app:v2"}, NoFilter)
+
+	container := new(mockContainer.FilterableContainer)
+	container.On("ImageName").Return("localhost:5000/app:v1")
+	container.On("Name").Return("/app")
+	assert.False(t, filterTagged(container))
+	container.AssertExpectations(t)
+
+	container = new(mockContainer.FilterableContainer)
+	container.On("ImageName").Return("localhost:5000/app:v2")
+	container.On("Name").Return("/app")
+	assert.True(t, filterTagged(container))
+	container.AssertExpectations(t)
+}
+
 func TestBuildFilter(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -152,10 +152,12 @@ func CompareDigest(
 }
 
 // isLocalImageNotFound reports whether the digest fetch failed because the
-// registry returned 404 for a manifest request and the container's image name
-// does not explicitly specify a registry domain. That pattern indicates a
-// locally built image that has never been pushed, so there is no remote
-// manifest to compare against.
+// registry returned 404 for a manifest request and the container's image looks
+// local-only: domain-less Config.Image and no registry-qualified RepoDigests.
+//
+// Official Hub short names (for example nginx) often store Config.Image without
+// a domain but still have docker.io/... RepoDigests. Those must not be cached as
+// local-only after a transient 404, or updates are skipped for the process life.
 //
 // Parameters:
 //   - container: Container whose image name is inspected.
@@ -185,7 +187,43 @@ func isLocalImageNotFound(container types.Container, err error) bool {
 		}
 	}
 
-	return !strings.ContainsAny(namePart, "./")
+	if strings.ContainsAny(namePart, "./") {
+		return false
+	}
+
+	// Registry-qualified digests mean the image was pulled from a remote source;
+	// a 404 is a probe failure, not proof the image is local-only. Official Hub
+	// short names often keep a domain-less Config.Image while RepoDigests still
+	// records docker.io/library/... .
+	for _, digestRef := range container.ImageInfo().RepoDigests {
+		repoPart, _, _ := strings.Cut(digestRef, "@")
+		if repoPartHasRegistryHost(repoPart) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// repoPartHasRegistryHost reports whether a RepoDigest repository path includes
+// a registry host (hostname with a dot, or host:port).
+func repoPartHasRegistryHost(repoPart string) bool {
+	// Strip optional scheme leftovers; RepoDigests are host/path form.
+	hostOrName, remainder, hasSlash := strings.Cut(repoPart, "/")
+	if !hasSlash {
+		// Bare name (e.g. "nginx") has no host segment.
+		return false
+	}
+
+	// host:port/path or registry.example.com/path
+	if strings.Contains(hostOrName, ":") || strings.Contains(hostOrName, ".") {
+		return true
+	}
+
+	// Remainder unused; keep signature clear for future extension.
+	_ = remainder
+
+	return false
 }
 
 // CompareDigestWithRemote checks whether a container's current image digest matches

--- a/pkg/registry/digest/digest_test.go
+++ b/pkg/registry/digest/digest_test.go
@@ -286,6 +286,11 @@ func TestIsLocalImageNotFound(t *testing.T) {
 	t.Run("true for domain-less Config.Image with wrapped ErrManifestNotFound", func(t *testing.T) {
 		mc := mockTypes.NewMockContainer(t)
 		mc.On("HasImageInfo").Return(true)
+		mc.On("ImageInfo").Return(&dockerImage.InspectResponse{
+			RepoDigests: []string{
+				"atlas-badgerdb@sha256:80f07677bee57274a48929d0688bf0cfabe5e83f06f2f152dab4076445d6ab35",
+			},
+		})
 		mc.On("ContainerInfo").Return(&dockerContainer.InspectResponse{
 			Config: &dockerContainer.Config{Image: "atlas-badgerdb"},
 		})
@@ -297,6 +302,11 @@ func TestIsLocalImageNotFound(t *testing.T) {
 	t.Run("true for domain-less image with version tag containing dots", func(t *testing.T) {
 		mc := mockTypes.NewMockContainer(t)
 		mc.On("HasImageInfo").Return(true)
+		mc.On("ImageInfo").Return(&dockerImage.InspectResponse{
+			RepoDigests: []string{
+				"my-app@sha256:80f07677bee57274a48929d0688bf0cfabe5e83f06f2f152dab4076445d6ab35",
+			},
+		})
 		mc.On("ContainerInfo").Return(&dockerContainer.InspectResponse{
 			Config: &dockerContainer.Config{Image: "my-app:1.0"},
 		})
@@ -310,6 +320,25 @@ func TestIsLocalImageNotFound(t *testing.T) {
 		mc.On("HasImageInfo").Return(true)
 		mc.On("ContainerInfo").Return(&dockerContainer.InspectResponse{
 			Config: &dockerContainer.Config{Image: "registry.example.com/app:latest"},
+		})
+
+		err := fmt.Errorf("%w: status 404 Not Found", ErrManifestNotFound)
+		assert.False(t, isLocalImageNotFound(mc, err))
+	})
+
+	t.Run("false for Hub short name with registry-qualified RepoDigests", func(t *testing.T) {
+		// Official images often keep Config.Image as "nginx" while RepoDigests
+		// records docker.io/library/nginx@sha256:.... A transient 404 must not
+		// mark them local-only for the process lifetime.
+		mc := mockTypes.NewMockContainer(t)
+		mc.On("HasImageInfo").Return(true)
+		mc.On("ImageInfo").Return(&dockerImage.InspectResponse{
+			RepoDigests: []string{
+				"docker.io/library/nginx@sha256:80f07677bee57274a48929d0688bf0cfabe5e83f06f2f152dab4076445d6ab35",
+			},
+		})
+		mc.On("ContainerInfo").Return(&dockerContainer.InspectResponse{
+			Config: &dockerContainer.Config{Image: "nginx:latest"},
 		})
 
 		err := fmt.Errorf("%w: status 404 Not Found", ErrManifestNotFound)


### PR DESCRIPTION
This PR corrects image selection and local-only detection so private-registry tags and Hub short names are handled accurately during updates.

## Problem

API image filters could mis-parse host and port as image tags, matching the wrong containers. Separately, official Hub short names could be cached as local-only after a transient registry 404, skipping later update checks for the process lifetime.

## Solution

Match filtered images with proper reference parsing so host:port registries keep real tags. Treat domain-less images as local-only only when repository digests also lack a remote registry host.

## Changes

- Parse host:port image references when matching API image filters
- Require registry-less repository digests before treating 404 responses as local-only
- Add unit coverage for private-registry filter matching and Hub short-name detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image filtering for registries that include hostnames and ports.
  * Ensured image and tag matching correctly handles fully qualified references.
  * Improved detection of locally available images versus images hosted in registries.
  * Prevented Hub-hosted short names from being incorrectly treated as local-only images.
* **Tests**
  * Added coverage for registry host-and-port image references and short-name image detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->