### PR TITLE
fix(scheduling): honor Compose depends_on during scheduled updates

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1108,6 +1108,7 @@ func runMain(cfg types.RunConfig) int {
 		startupMessageSent,
 		ephemeralSelfUpdate,
 		reviveStopped,
+		useComposeDependsOn,
 	)
 	if err != nil {
 		logNotify("Scheduled upgrades failed", err)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -551,6 +551,7 @@ func TestUpdateOnStartTriggersImmediateUpdate(t *testing.T) {
 		false, // startupMessageSent
 		false, // ephemeralSelfUpdate
 		false, // reviveStopped
+		false, // useComposeDependsOn
 	)
 
 	// Should not return an error (context cancellation is expected)
@@ -642,6 +643,7 @@ func TestUpdateOnStartIntegratesWithCronScheduling(t *testing.T) {
 			false, // startupMessageSent
 			false, // ephemeralSelfUpdate
 			false, // reviveStopped
+			false, // useComposeDependsOn
 		)
 
 		// Should not return an error (context cancellation is expected)
@@ -737,6 +739,7 @@ func TestUpdateOnStartLockingBehavior(t *testing.T) {
 			false, // startupMessageSent
 			false, // ephemeralSelfUpdate
 			false, // reviveStopped
+			false, // useComposeDependsOn
 		)
 
 		// Should not return an error
@@ -813,6 +816,7 @@ func TestUpdateOnStartSelfUpdateScenario(t *testing.T) {
 			false, // startupMessageSent
 			false, // ephemeralSelfUpdate
 			false, // reviveStopped
+			false, // useComposeDependsOn
 		)
 
 		// Should not return an error
@@ -902,6 +906,7 @@ func TestUpdateOnStartMultiInstanceScenario(t *testing.T) {
 				false, // startupMessageSent
 				false, // ephemeralSelfUpdate
 				false, // reviveStopped
+				false, // useComposeDependsOn
 			)
 			assert.NoError(t, err)
 			completed.Add(1)
@@ -936,6 +941,7 @@ func TestUpdateOnStartMultiInstanceScenario(t *testing.T) {
 				false, // startupMessageSent
 				false, // ephemeralSelfUpdate
 				false, // reviveStopped
+				false, // useComposeDependsOn
 			)
 			assert.NoError(t, err)
 			completed.Add(1)
@@ -1137,6 +1143,7 @@ func TestRunUpgradesOnSchedule_ShutdownWaitsForRunningUpdate(t *testing.T) {
 				false, // startupMessageSent
 				false, // ephemeralSelfUpdate
 				false, // reviveStopped
+				false, // useComposeDependsOn
 			)
 			assert.NoError(t, err)
 
@@ -1303,6 +1310,7 @@ func TestEphemeralSelfUpdateExercisesTruePath(t *testing.T) {
 		false, // startupMessageSent
 		true,  // ephemeralSelfUpdate
 		false, // reviveStopped
+		false, // useComposeDependsOn
 	)
 
 	require.NoError(t, err)

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -674,6 +674,7 @@ func TestIntegration_APIAndScheduling_ConcurrentWithUnblockHTTPAPI(t *testing.T)
 		true,
 		false,
 		false, // reviveStopped
+		false, // useComposeDependsOn
 	)
 	require.NoError(t, err, "RunUpgradesOnSchedule should run concurrently after SetupAndStartAPI returns")
 }

