### PR TITLE
fix(container): clean up failed recreates and nil host config

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -34,6 +34,11 @@ type Operations interface {
 		containerID string,
 		options dockerClient.ContainerStartOptions,
 	) (dockerClient.ContainerStartResult, error)
+	ContainerInspect(
+		ctx context.Context,
+		containerID string,
+		options dockerClient.ContainerInspectOptions,
+	) (dockerClient.ContainerInspectResult, error)
 	ContainerRemove(
 		ctx context.Context,
 		containerID string,

--- a/pkg/container/container_mock_test.go
+++ b/pkg/container/container_mock_test.go
@@ -399,10 +399,12 @@ func WithDevices(devices []dockerContainer.DeviceMapping) MockContainerUpdate {
 type MockClient struct {
 	createFunc        func(context.Context, *dockerContainer.Config, *dockerContainer.HostConfig, *dockerNetwork.NetworkingConfig, *ocispec.Platform, string) (dockerClient.ContainerCreateResult, error)
 	startFunc         func(context.Context, string, dockerClient.ContainerStartOptions) (dockerClient.ContainerStartResult, error)
+	inspectFunc       func(context.Context, string, dockerClient.ContainerInspectOptions) (dockerClient.ContainerInspectResult, error)
 	removeFunc        func(context.Context, string, dockerClient.ContainerRemoveOptions) (dockerClient.ContainerRemoveResult, error)
 	connectFunc       func(context.Context, string, string, *dockerNetwork.EndpointSettings) (dockerClient.NetworkConnectResult, error)
 	renameFunc        func(context.Context, string, string) (dockerClient.ContainerRenameResult, error)
 	removeFuncCalled  atomic.Bool
+	inspectFuncCalled atomic.Bool
 	createFuncCalled  atomic.Bool
 	startFuncCalled   atomic.Bool
 	connectFuncCalled atomic.Bool
@@ -456,6 +458,39 @@ func (m *MockClient) ContainerStart(
 	}
 
 	return dockerClient.ContainerStartResult{}, nil
+}
+
+// ContainerInspect mocks inspection of a container.
+//
+// Parameters:
+//   - ctx: Context for the operation.
+//   - containerID: ID of the container to inspect.
+//   - options: Inspect options.
+//
+// Returns:
+//   - dockerClient.ContainerInspectResult: Mocked inspect result.
+//   - error: Error if the mock inspect function is set to fail, nil otherwise.
+func (m *MockClient) ContainerInspect(
+	ctx context.Context,
+	containerID string,
+	options dockerClient.ContainerInspectOptions,
+) (dockerClient.ContainerInspectResult, error) {
+	m.inspectFuncCalled.Store(true)
+
+	if m.inspectFunc != nil {
+		return m.inspectFunc(ctx, containerID, options)
+	}
+
+	// Default: created but not running (typical after a start failure).
+	return dockerClient.ContainerInspectResult{
+		Container: dockerContainer.InspectResponse{
+			ID: containerID,
+			State: &dockerContainer.State{
+				Status:  "created",
+				Running: false,
+			},
+		},
+	}, nil
 }
 
 // ContainerRemove mocks the removal of a container.

--- a/pkg/container/container_source.go
+++ b/pkg/container/container_source.go
@@ -343,7 +343,8 @@ func StopAndRemoveSourceContainer(
 
 	// Check if the container has AutoRemove enabled in its HostConfig, which automatically removes
 	// the container after stopping, eliminating the need for an explicit removal call.
-	if sourceContainer.ContainerInfo().HostConfig.AutoRemove {
+	info := sourceContainer.ContainerInfo()
+	if info != nil && info.HostConfig != nil && info.HostConfig.AutoRemove {
 		// Log that the container is skipped due to AutoRemove configuration.
 		clog.Debug("Skipping container removal due to AutoRemove configuration")
 
@@ -448,7 +449,11 @@ func getNetworkConfig(
 		return config
 	}
 
-	networkMode := containerInfo.HostConfig.NetworkMode
+	var networkMode dockerContainer.NetworkMode
+	if containerInfo.HostConfig != nil {
+		networkMode = containerInfo.HostConfig.NetworkMode
+	}
+
 	isHostNetwork := string(networkMode) == "host"
 	clog.WithFields(logrus.Fields{
 		"network_mode": networkMode,

--- a/pkg/container/container_source_test.go
+++ b/pkg/container/container_source_test.go
@@ -818,6 +818,9 @@ var _ = ginkgo.Describe("StopAndRemoveSourceContainer", func() {
 				true,
 			)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			// Stop + DELETE (nil HostConfig is not AutoRemove).
+			// ReceivedRequests includes the initial API version ping.
+			gomega.Expect(mockServer.ReceivedRequests()).To(gomega.HaveLen(3))
 		})
 	})
 

--- a/pkg/container/container_source_test.go
+++ b/pkg/container/container_source_test.go
@@ -783,6 +783,44 @@ var _ = ginkgo.Describe("StopAndRemoveSourceContainer", func() {
 		})
 	})
 
+	ginkgo.When("container HostConfig is nil", func() {
+		ginkgo.It("should stop and remove without panicking", func() {
+			container := MockContainer(
+				WithContainerState(dockerContainer.State{Running: true}),
+				func(c *dockerContainer.InspectResponse, _ *dockerImage.InspectResponse) {
+					c.HostConfig = nil
+				},
+			)
+			cid := container.ContainerInfo().ID
+
+			mockServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(
+						"POST",
+						gomega.HaveSuffix(fmt.Sprintf("containers/%s/stop", cid)),
+					),
+					ghttp.RespondWith(http.StatusNoContent, nil),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(
+						"DELETE",
+						gomega.MatchRegexp(fmt.Sprintf("^/v[0-9.]+/containers/%s$", cid)),
+					),
+					ghttp.RespondWith(http.StatusNoContent, nil),
+				),
+			)
+
+			err := StopAndRemoveSourceContainer(
+				context.Background(),
+				docker,
+				container,
+				10*time.Second,
+				true,
+			)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		})
+	})
+
 	ginkgo.When("container is not running", func() {
 		ginkgo.It("should skip stop and remove successfully", func() {
 			container := MockContainer(

--- a/pkg/container/container_target.go
+++ b/pkg/container/container_target.go
@@ -97,7 +97,26 @@ func StartTargetContainer(
 			WithField("new_id", createdContainerID).
 			Debug("Failed to start new container")
 
-		return createdContainerID, fmt.Errorf("%w: %w", errStartContainerFailed, err)
+		// Remove the unstarted container so retries are not blocked by name
+		// conflicts and orphaned created containers do not accumulate.
+		cleanupCtx, cancel := context.WithTimeout(
+			context.WithoutCancel(ctx),
+			cleanupTimeout,
+		)
+		defer cancel()
+
+		_, rmErr := api.ContainerRemove(
+			cleanupCtx,
+			string(createdContainerID),
+			dockerClient.ContainerRemoveOptions{Force: true},
+		)
+		if rmErr != nil {
+			clog.WithError(rmErr).
+				WithField("new_id", createdContainerID).
+				Warn("Failed to clean up container after start error")
+		}
+
+		return "", fmt.Errorf("%w: %w", errStartContainerFailed, err)
 	}
 
 	// Log detailed start message
@@ -160,7 +179,11 @@ func CreateTargetContainer(
 	handleCPUSettings(hostConfig, cpuCopyMode, isPodman, clog)
 
 	// Log network details for debugging, including MAC address validation.
-	isHostNetwork := sourceContainer.ContainerInfo().HostConfig.NetworkMode.IsHost()
+	isHostNetwork := false
+	if info := sourceContainer.ContainerInfo(); info != nil && info.HostConfig != nil {
+		isHostNetwork = info.HostConfig.NetworkMode.IsHost()
+	}
+
 	debugLogMacAddress(
 		networkConfig,
 		sourceContainer.ID(),

--- a/pkg/container/container_target.go
+++ b/pkg/container/container_target.go
@@ -97,24 +97,11 @@ func StartTargetContainer(
 			WithField("new_id", createdContainerID).
 			Debug("Failed to start new container")
 
-		// Remove the unstarted container so retries are not blocked by name
-		// conflicts and orphaned created containers do not accumulate.
-		cleanupCtx, cancel := context.WithTimeout(
-			context.WithoutCancel(ctx),
-			cleanupTimeout,
-		)
-		defer cancel()
+		// Start failures from cancellation or transport errors can leave the
+		// container state ambiguous. Inspect first and force-remove only when
+		// the container is still stopped so a late-started instance is kept.
 
-		_, rmErr := api.ContainerRemove(
-			cleanupCtx,
-			string(createdContainerID),
-			dockerClient.ContainerRemoveOptions{Force: true},
-		)
-		if rmErr != nil {
-			clog.WithError(rmErr).
-				WithField("new_id", createdContainerID).
-				Warn("Failed to clean up container after start error")
-		}
+		cleanupFailedStartContainer(ctx, api, clog, createdContainerID)
 
 		return "", fmt.Errorf("%w: %w", errStartContainerFailed, err)
 	}
@@ -128,6 +115,60 @@ func StartTargetContainer(
 	clog.WithField("new_id", createdContainerID.ShortID()).Info(message)
 
 	return createdContainerID, nil
+}
+
+// cleanupFailedStartContainer inspects a container that failed to start and
+// force-removes it only when it is still stopped. Cancellation or transport
+// failures can leave state ambiguous. A late-started container is left alone.
+//
+// Parameters:
+//   - parentCtx: Parent context; deadlines are detached so cleanup can finish.
+//   - api: Interface for container operations.
+//   - clog: Logger with container context fields.
+//   - containerID: ID of the container created before the start failure.
+func cleanupFailedStartContainer(
+	parentCtx context.Context,
+	api Operations,
+	clog *logrus.Entry,
+	containerID types.ContainerID,
+) {
+	cleanupCtx, cancel := context.WithTimeout(
+		context.WithoutCancel(parentCtx),
+		cleanupTimeout,
+	)
+	defer cancel()
+
+	inspectResult, inspectErr := api.ContainerInspect(
+		cleanupCtx,
+		string(containerID),
+		dockerClient.ContainerInspectOptions{},
+	)
+	if inspectErr != nil {
+		clog.WithError(inspectErr).
+			WithField("new_id", containerID).
+			Debug("Failed to inspect container after start error")
+
+		return
+	}
+
+	state := inspectResult.Container.State
+	if state != nil && state.Running {
+		clog.WithField("new_id", containerID).
+			Debug("Skipped cleanup of running container after start error")
+
+		return
+	}
+
+	_, rmErr := api.ContainerRemove(
+		cleanupCtx,
+		string(containerID),
+		dockerClient.ContainerRemoveOptions{Force: true},
+	)
+	if rmErr != nil {
+		clog.WithError(rmErr).
+			WithField("new_id", containerID).
+			Debug("Failed to clean up container after start error")
+	}
 }
 
 // CreateTargetContainer creates a new container based on the source container's

--- a/pkg/container/container_target_test.go
+++ b/pkg/container/container_target_test.go
@@ -258,8 +258,57 @@ var _ = ginkgo.Describe("Target Container Operations", func() {
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("start failed"))
 			gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("Failed to start new container"))
+			gomega.Expect(client.inspectFuncCalled.Load()).To(gomega.BeTrue())
 			gomega.Expect(client.removeFuncCalled.Load()).To(gomega.BeTrue())
 			gomega.Expect(removedID).To(gomega.Equal("new_container_id"))
+		})
+
+		ginkgo.It("should skip cleanup when container is running after start timeout", func() {
+			client.startFunc = func(_ context.Context, _ string, _ dockerClient.ContainerStartOptions) (dockerClient.ContainerStartResult, error) {
+				return dockerClient.ContainerStartResult{}, context.DeadlineExceeded
+			}
+			client.inspectFunc = func(_ context.Context, id string, _ dockerClient.ContainerInspectOptions) (dockerClient.ContainerInspectResult, error) {
+				return dockerClient.ContainerInspectResult{
+					Container: dockerContainer.InspectResponse{
+						ID: id,
+						State: &dockerContainer.State{
+							Status:  "running",
+							Running: true,
+						},
+					},
+				}, nil
+			}
+
+			newID, err := StartTargetContainer(
+				context.Background(), client, mockCont, networkConfig,
+				true, "1.44", flags.DockerAPIMinVersion, false, "auto", false,
+			)
+			gomega.Expect(newID).To(gomega.BeEmpty())
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(errors.Is(err, context.DeadlineExceeded)).To(gomega.BeTrue())
+			gomega.Expect(client.inspectFuncCalled.Load()).To(gomega.BeTrue())
+			gomega.Expect(client.removeFuncCalled.Load()).To(gomega.BeFalse())
+			gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("Skipped cleanup of running container after start error"))
+		})
+
+		ginkgo.It("should skip cleanup when inspect fails after transport error", func() {
+			client.startFunc = func(_ context.Context, _ string, _ dockerClient.ContainerStartOptions) (dockerClient.ContainerStartResult, error) {
+				return dockerClient.ContainerStartResult{}, errors.New("connection reset by peer")
+			}
+			client.inspectFunc = func(_ context.Context, _ string, _ dockerClient.ContainerInspectOptions) (dockerClient.ContainerInspectResult, error) {
+				return dockerClient.ContainerInspectResult{}, errors.New("inspect transport failure")
+			}
+
+			newID, err := StartTargetContainer(
+				context.Background(), client, mockCont, networkConfig,
+				true, "1.44", flags.DockerAPIMinVersion, false, "auto", false,
+			)
+			gomega.Expect(newID).To(gomega.BeEmpty())
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("connection reset by peer"))
+			gomega.Expect(client.inspectFuncCalled.Load()).To(gomega.BeTrue())
+			gomega.Expect(client.removeFuncCalled.Load()).To(gomega.BeFalse())
+			gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("Failed to inspect container after start error"))
 		})
 
 		ginkgo.It("should handle ContainerCreate Conflict error", func() {

--- a/pkg/container/container_target_test.go
+++ b/pkg/container/container_target_test.go
@@ -240,14 +240,26 @@ var _ = ginkgo.Describe("Target Container Operations", func() {
 			client.startFunc = func(_ context.Context, _ string, _ dockerClient.ContainerStartOptions) (dockerClient.ContainerStartResult, error) {
 				return dockerClient.ContainerStartResult{}, startErr
 			}
+
+			var removedID string
+
+			client.removeFunc = func(_ context.Context, id string, _ dockerClient.ContainerRemoveOptions) (dockerClient.ContainerRemoveResult, error) {
+				removedID = id
+
+				client.removeFuncCalled.Store(true)
+
+				return dockerClient.ContainerRemoveResult{}, nil
+			}
 			newID, err := StartTargetContainer(
 				context.Background(), client, mockCont, networkConfig,
 				true, "1.44", flags.DockerAPIMinVersion, false, "auto", false,
 			)
-			gomega.Expect(newID).To(gomega.Equal(types.ContainerID("new_container_id")))
+			gomega.Expect(newID).To(gomega.BeEmpty())
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("start failed"))
 			gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("Failed to start new container"))
+			gomega.Expect(client.removeFuncCalled.Load()).To(gomega.BeTrue())
+			gomega.Expect(removedID).To(gomega.Equal("new_container_id"))
 		})
 
 		ginkgo.It("should handle ContainerCreate Conflict error", func() {
@@ -289,7 +301,7 @@ var _ = ginkgo.Describe("Target Container Operations", func() {
 				context.Background(), client, mockCont, networkConfig,
 				true, "1.44", flags.DockerAPIMinVersion, false, "auto", false,
 			)
-			gomega.Expect(newID).To(gomega.Equal(types.ContainerID("new_container_id")))
+			gomega.Expect(newID).To(gomega.BeEmpty())
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to start container"))
 			gomega.Expect(cerrdefs.IsConflict(err)).To(gomega.BeTrue(),
@@ -297,6 +309,7 @@ var _ = ginkgo.Describe("Target Container Operations", func() {
 			gomega.Expect(errors.Is(err, cerrdefs.ErrConflict)).To(gomega.BeTrue(),
 				"wrapped error should be detectable via errors.Is")
 			gomega.Expect(logOutput.String()).To(gomega.ContainSubstring("Failed to start new container"))
+			gomega.Expect(client.removeFuncCalled.Load()).To(gomega.BeTrue())
 		})
 
 		ginkgo.It("should handle ContainerStart NotFound error", func() {
@@ -307,9 +320,10 @@ var _ = ginkgo.Describe("Target Container Operations", func() {
 				context.Background(), client, mockCont, networkConfig,
 				true, "1.44", flags.DockerAPIMinVersion, false, "auto", false,
 			)
-			gomega.Expect(newID).To(gomega.Equal(types.ContainerID("new_container_id")))
+			gomega.Expect(newID).To(gomega.BeEmpty())
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to start container"))
+			gomega.Expect(client.removeFuncCalled.Load()).To(gomega.BeTrue())
 		})
 
 		ginkgo.It("should log successful container start", func() {

--- a/pkg/container/mocks/Operations.go
+++ b/pkg/container/mocks/Operations.go
@@ -104,6 +104,78 @@ func (_c *MockOperations_ContainerCreate_Call) RunAndReturn(run func(ctx context
 	return _c
 }
 
+// ContainerInspect provides a mock function for the type MockOperations
+func (_mock *MockOperations) ContainerInspect(ctx context.Context, containerID string, options client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+	ret := _mock.Called(ctx, containerID, options)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ContainerInspect")
+	}
+
+	var r0 client.ContainerInspectResult
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, client.ContainerInspectOptions) (client.ContainerInspectResult, error)); ok {
+		return returnFunc(ctx, containerID, options)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, client.ContainerInspectOptions) client.ContainerInspectResult); ok {
+		r0 = returnFunc(ctx, containerID, options)
+	} else {
+		r0 = ret.Get(0).(client.ContainerInspectResult)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, client.ContainerInspectOptions) error); ok {
+		r1 = returnFunc(ctx, containerID, options)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockOperations_ContainerInspect_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ContainerInspect'
+type MockOperations_ContainerInspect_Call struct {
+	*mock.Call
+}
+
+// ContainerInspect is a helper method to define mock.On call
+//   - ctx context.Context
+//   - containerID string
+//   - options client.ContainerInspectOptions
+func (_e *MockOperations_Expecter) ContainerInspect(ctx any, containerID any, options any) *MockOperations_ContainerInspect_Call {
+	return &MockOperations_ContainerInspect_Call{Call: _e.mock.On("ContainerInspect", ctx, containerID, options)}
+}
+
+func (_c *MockOperations_ContainerInspect_Call) Run(run func(ctx context.Context, containerID string, options client.ContainerInspectOptions)) *MockOperations_ContainerInspect_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 client.ContainerInspectOptions
+		if args[2] != nil {
+			arg2 = args[2].(client.ContainerInspectOptions)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockOperations_ContainerInspect_Call) Return(containerInspectResult client.ContainerInspectResult, err error) *MockOperations_ContainerInspect_Call {
+	_c.Call.Return(containerInspectResult, err)
+	return _c
+}
+
+func (_c *MockOperations_ContainerInspect_Call) RunAndReturn(run func(ctx context.Context, containerID string, options client.ContainerInspectOptions) (client.ContainerInspectResult, error)) *MockOperations_ContainerInspect_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ContainerRemove provides a mock function for the type MockOperations
 func (_mock *MockOperations) ContainerRemove(ctx context.Context, containerID string, options client.ContainerRemoveOptions) (client.ContainerRemoveResult, error) {
 	ret := _mock.Called(ctx, containerID, options)


### PR DESCRIPTION
This PR hardens container recreation so failed starts do not leave orphaned containers and incomplete inspect data does not panic the update path.

## Problem

When a recreated container failed to start, the unstarted instance could remain and block retries by holding the container name. Missing host configuration on inspect responses could also cause panics during stop and network handling.

## Solution

Remove unstarted containers after start failure and treat missing host configuration as a non-AutoRemove path with safe defaults for network mode checks.

## Changes

- Remove unstarted containers after start failure
- Guard nil host configuration when checking AutoRemove and network mode
- Extend container unit coverage for start-failure cleanup and nil host config handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented potential crashes when container configuration details (such as host settings) are missing.
  * Improved reliability of container startup by performing best-effort cleanup on failure.
  * Made network-mode detection safer to avoid nil-related issues.
  * Enhanced stop/remove behavior to correctly handle cases where host configuration is absent.
* **Tests**
  * Expanded scenarios to cover missing host configuration and verify container cleanup and stop/delete requests on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->