### PR TITLE
fix(actions): harden self-update failure and cancel recovery

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1217,15 +1217,17 @@ func TestValidateRollingRestartDependenciesAcceptsCancelableContext(t *testing.T
 
 	// Test with timeout context
 	t.Run("timeout context is propagated to client", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		// Use a short but non-trivial timeout; Windows timer resolution can
+		// delay sub-15ms deadlines, so wait by polling rather than a fixed sleep.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
 		defer cancel()
 
-		// Wait for context to timeout; sleep long enough for the deadline
-		// to pass reliably across all platforms, including Windows where
-		// timer resolution can delay very short timeouts.
-		time.Sleep(time.Millisecond * 10)
+		deadline := time.Now().Add(500 * time.Millisecond)
+		for ctx.Err() == nil {
+			require.True(t, time.Now().Before(deadline), "context deadline should expire within wait window")
+			time.Sleep(5 * time.Millisecond)
+		}
 
-		// Verify context has expired before proceeding
 		require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
 
 		// Mock expects ListContainers to be called with timed out context

--- a/internal/actions/actions_internal_test.go
+++ b/internal/actions/actions_internal_test.go
@@ -1461,6 +1461,107 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 		}
 	})
 
+	ginkgo.Describe("Watchtower self-update create failure recovery", func() {
+		ginkgo.It("renames the source back to the original name when create fails", func() {
+			client := mockActions.CreateMockClient(
+				&mockActions.TestData{
+					Containers: []types.Container{
+						mockActions.CreateMockContainerWithConfig(
+							"watchtower-source-id",
+							"/watchtower",
+							"watchtower:latest",
+							true,
+							false,
+							time.Now(),
+							&dockerContainer.Config{
+								Labels: map[string]string{
+									"com.centurylinklabs.watchtower": "true",
+								},
+							}),
+					},
+					Staleness: map[string]bool{
+						"watchtower": true,
+					},
+					CreateContainerError: errors.New("simulated create failure"),
+				},
+				false,
+				false,
+			)
+
+			params := types.UpdateParams{
+				Timeout: 0,
+				RunOnce: false,
+			}
+
+			testContainer := client.TestData.Containers[0]
+			_, renamed, err := restartStaleContainer(
+				context.Background(),
+				testContainer,
+				client,
+				params,
+			)
+
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to create container"))
+			gomega.Expect(renamed).To(gomega.BeFalse(), "name should be restored after create failure")
+			gomega.Expect(client.TestData.RenameContainerCount.Load()).To(gomega.Equal(int32(2)))
+			gomega.Expect(client.TestData.RenameTargets).To(gomega.HaveLen(2))
+			gomega.Expect(client.TestData.RenameTargets[1]).To(gomega.Equal("watchtower"))
+			gomega.Expect(client.TestData.StartContainerCount.Load()).To(gomega.Equal(int32(0)))
+		})
+	})
+
+	ginkgo.Describe("Watchtower self-update start failure cleanup", func() {
+		ginkgo.It("removes the newly created container, not the renamed source", func() {
+			client := mockActions.CreateMockClient(
+				&mockActions.TestData{
+					Containers: []types.Container{
+						mockActions.CreateMockContainerWithConfig(
+							"watchtower-source-id",
+							"/watchtower",
+							"watchtower:latest",
+							true,
+							false,
+							time.Now(),
+							&dockerContainer.Config{
+								Labels: map[string]string{
+									"com.centurylinklabs.watchtower": "true",
+								},
+							}),
+					},
+					Staleness: map[string]bool{
+						"watchtower": true,
+					},
+					StartContainerError: errors.New("simulated start failure"),
+				},
+				false,
+				false,
+			)
+
+			params := types.UpdateParams{
+				Timeout: 0,
+				RunOnce: false,
+			}
+
+			testContainer := client.TestData.Containers[0]
+			_, renamed, err := restartStaleContainer(
+				context.Background(),
+				testContainer,
+				client,
+				params,
+			)
+
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to start container"))
+			gomega.Expect(renamed).To(gomega.BeTrue())
+			gomega.Expect(client.TestData.CreateContainerCount.Load()).To(gomega.Equal(int32(1)))
+			gomega.Expect(client.TestData.LastCreatedContainerID).ToNot(gomega.BeEmpty())
+			gomega.Expect(client.TestData.StopAndRemoveContainerCount.Load()).To(gomega.Equal(int32(1)))
+			gomega.Expect(client.TestData.LastStopAndRemoveID).To(gomega.Equal(client.TestData.LastCreatedContainerID))
+			gomega.Expect(client.TestData.LastStopAndRemoveID).ToNot(gomega.Equal(testContainer.ID()))
+		})
+	})
+
 	ginkgo.Describe("restartStaleContainer detached context survival", func() {
 		ginkgo.It("cleanup operations complete when parent context is canceled during execution", func() {
 			// Create a parent context that we will cancel while restartStaleContainer is running.
@@ -2100,6 +2201,70 @@ var _ = ginkgo.Describe("stopContainersInReversedOrder", func() {
 			gomega.Expect(client.TestData.StopOrder[1]).To(gomega.Equal("container-1"))
 			gomega.Expect(client.TestData.StopOrder[2]).To(gomega.Equal("container-0"))
 		})
+	})
+})
+
+var _ = ginkgo.Describe("restartContainersInSortedOrder cancel recovery", func() {
+	ginkgo.It("still recreates containers that were already stopped when parent ctx is canceled", func() {
+		containers := make([]types.Container, 3)
+
+		for i := range 3 {
+			c := mockActions.CreateMockContainerWithConfig(
+				fmt.Sprintf("container-%d", i),
+				fmt.Sprintf("/container-%d", i),
+				fmt.Sprintf("image-%d:latest", i),
+				true,
+				false,
+				time.Now(),
+				&dockerContainer.Config{
+					Labels:       map[string]string{},
+					ExposedPorts: dockerNetwork.PortSet{},
+				},
+			)
+			c.SetStale(true)
+			containers[i] = c
+		}
+
+		client := mockActions.CreateMockClient(
+			&mockActions.TestData{
+				Containers: containers,
+				Staleness: map[string]bool{
+					"container-0": true,
+					"container-1": true,
+					"container-2": true,
+				},
+			},
+			false,
+			false,
+		)
+
+		// Pretend the stop phase already removed all three.
+		stoppedImages := []types.RemovedImageInfo{
+			{ContainerID: containers[0].ID(), ImageID: containers[0].ImageID(), ImageName: containers[0].ImageName(), ContainerName: containers[0].Name()},
+			{ContainerID: containers[1].ID(), ImageID: containers[1].ImageID(), ImageName: containers[1].ImageName(), ContainerName: containers[1].Name()},
+			{ContainerID: containers[2].ID(), ImageID: containers[2].ImageID(), ImageName: containers[2].ImageName(), ContainerName: containers[2].Name()},
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		progress := session.Progress{}
+
+		var cleanup []types.RemovedImageInfo
+
+		failed := restartContainersInSortedOrder(
+			ctx,
+			containers,
+			client,
+			types.UpdateParams{Timeout: 0},
+			stoppedImages,
+			&cleanup,
+			&progress,
+		)
+
+		gomega.Expect(failed).To(gomega.BeEmpty(), "stopped containers must still be recreated after cancel")
+		gomega.Expect(client.TestData.CreateContainerCount.Load()).To(gomega.Equal(int32(3)))
+		gomega.Expect(client.TestData.StartContainerCount.Load()).To(gomega.Equal(int32(3)))
 	})
 })
 
@@ -2995,5 +3160,20 @@ var _ = ginkgo.Describe("isPinned", func() {
 		gomega.Expect(err).To(gomega.HaveOccurred())
 		gomega.Expect(pinned).To(gomega.BeFalse())
 		gomega.Expect(progress).To(gomega.BeEmpty())
+	})
+
+	ginkgo.It("does not panic when ContainerInfo Config is nil", func() {
+		cont := mockTypes.NewMockContainer(ginkgo.GinkgoT())
+		cont.On("Name").Return("/nil-config")
+		cont.On("ImageName").Return("nginx:latest")
+		cont.On("ContainerInfo").Return(&dockerContainer.InspectResponse{
+			Config: nil,
+		})
+
+		progress := session.Progress{}
+
+		pinned, err := isPinned(cont, &progress, types.UpdateParams{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pinned).To(gomega.BeFalse())
 	})
 })