--- a/internal/scheduling/scheduling.go
+++ b/internal/scheduling/scheduling.go
@@ -79,6 +79,7 @@ func WaitForRunningUpdate(ctx context.Context, lock chan bool) {
 //   - startupMessageSent: Whether the startup message was already sent (e.g., by the HTTP API in blocking mode).
 //   - ephemeralSelfUpdate: Whether the self-update uses ephemeral mode (removes old container before creating new one).
 //   - reviveStopped: Whether to start stopped containers after update.
+//   - useComposeDependsOn: Whether to honor Docker Compose depends_on labels during updates.
 //
 // Returns:
 //   - error: An error if scheduling fails (e.g., invalid cron spec), nil on successful shutdown.
@@ -103,6 +104,7 @@ func RunUpgradesOnSchedule(
 	startupMessageSent bool,
 	ephemeralSelfUpdate bool,
 	reviveStopped bool,
+	useComposeDependsOn bool,
 ) error {
 	// Initialize lock if not provided, ensuring single-update concurrency.
 	if lock == nil {
@@ -182,11 +184,12 @@ func RunUpgradesOnSchedule(
 		}
 
 		params := types.UpdateParams{
-			Cleanup:        cleanup,
-			RunOnce:        false,
-			MonitorOnly:    monitorOnly,
-			SkipSelfUpdate: skipWatchtowerSelfUpdate,
-			ReviveStopped:  reviveStopped,
+			Cleanup:             cleanup,
+			RunOnce:             false,
+			MonitorOnly:         monitorOnly,
+			SkipSelfUpdate:      skipWatchtowerSelfUpdate,
+			ReviveStopped:       reviveStopped,
+			UseComposeDependsOn: useComposeDependsOn,
 		}
 
 		metric := runUpdatesWithNotifications(ctx, filter, params)

--- a/internal/scheduling/scheduling_test.go
+++ b/internal/scheduling/scheduling_test.go
@@ -145,6 +145,7 @@ func TestRunUpgradesOnSchedule_EmptySchedule(t *testing.T) {
 		false, // startupMessageSent
 		false, // ephemeralSelfUpdate
 		false, // reviveStopped
+		false, // useComposeDependsOn
 	)
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
@@ -195,6 +196,7 @@ func TestRunUpgradesOnSchedule_StartupMessageSuppressed(t *testing.T) {
 		true,  // startupMessageSent - suppress the startup message
 		false, // ephemeralSelfUpdate
 		false, // reviveStopped
+		false, // useComposeDependsOn
 	)
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
@@ -249,6 +251,7 @@ func TestRunUpgradesOnSchedule_UpdateOnStart(t *testing.T) {
 		false, // startupMessageSent
 		false, // ephemeralSelfUpdate
 		false, // reviveStopped
+		false, // useComposeDependsOn
 	)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -309,6 +312,7 @@ func TestRunUpgradesOnSchedule_InvalidCronSpec(t *testing.T) {
 		false, // startupMessageSent
 		false, // ephemeralSelfUpdate
 		false, // reviveStopped
+		false, // useComposeDependsOn
 	)
 	if err == nil {
 		t.Error("expected error")
@@ -394,6 +398,7 @@ func TestRunUpgradesOnSchedule_QuotedScheduleSpec(t *testing.T) {
 				false, // startupMessageSent
 				false, // ephemeralSelfUpdate
 				false, // reviveStopped
+				false, // useComposeDependsOn
 			)
 
 			if tt.expectError {
@@ -446,6 +451,7 @@ func TestRunUpgradesOnSchedule_ContextCancellation(t *testing.T) {
 		false, // startupMessageSent
 		false, // ephemeralSelfUpdate
 		false, // reviveStopped
+		false, // useComposeDependsOn
 	)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -512,6 +518,7 @@ func TestRunUpgradesOnSchedule_MonitorOnlyParameter(t *testing.T) {
 				false,          // startupMessageSent
 				false,          // ephemeralSelfUpdate
 				false,          // reviveStopped
+				false,          // useComposeDependsOn
 			)
 			if err != nil {
 				t.Errorf("expected no error, got %v", err)
@@ -647,6 +654,7 @@ func TestRunUpgradesOnSchedule_CronWithSeconds(t *testing.T) {
 		false, // startupMessageSent
 		false, // ephemeralSelfUpdate
 		false, // reviveStopped
+		false, // useComposeDependsOn
 	)
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
@@ -703,6 +711,7 @@ func TestRunUpgradesOnSchedule_SkipFirstRun_True(t *testing.T) {
 		false, // startupMessageSent
 		false, // ephemeralSelfUpdate
 		false, // reviveStopped
+		false, // useComposeDependsOn
 	)
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
@@ -771,6 +780,7 @@ func TestRunUpgradesOnSchedule_WatchtowerParent_Skipping(t *testing.T) {
 		false,           // startupMessageSent
 		false,           // ephemeralSelfUpdate
 		false,           // reviveStopped
+		false,           // useComposeDependsOn
 	)
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
@@ -832,6 +842,7 @@ func TestRunUpgradesOnSchedule_ScheduledRuns_Execution(t *testing.T) {
 		false, // startupMessageSent
 		false, // ephemeralSelfUpdate
 		false, // reviveStopped
+		false, // useComposeDependsOn
 	)
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
@@ -913,6 +924,7 @@ func TestRunUpgradesOnSchedule_EphemeralSelfUpdateWithExposedPorts(t *testing.T)
 		false,              // startupMessageSent
 		true,               // ephemeralSelfUpdate - bypasses port-conflict guard
 		false,              // reviveStopped
+		false,              // useComposeDependsOn
 	)
 	require.NoError(t, err)
 
@@ -977,6 +989,7 @@ func TestRunUpgradesOnSchedule_PortConflictGuard_SkipsSelfUpdate(t *testing.T) {
 		false,              // startupMessageSent
 		false,              // ephemeralSelfUpdate - port-conflict guard is active
 		false,              // reviveStopped
+		false,              // useComposeDependsOn
 	)
 	require.NoError(t, err)
 
@@ -1056,6 +1069,7 @@ func TestRunUpgradesOnSchedule_NoExposedPorts_AllowsSelfUpdate(t *testing.T) {
 				false,            // startupMessageSent
 				tt.ephemeralSelfUpdate,
 				false, // reviveStopped
+				false, // useComposeDependsOn
 			)
 			require.NoError(t, err)
 
@@ -1131,11 +1145,88 @@ func TestRunUpgradesOnSchedule_ReviveStoppedPropagation(t *testing.T) {
 				false,            // startupMessageSent
 				false,            // ephemeralSelfUpdate
 				tt.reviveStopped, // reviveStopped
+				false,            // useComposeDependsOn
 			)
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.expectSelected, capturedParams.ReviveStopped,
 				"ReviveStopped should be %v in UpdateParams", tt.expectSelected)
+		})
+	}
+}
+
+// TestRunUpgradesOnSchedule_UseComposeDependsOnPropagation verifies that
+// RunUpgradesOnSchedule passes UseComposeDependsOn through UpdateParams so
+// scheduled cycles honor Compose depends_on the same way as --run-once.
+func TestRunUpgradesOnSchedule_UseComposeDependsOnPropagation(t *testing.T) {
+	tests := []struct {
+		name                string
+		useComposeDependsOn bool
+		expectSelected      bool
+	}{
+		{
+			name:                "useComposeDependsOn=true",
+			useComposeDependsOn: true,
+			expectSelected:      true,
+		},
+		{
+			name:                "useComposeDependsOn=false",
+			useComposeDependsOn: false,
+			expectSelected:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
+
+			ctx := t.Context()
+
+			var capturedParams types.UpdateParams
+
+			runUpdatesWithNotifications := func(_ context.Context, _ types.Filter, params types.UpdateParams) *metrics.Metric {
+				capturedParams = params
+
+				return &metrics.Metric{Scanned: 1, Updated: 0, Failed: 0}
+			}
+
+			writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {}
+
+			cmd.PersistentFlags().Bool("update-on-start", true, "")
+
+			timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
+			defer timeoutCancel()
+
+			err := scheduling.RunUpgradesOnSchedule(
+				timeoutCtx,
+				cmd,
+				filters.NoFilter,
+				"test filter",
+				nil,   // lock (auto-created)
+				false, // cleanup
+				"",    // empty schedule
+				writeStartupMessage,
+				runUpdatesWithNotifications,
+				client,
+				"",  // scope
+				nil, // no notifier
+				"v1.0.0",
+				false,                  // monitorOnly
+				true,                   // updateOnStart - triggers immediate update
+				false,                  // skipFirstRun
+				nil,                    // currentWatchtowerContainer
+				false,                  // startupMessageSent
+				false,                  // ephemeralSelfUpdate
+				false,                  // reviveStopped
+				tt.useComposeDependsOn, // useComposeDependsOn
+			)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectSelected, capturedParams.UseComposeDependsOn,
+				"UseComposeDependsOn should be %v in UpdateParams", tt.expectSelected)
+			assert.False(t, capturedParams.RunOnce,
+				"scheduled updates must keep RunOnce=false")
 		})
 	}
 }


### PR DESCRIPTION
This PR restores Compose `depends_on` handling on scheduled update cycles so polling runs order container stop/start the same way as `--run-once`.

## Problem

Compose dependency ordering worked on scheduled runs until it became flag-gated. The scheduled path never forwarded that flag into update params, so polling always treated Compose `depends_on` as disabled and could stop or start containers out of dependency order.

## Solution

Propagate the Compose depends-on setting through the scheduler into scheduled update params, matching the run-once path, and cover the propagation with unit tests.

## Changes

- Forward Compose depends-on configuration into scheduled update runs
- Keep scheduler call sites aligned with the updated entrypoint
- Add unit coverage for scheduled propagation of the setting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Scheduled updates now honor the Docker Compose `depends_on` handling setting, including immediate and recurring update runs.

- **Tests**
  - Added coverage to verify that the setting is correctly propagated during scheduled updates.
  - Updated existing scheduling and integration scenarios to account for the new configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->