--- a/internal/actions/ephemeral.go
+++ b/internal/actions/ephemeral.go
@@ -44,6 +44,8 @@ var (
 	errOrchestratorStartFailed = errors.New("failed to start new container")
 	// errOrchestratorInspectFailed indicates a failure to inspect a container during orchestration.
 	errOrchestratorInspectFailed = errors.New("failed to inspect container during orchestration")
+	// errOrchestratorRenameFailed indicates a failure to rename the old container before handoff.
+	errOrchestratorRenameFailed = errors.New("failed to rename old container for handoff")
 	// errNewContainerNotRunning indicates the new container is not running after start.
 	errNewContainerNotRunning = errors.New("new container is not running after start")
 )
@@ -179,15 +181,14 @@ func EphemeralSelfUpdate(
 // The orchestrator follows a deterministic state machine:
 //  1. VALIDATE: Read and validate environment variables
 //  2. INSPECT: Get the old container's full configuration
-//  3. STOP OLD: Stop the old Watchtower container
+//  3. RENAME OLD: Free the original name while keeping the process running
 //  4. CREATE NEW: Create a new container from the new image with the same config
 //  5. START NEW: Start the new Watchtower container
 //  6. VERIFY: Confirm the new container is running
-//  7. CLEANUP OLD: Remove the old container
+//  7. CLEANUP OLD: Stop and remove the renamed predecessor
 //
-// If the new container fails to start or is not running, the old container is
-// preserved for manual recovery. Automatic rollback is not supported because
-// client.StartContainer creates a new container rather than restarting the old one.
+// If create/start/verify fails after rename, the original name is restored on the
+// old container so a running Watchtower remains addressable.
 //
 // Parameters:
 //   - ctx: Context for cancellation and timeouts.
@@ -282,14 +283,16 @@ func readOrchestratorEnv() (string, string, string, string, error) {
 // orchestrateSelfUpdate performs the container replacement sequence for a
 // Watchtower self-update.
 //
-// It follows a deterministic state machine that inspects the old container,
-// stops and removes it, creates and starts a new container from the updated
-// image, and verifies the new container is running before returning.
+// Sequence:
+//  1. Inspect the old container and propagate the chain label.
+//  2. Pin Config.Image to newImage for create.
+//  3. Rename the old container off the original name (process keeps running).
+//  4. Create and start the new container under the original name.
+//  5. Verify the new container is running.
+//  6. Stop and remove the renamed old container.
 //
-// If the new container fails to start or is not running after the update,
-// manual recovery is required because the old container has already been
-// removed. Automatic rollback is not supported since the new container
-// replaces the old one rather than renaming it.
+// On create/start/verify failure after rename, the original name is restored on
+// the old container so a running Watchtower remains addressable.
 //
 // Parameters:
 //   - ctx: Context for cancellation and timeouts.
@@ -327,18 +330,12 @@ func orchestrateSelfUpdate(
 		return err
 	}
 
-	// Stop and remove the old container to free its name.
-	skipRemoval, err := stopAndRemoveOldContainer(
-		ctx,
-		client,
-		clog,
-		oldContainer,
-	)
+	pinContainerCreateImage(oldContainer, newImage, clog)
+
+	renamed, err := renameOldContainerForHandoff(ctx, client, clog, oldContainer, originalName)
 	if err != nil {
 		return err
 	}
-
-	_ = skipRemoval // Removal is skipped only when StopContainer returns NotFound.
 
 	newContainerID, err := createAndStartNewContainer(
 		ctx,
@@ -347,13 +344,30 @@ func orchestrateSelfUpdate(
 		oldContainer,
 	)
 	if err != nil {
+		if renamed {
+			restoreOldContainerName(ctx, client, clog, oldContainer, originalName)
+		}
+
 		return err
 	}
 
 	// Verify the new container is running, starting it explicitly if needed.
 	err = ensureContainerRunning(ctx, client, clog, newContainerID)
 	if err != nil {
+		cleanupFailedNewContainer(ctx, client, clog, newContainerID)
+
+		if renamed {
+			restoreOldContainerName(ctx, client, clog, oldContainer, originalName)
+		}
+
 		return err
+	}
+
+	// New instance is healthy; stop and remove the renamed predecessor.
+	_, stopErr := stopAndRemoveOldContainer(ctx, client, clog, oldContainer)
+	if stopErr != nil {
+		clog.WithError(stopErr).
+			Warn("New Watchtower is running but cleanup of the old container failed")
 	}
 
 	// Emit the actual new container ID at Info level so notification templates
@@ -363,6 +377,124 @@ func orchestrateSelfUpdate(
 		Info("Started new container")
 
 	return nil
+}
+
+// pinContainerCreateImage sets Config.Image on a concrete container.Container so
+// GetCreateConfig uses newImage for the replacement instance.
+func pinContainerCreateImage(oldContainer types.Container, newImage string, clog *logrus.Entry) {
+	if newImage == "" {
+		return
+	}
+
+	c, ok := oldContainer.(*container.Container)
+	if !ok {
+		clog.Debug("Old container is not a concrete Container; cannot pin create image")
+
+		return
+	}
+
+	info := c.ContainerInfo()
+	if info == nil || info.Config == nil {
+		return
+	}
+
+	info.Config.Image = newImage
+	clog.WithField("pinned_image", newImage).Debug("Pinned create image for ephemeral self-update")
+}
+
+// renameOldContainerForHandoff renames the old container off its original name so
+// StartContainer can claim that name. The process keeps running under the new name.
+//
+// Returns:
+//   - renamed: True when a rename was performed (caller must restore on failure).
+//   - error: Non-nil if rename fails.
+func renameOldContainerForHandoff(
+	ctx context.Context,
+	client container.Client,
+	clog *logrus.Entry,
+	oldContainer types.Container,
+	originalName string,
+) (bool, error) {
+	if container.IsOldContainer(oldContainer.Name()) {
+		clog.Debug("Old container already has a watchtower-old name; skipping rename")
+
+		return false, nil
+	}
+
+	targetName := types.WatchtowerOldPrefix + oldContainer.ID().ShortID()
+	clog.WithField("target_name", targetName).Debug("Renaming old Watchtower container to free original name")
+
+	err := client.RenameContainer(ctx, oldContainer, targetName)
+	if err != nil {
+		clog.WithError(err).Error("Failed to rename old container before handoff")
+
+		return false, fmt.Errorf("%w: %w", errOrchestratorRenameFailed, err)
+	}
+
+	clog.WithFields(logrus.Fields{
+		"original_name": originalName,
+		"target_name":   targetName,
+	}).Debug("Renamed old Watchtower container for handoff")
+
+	return true, nil
+}
+
+// restoreOldContainerName renames the old container back to originalName after a
+// failed create/start so operators keep a named running instance.
+func restoreOldContainerName(
+	ctx context.Context,
+	client container.Client,
+	clog *logrus.Entry,
+	oldContainer types.Container,
+	originalName string,
+) {
+	if originalName == "" {
+		return
+	}
+
+	clog.WithField("original_name", originalName).
+		Warn("Restoring old Watchtower container name after handoff failure")
+
+	err := client.RenameContainer(ctx, oldContainer, originalName)
+	if err != nil {
+		clog.WithError(err).
+			WithField("original_name", originalName).
+			Error("Failed to restore old Watchtower container name; manual intervention required")
+
+		return
+	}
+
+	clog.WithField("original_name", originalName).
+		Info("Restored old Watchtower container name after handoff failure")
+}
+
+// cleanupFailedNewContainer best-effort removes a new container that failed
+// verification so the original name can be restored on the old instance.
+func cleanupFailedNewContainer(
+	ctx context.Context,
+	client container.Client,
+	clog *logrus.Entry,
+	newContainerID types.ContainerID,
+) {
+	if newContainerID == "" {
+		return
+	}
+
+	failedNew, err := client.GetContainer(ctx, newContainerID)
+	if err != nil {
+		clog.WithError(err).
+			WithField("new_id", newContainerID.ShortID()).
+			Debug("Failed to inspect failed new container for cleanup")
+
+		return
+	}
+
+	cleanupErr := client.StopAndRemoveContainer(ctx, failedNew, orchestratorStopTimeout)
+	if cleanupErr != nil {
+		clog.WithError(cleanupErr).
+			WithField("new_id", newContainerID.ShortID()).
+			Debug("Failed to remove failed new container after verify error")
+	}
 }
 
 // inspectOldContainer retrieves the old container's configuration and propagates
@@ -559,7 +691,6 @@ func createAndStartNewContainer(
 	)
 	if err != nil {
 		clog.WithError(err).Error("Failed to create and start new container")
-		clog.Warn("Rollback unavailable: the old container has been removed. Manual intervention required.")
 
 		return "", fmt.Errorf("%w: %w", errOrchestratorCreateFailed, err)
 	}
@@ -592,7 +723,6 @@ func ensureContainerRunning(
 	ctr, err := client.GetContainer(ctx, containerID)
 	if err != nil {
 		clog.WithError(err).Error("Failed to inspect new container")
-		clog.Warn("Cannot verify new container is running. Old container was removed. Manual recovery requires recreating the container.")
 
 		return fmt.Errorf("%w: %w", errOrchestratorInspectFailed, err)
 	}
@@ -609,7 +739,6 @@ func ensureContainerRunning(
 	err = client.StartContainerByID(ctx, containerID)
 	if err != nil {
 		clog.WithError(err).Error("Failed to start new container")
-		clog.Warn("Rollback unavailable: the old container has been removed. Manual intervention required.")
 
 		return fmt.Errorf("%w: %w", errOrchestratorStartFailed, err)
 	}
@@ -618,13 +747,12 @@ func ensureContainerRunning(
 	ctr, err = client.GetContainer(ctx, containerID)
 	if err != nil {
 		clog.WithError(err).Error("Failed to inspect new container after start")
-		clog.Warn("Cannot verify new container is running. Old container was removed. Manual recovery requires recreating the container.")
 
 		return fmt.Errorf("%w: %w", errOrchestratorInspectFailed, err)
 	}
 
 	if !ctr.IsRunning() {
-		clog.Error("New container is not running after explicit start. Old container was removed. Manual recovery requires recreating the container.")
+		clog.Error("New container is not running after explicit start")
 
 		return fmt.Errorf("%w: %s", errNewContainerNotRunning, containerID.ShortID())
 	}

--- a/internal/actions/ephemeral_internal_test.go
+++ b/internal/actions/ephemeral_internal_test.go
@@ -1,0 +1,103 @@
+package actions
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	dockerContainer "github.com/moby/moby/api/types/container"
+
+	mockActions "github.com/nicholas-fedor/watchtower/internal/actions/mocks"
+	"github.com/nicholas-fedor/watchtower/pkg/types"
+)
+
+var _ = ginkgo.Describe("orchestrateSelfUpdate handoff", func() {
+	ginkgo.It("renames old container before create and restores name when create fails", func() {
+		old := mockActions.CreateMockContainerWithConfig(
+			"wt-old-id",
+			"/watchtower",
+			"watchtower:v1",
+			true,
+			false,
+			time.Now(),
+			&dockerContainer.Config{
+				Image: "watchtower:v1",
+				Labels: map[string]string{
+					"com.centurylinklabs.watchtower": "true",
+				},
+			},
+		)
+
+		client := mockActions.CreateMockClient(
+			&mockActions.TestData{
+				Containers: []types.Container{old},
+				// Mock StartContainer is the create+start path used by the orchestrator.
+				StartContainerError: errors.New("simulated create failure"),
+			},
+			false,
+			false,
+		)
+
+		err := orchestrateSelfUpdate(
+			context.Background(),
+			client,
+			"wt-old-id",
+			"watchtower:v2",
+			"watchtower",
+			"",
+		)
+
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to create new container"))
+		// Rename off original name, then rename back after create failure.
+		gomega.Expect(client.TestData.RenameContainerCount.Load()).To(gomega.Equal(int32(2)))
+		gomega.Expect(client.TestData.RenameTargets).To(gomega.HaveLen(2))
+		gomega.Expect(client.TestData.RenameTargets[0]).To(gomega.HavePrefix(types.WatchtowerOldPrefix))
+		gomega.Expect(client.TestData.RenameTargets[1]).To(gomega.Equal("watchtower"))
+		// Old instance must not have been stop/removed before create failed.
+		gomega.Expect(client.TestData.StopContainerCount.Load()).To(gomega.Equal(int32(0)))
+	})
+
+	ginkgo.It("stops and removes the renamed old container after successful handoff", func() {
+		old := mockActions.CreateMockContainerWithConfig(
+			"wt-old-id-ok",
+			"/watchtower",
+			"watchtower:v1",
+			true,
+			false,
+			time.Now(),
+			&dockerContainer.Config{
+				Image: "watchtower:v1",
+				Labels: map[string]string{
+					"com.centurylinklabs.watchtower": "true",
+				},
+			},
+		)
+
+		client := mockActions.CreateMockClient(
+			&mockActions.TestData{
+				Containers: []types.Container{old},
+			},
+			false,
+			false,
+		)
+
+		err := orchestrateSelfUpdate(
+			context.Background(),
+			client,
+			"wt-old-id-ok",
+			"watchtower:v2",
+			"watchtower",
+			"",
+		)
+
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(client.TestData.RenameContainerCount.Load()).To(gomega.Equal(int32(1)))
+		gomega.Expect(client.TestData.StartContainerCount.Load()).To(gomega.BeNumerically(">=", int32(1)))
+		// Cleanup of renamed predecessor after successful handoff.
+		gomega.Expect(client.TestData.StopContainerCount.Load()).To(gomega.BeNumerically(">=", int32(1)))
+	})
+})

--- a/internal/actions/mocks/client.go
+++ b/internal/actions/mocks/client.go
@@ -31,8 +31,13 @@ type TestData struct {
 	TriedToRemoveImageCount      atomic.Int32                          // Number of times RemoveImageByID was called.
 	RenameContainerCount         atomic.Int32                          // Number of times RenameContainer was called.
 	StopContainerCount           atomic.Int32                          // Number of times StopContainer was called.
+	StopAndRemoveContainerCount  atomic.Int32                          // Number of times StopAndRemoveContainer was called.
 	StartContainerCount          atomic.Int32                          // Number of times StartContainer was called.
 	CreateContainerCount         atomic.Int32                          // Number of times CreateContainer was called.
+	LastStopAndRemoveID          types.ContainerID                     // ID of the last container passed to StopAndRemoveContainer.
+	LastCreatedContainerID       types.ContainerID                     // ID returned by the last successful CreateContainer call.
+	LastRenameTarget             string                                // Last new name passed to RenameContainer.
+	RenameTargets                []string                              // Ordered list of rename targets.
 	UpdateContainerCount         atomic.Int32                          // Number of times UpdateContainer was called.
 	SetNoRestartPolicyCount      atomic.Int32                          // Number of times SetNoRestartPolicy was called.
 	IsContainerStaleCount        atomic.Int32                          // Number of times IsContainerStale was called.
@@ -189,6 +194,9 @@ func (client MockClient) StopContainer(ctx context.Context, c types.Container, _
 // StopAndRemoveContainer simulates stopping and removing a container by calling StopContainer followed by RemoveContainer.
 // It properly simulates the stop-and-remove operation sequence while respecting error conditions.
 func (client MockClient) StopAndRemoveContainer(ctx context.Context, c types.Container, timeout time.Duration) error {
+	client.TestData.StopAndRemoveContainerCount.Add(1)
+	client.TestData.LastStopAndRemoveID = c.ID()
+
 	err := client.StopContainer(ctx, c, timeout)
 	if err != nil {
 		return err
@@ -207,6 +215,8 @@ func (client MockClient) IsContainerRunning(c types.Container) bool {
 // configuration without starting it.
 // It provides a minimal implementation for testing purposes.
 // Returns the configured CreateContainerError if set.
+// On success it returns a distinct container ID so callers can distinguish the
+// new instance from the source (required for self-update failure cleanup tests).
 func (client MockClient) CreateContainer(ctx context.Context, c types.Container) (types.ContainerID, error) {
 	client.TestData.CreateContainerCount.Add(1)
 
@@ -220,7 +230,24 @@ func (client MockClient) CreateContainer(ctx context.Context, c types.Container)
 
 	client.TestData.CreateOrder = append(client.TestData.CreateOrder, c.Name())
 
-	return c.ID(), nil
+	newID := types.ContainerID(string(c.ID()) + "-recreated")
+	client.TestData.LastCreatedContainerID = newID
+
+	// Register a lookup entry so GetContainer(newID) succeeds for cleanup paths.
+	if client.TestData.ContainersByID == nil {
+		client.TestData.ContainersByID = make(map[types.ContainerID]types.Container)
+	}
+
+	if _, exists := client.TestData.ContainersByID[newID]; !exists {
+		client.TestData.ContainersByID[newID] = CreateMockContainer(
+			string(newID),
+			c.Name(),
+			c.ImageName(),
+			time.Now(),
+		)
+	}
+
+	return newID, nil
 }
 
 // StartContainer simulates starting a container, returning the container's ID.
@@ -261,8 +288,10 @@ func (client MockClient) StartContainerByID(ctx context.Context, containerID typ
 
 // RenameContainer simulates renaming a container, incrementing the RenameContainerCount.
 // It returns nil to indicate success without modifying any state.
-func (client MockClient) RenameContainer(ctx context.Context, _ types.Container, _ string) error {
+func (client MockClient) RenameContainer(ctx context.Context, _ types.Container, newName string) error {
 	client.TestData.RenameContainerCount.Add(1)
+	client.TestData.LastRenameTarget = newName
+	client.TestData.RenameTargets = append(client.TestData.RenameTargets, newName)
 
 	if err := client.checkContextCancellation(ctx); err != nil {
 		return err

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -1198,7 +1198,12 @@ func isPinned(
 
 	// Get initial image name and configuration.
 	imageName := cont.ImageName()
-	configImage := cont.ContainerInfo().Config.Image
+
+	var configImage string
+	if info := cont.ContainerInfo(); info != nil && info.Config != nil {
+		configImage = info.Config.Image
+	}
+
 	fallbackImage := getFallbackImage(cont)
 
 	// Check if ImageName is invalid and fall back to Config.Image or a derived name.
@@ -1662,33 +1667,6 @@ func restartContainersInSortedOrder(
 	for i := range containers {
 		c := containers[i]
 
-		// Check for context cancellation to avoid additional work when context is canceled.
-		// First, log and track the current container, then iterate remaining containers.
-		if ctx.Err() != nil {
-			// Handle the current container that was not processed due to cancellation.
-			logrus.WithFields(
-				logrus.Fields{
-					"container":    c.Name(),
-					"image":        c.ImageName(),
-					"container_id": c.ID().ShortID(),
-				}).Info("Skipped container restart due to context cancellation")
-			failed[c.ID()] = fmt.Errorf("restart skipped: %w", ctx.Err())
-
-			// Handle remaining containers that were not processed due to cancellation.
-			for j := i + 1; j < len(containers); j++ {
-				skipped := containers[j]
-				logrus.WithFields(
-					logrus.Fields{
-						"container":    skipped.Name(),
-						"image":        skipped.ImageName(),
-						"container_id": skipped.ID().ShortID(),
-					}).Info("Skipped container restart due to context cancellation")
-				failed[skipped.ID()] = fmt.Errorf("restart skipped: %w", ctx.Err())
-			}
-
-			return failed
-		}
-
 		if !c.ToRestart() {
 			continue
 		}
@@ -1713,6 +1691,28 @@ func restartContainersInSortedOrder(
 		if c.IsWatchtower() && config.CurrentContainerID != "" &&
 			c.ID() != config.CurrentContainerID {
 			continue
+		}
+
+		// Parent cancellation must not strand containers already removed in the
+		// stop phase. restartStaleContainer uses a detached context for create/start,
+		// so continue recreating stopped (and self-update) instances. Containers that
+		// were never stopped can be skipped safely.
+		if ctx.Err() != nil && !c.IsWatchtower() && !wasStopped {
+			logrus.WithFields(
+				logrus.Fields{
+					"container":    c.Name(),
+					"image":        c.ImageName(),
+					"container_id": c.ID().ShortID(),
+				}).Info("Skipped container restart due to context cancellation")
+			failed[c.ID()] = fmt.Errorf("restart skipped: %w", ctx.Err())
+
+			continue
+		}
+
+		if ctx.Err() != nil && (c.IsWatchtower() || wasStopped) {
+			logrus.WithFields(fields).
+				WithField("container_id", c.ID().ShortID()).
+				Info("Parent context canceled; continuing restart of stopped container")
 		}
 
 		// Restart Watchtower containers regardless of stoppedImages, as they are renamed.
@@ -1833,7 +1833,10 @@ func restartStaleContainer(
 		"image":     sourceContainer.ImageName(),
 	}
 
-	var renamed bool
+	var (
+		renamed                bool
+		originalWatchtowerName string
+	)
 
 	// Rename Watchtower containers regardless of NoRestart flag,
 	// but skip in run-once mode as there's no need to avoid conflicts
@@ -1876,6 +1879,7 @@ func restartStaleContainer(
 
 			renamed = true
 		} else {
+			originalWatchtowerName = sourceContainer.Name()
 			newName := targetOldName
 
 			err := client.RenameContainer(
@@ -1946,6 +1950,29 @@ func restartStaleContainer(
 			WithError(err).
 			Debug("Failed to create container")
 
+		// Restore the original name so the running instance is not left only as
+		// watchtower-old-* with the canonical name free and unused.
+		if renamed && originalWatchtowerName != "" && sourceContainer.IsWatchtower() {
+			//nolint:contextcheck // Using detached context intentionally to survive parent cancellation
+			renameBackErr := client.RenameContainer(
+				detachedCtx,
+				sourceContainer,
+				originalWatchtowerName,
+			)
+			if renameBackErr != nil {
+				logrus.WithError(renameBackErr).
+					WithFields(fields).
+					WithField("original_name", originalWatchtowerName).
+					Debug("Failed to rename Watchtower container back after create failure")
+			} else {
+				renamed = false
+
+				logrus.WithFields(fields).
+					WithField("original_name", originalWatchtowerName).
+					Debug("Restored Watchtower container name after create failure")
+			}
+		}
+
 		return "",
 			renamed,
 			fmt.Errorf(
@@ -1969,22 +1996,34 @@ func restartStaleContainer(
 				WithError(err).
 				Debug("Failed to start container")
 
-			// If there's an error and the container is an old Watchtower container,
-			// then stop and remove it.
+				// On start failure after a Watchtower rename, remove only the newly
+			// created container. The renamed source still holds the running process
+			// and must remain so the host keeps a Watchtower instance.
 			if renamed && sourceContainer.IsWatchtower() {
 				logrus.WithFields(fields).
+					WithField("new_id", newContainerID.ShortID()).
 					Debug("Cleaning up failed Watchtower container")
 
 				//nolint:contextcheck // Using detached context intentionally to survive parent cancellation
-				cleanupErr := client.StopAndRemoveContainer(
-					detachedCtx,
-					sourceContainer,
-					config.Timeout,
-				)
-				if cleanupErr != nil {
-					logrus.WithError(cleanupErr).
+				failedNew, getErr := client.GetContainer(detachedCtx, newContainerID)
+				if getErr != nil {
+					logrus.WithError(getErr).
 						WithFields(fields).
-						Debug("Failed to stop failed Watchtower container")
+						WithField("new_id", newContainerID.ShortID()).
+						Debug("Failed to inspect failed Watchtower container for cleanup")
+				} else {
+					//nolint:contextcheck // Using detached context intentionally to survive parent cancellation
+					cleanupErr := client.StopAndRemoveContainer(
+						detachedCtx,
+						failedNew,
+						config.Timeout,
+					)
+					if cleanupErr != nil {
+						logrus.WithError(cleanupErr).
+							WithFields(fields).
+							WithField("new_id", newContainerID.ShortID()).
+							Debug("Failed to stop failed Watchtower container")
+					}
 				}
 			}
 


### PR DESCRIPTION
This PR hardens Watchtower self-update and batch restart recovery so failed handoffs and mid-update cancellation are less likely to leave the host without a running instance.

## Problem

Self-update failure paths could clean up the wrong container, leave the live instance under an old name after create failure, or remove the only running instance before a replacement was ready. Parent context cancellation after the stop phase could also skip recreation of containers that had already been removed.

## Solution

Keep legacy rename-based self-update expectations, restore names and clean up only failed replacements on error, continue recreating already-stopped containers after parent cancel, and use rename-first ephemeral handoff with name restore when create or start fails.

## Changes

- Restore Watchtower container names after failed self-update create
- Remove only the newly created container on Watchtower start failure
- Continue recreating stopped containers after parent context cancellation
- Use rename-first ephemeral self-update with name restore on failure
- Guard nil container config when resolving pinned image references
- Expand actions unit coverage for self-update failure and cancel recovery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-updates with rename-based handoffs, including automatic restoration when replacement creation or startup fails.
  * Fixed self-update failure handling to avoid removing or disrupting the currently working container.
  * Enhanced cleanup so only the newly created replacement is removed when recovery fails.
  * Improved restart behavior during cancellation by continuing eligible restarts while skipping non-stopped containers.
  * Made pinned-image detection more robust when container configuration details are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->