### PR TITLE
refactor: centralize process configuration as a single source of truth

### DIFF
--- a/cmd/notify-upgrade.go
+++ b/cmd/notify-upgrade.go
@@ -69,7 +69,8 @@ func runNotifyUpgrade(cmd *cobra.Command, args []string) {
 //     Non-critical failures (e.g., file removal after timeout) are logged but do not result in an error return.
 func runNotifyUpgradeE(cmd *cobra.Command, _ []string) error {
 	// Process flag aliases and expand secrets before resolving configuration.
-	flagSet := cmd.Flags()
+	// Use PersistentFlags so env/alias bridging matches config.Load's bind source.
+	flagSet := cmd.PersistentFlags()
 
 	err := flags.ApplyEnvToFlags(flagSet, flags.AllSpecs())
 	if err != nil {

--- a/cmd/notify-upgrade.go
+++ b/cmd/notify-upgrade.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	appconfig "github.com/nicholas-fedor/watchtower/internal/config"
 	"github.com/nicholas-fedor/watchtower/internal/flags"
 	"github.com/nicholas-fedor/watchtower/pkg/notifications"
 )
@@ -67,12 +68,23 @@ func runNotifyUpgrade(cmd *cobra.Command, args []string) {
 //     completes successfully, including cleanup, indicating the notification upgrade process ran without fatal issues.
 //     Non-critical failures (e.g., file removal after timeout) are logged but do not result in an error return.
 func runNotifyUpgradeE(cmd *cobra.Command, _ []string) error {
-	// Process flag aliases to normalize inputs from environment variables or shorthand flags, ensuring consistent configuration.
-	f := cmd.Flags()
-	flags.ProcessFlagAliases(f)
+	// Process flag aliases and expand secrets before resolving configuration.
+	flagSet := cmd.Flags()
 
-	// Initialize the notifier with flag-derived settings, extracting legacy notification configurations into shoutrrr URLs.
-	notifier := notifications.NewNotifier(cmd)
+	err := flags.ApplyEnvToFlags(flagSet, flags.AllSpecs())
+	if err != nil {
+		return fmt.Errorf("apply environment configuration: %w", err)
+	}
+
+	flags.ProcessFlagAliases(flagSet)
+	flags.GetSecretsFromFiles(cmd)
+
+	cfg, loadErr := appconfig.Load(cmd, nil)
+	if loadErr != nil {
+		return fmt.Errorf("load configuration: %w", loadErr)
+	}
+
+	notifier := notifications.NewNotifier(cfg.Notify)
 	urls := notifier.GetURLs()
 
 	// Log the identified notification types (e.g., "email, slack") to inform the user of what configurations are being upgraded.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,11 +3,8 @@ package cmd
 import (
 	"context"
 	"errors"
-	"fmt"
-	"net"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -18,12 +15,12 @@ import (
 	"github.com/nicholas-fedor/watchtower/internal/api"
 	"github.com/nicholas-fedor/watchtower/internal/api/config"
 	"github.com/nicholas-fedor/watchtower/internal/api/handlers/events"
+	appConfig "github.com/nicholas-fedor/watchtower/internal/config"
 	"github.com/nicholas-fedor/watchtower/internal/flags"
 	"github.com/nicholas-fedor/watchtower/internal/logging"
 	"github.com/nicholas-fedor/watchtower/internal/meta"
 	"github.com/nicholas-fedor/watchtower/internal/metrics"
 	"github.com/nicholas-fedor/watchtower/internal/scheduling"
-	"github.com/nicholas-fedor/watchtower/internal/util"
 	"github.com/nicholas-fedor/watchtower/pkg/container"
 	"github.com/nicholas-fedor/watchtower/pkg/filters"
 	"github.com/nicholas-fedor/watchtower/pkg/notifications"
@@ -49,191 +46,25 @@ const (
 )
 
 var (
+	// appCfg is the resolved process configuration from appconfig.Load.
+	//
+	// It is the single source of operational policy for run-once, schedule, and API paths.
+	// Values originate from CLI flags and environment variables registered in internal/flags
+	// and are resolved once at startup (and again in run when positional container names apply).
+	appCfg appConfig.Config
+
 	// client is the Docker client instance used to interact with container operations in Watchtower.
 	//
 	// It provides an interface for listing, stopping, starting, and managing containers, initialized during
-	// the preRun phase with options derived from command-line flags and environment variables such as
-	// DOCKER_HOST, DOCKER_TLS_VERIFY, and DOCKER_API_VERSION.
+	// the preRun phase with options derived from appCfg.ClientOptions() (DOCKER_HOST, TLS, API version, and
+	// related client flags/environment variables).
 	client container.Client
-
-	// useComposeDependsOn is a flag that controls whether the Docker Compose depends_on label
-	// is processed for container dependency ordering.
-	//
-	// It is set in preRun via the --use-compose-depends-on flag or the WATCHTOWER_USE_COMPOSE_DEPENDS_ON environment variable,
-	// defaulting to true for backward compatibility.
-	useComposeDependsOn bool
-
-	// scheduleSpec holds the cron-formatted schedule string that dictates when periodic container updates occur.
-	//
-	// It is populated during preRun from the --schedule flag or the WATCHTOWER_SCHEDULE environment variable,
-	// supporting formats like "@every 1h" or standard cron syntax (e.g., "0 0 * * * *") for flexible scheduling.
-	scheduleSpec string
-
-	// cleanup is a boolean flag determining whether to remove old images after a container update.
-	//
-	// It is set during preRun via the --cleanup flag or the WATCHTOWER_CLEANUP environment variable,
-	// enabling disk space management by deleting outdated images post-update.
-	cleanup bool
-
-	// noRestart is a boolean flag that prevents containers from being restarted after an update.
-	//
-	// It is configured in preRun via the --no-restart flag or the WATCHTOWER_NO_RESTART environment variable,
-	// useful when users prefer manual restart control or want to minimize downtime during updates.
-	noRestart bool
-
-	// reviveStopped is a boolean flag that starts stopped containers after an update.
-	//
-	// It is set in preRun via the --revive-stopped flag or the WATCHTOWER_REVIVE_STOPPED environment variable,
-	// allowing users to have Watchtower start containers that were originally stopped before the update.
-	reviveStopped bool
-
-	// noPull is a boolean flag that skips pulling new images from the registry during updates.
-	//
-	// It is enabled in preRun via the --no-pull flag or the WATCHTOWER_NO_PULL environment variable,
-	// allowing updates to proceed using only locally cached images, potentially reducing network usage.
-	noPull bool
-
-	// monitorOnly is a boolean flag enabling a mode where Watchtower monitors containers without updating them.
-	//
-	// It is set in preRun via the --monitor-only flag or the WATCHTOWER_MONITOR_ONLY environment variable,
-	// ideal for observing image staleness without triggering automatic updates.
-	monitorOnly bool
-
-	// enableLabel is a boolean flag restricting updates to containers with the "com.centurylinklabs.watchtower.enable" label set to true.
-	//
-	// It is configured in preRun via the --label-enable flag or the WATCHTOWER_LABEL_ENABLE environment variable,
-	// providing granular control over which containers are targeted for updates.
-	enableLabel bool
-
-	// disableContainers is a slice of container names explicitly excluded from updates.
-	//
-	// It is populated in preRun from the --disable-containers flag or the WATCHTOWER_DISABLE_CONTAINERS environment variable,
-	// allowing users to blacklist specific containers from Watchtower's operations.
-	disableContainers []string
-
-	// monitoredImageNamePatterns is a slice of image name patterns that
-	// restricts which containers are monitored.
-	//
-	// When set, only containers whose image matches one of these patterns are monitored.
-	// It is populated in preRun from the --monitored-image-name-patterns flag or the
-	// WATCHTOWER_MONITORED_IMAGE_NAME_PATTERNS environment variable, allowing users to
-	// configure specific image patterns for Watchtower's monitoring scope.
-	monitoredImageNamePatterns []string
-
-	// skippedImageNamePatterns is a slice of image name patterns for
-	// containers to exclude from monitoring.
-	//
-	// Matching containers are not monitored. It is populated in preRun from the
-	// --skipped-image-name-patterns flag or the WATCHTOWER_SKIPPED_IMAGE_NAME_PATTERNS
-	// environment variable, providing a way to blacklist specific image patterns.
-	skippedImageNamePatterns []string
-
-	// enabledContainersByLabel is a slice of "key=value" label pairs that
-	// restricts which containers are monitored.
-	//
-	// When set, only containers matching at least one pair are monitored.
-	// It is populated in preRun from the --enable-containers-by-label flag or the
-	// WATCHTOWER_ENABLE_CONTAINERS_BY_LABEL environment variable.
-	enabledContainersByLabel []string
-
-	// disabledContainersByLabel is a slice of "key=value" label pairs for
-	// containers to exclude from monitoring.
-	//
-	// Matching containers are not monitored. It is populated in preRun from the
-	// --disable-containers-by-label flag or the WATCHTOWER_DISABLE_CONTAINERS_BY_LABEL
-	// environment variable, providing a way to blacklist containers by label.
-	disabledContainersByLabel []string
 
 	// notifier is the notification system instance responsible for sending update status messages to configured channels.
 	//
-	// It is initialized in preRun with notification types specified via flags (e.g., --notifications), supporting
-	// multiple methods like email, Slack, or MSTeams to inform users about update successes, failures, or skips.
+	// It is initialized in preRun from appCfg.Notify via notifications.NewNotifier, supporting
+	// Shoutrrr URLs and (deprecated) legacy types such as email, Slack, or MSTeams.
 	notifier types.Notifier
-
-	// timeout specifies the maximum duration allowed for container stop operations during updates.
-	//
-	// It defaults to a value defined in the flags package and can be overridden in preRun via the --timeout flag or
-	// WATCHTOWER_TIMEOUT environment variable, ensuring containers are stopped gracefully within a specified time limit.
-	timeout time.Duration
-
-	// cooldownDelay specifies the minimum age a new image must have before Watchtower will update a container.
-	//
-	// It is set in preRun via the --cooldown-delay flag or the WATCHTOWER_COOLDOWN_DELAY environment variable,
-	// providing a safeguard against supply chain attacks by deferring updates to newly pushed images.
-	cooldownDelay time.Duration
-
-	// lifecycleHooks is a boolean flag enabling the execution of pre- and post-update lifecycle hook commands.
-	//
-	// It is set in preRun via the --enable-lifecycle-hooks flag or the WATCHTOWER_LIFECYCLE_HOOKS environment variable,
-	// allowing custom scripts to run at specific update stages for additional validation or actions.
-	lifecycleHooks bool
-
-	// rollingRestart is a boolean flag enabling rolling restarts, updating containers sequentially rather than all at once.
-	//
-	// It is configured in preRun via the --rolling-restart flag or the WATCHTOWER_ROLLING_RESTART environment variable,
-	// reducing downtime by restarting containers one-by-one during updates.
-	rollingRestart bool
-
-	// includeStopped indicates whether stopped containers are included in updates.
-	//
-	// It is set in preRun via the --include-stopped flag or the WATCHTOWER_INCLUDE_STOPPED environment variable,
-	// allowing Watchtower to manage containers that are not currently running.
-	includeStopped bool
-
-	// includeRestarting indicates whether restarting containers are included in updates.
-	//
-	// It is set in preRun via the --include-restarting flag or the WATCHTOWER_INCLUDE_RESTARTING environment variable,
-	// allowing Watchtower to manage containers that are in the process of restarting.
-	includeRestarting bool
-
-	// scope defines a specific operational scope for Watchtower, limiting updates to containers matching this scope.
-	//
-	// It is set in preRun via the --scope flag or the WATCHTOWER_SCOPE environment variable, useful for isolating
-	// Watchtower's actions to a subset of containers (e.g., a project or environment).
-	scope string
-
-	// labelPrecedence is a boolean flag giving container label settings priority over global command-line flags.
-	//
-	// It is enabled in preRun via the --label-take-precedence flag or the WATCHTOWER_LABEL_PRECEDENCE environment variable,
-	// allowing container-specific configurations to override broader settings for flexibility.
-	labelPrecedence bool
-
-	// lifecycleUID is the default UID to run lifecycle hooks as.
-	//
-	// It is set in preRun via the --lifecycle-uid flag or the WATCHTOWER_LIFECYCLE_UID environment variable,
-	// providing a global default that can be overridden by container labels.
-	lifecycleUID int
-
-	// lifecycleGID is the default GID to run lifecycle hooks as.
-	//
-	// It is set in preRun via the --lifecycle-gid flag or the WATCHTOWER_LIFECYCLE_GID environment variable,
-	// providing a global default that can be overridden by container labels.
-	lifecycleGID int
-
-	// notificationSplitByContainer is a boolean flag enabling separate notifications for each updated container.
-	//
-	// It is set in preRun via the --notification-split-by-container flag or the WATCHTOWER_NOTIFICATION_SPLIT_BY_CONTAINER environment variable,
-	// allowing users to receive individual notifications instead of grouped ones.
-	notificationSplitByContainer bool
-
-	// notificationReport is a boolean flag enabling report-based notifications.
-	//
-	// It is set in preRun via the --notification-report flag or the WATCHTOWER_NOTIFICATION_REPORT environment variable,
-	// controlling whether notifications include session reports or just log entries.
-	notificationReport bool
-
-	// cpuCopyMode specifies how CPU settings are handled when recreating containers.
-	//
-	// It is set during preRun via the --cpu-copy-mode flag or the WATCHTOWER_CPU_COPY_MODE environment variable,
-	// controlling CPU limit copying behavior for compatibility with different container runtimes like Podman.
-	cpuCopyMode string
-
-	// ephemeralSelfUpdate is a boolean flag enabling the ephemeral container-based self-update mechanism.
-	//
-	// When true, Watchtower uses a short-lived orchestrator container to perform the self-update
-	// transition atomically. When false (default), the existing rename-based approach is used.
-	// It is set in preRun via the --ephemeral-self-update flag or WATCHTOWER_EPHEMERAL_SELF_UPDATE env var.
-	ephemeralSelfUpdate bool
 
 	// currentWatchtowerContainerID stores the current Watchtower container ID.
 	//
@@ -274,11 +105,6 @@ var (
 	rootCmd = NewRootCommand()
 )
 
-// errInvalidAPIHost indicates http-api-host is neither empty nor a valid IP.
-var errInvalidAPIHost = errors.New(
-	"invalid http-api-host: must be empty or a valid IP address (IPv4 or IPv6)",
-)
-
 // init registers command-line flags for the root command during package initialization.
 //
 // It invokes functions from the flags package to set default values and register flags for Docker configuration
@@ -286,9 +112,7 @@ var errInvalidAPIHost = errors.New(
 // the CLI's configurable parameters before execution begins.
 func init() {
 	flags.SetDefaults()
-	flags.RegisterDockerFlags(rootCmd)
-	flags.RegisterSystemFlags(rootCmd)
-	flags.RegisterNotificationFlags(rootCmd)
+	flags.RegisterAll(rootCmd)
 }
 
 // NewRootCommand creates and configures the root command for the Watchtower CLI.
@@ -305,9 +129,9 @@ func NewRootCommand() *cobra.Command {
 		Use:    "watchtower",
 		Short:  "Automatically updates running Docker containers",
 		Long:   "\nWatchtower automatically updates running Docker containers whenever a new image is released.\nMore information available at https://github.com/nicholas-fedor/watchtower/.",
-		Run:    run,
-		PreRun: preRun,
 		Args:   cobra.ArbitraryArgs, // Permits any number of positional arguments, processed as container names later.
+		PreRun: preRun,
+		Run:    run,
 	}
 }
 
@@ -325,167 +149,67 @@ func Execute() {
 
 // preRun prepares the environment and configuration before the main command execution begins.
 //
-// It processes command-line flags and their aliases, configures logging based on verbosity settings,
-// initializes the Docker client and notification system, retrieves operational flags, and validates
-// flag combinations to ensure Watchtower is correctly set up for its tasks.
+// It processes command-line flag aliases, configures logging based on verbosity settings,
+// expands secrets from files, maps Docker flags into the process environment, loads the
+// immutable appconfig snapshot, initializes the Docker client and notification client, and
+// handles early-exit paths (ephemeral self-update orchestrator and invalid old-container restarts).
 //
 // Parameters:
 //   - cmd: The cobra.Command instance being executed, providing access to parsed flags.
-//   - _: A slice of string arguments (unused here, as container names are handled in run).
+//   - _: A slice of string arguments (unused here, as container names are applied in run when
+//     reloading configuration for filtering).
 func preRun(cmd *cobra.Command, _ []string) {
 	flagsSet := cmd.PersistentFlags()
+
+	// Bridge environment values onto unset flags so aliases and logging still see them.
+	err := flags.ApplyEnvToFlags(flagsSet, flags.AllSpecs())
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to apply environment configuration")
+	}
+
+	// Apply porcelain, interval→schedule, and debug/trace log-level aliases.
 	flags.ProcessFlagAliases(flagsSet)
 
-	// Setup logging based on flags such as --debug, --trace, and --log-format.
-	err := flags.SetupLogging(flagsSet)
+	// Configure logging based on flags such as --debug, --trace, and --log-format.
+	err = flags.SetupLogging(flagsSet)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to initialize logging")
 	}
 
-	// Get the cron schedule specification from flags or environment variables.
-	scheduleSpec, _ = flagsSet.GetString("schedule")
-	logrus.WithField("scheduleSpec", scheduleSpec).
-		Debug("Retrieved cron schedule specification from flags")
-
-	// Get secrets from files (e.g., for notifications) and read core operational flags.
+	// Expand secrets from files (for example notification URLs and API tokens).
 	flags.GetSecretsFromFiles(cmd)
-	cleanup, noRestart, monitorOnly, timeout = flags.ReadFlags(cmd)
 
-	// Validate the timeout value to ensure it's non-negative, preventing invalid stop durations.
-	if timeout < 0 {
-		logrus.Fatal("Please specify a positive value for timeout value.")
-	}
-
-	// Warn if timeout is unreasonably small, which likely indicates a configuration
-	// error (such as passing a raw value without a time duration unit).
-	if timeout > 0 && timeout < time.Second {
-		logrus.WithField("timeout", timeout).
-			Warn("WATCHTOWER_TIMEOUT is less than 1 second")
-	}
-
-	// Set additional configuration flags that control update behavior and scope.
-	enableLabel, _ = flagsSet.GetBool("label-enable")
-
-	// Set containers that are excluded from Watchtower's handling.
-	disableContainers, _ = flagsSet.GetStringSlice("disable-containers")
-	for i := range disableContainers {
-		disableContainers[i] = util.NormalizeContainerName(disableContainers[i])
-	}
-
-	// Set image name patterns to define which respective containers are monitored.
-	monitoredImageNamePatterns, _ = flagsSet.GetStringSlice("monitor-image-names")
-	for i := range monitoredImageNamePatterns {
-		monitoredImageNamePatterns[i] = strings.TrimSpace(monitoredImageNamePatterns[i])
-	}
-
-	// Set image name patterns for respective containers to skip during monitoring.
-	skippedImageNamePatterns, _ = flagsSet.GetStringSlice("skip-image-names")
-	for i := range skippedImageNamePatterns {
-		skippedImageNamePatterns[i] = strings.TrimSpace(skippedImageNamePatterns[i])
-	}
-
-	// Set label key-value pairs that restrict which containers are monitored.
-	enabledContainersByLabel, _ = flagsSet.GetStringSlice("enable-containers-by-label")
-
-	// Set label key-value pairs for containers to skip during monitoring.
-	disabledContainersByLabel, _ = flagsSet.GetStringSlice("disable-containers-by-label")
-
-	// Enable/disable execution of scripts before or after updates.
-	lifecycleHooks, _ = flagsSet.GetBool("enable-lifecycle-hooks")
-
-	// Enable/disable execution of container-by-container updates.
-	rollingRestart, _ = flagsSet.GetBool("rolling-restart")
-
-	// Define the operational scope of the Watchtower instance.
-	scope, _ = flagsSet.GetString("scope")
-
-	// Enable/disable operational precedence of labels.
-	labelPrecedence, _ = flagsSet.GetBool("label-take-precedence")
-
-	// Enable/disable Docker Compose depends_on label processing.
-	useComposeDependsOn, _ = flagsSet.GetBool("use-compose-depends-on")
-
-	// Retrieve lifecycle UID and GID flags.
-	lifecycleUID, _ = flagsSet.GetInt("lifecycle-uid")
-	lifecycleGID, _ = flagsSet.GetInt("lifecycle-gid")
-
-	// Retrieve cooldown delay for minimum image age before updating.
-	// Supports extended units: d (days), w (weeks), M (months).
-	// Reset to zero to avoid persisting values from a previous preRun invocation.
-	cooldownDelay = time.Duration(0)
-
-	cooldownDelayStr, _ := flagsSet.GetString("cooldown-delay")
-
-	if cooldownDelayStr != "" {
-		parsed, err := util.ParseDuration(cooldownDelayStr)
-		if err != nil {
-			logrus.WithError(err).Fatal("Please specify a valid cooldown delay value (e.g., 24h, 3d, 1w, 1M).")
-		}
-
-		cooldownDelay = parsed
-	}
-
-	// Validate the cooldown delay value to ensure it's non-negative.
-	if cooldownDelay < 0 {
-		logrus.Fatal("Please specify a positive value for cooldown delay value.")
-	}
-
-	// Retrieve notification split flag.
-	notificationSplitByContainer, _ = flagsSet.GetBool("notification-split-by-container")
-
-	// Retrieve notification report flag.
-	notificationReport, _ = flagsSet.GetBool("notification-report")
-
-	// Log the scope if specified, aiding debugging by confirming the operational boundary.
-	if scope != "" {
-		logrus.WithField("scope", scope).Debug("Configured operational scope")
-	}
-
-	// Set Docker environment variables (e.g., DOCKER_HOST) based on flags for client initialization.
+	// Map Docker connection flags into the process environment for the client stack.
 	err = flags.EnvConfig(cmd)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to configure Docker environment")
 	}
 
-	// Retrieve flags controlling container inclusion and image handling behavior.
-	noPull, _ = flagsSet.GetBool("no-pull")
-	includeStopped, _ = flagsSet.GetBool("include-stopped")
-	includeRestarting, _ = flagsSet.GetBool("include-restarting")
-	reviveStopped, _ = flagsSet.GetBool("revive-stopped")
-	removeVolumes, _ := flagsSet.GetBool("remove-volumes")
-	warnOnHeadPullFailed, _ := flagsSet.GetString("warn-on-head-failure")
-	disableMemorySwappiness, _ := flagsSet.GetBool("disable-memory-swappiness")
-	cpuCopyMode, _ = flagsSet.GetString("cpu-copy-mode")
-	ephemeralSelfUpdate, _ = flagsSet.GetBool("ephemeral-self-update")
+	// Load without positional names; run reloads with args for the final filter.
+	appCfg, err = appConfig.Load(cmd, nil)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to load configuration")
+	}
 
-	// Initialize the Docker client before the orchestrator check.
-	// The orchestrator needs a valid client to perform container operations.
-	client = container.NewClient(container.ClientOptions{
-		IncludeStopped:          includeStopped,
-		ReviveStopped:           reviveStopped,
-		RemoveVolumes:           removeVolumes,
-		IncludeRestarting:       includeRestarting,
-		DisableMemorySwappiness: disableMemorySwappiness,
-		CPUCopyMode:             cpuCopyMode,
-		WarnOnHeadFailed:        container.WarningStrategy(warnOnHeadPullFailed),
-	})
+	logrus.WithField("scheduleSpec", appCfg.Schedule.Spec).
+		Debug("Retrieved cron schedule specification from configuration")
 
-	// Check for orchestrator mode early — this is an internal mode where Watchtower
-	// runs as a one-shot orchestrator for self-update. It reads environment variables
-	// to determine the old container ID, new image, and original container name.
-	isOrchestrator, _ := flagsSet.GetBool("self-update-orchestrator")
-	if isOrchestrator {
+	// Log the scope if specified, aiding debugging by confirming the operational boundary.
+	if appCfg.Filter.Scope != "" {
+		logrus.WithField("scope", appCfg.Filter.Scope).
+			Debug("Configured operational scope")
+	}
+
+	// Initialize the Docker client from the resolved ClientOptions projection.
+	client = container.NewClient(appCfg.ClientOptions())
+
+	// Check for orchestrator mode early. This is an internal mode where Watchtower
+	// runs as a one-shot orchestrator for self-update.
+	if appCfg.Mode.SelfUpdateOrchestrator {
 		logrus.Info("Running in ephemeral self-update orchestrator mode")
 
 		actions.RunOrchestrator(context.Background(), client)
 
-		// RunOrchestrator should always call os.Exit, but if it ever
-		// returns unexpectedly, ensure the process terminates to prevent the
-		// preRun flow from continuing into the main Watchtower loop.
-		//
-		// Resolve the current Watchtower container directly here, before the
-		// general lookup later in preRun, so the restart policy update targets
-		// the actual container instead of a nil reference.
 		currentWatchtowerContainer = resolveCurrentWatchtowerContainerForFallback(
 			context.Background(),
 			client,
@@ -506,18 +230,10 @@ func preRun(cmd *cobra.Command, _ []string) {
 			Fatal("RunOrchestrator returned unexpectedly. Exiting to prevent unintended execution")
 	}
 
-	// Warn about potential redundancy in flag combinations that could result in no action.
-	if monitorOnly && noPull {
-		logrus.WithFields(logrus.Fields{
-			"monitor_only": monitorOnly,
-			"no_pull":      noPull,
-		}).Warn("Combining monitor-only and no-pull might result in no updates")
-	}
-
-	// Create a timeout-bound context for Docker API lookups to prevent hanging indefinitely.
-	// This ensures the container ID lookup fails fast if the Docker API is unresponsive.
-
-	ctx, cancel := context.WithTimeout(context.Background(), containerLookupTimeout)
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		containerLookupTimeout,
+	)
 	defer cancel()
 
 	// Retrieve and store the current container ID for use throughout the application.
@@ -547,39 +263,42 @@ func preRun(cmd *cobra.Command, _ []string) {
 	}
 
 	// Check if this is an old Watchtower container that should not run continuously.
-	if scheduling.ShouldExitDueToInvalidRestart(currentWatchtowerContainer, flagsSet) {
+	if scheduling.ShouldExitDueToInvalidRestart(
+		currentWatchtowerContainer,
+		appCfg.Mode.RunOnce,
+	) {
 		logrus.Info(
 			"Detected invalid restart of old Watchtower container, stopping Watchtower container now",
 		)
 
-		ctx, cancel := context.WithTimeout(
+		exitCtx, exitCancel := context.WithTimeout(
 			context.Background(),
 			containerLookupTimeout,
 		)
-		defer cancel()
+		defer exitCancel()
 
 		// Update current Watchtower container's restart policy to "no" to prevent unwanted restarts
-		client.SetNoRestartPolicy(ctx, currentWatchtowerContainer)
+		client.SetNoRestartPolicy(exitCtx, currentWatchtowerContainer)
 
 		logrus.Exit(0)
 	}
 
-	// Set up the notification system with types specified via flags (e.g., email, Slack).
-	notifier = notifications.NewNotifier(cmd)
+	// Set up the notification client from loaded process config (appCfg.Notify).
+	notifier = notifications.NewNotifier(appCfg.Notify)
 	notifier.AddLogHook()
 
 	// Log deprecated notification configuration options, if set.
-	notificationTypes, _ := cmd.Flags().GetStringSlice("notifications")
-	notifications.LogLegacyDeprecationWarnings(notificationTypes)
+	notifications.LogLegacyDeprecationWarnings(appCfg.Notify.LegacyTypes)
 }
 
 // run executes the main Watchtower logic based on parsed command-line flags.
 //
-// It determines the operational mode (one-time update, HTTP API, or scheduled updates),
-// builds the container filter, and delegates to runMain for core execution,
-// exiting with a status code based on the outcome (0 for success, non-zero for failure).
+// It reloads process configuration with positional container names, derives the effective
+// operational scope (including scope persistence across self-updates), handles health-check
+// early exit, builds the HTTP API RunConfig from appCfg, and delegates to runMain for core
+// execution, exiting with a status code based on the outcome (0 for success, non-zero for failure).
 //
-// This function bridges flag parsing and the application's primary workflow.
+// This function bridges configuration loading and the application's primary workflow.
 //
 // Parameters:
 //   - command: The cobra.Command instance being executed, providing access to parsed flags.
@@ -588,36 +307,8 @@ func run(command *cobra.Command, args []string) {
 	logrus.WithField("positional_args", args).
 		Debug("Received positional arguments for container filtering")
 
-	// Strip forward slash from container names.
-	normalizedContainerNames := make([]string, 0, len(args))
-	for _, arg := range args {
-		normalizedContainerNames = append(
-			normalizedContainerNames,
-			util.NormalizeContainerName(arg),
-		)
-	}
-
-	// Determine the effective operational scope, prioritizing explicit scope
-	// over scope derived from the container's label.
-	// This ensures scope persistence during self-updates.
-	var err error
-
-	scope, err = container.GetEffectiveScope(currentWatchtowerContainer, scope)
-	if err != nil {
-		logrus.WithError(err).Debug("Scope derivation failed, continuing with current scope")
-	}
-
-	// Build the filter and its description based on normalized names, exclusions, and label settings.
-	filter, filterDesc, err := filters.BuildFilter(
-		normalizedContainerNames,
-		disableContainers,
-		monitoredImageNamePatterns,
-		skippedImageNamePatterns,
-		enabledContainersByLabel,
-		disabledContainersByLabel,
-		enableLabel,
-		scope,
-	)
+	// Reload configuration with positional names so the filter includes them.
+	loaded, err := appConfig.Load(command, args)
 	if err != nil {
 		if currentWatchtowerContainer != nil {
 			setNoRestartPolicyCtx, cancel := context.WithTimeout(
@@ -629,99 +320,53 @@ func run(command *cobra.Command, args []string) {
 			client.SetNoRestartPolicy(setNoRestartPolicyCtx, currentWatchtowerContainer)
 		}
 
-		logrus.WithError(err).Fatal("Failed to build container filter")
+		logrus.WithError(err).Fatal("Failed to load configuration")
 	}
 
-	// Get flags controlling execution mode.
-	runOnce, _ := command.PersistentFlags().GetBool("run-once")
-	updateOnStart, _ := command.PersistentFlags().GetBool("update-on-start")
-	noStartupMessage, _ := command.PersistentFlags().GetBool("no-startup-message")
-	healthCheck, _ := command.PersistentFlags().GetBool("health-check")
+	appCfg = loaded
 
-	// Get flags controlling HTTP API behavior.
-	apiEndpoints, _ := command.PersistentFlags().GetStringSlice("http-api-endpoints")
-	// TODO: Remove legacy HTTP API enable flags when dropping them in v2.
-	//nolint:godox
-	legacyUpdateAPI, _ := command.PersistentFlags().GetBool("http-api-update")
-	legacyMetricsAPI, _ := command.PersistentFlags().GetBool("http-api-metrics")
-	legacyContainersAPI, _ := command.PersistentFlags().GetBool("http-api-containers")
-	tlsCertPath, _ := command.PersistentFlags().GetString("http-api-tls-cert")
-	tlsKeyPath, _ := command.PersistentFlags().GetString("http-api-tls-key")
-	trustedProxies, _ := command.PersistentFlags().GetStringSlice("http-api-trusted-proxies")
-	proxyHeader, _ := command.PersistentFlags().GetString("http-api-proxy-header")
-	corsOrigins, _ := command.PersistentFlags().GetStringSlice("http-api-cors-origins")
-	unblockHTTPAPI, _ := command.PersistentFlags().GetBool("http-api-periodic-polls")
-	apiToken, _ := command.PersistentFlags().GetString("http-api-token")
-	apiEventsToken, _ := command.PersistentFlags().GetString("http-api-events-token")
+	normalizedContainerNames := append([]string(nil), appCfg.Filter.Names...)
 
-	endpointSet, err := config.ResolveEndpoints(
-		apiEndpoints,
-		legacyUpdateAPI,
-		legacyMetricsAPI,
-		legacyContainersAPI,
+	// Prefer explicit scope, then scope derived from the container label (self-update persistence).
+	effectiveScope, scopeErr := container.GetEffectiveScope(
+		currentWatchtowerContainer,
+		appCfg.Filter.Scope,
 	)
-	if err != nil {
-		logrus.WithError(err).Fatal("Invalid HTTP API endpoint configuration")
+	if scopeErr != nil {
+		logrus.WithError(scopeErr).Debug("Scope derivation failed, continuing with current scope")
+	} else if effectiveScope != appCfg.Filter.Scope {
+		appCfg.Filter.Scope = effectiveScope
+
+		// Rebuild the filter predicate with the effective scope.
+		predicate, desc, filterErr := filters.BuildFilter(
+			appCfg.Filter.Names,
+			appCfg.Filter.DisableContainers,
+			appCfg.Filter.MonitorImageNames,
+			appCfg.Filter.SkipImageNames,
+			appCfg.Filter.EnableContainersByLabel,
+			appCfg.Filter.DisableContainersByLabel,
+			appCfg.Filter.LabelEnable,
+			appCfg.Filter.Scope,
+		)
+		if filterErr != nil {
+			if currentWatchtowerContainer != nil {
+				setNoRestartPolicyCtx, cancel := context.WithTimeout(
+					context.Background(),
+					restartPolicyTimeout,
+				)
+				defer cancel()
+
+				client.SetNoRestartPolicy(setNoRestartPolicyCtx, currentWatchtowerContainer)
+			}
+
+			logrus.WithError(filterErr).Fatal("Failed to build container filter")
+		}
+
+		appCfg.Filter.Predicate = predicate
+		appCfg.Filter.Desc = desc
 	}
 
-	// Get the HTTP API host and port, falling back to "8080" for port if not specified.
-	flagsSet := command.PersistentFlags()
-
-	apiHost, err := flagsSet.GetString("http-api-host")
-	if err != nil {
-		logrus.WithError(err).Fatal("Failed to get http-api-host flag")
-	}
-
-	// Validate if the configuration option has been changed from the default value.
-	apiHostChanged := flagsSet.Lookup("http-api-host").Changed
-
-	err = validateAPIHost(apiHost)
-	if err != nil {
-		logrus.Fatal(err)
-	}
-
-	apiPort, err := flagsSet.GetString("http-api-port")
-	if err != nil {
-		logrus.WithError(err).Fatal("Failed to get http-api-port flag")
-	}
-
-	// Validate if the configuration option has been changed from the default value.
-	apiPortChanged := flagsSet.Lookup("http-api-port").Changed
-
-	if apiPort == "" {
-		apiPort = "8080" // Default port if unset.
-	}
-
-	// Get the HTTP API rate limit, defaulting to 60 requests per minute.
-	apiRateLimit, err := flagsSet.GetInt("http-api-rate-limit")
-	if err != nil {
-		logrus.WithError(err).Fatal("Failed to get http-api-rate-limit flag")
-	}
-
-	// Validate if the configuration option has been changed from the default value.
-	apiRateLimitChanged := flagsSet.Lookup("http-api-rate-limit").Changed
-
-	// Set the API rate limit to the default value (60) if set to an invalid value.
-	if apiRateLimit <= 0 {
-		apiRateLimit = 60
-	}
-
-	checkAPITimeout, err := flagsSet.GetDuration("http-api-check-timeout")
-	if err != nil {
-		logrus.WithError(err).Fatal("Failed to get http-api-check-timeout flag")
-	}
-
-	checkAPITimeoutChanged := flagsSet.Lookup("http-api-check-timeout").Changed
-
-	updateAPITimeout, err := flagsSet.GetDuration("http-api-update-timeout")
-	if err != nil {
-		logrus.WithError(err).Fatal("Failed to get http-api-update-timeout flag")
-	}
-
-	updateAPITimeoutChanged := flagsSet.Lookup("http-api-update-timeout").Changed
-
-	// Handle health check mode as an early exit, preventing updates or API setup.
-	if healthCheck {
+	if appCfg.Mode.HealthCheck {
 		if os.Getpid() == 1 {
 			time.Sleep(1 * time.Second)
 			logrus.Fatal(
@@ -729,43 +374,19 @@ func run(command *cobra.Command, args []string) {
 			)
 		}
 
-		return // Exit early without os.Exit to preserve defer in caller.
+		return
 	}
 
-	// Set configuration for core execution, encapsulating all operational parameters.
-	cfg := types.RunConfig{
-		Command:                 command,
-		Names:                   normalizedContainerNames,
-		Filter:                  filter,
-		FilterDesc:              filterDesc,
-		RunOnce:                 runOnce,
-		UpdateOnStart:           updateOnStart,
-		TLSCertPath:             tlsCertPath,
-		TLSKeyPath:              tlsKeyPath,
-		CORSAllowedOrigins:      corsOrigins,
-		TrustedProxies:          trustedProxies,
-		ProxyHeader:             proxyHeader,
-		UnblockHTTPAPI:          unblockHTTPAPI,
-		NoStartupMessage:        noStartupMessage,
-		APIToken:                apiToken,
-		APIEventsToken:          apiEventsToken,
-		APIHost:                 apiHost,
-		APIHostChanged:          apiHostChanged,
-		APIPort:                 apiPort,
-		APIPortChanged:          apiPortChanged,
-		APIRateLimit:            apiRateLimit,
-		APIRateLimitChanged:     apiRateLimitChanged,
-		CheckAPITimeout:         checkAPITimeout,
-		CheckAPITimeoutChanged:  checkAPITimeoutChanged,
-		UpdateAPITimeout:        updateAPITimeout,
-		UpdateAPITimeoutChanged: updateAPITimeoutChanged,
+	cfg, err := appCfg.BuildRunConfig(appConfig.RunConfigInput{
+		Command: command,
+		Names:   normalizedContainerNames,
+	})
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to build run configuration")
 	}
-
-	// Set the HTTP API Endpoint configuration.
-	config.SetEndpointConfig(endpointSet, &cfg)
 
 	// Warn if HTTP API configuration options are set without an endpoint enabled.
-	if !httpAPIEndpointsEnabled(cfg) && anyHTTPAPIConfig(cfg) {
+	if !appConfig.HTTPAPIEndpointsEnabled(cfg) && appConfig.AnyHTTPAPIConfig(cfg) {
 		logrus.Warn(
 			"HTTP API configuration options are set, but no endpoints are enabled.",
 		)
@@ -780,12 +401,14 @@ func run(command *cobra.Command, args []string) {
 
 // runMain contains the core Watchtower logic after early exits are handled.
 //
-// It validates the environment, performs one-time updates if specified,
-// sets up the HTTP API, and schedules periodic updates while managing
-// context and concurrency to ensure graceful operation.
+// It validates rolling-restart compatibility, performs one-time updates when run-once is set,
+// cleans up excess Watchtower instances, sets up the HTTP API when endpoints are enabled,
+// and schedules periodic updates while managing context and concurrency for graceful shutdown.
+// Update policy is taken from appCfg.UpdateParams so run-once, schedule, and API paths share
+// a complete types.UpdateParams snapshot.
 //
 // Parameters:
-//   - cfg: The RunConfig struct containing all necessary configuration parameters for execution.
+//   - cfg: The RunConfig struct containing filter, API, and mode parameters for this execution.
 //
 // Returns:
 //   - int: An exit code (0 for success, 1 for failure) used to terminate the program.
@@ -794,7 +417,7 @@ func runMain(cfg types.RunConfig) int {
 	logrus.WithField("container_names", cfg.Names).Debug("Processing specified containers")
 
 	// Validate flag compatibility to prevent conflicting operational modes.
-	if rollingRestart && monitorOnly {
+	if appCfg.Update.RollingRestart && appCfg.Update.MonitorOnly {
 		setNoRestartPolicyCtx, cancel := context.WithTimeout(
 			context.Background(),
 			restartPolicyTimeout,
@@ -807,8 +430,8 @@ func runMain(cfg types.RunConfig) int {
 		)
 
 		logrus.WithFields(logrus.Fields{
-			"rolling_restart": rollingRestart,
-			"monitor_only":    monitorOnly,
+			"rolling_restart": appCfg.Update.RollingRestart,
+			"monitor_only":    appCfg.Update.MonitorOnly,
 		}).Fatal("Incompatible flags: rolling restarts and monitor-only")
 	}
 
@@ -832,38 +455,23 @@ func runMain(cfg types.RunConfig) int {
 	// Returns:
 	//   - *metrics.Metric: A pointer to a metric object summarizing the update session (scanned, updated, failed counts).
 	runUpdatesWithNotifications = func(ctx context.Context, filter types.Filter, params types.UpdateParams) *metrics.Metric {
-		// Prepare parameters for the update action
-		actionParams := actions.RunUpdatesWithNotificationsParams{
-			Client:                       client,                       // Docker client for container operations
-			Notifier:                     notifier,                     // Notification system for sending update status messages
-			NotificationSplitByContainer: notificationSplitByContainer, // Enable separate notifications for each updated container
-			NotificationReport:           notificationReport,           // Enable report-based notifications
-			Filter:                       filter,                       // Container filter determining which containers are targeted
-			Cleanup:                      params.Cleanup,               // Remove old images after container updates
-			NoRestart:                    noRestart,                    // Prevent containers from being restarted after updates
-			ReviveStopped:                params.ReviveStopped,         // Start stopped containers after update if true
-			MonitorOnly:                  params.MonitorOnly,           // Monitor containers without performing updates
-			LifecycleHooks:               lifecycleHooks,               // Enable pre- and post-update lifecycle hook commands
-			RollingRestart:               rollingRestart,               // Update containers sequentially rather than all at once
-			LabelPrecedence:              labelPrecedence,              // Give container label settings priority over global flags
-			NoPull:                       noPull,                       // Skip pulling new images from registry during updates
-			Timeout:                      timeout,                      // Maximum duration for container stop operations
-			LifecycleUID:                 lifecycleUID,                 // Default UID to run lifecycle hooks as
-			LifecycleGID:                 lifecycleGID,                 // Default GID to run lifecycle hooks as
-			CPUCopyMode:                  cpuCopyMode,                  // CPU settings handling when recreating containers
-			PullFailureDelay:             params.PullFailureDelay,      // Delay after failed Watchtower self-update pulls
-			RunOnce:                      params.RunOnce,               // Perform one-time update and exit
-			CurrentContainerID:           currentWatchtowerContainerID, // ID of the current Watchtower container for self-update logic
-			UseComposeDependsOn:          params.UseComposeDependsOn,   // Enable Docker Compose depends_on label processing
-			SkipSelfUpdate:               params.SkipSelfUpdate,        // Skip Watchtower self-update
-			EphemeralSelfUpdate:          ephemeralSelfUpdate,          // Use ephemeral container for self-update
-			CooldownDelay:                cooldownDelay,                // Minimum time since image creation before allowing updates
-			EventBroadcaster:             eventsBroadcaster,            // Broadcaster for SSE event streaming
+		update := params
+		if filter != nil {
+			update.Filter = filter
 		}
 
-		metric := actions.RunUpdatesWithNotifications(ctx, actionParams)
+		if update.CurrentContainerID == "" {
+			update.CurrentContainerID = currentWatchtowerContainerID
+		}
 
-		return metric
+		return actions.RunUpdatesWithNotifications(ctx, actions.RunUpdatesWithNotificationsParams{
+			Client:                       client,
+			Notifier:                     notifier,
+			NotificationSplitByContainer: appCfg.Notify.SplitByContainer,
+			NotificationReport:           appCfg.Notify.Report,
+			EventBroadcaster:             eventsBroadcaster,
+			Update:                       update,
+		})
 	}
 
 	// Create a context that is automatically canceled on SIGINT/SIGTERM signals,
@@ -879,11 +487,12 @@ func runMain(cfg types.RunConfig) int {
 
 	// If rolling restarts are enabled, validate that the containers being monitored for
 	// updates do not have linked dependencies.
-	if rollingRestart {
+	if appCfg.Update.RollingRestart {
 		err := actions.ValidateRollingRestartDependencies(
 			ctx,
 			client,
-			cfg.Filter, useComposeDependsOn,
+			cfg.Filter,
+			appCfg.Update.UseComposeDependsOn,
 		)
 		if err != nil {
 			logNotify("Rolling restart compatibility validation failed", err)
@@ -905,32 +514,31 @@ func runMain(cfg types.RunConfig) int {
 	updateLock := make(chan bool, 1)
 	updateLock <- true
 
+	baseParams := appCfg.UpdateParams(appConfig.RunOverrides{
+		Filter:             cfg.Filter,
+		CurrentContainerID: currentWatchtowerContainerID,
+	})
+
 	// Handle one-time update mode, executing updates and registering metrics.
 	if cfg.RunOnce {
-		logging.WriteStartupMessage(
-			cfg.Command,
-			time.Time{},
-			cfg.FilterDesc,
-			scope,
-			client,
-			notifier,
-			meta.Version,
-			nil, // read from flags
-		)
-		params := types.UpdateParams{
-			Cleanup:             cleanup,
-			RunOnce:             cfg.RunOnce,
-			MonitorOnly:         monitorOnly,
-			UseComposeDependsOn: useComposeDependsOn,
-			SkipSelfUpdate:      false, // SkipSelfUpdate is dynamically set in RunUpgradesOnSchedule based on skipFirstRun
-			CooldownDelay:       cooldownDelay,
-			ReviveStopped:       reviveStopped,
-		}
+		// Write startup message from resolved config (no CLI flag reads).
+		startup := appCfg.StartupParams(cfg)
+		startup.Sched = time.Time{}
+		startup.Filtering = cfg.FilterDesc
+		startup.Scope = appCfg.Filter.Scope
+		startup.Client = client
+		startup.Notifier = notifier
+		startup.Version = meta.Version
+		logging.WriteStartupMessage(startup)
+
+		params := baseParams
+		params.RunOnce = true
+
 		metric := runUpdatesWithNotifications(ctx, cfg.Filter, params)
 		metrics.Default().RegisterScan(metric)
 		notifier.Close()
 
-		// Update current Watchtower container's restart policy to "no" to prevent unwanted restarts
+		// Update current Watchtower container's restart policy to "no" to prevent unwanted restarts.
 		setNoRestartPolicyCtx, cancel := context.WithTimeout(
 			context.Background(),
 			restartPolicyTimeout,
@@ -939,7 +547,7 @@ func runMain(cfg types.RunConfig) int {
 
 		client.SetNoRestartPolicy(setNoRestartPolicyCtx, currentWatchtowerContainer)
 
-		return 0 // Exit after successful execution
+		return 0 // Exit after successful execution.
 	}
 
 	// Retrieve the current Watchtower container for cleanup operations.
@@ -951,8 +559,8 @@ func runMain(cfg types.RunConfig) int {
 	totalRemovedInstances, err := actions.RemoveExcessWatchtowerInstances(
 		ctx,
 		client,
-		cleanup,
-		scope,
+		appCfg.Update.Cleanup,
+		appCfg.Filter.Scope,
 		&[]types.RemovedImageInfo{},
 		currentWatchtowerContainer,
 	)
@@ -977,13 +585,9 @@ func runMain(cfg types.RunConfig) int {
 			Debug("Cleaned up orphaned orchestrator containers")
 	}
 
-	// Track if cleanup occurred to prevent redundant updates after self-update
-	var cleanupOccurred bool
-	if totalRemovedInstances > 0 {
-		cleanupOccurred = true
-	}
-
-	// Disable update-on-start if cleanup occurred to prevent redundant updates after self-update
+	// Track whether cleanup occurred to prevent redundant updates after self-update.
+	cleanupOccurred := totalRemovedInstances > 0
+	// Disable update-on-start if cleanup occurred to prevent redundant updates after self-update.
 	if cleanupOccurred {
 		cfg.UpdateOnStart = false
 
@@ -1001,10 +605,19 @@ func runMain(cfg types.RunConfig) int {
 	// and SetupAndStartAPI returns early.
 	skipSelfUpdate := currentWatchtowerContainer != nil &&
 		currentWatchtowerContainer.HasExposedPorts() &&
-		!ephemeralSelfUpdate
+		!appCfg.Update.EphemeralSelfUpdate
 	if skipSelfUpdate {
 		logrus.Warn("Published port detected - self-updates disabled.")
 	}
+
+	// Share one complete UpdateParams snapshot with HTTP API and schedule paths.
+	apiBase := baseParams
+	if skipSelfUpdate {
+		apiBase.SkipSelfUpdate = true
+	}
+
+	// Mode and HTTP API values for startup messaging (runtime fields filled by callers).
+	startupBase := appCfg.StartupParams(cfg)
 
 	err = api.SetupAndStartAPI(
 		ctx,
@@ -1034,28 +647,18 @@ func runMain(cfg types.RunConfig) int {
 			UnblockHTTPAPI:               cfg.UnblockHTTPAPI,
 			NoStartupMessage:             cfg.NoStartupMessage,
 			Filter:                       cfg.Filter,
-			Command:                      cfg.Command,
 			FilterDesc:                   cfg.FilterDesc,
 			UpdateLock:                   updateLock,
-			Cleanup:                      cleanup,
-			MonitorOnly:                  monitorOnly,
-			NoPull:                       noPull,
-			NoRestart:                    noRestart,
-			RollingRestart:               rollingRestart,
-			IncludeStopped:               includeStopped,
-			IncludeRestarting:            includeRestarting,
-			LifecycleHooks:               lifecycleHooks,
-			LabelEnable:                  enableLabel,
-			LabelPrecedence:              labelPrecedence,
-			CooldownDelay:                cooldownDelay,
-			SkipSelfUpdate:               skipSelfUpdate,
-			ReviveStopped:                reviveStopped,
-			UseComposeDependsOn:          useComposeDependsOn,
+			BaseParams:                   apiBase,
+			IncludeStopped:               appCfg.Client.IncludeStopped,
+			IncludeRestarting:            appCfg.Client.IncludeRestarting,
+			LabelEnable:                  appCfg.Filter.LabelEnable,
 			Client:                       client,
 			Notifier:                     notifier,
-			NotificationSplitByContainer: notificationSplitByContainer,
-			Scope:                        scope,
+			NotificationSplitByContainer: appCfg.Notify.SplitByContainer,
+			Scope:                        appCfg.Filter.Scope,
 			Version:                      meta.Version,
+			Startup:                      startupBase,
 			RunUpdatesWithNotifications:  runUpdatesWithNotifications,
 			FilterByImage:                filters.FilterByImage,
 			DefaultMetrics:               metrics.Default,
@@ -1088,28 +691,29 @@ func runMain(cfg types.RunConfig) int {
 	// The startup message is skipped here if it was already sent by the HTTP API in blocking mode.
 	startupMessageSent := cfg.EnableUpdateAPI && !cfg.UnblockHTTPAPI
 
-	err = scheduling.RunUpgradesOnSchedule(
-		ctx, cfg.Command,
-		cfg.Filter,
-		cfg.FilterDesc,
-		updateLock,
-		cleanup,
-		scheduleSpec,
-		logging.WriteStartupMessage,
-		runUpdatesWithNotifications,
-		client,
-		scope,
-		notifier,
-		meta.Version,
-		monitorOnly,
-		cfg.UpdateOnStart,
-		cleanupOccurred,
-		currentWatchtowerContainer,
-		startupMessageSent,
-		ephemeralSelfUpdate,
-		reviveStopped,
-		useComposeDependsOn,
-	)
+	scheduleBase := baseParams
+	if skipSelfUpdate {
+		scheduleBase.SkipSelfUpdate = true
+	}
+
+	err = scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
+		Filter:                     cfg.Filter,
+		FilterDesc:                 cfg.FilterDesc,
+		Lock:                       updateLock,
+		ScheduleSpec:               appCfg.Schedule.Spec,
+		Startup:                    startupBase,
+		WriteStartupMessage:        logging.WriteStartupMessage,
+		RunUpdate:                  runUpdatesWithNotifications,
+		Client:                     client,
+		Scope:                      appCfg.Filter.Scope,
+		Notifier:                   notifier,
+		MetaVersion:                meta.Version,
+		UpdateOnStart:              cfg.UpdateOnStart,
+		SkipFirstRun:               cleanupOccurred,
+		CurrentWatchtowerContainer: currentWatchtowerContainer,
+		StartupMessageSent:         startupMessageSent,
+		BaseParams:                 scheduleBase,
+	})
 	if err != nil {
 		logNotify("Scheduled upgrades failed", err)
 
@@ -1181,54 +785,4 @@ func resolveCurrentWatchtowerContainerForFallback(ctx context.Context, c contain
 	}
 
 	return nil
-}
-
-// validateAPIHost ensures http-api-host is empty (all interfaces) or a valid IP.
-//
-// Parameters:
-//   - host: Value of the http-api-host flag.
-//
-// Returns:
-//   - error: Non-nil when host is a non-empty non-IP string (e.g. a hostname).
-func validateAPIHost(host string) error {
-	if host == "" {
-		return nil
-	}
-
-	if net.ParseIP(host) == nil {
-		return fmt.Errorf("%w: %q", errInvalidAPIHost, host)
-	}
-
-	return nil
-}
-
-// anyHTTPAPIConfig reports whether any HTTP API-related settings are present
-// without enabled endpoints, so operators can be warned about a no-op config.
-func anyHTTPAPIConfig(cfg types.RunConfig) bool {
-	return cfg.APIToken != "" ||
-		cfg.APIEventsToken != "" ||
-		cfg.TLSCertPath != "" ||
-		cfg.TLSKeyPath != "" ||
-		len(cfg.CORSAllowedOrigins) > 0 ||
-		len(cfg.TrustedProxies) > 0 ||
-		cfg.ProxyHeader != "" ||
-		cfg.APIHostChanged ||
-		cfg.APIPortChanged ||
-		cfg.APIRateLimitChanged ||
-		cfg.CheckAPITimeoutChanged ||
-		cfg.UpdateAPITimeoutChanged
-}
-
-// httpAPIEndpointsEnabled reports whether any HTTP API endpoint is enabled.
-func httpAPIEndpointsEnabled(cfg types.RunConfig) bool {
-	return cfg.EnableUpdateAPI ||
-		cfg.EnableMetricsAPI ||
-		cfg.EnableContainersAPI ||
-		cfg.EnableCheckAPI ||
-		cfg.EnableSwaggerAPI ||
-		cfg.EnableHealthAPI ||
-		cfg.EnableHistoryAPI ||
-		cfg.EnableImagesAPI ||
-		cfg.EnableConfigAPI ||
-		cfg.EnableEventsAPI
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -616,8 +616,14 @@ func runMain(cfg types.RunConfig) int {
 		sharedBase.SkipSelfUpdate = true
 	}
 
-	// Mode and HTTP API values for startup messaging (runtime fields filled by callers).
+	// Startup messaging snapshot. Sched/UpdateOnStart are filled by schedule/API callers;
+	// populate the rest here so scheduling does not re-derive them from scalar deps.
 	startupBase := appCfg.StartupParams(cfg)
+	startupBase.Filtering = cfg.FilterDesc
+	startupBase.Scope = appCfg.Filter.Scope
+	startupBase.Client = client
+	startupBase.Notifier = notifier
+	startupBase.Version = meta.Version
 
 	err = api.SetupAndStartAPI(
 		ctx,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -610,10 +610,10 @@ func runMain(cfg types.RunConfig) int {
 		logrus.Warn("Published port detected - self-updates disabled.")
 	}
 
-	// Share one complete UpdateParams snapshot with HTTP API and schedule paths.
-	apiBase := baseParams
+	// One UpdateParams snapshot for HTTP API and schedule paths.
+	sharedBase := baseParams
 	if skipSelfUpdate {
-		apiBase.SkipSelfUpdate = true
+		sharedBase.SkipSelfUpdate = true
 	}
 
 	// Mode and HTTP API values for startup messaging (runtime fields filled by callers).
@@ -649,7 +649,7 @@ func runMain(cfg types.RunConfig) int {
 			Filter:                       cfg.Filter,
 			FilterDesc:                   cfg.FilterDesc,
 			UpdateLock:                   updateLock,
-			BaseParams:                   apiBase,
+			BaseParams:                   sharedBase,
 			IncludeStopped:               appCfg.Client.IncludeStopped,
 			IncludeRestarting:            appCfg.Client.IncludeRestarting,
 			LabelEnable:                  appCfg.Filter.LabelEnable,
@@ -691,11 +691,6 @@ func runMain(cfg types.RunConfig) int {
 	// The startup message is skipped here if it was already sent by the HTTP API in blocking mode.
 	startupMessageSent := cfg.EnableUpdateAPI && !cfg.UnblockHTTPAPI
 
-	scheduleBase := baseParams
-	if skipSelfUpdate {
-		scheduleBase.SkipSelfUpdate = true
-	}
-
 	err = scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
 		Filter:                     cfg.Filter,
 		FilterDesc:                 cfg.FilterDesc,
@@ -712,7 +707,7 @@ func runMain(cfg types.RunConfig) int {
 		SkipFirstRun:               cleanupOccurred,
 		CurrentWatchtowerContainer: currentWatchtowerContainer,
 		StartupMessageSent:         startupMessageSent,
-		BaseParams:                 scheduleBase,
+		BaseParams:                 sharedBase,
 	})
 	if err != nil {
 		logNotify("Scheduled upgrades failed", err)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -470,6 +470,26 @@ func TestHandleAsync(t *testing.T) {
 	}
 }
 
+// testScheduleDeps returns ScheduleDeps with shared defaults for cmd scheduling tests.
+// Callers set Filter, FilterDesc, Lock, UpdateOnStart, and BaseParams.EphemeralSelfUpdate as needed.
+func testScheduleDeps(
+	filter types.Filter,
+	filterDesc string,
+	lock chan bool,
+	updateOnStart bool,
+) scheduling.ScheduleDeps {
+	return scheduling.ScheduleDeps{
+		Filter:              filter,
+		FilterDesc:          filterDesc,
+		Lock:                lock,
+		ScheduleSpec:        "",
+		WriteStartupMessage: logging.WriteStartupMessage,
+		RunUpdate:           runUpdatesWithNotifications,
+		UpdateOnStart:       updateOnStart,
+		BaseParams:          types.UpdateParams{},
+	}
+}
+
 // TestUpdateOnStartTriggersImmediateUpdate verifies that the --update-on-start flag
 // triggers an immediate update before scheduling periodic updates.
 func TestUpdateOnStartTriggersImmediateUpdate(t *testing.T) {
@@ -511,29 +531,8 @@ func TestUpdateOnStartTriggersImmediateUpdate(t *testing.T) {
 	filterDesc := testFilterDesc
 
 	// The function should trigger immediate update and then start scheduler
-	err = scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
-		Filter:                     filter,
-		FilterDesc:                 filterDesc,
-		Lock:                       updateLock,
-		ScheduleSpec:               "",
-		WriteStartupMessage:        logging.WriteStartupMessage,
-		RunUpdate:                  runUpdatesWithNotifications,
-		Client:                     nil,
-		Scope:                      "",
-		Notifier:                   nil,
-		MetaVersion:                "",
-		UpdateOnStart:              true,
-		SkipFirstRun:               false,
-		CurrentWatchtowerContainer: nil,
-		StartupMessageSent:         false,
-		BaseParams: types.UpdateParams{
-			Cleanup:             false,
-			MonitorOnly:         false,
-			EphemeralSelfUpdate: false,
-			ReviveStopped:       false,
-			UseComposeDependsOn: false,
-		},
-	})
+	deps := testScheduleDeps(filter, filterDesc, updateLock, true)
+	err = scheduling.RunUpgradesOnSchedule(ctx, deps)
 
 	// Should not return an error (context cancellation is expected)
 	require.NoError(t, err)
@@ -596,29 +595,8 @@ func TestUpdateOnStartIntegratesWithCronScheduling(t *testing.T) {
 		filterDesc := testFilterDesc
 
 		startTime := time.Now()
-		err = scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
-			Filter:                     filter,
-			FilterDesc:                 filterDesc,
-			Lock:                       updateLock,
-			ScheduleSpec:               "",
-			WriteStartupMessage:        logging.WriteStartupMessage,
-			RunUpdate:                  runUpdatesWithNotifications,
-			Client:                     nil,
-			Scope:                      "",
-			Notifier:                   nil,
-			MetaVersion:                "",
-			UpdateOnStart:              true,
-			SkipFirstRun:               false,
-			CurrentWatchtowerContainer: nil,
-			StartupMessageSent:         false,
-			BaseParams: types.UpdateParams{
-				Cleanup:             false,
-				MonitorOnly:         false,
-				EphemeralSelfUpdate: false,
-				ReviveStopped:       false,
-				UseComposeDependsOn: false,
-			},
-		})
+		deps := testScheduleDeps(filter, filterDesc, updateLock, true)
+		err = scheduling.RunUpgradesOnSchedule(ctx, deps)
 
 		// Should not return an error (context cancellation is expected)
 		require.NoError(t, err)
@@ -692,29 +670,8 @@ func TestUpdateOnStartLockingBehavior(t *testing.T) {
 		filter := types.Filter(func(_ types.FilterableContainer) bool { return false })
 		filterDesc := testFilterDesc
 
-		err = scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
-			Filter:                     filter,
-			FilterDesc:                 filterDesc,
-			Lock:                       updateLock,
-			ScheduleSpec:               "",
-			WriteStartupMessage:        logging.WriteStartupMessage,
-			RunUpdate:                  runUpdatesWithNotifications,
-			Client:                     nil,
-			Scope:                      "",
-			Notifier:                   nil,
-			MetaVersion:                "",
-			UpdateOnStart:              false,
-			SkipFirstRun:               false,
-			CurrentWatchtowerContainer: nil,
-			StartupMessageSent:         false,
-			BaseParams: types.UpdateParams{
-				Cleanup:             false,
-				MonitorOnly:         false,
-				EphemeralSelfUpdate: false,
-				ReviveStopped:       false,
-				UseComposeDependsOn: false,
-			},
-		})
+		deps := testScheduleDeps(filter, filterDesc, updateLock, false)
+		err = scheduling.RunUpgradesOnSchedule(ctx, deps)
 
 		// Should not return an error
 		require.NoError(t, err)
@@ -769,29 +726,8 @@ func TestUpdateOnStartSelfUpdateScenario(t *testing.T) {
 		filter := types.Filter(func(_ types.FilterableContainer) bool { return true })
 		filterDesc := testFilterDesc
 
-		err = scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
-			Filter:                     filter,
-			FilterDesc:                 filterDesc,
-			Lock:                       updateLock,
-			ScheduleSpec:               "",
-			WriteStartupMessage:        logging.WriteStartupMessage,
-			RunUpdate:                  runUpdatesWithNotifications,
-			Client:                     nil,
-			Scope:                      "",
-			Notifier:                   nil,
-			MetaVersion:                "",
-			UpdateOnStart:              updateOnStart,
-			SkipFirstRun:               false,
-			CurrentWatchtowerContainer: nil,
-			StartupMessageSent:         false,
-			BaseParams: types.UpdateParams{
-				Cleanup:             false,
-				MonitorOnly:         false,
-				EphemeralSelfUpdate: false,
-				ReviveStopped:       false,
-				UseComposeDependsOn: false,
-			},
-		})
+		deps := testScheduleDeps(filter, filterDesc, updateLock, updateOnStart)
+		err = scheduling.RunUpgradesOnSchedule(ctx, deps)
 
 		// Should not return an error
 		require.NoError(t, err)
@@ -859,29 +795,8 @@ func TestUpdateOnStartMultiInstanceScenario(t *testing.T) {
 			filter := types.Filter(func(_ types.FilterableContainer) bool { return false })
 			filterDesc := "instance1"
 
-			err := scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
-				Filter:                     filter,
-				FilterDesc:                 filterDesc,
-				Lock:                       updateLock,
-				ScheduleSpec:               "",
-				WriteStartupMessage:        logging.WriteStartupMessage,
-				RunUpdate:                  runUpdatesWithNotifications,
-				Client:                     nil,
-				Scope:                      "",
-				Notifier:                   nil,
-				MetaVersion:                "",
-				UpdateOnStart:              updateOnStart1,
-				SkipFirstRun:               false,
-				CurrentWatchtowerContainer: nil,
-				StartupMessageSent:         false,
-				BaseParams: types.UpdateParams{
-					Cleanup:             false,
-					MonitorOnly:         false,
-					EphemeralSelfUpdate: false,
-					ReviveStopped:       false,
-					UseComposeDependsOn: false,
-				},
-			})
+			deps := testScheduleDeps(filter, filterDesc, updateLock, updateOnStart1)
+			err = scheduling.RunUpgradesOnSchedule(ctx, deps)
 			assert.NoError(t, err)
 			completed.Add(1)
 			close(instance1Called)
@@ -894,29 +809,8 @@ func TestUpdateOnStartMultiInstanceScenario(t *testing.T) {
 			filter := types.Filter(func(_ types.FilterableContainer) bool { return false })
 			filterDesc := "instance2"
 
-			err := scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
-				Filter:                     filter,
-				FilterDesc:                 filterDesc,
-				Lock:                       updateLock,
-				ScheduleSpec:               "",
-				WriteStartupMessage:        logging.WriteStartupMessage,
-				RunUpdate:                  runUpdatesWithNotifications,
-				Client:                     nil,
-				Scope:                      "",
-				Notifier:                   nil,
-				MetaVersion:                "",
-				UpdateOnStart:              updateOnStart2,
-				SkipFirstRun:               false,
-				CurrentWatchtowerContainer: nil,
-				StartupMessageSent:         false,
-				BaseParams: types.UpdateParams{
-					Cleanup:             false,
-					MonitorOnly:         false,
-					EphemeralSelfUpdate: false,
-					ReviveStopped:       false,
-					UseComposeDependsOn: false,
-				},
-			})
+			deps := testScheduleDeps(filter, filterDesc, updateLock, updateOnStart2)
+			err = scheduling.RunUpgradesOnSchedule(ctx, deps)
 			assert.NoError(t, err)
 			completed.Add(1)
 			close(instance2Called)
@@ -1096,29 +990,8 @@ func TestRunUpgradesOnSchedule_ShutdownWaitsForRunningUpdate(t *testing.T) {
 			filterDesc := testFilterDesc
 
 			// This should start and wait for context cancellation
-			err := scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
-				Filter:                     filter,
-				FilterDesc:                 filterDesc,
-				Lock:                       updateLock,
-				ScheduleSpec:               "",
-				WriteStartupMessage:        logging.WriteStartupMessage,
-				RunUpdate:                  runUpdatesWithNotifications,
-				Client:                     nil,
-				Scope:                      "",
-				Notifier:                   nil,
-				MetaVersion:                "",
-				UpdateOnStart:              false,
-				SkipFirstRun:               false,
-				CurrentWatchtowerContainer: nil,
-				StartupMessageSent:         false,
-				BaseParams: types.UpdateParams{
-					Cleanup:             false,
-					MonitorOnly:         false,
-					EphemeralSelfUpdate: false,
-					ReviveStopped:       false,
-					UseComposeDependsOn: false,
-				},
-			})
+			deps := testScheduleDeps(filter, filterDesc, updateLock, false)
+			err = scheduling.RunUpgradesOnSchedule(ctx, deps)
 			assert.NoError(t, err)
 
 			shutdownCompleted <- true
@@ -1263,29 +1136,9 @@ func TestEphemeralSelfUpdateExercisesTruePath(t *testing.T) {
 	filterDesc := testFilterDesc
 
 	// Call RunUpgradesOnSchedule with ephemeralSelfUpdate=true
-	err = scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
-		Filter:                     filter,
-		FilterDesc:                 filterDesc,
-		Lock:                       updateLock,
-		ScheduleSpec:               "",
-		WriteStartupMessage:        logging.WriteStartupMessage,
-		RunUpdate:                  runUpdatesWithNotifications,
-		Client:                     nil,
-		Scope:                      "",
-		Notifier:                   nil,
-		MetaVersion:                "",
-		UpdateOnStart:              true,
-		SkipFirstRun:               false,
-		CurrentWatchtowerContainer: nil,
-		StartupMessageSent:         false,
-		BaseParams: types.UpdateParams{
-			Cleanup:             false,
-			MonitorOnly:         false,
-			EphemeralSelfUpdate: true,
-			ReviveStopped:       false,
-			UseComposeDependsOn: false,
-		},
-	})
+	deps := testScheduleDeps(filter, filterDesc, updateLock, true)
+	deps.BaseParams.EphemeralSelfUpdate = true
+	err = scheduling.RunUpgradesOnSchedule(ctx, deps)
 
 	require.NoError(t, err)
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nicholas-fedor/watchtower/internal/actions"
 	"github.com/nicholas-fedor/watchtower/internal/api"
 	"github.com/nicholas-fedor/watchtower/internal/api/handlers/update"
+	appconfig "github.com/nicholas-fedor/watchtower/internal/config"
 	"github.com/nicholas-fedor/watchtower/internal/flags"
 	"github.com/nicholas-fedor/watchtower/internal/logging"
 	"github.com/nicholas-fedor/watchtower/internal/metrics"
@@ -200,39 +201,19 @@ func TestAwaitDockerClient(t *testing.T) {
 }
 
 func TestLifecycleFlags(t *testing.T) {
-	// Test that lifecycle UID and GID flags are properly read
-	originalLifecycleUID := lifecycleUID
-	originalLifecycleGID := lifecycleGID
-
-	defer func() {
-		lifecycleUID = originalLifecycleUID
-		lifecycleGID = originalLifecycleGID
-	}()
-
-	// Reset to defaults
-	lifecycleUID = 0
-	lifecycleGID = 0
-
-	// Test setting flags
 	cmd := &cobra.Command{}
-	flags.RegisterSystemFlags(cmd)
+
+	flags.SetDefaults()
+	flags.RegisterAll(cmd)
 
 	err := cmd.ParseFlags([]string{"--lifecycle-uid", "1000", "--lifecycle-gid", "1001"})
 	require.NoError(t, err)
 
-	// Simulate preRun flag reading
-	uid, err := cmd.Flags().GetInt("lifecycle-uid")
+	cfg, err := appconfig.Load(cmd, nil)
 	require.NoError(t, err)
 
-	lifecycleUID = uid
-
-	gid, err := cmd.Flags().GetInt("lifecycle-gid")
-	require.NoError(t, err)
-
-	lifecycleGID = gid
-
-	assert.Equal(t, 1000, lifecycleUID, "lifecycleUID should be set to 1000")
-	assert.Equal(t, 1001, lifecycleGID, "lifecycleGID should be set to 1001")
+	assert.Equal(t, 1000, cfg.Lifecycle.UID, "lifecycle UID should be set to 1000")
+	assert.Equal(t, 1001, cfg.Lifecycle.GID, "lifecycle GID should be set to 1001")
 }
 
 func TestGetAPIAddr(t *testing.T) {
@@ -530,29 +511,29 @@ func TestUpdateOnStartTriggersImmediateUpdate(t *testing.T) {
 	filterDesc := testFilterDesc
 
 	// The function should trigger immediate update and then start scheduler
-	err = scheduling.RunUpgradesOnSchedule(
-		ctx,
-		cmd,
-		filter,
-		filterDesc,
-		updateLock,
-		false,
-		"",
-		logging.WriteStartupMessage,
-		runUpdatesWithNotifications,
-		nil,
-		"",
-		nil,
-		"",
-		false,
-		true,
-		false,
-		nil,
-		false, // startupMessageSent
-		false, // ephemeralSelfUpdate
-		false, // reviveStopped
-		false, // useComposeDependsOn
-	)
+	err = scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
+		Filter:                     filter,
+		FilterDesc:                 filterDesc,
+		Lock:                       updateLock,
+		ScheduleSpec:               "",
+		WriteStartupMessage:        logging.WriteStartupMessage,
+		RunUpdate:                  runUpdatesWithNotifications,
+		Client:                     nil,
+		Scope:                      "",
+		Notifier:                   nil,
+		MetaVersion:                "",
+		UpdateOnStart:              true,
+		SkipFirstRun:               false,
+		CurrentWatchtowerContainer: nil,
+		StartupMessageSent:         false,
+		BaseParams: types.UpdateParams{
+			Cleanup:             false,
+			MonitorOnly:         false,
+			EphemeralSelfUpdate: false,
+			ReviveStopped:       false,
+			UseComposeDependsOn: false,
+		},
+	})
 
 	// Should not return an error (context cancellation is expected)
 	require.NoError(t, err)
@@ -580,13 +561,6 @@ func TestUpdateOnStartIntegratesWithCronScheduling(t *testing.T) {
 			[]string{"--update-on-start", "--schedule", "@every 1h", "--no-startup-message"},
 		)
 		require.NoError(t, err)
-
-		// Save original scheduleSpec and restore after test
-		originalScheduleSpec := scheduleSpec
-
-		defer func() { scheduleSpec = originalScheduleSpec }()
-
-		scheduleSpec = "@every 1h" // Set the schedule spec that was parsed
 
 		// Track update calls
 		updateCallCount := int32(0)
@@ -622,29 +596,29 @@ func TestUpdateOnStartIntegratesWithCronScheduling(t *testing.T) {
 		filterDesc := testFilterDesc
 
 		startTime := time.Now()
-		err = scheduling.RunUpgradesOnSchedule(
-			ctx,
-			cmd,
-			filter,
-			filterDesc,
-			updateLock,
-			false,
-			"",
-			logging.WriteStartupMessage,
-			runUpdatesWithNotifications,
-			nil,
-			"",
-			nil,
-			"",
-			false,
-			true,
-			false,
-			nil,
-			false, // startupMessageSent
-			false, // ephemeralSelfUpdate
-			false, // reviveStopped
-			false, // useComposeDependsOn
-		)
+		err = scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
+			Filter:                     filter,
+			FilterDesc:                 filterDesc,
+			Lock:                       updateLock,
+			ScheduleSpec:               "",
+			WriteStartupMessage:        logging.WriteStartupMessage,
+			RunUpdate:                  runUpdatesWithNotifications,
+			Client:                     nil,
+			Scope:                      "",
+			Notifier:                   nil,
+			MetaVersion:                "",
+			UpdateOnStart:              true,
+			SkipFirstRun:               false,
+			CurrentWatchtowerContainer: nil,
+			StartupMessageSent:         false,
+			BaseParams: types.UpdateParams{
+				Cleanup:             false,
+				MonitorOnly:         false,
+				EphemeralSelfUpdate: false,
+				ReviveStopped:       false,
+				UseComposeDependsOn: false,
+			},
+		})
 
 		// Should not return an error (context cancellation is expected)
 		require.NoError(t, err)
@@ -718,29 +692,29 @@ func TestUpdateOnStartLockingBehavior(t *testing.T) {
 		filter := types.Filter(func(_ types.FilterableContainer) bool { return false })
 		filterDesc := testFilterDesc
 
-		err = scheduling.RunUpgradesOnSchedule(
-			ctx,
-			cmd,
-			filter,
-			filterDesc,
-			updateLock,
-			false,
-			"",
-			logging.WriteStartupMessage,
-			runUpdatesWithNotifications,
-			nil,
-			"",
-			nil,
-			"",
-			false,
-			false,
-			false,
-			nil,
-			false, // startupMessageSent
-			false, // ephemeralSelfUpdate
-			false, // reviveStopped
-			false, // useComposeDependsOn
-		)
+		err = scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
+			Filter:                     filter,
+			FilterDesc:                 filterDesc,
+			Lock:                       updateLock,
+			ScheduleSpec:               "",
+			WriteStartupMessage:        logging.WriteStartupMessage,
+			RunUpdate:                  runUpdatesWithNotifications,
+			Client:                     nil,
+			Scope:                      "",
+			Notifier:                   nil,
+			MetaVersion:                "",
+			UpdateOnStart:              false,
+			SkipFirstRun:               false,
+			CurrentWatchtowerContainer: nil,
+			StartupMessageSent:         false,
+			BaseParams: types.UpdateParams{
+				Cleanup:             false,
+				MonitorOnly:         false,
+				EphemeralSelfUpdate: false,
+				ReviveStopped:       false,
+				UseComposeDependsOn: false,
+			},
+		})
 
 		// Should not return an error
 		require.NoError(t, err)
@@ -795,29 +769,29 @@ func TestUpdateOnStartSelfUpdateScenario(t *testing.T) {
 		filter := types.Filter(func(_ types.FilterableContainer) bool { return true })
 		filterDesc := testFilterDesc
 
-		err = scheduling.RunUpgradesOnSchedule(
-			ctx,
-			cmd,
-			filter,
-			filterDesc,
-			updateLock,
-			false,
-			"",
-			logging.WriteStartupMessage,
-			runUpdatesWithNotifications,
-			nil,
-			"",
-			nil,
-			"",
-			false,
-			updateOnStart,
-			false,
-			nil,
-			false, // startupMessageSent
-			false, // ephemeralSelfUpdate
-			false, // reviveStopped
-			false, // useComposeDependsOn
-		)
+		err = scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
+			Filter:                     filter,
+			FilterDesc:                 filterDesc,
+			Lock:                       updateLock,
+			ScheduleSpec:               "",
+			WriteStartupMessage:        logging.WriteStartupMessage,
+			RunUpdate:                  runUpdatesWithNotifications,
+			Client:                     nil,
+			Scope:                      "",
+			Notifier:                   nil,
+			MetaVersion:                "",
+			UpdateOnStart:              updateOnStart,
+			SkipFirstRun:               false,
+			CurrentWatchtowerContainer: nil,
+			StartupMessageSent:         false,
+			BaseParams: types.UpdateParams{
+				Cleanup:             false,
+				MonitorOnly:         false,
+				EphemeralSelfUpdate: false,
+				ReviveStopped:       false,
+				UseComposeDependsOn: false,
+			},
+		})
 
 		// Should not return an error
 		require.NoError(t, err)
@@ -885,29 +859,29 @@ func TestUpdateOnStartMultiInstanceScenario(t *testing.T) {
 			filter := types.Filter(func(_ types.FilterableContainer) bool { return false })
 			filterDesc := "instance1"
 
-			err := scheduling.RunUpgradesOnSchedule(
-				ctx,
-				cmd1,
-				filter,
-				filterDesc,
-				updateLock,
-				false,
-				"",
-				logging.WriteStartupMessage,
-				runUpdatesWithNotifications,
-				nil,
-				"",
-				nil,
-				"",
-				false,
-				updateOnStart1,
-				false,
-				nil,
-				false, // startupMessageSent
-				false, // ephemeralSelfUpdate
-				false, // reviveStopped
-				false, // useComposeDependsOn
-			)
+			err := scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
+				Filter:                     filter,
+				FilterDesc:                 filterDesc,
+				Lock:                       updateLock,
+				ScheduleSpec:               "",
+				WriteStartupMessage:        logging.WriteStartupMessage,
+				RunUpdate:                  runUpdatesWithNotifications,
+				Client:                     nil,
+				Scope:                      "",
+				Notifier:                   nil,
+				MetaVersion:                "",
+				UpdateOnStart:              updateOnStart1,
+				SkipFirstRun:               false,
+				CurrentWatchtowerContainer: nil,
+				StartupMessageSent:         false,
+				BaseParams: types.UpdateParams{
+					Cleanup:             false,
+					MonitorOnly:         false,
+					EphemeralSelfUpdate: false,
+					ReviveStopped:       false,
+					UseComposeDependsOn: false,
+				},
+			})
 			assert.NoError(t, err)
 			completed.Add(1)
 			close(instance1Called)
@@ -920,29 +894,29 @@ func TestUpdateOnStartMultiInstanceScenario(t *testing.T) {
 			filter := types.Filter(func(_ types.FilterableContainer) bool { return false })
 			filterDesc := "instance2"
 
-			err := scheduling.RunUpgradesOnSchedule(
-				ctx,
-				cmd2,
-				filter,
-				filterDesc,
-				updateLock,
-				false,
-				"",
-				logging.WriteStartupMessage,
-				runUpdatesWithNotifications,
-				nil,
-				"",
-				nil,
-				"",
-				false,
-				updateOnStart2,
-				false,
-				nil,
-				false, // startupMessageSent
-				false, // ephemeralSelfUpdate
-				false, // reviveStopped
-				false, // useComposeDependsOn
-			)
+			err := scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
+				Filter:                     filter,
+				FilterDesc:                 filterDesc,
+				Lock:                       updateLock,
+				ScheduleSpec:               "",
+				WriteStartupMessage:        logging.WriteStartupMessage,
+				RunUpdate:                  runUpdatesWithNotifications,
+				Client:                     nil,
+				Scope:                      "",
+				Notifier:                   nil,
+				MetaVersion:                "",
+				UpdateOnStart:              updateOnStart2,
+				SkipFirstRun:               false,
+				CurrentWatchtowerContainer: nil,
+				StartupMessageSent:         false,
+				BaseParams: types.UpdateParams{
+					Cleanup:             false,
+					MonitorOnly:         false,
+					EphemeralSelfUpdate: false,
+					ReviveStopped:       false,
+					UseComposeDependsOn: false,
+				},
+			})
 			assert.NoError(t, err)
 			completed.Add(1)
 			close(instance2Called)
@@ -1122,29 +1096,29 @@ func TestRunUpgradesOnSchedule_ShutdownWaitsForRunningUpdate(t *testing.T) {
 			filterDesc := testFilterDesc
 
 			// This should start and wait for context cancellation
-			err := scheduling.RunUpgradesOnSchedule(
-				ctx,
-				cmd,
-				filter,
-				filterDesc,
-				updateLock,
-				false,
-				"",
-				logging.WriteStartupMessage,
-				runUpdatesWithNotifications,
-				nil,
-				"",
-				nil,
-				"",
-				false,
-				false,
-				false,
-				nil,
-				false, // startupMessageSent
-				false, // ephemeralSelfUpdate
-				false, // reviveStopped
-				false, // useComposeDependsOn
-			)
+			err := scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
+				Filter:                     filter,
+				FilterDesc:                 filterDesc,
+				Lock:                       updateLock,
+				ScheduleSpec:               "",
+				WriteStartupMessage:        logging.WriteStartupMessage,
+				RunUpdate:                  runUpdatesWithNotifications,
+				Client:                     nil,
+				Scope:                      "",
+				Notifier:                   nil,
+				MetaVersion:                "",
+				UpdateOnStart:              false,
+				SkipFirstRun:               false,
+				CurrentWatchtowerContainer: nil,
+				StartupMessageSent:         false,
+				BaseParams: types.UpdateParams{
+					Cleanup:             false,
+					MonitorOnly:         false,
+					EphemeralSelfUpdate: false,
+					ReviveStopped:       false,
+					UseComposeDependsOn: false,
+				},
+			})
 			assert.NoError(t, err)
 
 			shutdownCompleted <- true
@@ -1289,29 +1263,29 @@ func TestEphemeralSelfUpdateExercisesTruePath(t *testing.T) {
 	filterDesc := testFilterDesc
 
 	// Call RunUpgradesOnSchedule with ephemeralSelfUpdate=true
-	err = scheduling.RunUpgradesOnSchedule(
-		ctx,
-		cmd,
-		filter,
-		filterDesc,
-		updateLock,
-		false,
-		"",
-		logging.WriteStartupMessage,
-		runUpdatesWithNotifications,
-		nil,
-		"",
-		nil,
-		"",
-		false,
-		true,
-		false,
-		nil,
-		false, // startupMessageSent
-		true,  // ephemeralSelfUpdate
-		false, // reviveStopped
-		false, // useComposeDependsOn
-	)
+	err = scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
+		Filter:                     filter,
+		FilterDesc:                 filterDesc,
+		Lock:                       updateLock,
+		ScheduleSpec:               "",
+		WriteStartupMessage:        logging.WriteStartupMessage,
+		RunUpdate:                  runUpdatesWithNotifications,
+		Client:                     nil,
+		Scope:                      "",
+		Notifier:                   nil,
+		MetaVersion:                "",
+		UpdateOnStart:              true,
+		SkipFirstRun:               false,
+		CurrentWatchtowerContainer: nil,
+		StartupMessageSent:         false,
+		BaseParams: types.UpdateParams{
+			Cleanup:             false,
+			MonitorOnly:         false,
+			EphemeralSelfUpdate: true,
+			ReviveStopped:       false,
+			UseComposeDependsOn: false,
+		},
+	})
 
 	require.NoError(t, err)
 
@@ -1810,7 +1784,7 @@ func TestValidateAPIHost(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := validateAPIHost(tt.host)
+			err := appconfig.ValidateAPIHost(tt.host)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -1823,21 +1797,21 @@ func TestValidateAPIHost(t *testing.T) {
 func TestAnyHTTPAPIConfig(t *testing.T) {
 	t.Parallel()
 
-	assert.False(t, anyHTTPAPIConfig(types.RunConfig{}))
-	assert.True(t, anyHTTPAPIConfig(types.RunConfig{APIToken: "secret"}))
-	assert.True(t, anyHTTPAPIConfig(types.RunConfig{TLSCertPath: "/cert.pem"}))
-	assert.True(t, anyHTTPAPIConfig(types.RunConfig{CORSAllowedOrigins: []string{"https://app.example.com"}}))
-	assert.True(t, anyHTTPAPIConfig(types.RunConfig{APIHostChanged: true}))
-	assert.True(t, anyHTTPAPIConfig(types.RunConfig{APIPortChanged: true}))
-	assert.True(t, anyHTTPAPIConfig(types.RunConfig{APIRateLimitChanged: true}))
+	assert.False(t, appconfig.AnyHTTPAPIConfig(types.RunConfig{}))
+	assert.True(t, appconfig.AnyHTTPAPIConfig(types.RunConfig{APIToken: "secret"}))
+	assert.True(t, appconfig.AnyHTTPAPIConfig(types.RunConfig{TLSCertPath: "/cert.pem"}))
+	assert.True(t, appconfig.AnyHTTPAPIConfig(types.RunConfig{CORSAllowedOrigins: []string{"https://app.example.com"}}))
+	assert.True(t, appconfig.AnyHTTPAPIConfig(types.RunConfig{APIHostChanged: true}))
+	assert.True(t, appconfig.AnyHTTPAPIConfig(types.RunConfig{APIPortChanged: true}))
+	assert.True(t, appconfig.AnyHTTPAPIConfig(types.RunConfig{APIRateLimitChanged: true}))
 }
 
 func TestHTTPAPIEndpointsEnabled(t *testing.T) {
 	t.Parallel()
 
-	assert.False(t, httpAPIEndpointsEnabled(types.RunConfig{}))
-	assert.True(t, httpAPIEndpointsEnabled(types.RunConfig{EnableHealthAPI: true}))
-	assert.True(t, httpAPIEndpointsEnabled(types.RunConfig{EnableUpdateAPI: true}))
+	assert.False(t, appconfig.HTTPAPIEndpointsEnabled(types.RunConfig{}))
+	assert.True(t, appconfig.HTTPAPIEndpointsEnabled(types.RunConfig{EnableHealthAPI: true}))
+	assert.True(t, appconfig.HTTPAPIEndpointsEnabled(types.RunConfig{EnableUpdateAPI: true}))
 }
 
 func TestRootCommand_ReviveStoppedFlagParsing(t *testing.T) {

--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -34,33 +34,23 @@ const (
 	ContainerRemainsRunningMessage = "Container remains running (monitor-only mode)"
 )
 
-// RunUpdatesWithNotificationsParams holds the parameters for RunUpdatesWithNotifications.
+// RunUpdatesWithNotificationsParams holds runtime dependencies and update policy.
+//
+// Update carries the full types.UpdateParams snapshot from config.UpdateParams
+// (or an equivalent complete construction).
 type RunUpdatesWithNotificationsParams struct {
-	Client                       container.Client    // Docker client for container operations
-	Notifier                     types.Notifier      // Notification system for sending update status messages
-	NotificationSplitByContainer bool                // Enable separate notifications for each updated container
-	NotificationReport           bool                // Enable report-based notifications
-	Filter                       types.Filter        // Container filter determining which containers are targeted
-	Cleanup                      bool                // Remove old images after container updates
-	NoRestart                    bool                // Prevent containers from being restarted after updates
-	ReviveStopped                bool                // Start stopped containers after update if true.
-	MonitorOnly                  bool                // Monitor containers without performing updates
-	LifecycleHooks               bool                // Enable pre- and post-update lifecycle hook commands
-	RollingRestart               bool                // Update containers sequentially rather than all at once
-	LabelPrecedence              bool                // Give container label settings priority over global flags
-	NoPull                       bool                // Skip pulling new images from registry during updates
-	Timeout                      time.Duration       // Maximum duration for container stop operations
-	LifecycleUID                 int                 // Default UID to run lifecycle hooks as
-	LifecycleGID                 int                 // Default GID to run lifecycle hooks as
-	CPUCopyMode                  string              // CPU settings handling when recreating containers
-	PullFailureDelay             time.Duration       // Delay after failed Watchtower self-update pulls
-	RunOnce                      bool                // Perform one-time update and exit
-	CurrentContainerID           types.ContainerID   // ID of the current Watchtower container for self-update logic
-	UseComposeDependsOn          bool                // Enable Docker Compose depends_on label processing
-	SkipSelfUpdate               bool                // Skip Watchtower self-update
-	EphemeralSelfUpdate          bool                // Use ephemeral container for self-update if true
-	CooldownDelay                time.Duration       // Minimum time since image creation before allowing updates.
-	EventBroadcaster             *events.Broadcaster // Broadcaster for SSE event streaming
+	// Client is the Docker client for container operations.
+	Client container.Client
+	// Notifier sends update status messages to configured channels.
+	Notifier types.Notifier
+	// NotificationSplitByContainer enables a separate notification per updated container.
+	NotificationSplitByContainer bool
+	// NotificationReport enables report-based notification templates.
+	NotificationReport bool
+	// EventBroadcaster publishes SSE events during the update session.
+	EventBroadcaster *events.Broadcaster
+	// Update is the complete update policy for this invocation (filter, cleanup, timeouts, etc.).
+	Update types.UpdateParams
 }
 
 // RunUpdatesWithNotifications performs container updates and sends notifications about the results.
@@ -80,32 +70,10 @@ func RunUpdatesWithNotifications(
 ) *metrics.Metric {
 	logrus.Debug("Starting RunUpdatesWithNotifications")
 
-	// Initiate notification batching
+	// Initiate notification batching.
 	startNotifications(params.Notifier, params.NotificationSplitByContainer)
 
-	// Configure update parameters based on provided flags
-	updateConfig := types.UpdateParams{
-		Filter:              params.Filter,              // Container filter determining which containers are targeted
-		Cleanup:             params.Cleanup,             // Remove old images after container updates
-		NoRestart:           params.NoRestart,           // Prevent containers from being restarted after updates
-		MonitorOnly:         params.MonitorOnly,         // Monitor containers without performing updates
-		LifecycleHooks:      params.LifecycleHooks,      // Enable pre- and post-update lifecycle hook commands
-		RollingRestart:      params.RollingRestart,      // Update containers sequentially rather than all at once
-		LabelPrecedence:     params.LabelPrecedence,     // Give container label settings priority over global flags
-		NoPull:              params.NoPull,              // Skip pulling new images from registry during updates
-		Timeout:             params.Timeout,             // Maximum duration for container stop operations
-		PullFailureDelay:    params.PullFailureDelay,    // Delay after failed Watchtower self-update pulls
-		LifecycleUID:        params.LifecycleUID,        // Default UID to run lifecycle hooks as
-		LifecycleGID:        params.LifecycleGID,        // Default GID to run lifecycle hooks as
-		CPUCopyMode:         params.CPUCopyMode,         // CPU settings handling when recreating containers
-		RunOnce:             params.RunOnce,             // Perform one-time update and exit
-		CurrentContainerID:  params.CurrentContainerID,  // ID of the current Watchtower container for self-update logic
-		UseComposeDependsOn: params.UseComposeDependsOn, // Enable Docker Compose depends_on label processing
-		SkipSelfUpdate:      params.SkipSelfUpdate,      // Skip Watchtower self-update
-		EphemeralSelfUpdate: params.EphemeralSelfUpdate, // Use ephemeral container for self-update if true
-		CooldownDelay:       params.CooldownDelay,       // Minimum time since image creation before allowing updates
-		ReviveStopped:       params.ReviveStopped,       // Start stopped containers after update if true
-	}
+	updateConfig := params.Update
 
 	// Publish redacted policy flags only to avoid UpdateParams leaking internal IDs.
 	if params.EventBroadcaster != nil {
@@ -156,11 +124,11 @@ func RunUpdatesWithNotifications(
 		return metric
 	}
 
-	// Perform image cleanup if enabled
+	// Perform image cleanup if enabled.
 	cleanedImages := performImageCleanup(
 		ctx,
 		params.Client,
-		params.Cleanup,
+		updateConfig.Cleanup,
 		cleanupImageInfosPtr,
 	)
 

--- a/internal/actions/actions_test.go
+++ b/internal/actions/actions_test.go
@@ -19,6 +19,23 @@ import (
 	mockTypes "github.com/nicholas-fedor/watchtower/pkg/types/mocks"
 )
 
+// defaultTestUpdateParams returns a complete UpdateParams snapshot for tests.
+//
+// Parameters:
+//   - filter: Container filter for the update session.
+//
+// Returns:
+//   - types.UpdateParams: Policy values matching the previous test defaults.
+func defaultTestUpdateParams(filter types.Filter) types.UpdateParams {
+	return types.UpdateParams{
+		Filter:       filter,
+		Timeout:      time.Minute,
+		LifecycleUID: 1000,
+		LifecycleGID: 1001,
+		CPUCopyMode:  "auto",
+	}
+}
+
 var _ = ginkgo.Describe("Actions", func() {
 	ginkgo.Describe("handleUpdateResult", func() {
 		ginkgo.When("given an error", func() {
@@ -79,19 +96,7 @@ var _ = ginkgo.Describe("Actions", func() {
 					Notifier:                     nil,
 					NotificationSplitByContainer: false,
 					NotificationReport:           false,
-					Filter:                       filters.NoFilter,
-					Cleanup:                      false,
-					NoRestart:                    false,
-					MonitorOnly:                  false,
-					LifecycleHooks:               false,
-					RollingRestart:               false,
-					LabelPrecedence:              false,
-					NoPull:                       false,
-					Timeout:                      time.Minute,
-					LifecycleUID:                 1000,
-					LifecycleGID:                 1001,
-					CPUCopyMode:                  "auto",
-					PullFailureDelay:             time.Duration(0),
+					Update:                       defaultTestUpdateParams(filters.NoFilter),
 				}
 				metric := RunUpdatesWithNotifications(context.Background(), params)
 
@@ -130,19 +135,7 @@ var _ = ginkgo.Describe("Actions", func() {
 					Notifier:                     notifier,
 					NotificationSplitByContainer: true,
 					NotificationReport:           false,
-					Filter:                       filters.NoFilter,
-					Cleanup:                      false,
-					NoRestart:                    false,
-					MonitorOnly:                  false,
-					LifecycleHooks:               false,
-					RollingRestart:               false,
-					LabelPrecedence:              false,
-					NoPull:                       false,
-					Timeout:                      time.Minute,
-					LifecycleUID:                 1000,
-					LifecycleGID:                 1001,
-					CPUCopyMode:                  "auto",
-					PullFailureDelay:             time.Duration(0),
+					Update:                       defaultTestUpdateParams(filters.NoFilter),
 				}
 				metric := RunUpdatesWithNotifications(context.Background(), params)
 
@@ -167,19 +160,7 @@ var _ = ginkgo.Describe("Actions", func() {
 					Notifier:                     nil,
 					NotificationSplitByContainer: false,
 					NotificationReport:           false,
-					Filter:                       filters.NoFilter,
-					Cleanup:                      false,
-					NoRestart:                    false,
-					MonitorOnly:                  false,
-					LifecycleHooks:               false,
-					RollingRestart:               false,
-					LabelPrecedence:              false,
-					NoPull:                       false,
-					Timeout:                      time.Minute,
-					LifecycleUID:                 1000,
-					LifecycleGID:                 1001,
-					CPUCopyMode:                  "auto",
-					PullFailureDelay:             time.Duration(0),
+					Update:                       defaultTestUpdateParams(filters.NoFilter),
 				}
 
 				// Empty container list results in zero metrics
@@ -234,27 +215,15 @@ var _ = ginkgo.Describe("Actions", func() {
 						false,
 					)
 
+					update := defaultTestUpdateParams(filters.NoFilter)
+					update.CurrentContainerID = types.ContainerID("container1-id")
+
 					params := RunUpdatesWithNotificationsParams{
 						Client:                       client,
 						Notifier:                     nil,
 						NotificationSplitByContainer: false,
 						NotificationReport:           false,
-						Filter:                       filters.NoFilter,
-						Cleanup:                      false,
-						NoRestart:                    false,
-						MonitorOnly:                  false,
-						LifecycleHooks:               false,
-						RollingRestart:               false,
-						LabelPrecedence:              false,
-						NoPull:                       false,
-						Timeout:                      time.Minute,
-						LifecycleUID:                 1000,
-						LifecycleGID:                 1001,
-						CPUCopyMode:                  "auto",
-						PullFailureDelay:             time.Duration(0),
-						CurrentContainerID: types.ContainerID(
-							"container1-id",
-						), // Set to first container
+						Update:                       update,
 					}
 
 					metric := RunUpdatesWithNotifications(context.Background(), params)
@@ -967,22 +936,9 @@ var _ = ginkgo.Describe("Actions", func() {
 						Notifier:                     nil,
 						NotificationSplitByContainer: false,
 						NotificationReport:           false,
-						Filter: filters.FilterByScope(
-							"scope-a",
-							filters.NoFilter,
+						Update: defaultTestUpdateParams(
+							filters.FilterByScope("scope-a", filters.NoFilter),
 						),
-						Cleanup:          false,
-						NoRestart:        false,
-						MonitorOnly:      false,
-						LifecycleHooks:   false,
-						RollingRestart:   false,
-						LabelPrecedence:  false,
-						NoPull:           false,
-						Timeout:          time.Minute,
-						LifecycleUID:     1000,
-						LifecycleGID:     1001,
-						CPUCopyMode:      "auto",
-						PullFailureDelay: time.Duration(0),
 					}
 
 					metric := RunUpdatesWithNotifications(context.Background(), params)
@@ -997,22 +953,9 @@ var _ = ginkgo.Describe("Actions", func() {
 						Notifier:                     nil,
 						NotificationSplitByContainer: false,
 						NotificationReport:           false,
-						Filter: filters.FilterByScope(
-							"scope-b",
-							filters.NoFilter,
+						Update: defaultTestUpdateParams(
+							filters.FilterByScope("scope-b", filters.NoFilter),
 						),
-						Cleanup:          false,
-						NoRestart:        false,
-						MonitorOnly:      false,
-						LifecycleHooks:   false,
-						RollingRestart:   false,
-						LabelPrecedence:  false,
-						NoPull:           false,
-						Timeout:          time.Minute,
-						LifecycleUID:     1000,
-						LifecycleGID:     1001,
-						CPUCopyMode:      "auto",
-						PullFailureDelay: time.Duration(0),
 					}
 
 					metric := RunUpdatesWithNotifications(context.Background(), params)
@@ -1112,22 +1055,9 @@ var _ = ginkgo.Describe("Actions", func() {
 						Notifier:                     nil,
 						NotificationSplitByContainer: false,
 						NotificationReport:           false,
-						Filter: filters.FilterByScope(
-							"scope1",
-							filters.WatchtowerContainersFilter,
+						Update: defaultTestUpdateParams(
+							filters.FilterByScope("scope1", filters.WatchtowerContainersFilter),
 						),
-						Cleanup:          false,
-						NoRestart:        false,
-						MonitorOnly:      false,
-						LifecycleHooks:   false,
-						RollingRestart:   false,
-						LabelPrecedence:  false,
-						NoPull:           false,
-						Timeout:          time.Minute,
-						LifecycleUID:     1000,
-						LifecycleGID:     1001,
-						CPUCopyMode:      "auto",
-						PullFailureDelay: time.Duration(0),
 					}
 					RunUpdatesWithNotifications(context.Background(), params)
 				}()
@@ -1140,22 +1070,9 @@ var _ = ginkgo.Describe("Actions", func() {
 						Notifier:                     nil,
 						NotificationSplitByContainer: false,
 						NotificationReport:           false,
-						Filter: filters.FilterByScope(
-							"scope2",
-							filters.WatchtowerContainersFilter,
+						Update: defaultTestUpdateParams(
+							filters.FilterByScope("scope2", filters.WatchtowerContainersFilter),
 						),
-						Cleanup:          false,
-						NoRestart:        false,
-						MonitorOnly:      false,
-						LifecycleHooks:   false,
-						RollingRestart:   false,
-						LabelPrecedence:  false,
-						NoPull:           false,
-						Timeout:          time.Minute,
-						LifecycleUID:     1000,
-						LifecycleGID:     1001,
-						CPUCopyMode:      "auto",
-						PullFailureDelay: time.Duration(0),
 					}
 					RunUpdatesWithNotifications(context.Background(), params)
 				}()
@@ -1238,27 +1155,17 @@ var _ = ginkgo.Describe("Actions", func() {
 			go func() {
 				defer wg.Done()
 
+				updateA := defaultTestUpdateParams(
+					filters.FilterByScope("scope-a", filters.WatchtowerContainersFilter),
+				)
+				updateA.Cleanup = true
+
 				params := RunUpdatesWithNotificationsParams{
 					Client:                       clientA,
 					Notifier:                     nil,
 					NotificationSplitByContainer: false,
 					NotificationReport:           false,
-					Filter: filters.FilterByScope(
-						"scope-a",
-						filters.WatchtowerContainersFilter,
-					),
-					Cleanup:          true, // Enable cleanup
-					NoRestart:        false,
-					MonitorOnly:      false,
-					LifecycleHooks:   false,
-					RollingRestart:   false,
-					LabelPrecedence:  false,
-					NoPull:           false,
-					Timeout:          time.Minute,
-					LifecycleUID:     1000,
-					LifecycleGID:     1001,
-					CPUCopyMode:      "auto",
-					PullFailureDelay: time.Duration(0),
+					Update:                       updateA,
 				}
 				RunUpdatesWithNotifications(context.Background(), params)
 			}()
@@ -1266,27 +1173,17 @@ var _ = ginkgo.Describe("Actions", func() {
 			go func() {
 				defer wg.Done()
 
+				updateB := defaultTestUpdateParams(
+					filters.FilterByScope("scope-b", filters.WatchtowerContainersFilter),
+				)
+				updateB.Cleanup = true
+
 				params := RunUpdatesWithNotificationsParams{
 					Client:                       clientB,
 					Notifier:                     nil,
 					NotificationSplitByContainer: false,
 					NotificationReport:           false,
-					Filter: filters.FilterByScope(
-						"scope-b",
-						filters.WatchtowerContainersFilter,
-					),
-					Cleanup:          true, // Enable cleanup
-					NoRestart:        false,
-					MonitorOnly:      false,
-					LifecycleHooks:   false,
-					RollingRestart:   false,
-					LabelPrecedence:  false,
-					NoPull:           false,
-					Timeout:          time.Minute,
-					LifecycleUID:     1000,
-					LifecycleGID:     1001,
-					CPUCopyMode:      "auto",
-					PullFailureDelay: time.Duration(0),
+					Update:                       updateB,
 				}
 				RunUpdatesWithNotifications(context.Background(), params)
 			}()
@@ -1387,22 +1284,9 @@ var _ = ginkgo.Describe("Actions", func() {
 						Notifier:                     nil,
 						NotificationSplitByContainer: false,
 						NotificationReport:           false,
-						Filter: filters.FilterByScope(
-							"prod",
-							filters.NoFilter,
+						Update: defaultTestUpdateParams(
+							filters.FilterByScope("prod", filters.NoFilter),
 						),
-						Cleanup:          false,
-						NoRestart:        false,
-						MonitorOnly:      false,
-						LifecycleHooks:   false,
-						RollingRestart:   false,
-						LabelPrecedence:  false,
-						NoPull:           false,
-						Timeout:          time.Minute,
-						LifecycleUID:     1000,
-						LifecycleGID:     1001,
-						CPUCopyMode:      "auto",
-						PullFailureDelay: time.Duration(0),
 					}
 
 					metric := RunUpdatesWithNotifications(context.Background(), params)
@@ -1417,22 +1301,9 @@ var _ = ginkgo.Describe("Actions", func() {
 						Notifier:                     nil,
 						NotificationSplitByContainer: false,
 						NotificationReport:           false,
-						Filter: filters.FilterByScope(
-							"dev",
-							filters.NoFilter,
+						Update: defaultTestUpdateParams(
+							filters.FilterByScope("dev", filters.NoFilter),
 						),
-						Cleanup:          false,
-						NoRestart:        false,
-						MonitorOnly:      false,
-						LifecycleHooks:   false,
-						RollingRestart:   false,
-						LabelPrecedence:  false,
-						NoPull:           false,
-						Timeout:          time.Minute,
-						LifecycleUID:     1000,
-						LifecycleGID:     1001,
-						CPUCopyMode:      "auto",
-						PullFailureDelay: time.Duration(0),
 					}
 
 					metric := RunUpdatesWithNotifications(context.Background(), params)
@@ -1530,22 +1401,9 @@ var _ = ginkgo.Describe("Actions", func() {
 						Notifier:                     nil, // No notifications for this test
 						NotificationSplitByContainer: false,
 						NotificationReport:           false,
-						Filter: filters.FilterByScope(
-							"scope-a",
-							filters.NoFilter,
+						Update: defaultTestUpdateParams(
+							filters.FilterByScope("scope-a", filters.NoFilter),
 						),
-						Cleanup:          false,
-						NoRestart:        false,
-						MonitorOnly:      false,
-						LifecycleHooks:   false,
-						RollingRestart:   false,
-						LabelPrecedence:  false,
-						NoPull:           false,
-						Timeout:          time.Minute,
-						LifecycleUID:     1000,
-						LifecycleGID:     1001,
-						CPUCopyMode:      "auto",
-						PullFailureDelay: time.Duration(0),
 					}
 
 					metric := RunUpdatesWithNotifications(context.Background(), params)
@@ -1617,51 +1475,31 @@ var _ = ginkgo.Describe("Actions", func() {
 				clientB := mockActions.CreateMockClient(testDataB, false, false)
 
 				// Run scope-a operation (cleanup should fail)
+				updateA := defaultTestUpdateParams(
+					filters.FilterByScope("scope-a", filters.NoFilter),
+				)
+				updateA.Cleanup = true
+
 				paramsA := RunUpdatesWithNotificationsParams{
 					Client:                       clientA,
 					Notifier:                     nil,
 					NotificationSplitByContainer: false,
 					NotificationReport:           false,
-					Filter: filters.FilterByScope(
-						"scope-a",
-						filters.NoFilter,
-					),
-					Cleanup:          true,
-					NoRestart:        false,
-					MonitorOnly:      false,
-					LifecycleHooks:   false,
-					RollingRestart:   false,
-					LabelPrecedence:  false,
-					NoPull:           false,
-					Timeout:          time.Minute,
-					LifecycleUID:     1000,
-					LifecycleGID:     1001,
-					CPUCopyMode:      "auto",
-					PullFailureDelay: time.Duration(0),
+					Update:                       updateA,
 				}
 
 				// Run scope-b operation (cleanup should succeed)
+				updateB := defaultTestUpdateParams(
+					filters.FilterByScope("scope-b", filters.NoFilter),
+				)
+				updateB.Cleanup = true
+
 				paramsB := RunUpdatesWithNotificationsParams{
 					Client:                       clientB,
 					Notifier:                     nil,
 					NotificationSplitByContainer: false,
 					NotificationReport:           false,
-					Filter: filters.FilterByScope(
-						"scope-b",
-						filters.NoFilter,
-					),
-					Cleanup:          true,
-					NoRestart:        false,
-					MonitorOnly:      false,
-					LifecycleHooks:   false,
-					RollingRestart:   false,
-					LabelPrecedence:  false,
-					NoPull:           false,
-					Timeout:          time.Minute,
-					LifecycleUID:     1000,
-					LifecycleGID:     1001,
-					CPUCopyMode:      "auto",
-					PullFailureDelay: time.Duration(0),
+					Update:                       updateB,
 				}
 
 				var wg sync.WaitGroup
@@ -1771,22 +1609,9 @@ var _ = ginkgo.Describe("Actions", func() {
 							Notifier:                     nil,
 							NotificationSplitByContainer: false,
 							NotificationReport:           false,
-							Filter: filters.FilterByScope(
-								"scope-x",
-								filters.NoFilter,
+							Update: defaultTestUpdateParams(
+								filters.FilterByScope("scope-x", filters.NoFilter),
 							),
-							Cleanup:          false,
-							NoRestart:        false,
-							MonitorOnly:      false,
-							LifecycleHooks:   false,
-							RollingRestart:   false,
-							LabelPrecedence:  false,
-							NoPull:           false,
-							Timeout:          time.Minute,
-							LifecycleUID:     1000,
-							LifecycleGID:     1001,
-							CPUCopyMode:      "auto",
-							PullFailureDelay: time.Duration(0),
 						}
 
 						metric := RunUpdatesWithNotifications(context.Background(), params)
@@ -1801,22 +1626,9 @@ var _ = ginkgo.Describe("Actions", func() {
 							Notifier:                     nil,
 							NotificationSplitByContainer: false,
 							NotificationReport:           false,
-							Filter: filters.FilterByScope(
-								"scope-y",
-								filters.NoFilter,
+							Update: defaultTestUpdateParams(
+								filters.FilterByScope("scope-y", filters.NoFilter),
 							),
-							Cleanup:          false,
-							NoRestart:        false,
-							MonitorOnly:      false,
-							LifecycleHooks:   false,
-							RollingRestart:   false,
-							LabelPrecedence:  false,
-							NoPull:           false,
-							Timeout:          time.Minute,
-							LifecycleUID:     1000,
-							LifecycleGID:     1001,
-							CPUCopyMode:      "auto",
-							PullFailureDelay: time.Duration(0),
 						}
 
 						metric := RunUpdatesWithNotifications(context.Background(), params)

--- a/internal/actions/doc.go
+++ b/internal/actions/doc.go
@@ -25,20 +25,13 @@
 //		Notifier:                     notifier,
 //		NotificationSplitByContainer: false,
 //		NotificationReport:           false,
-//		Filter:                       filter,
-//		Cleanup:                      true,
-//		NoRestart:                    false,
-//		MonitorOnly:                  false,
-//		LifecycleHooks:               false,
-//		RollingRestart:               false,
-//		LabelPrecedence:              false,
-//		NoPull:                       false,
-//		Timeout:                      30 * time.Second,
-//		LifecycleUID:                 0,
-//		LifecycleGID:                 0,
-//		CPUCopyMode:                  "",
+//		Update: types.UpdateParams{
+//			Filter:  filter,
+//			Cleanup: true,
+//			Timeout: 30 * time.Second,
+//		},
 //	}
-//	metric := actions.RunUpdatesWithNotifications(params)
+//	metric := actions.RunUpdatesWithNotifications(ctx, params)
 //
 // The package integrates with the container package for Docker operations, session package for update reporting, sorter package for container ordering, and lifecycle package for pre/post-update
 // hooks, using logrus for logging operations and errors.

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -651,31 +650,31 @@ func TestIntegration_APIAndScheduling_ConcurrentWithUnblockHTTPAPI(t *testing.T)
 	schedCtx, schedCancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer schedCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(
-		schedCtx,
-		&cobra.Command{},
-		func(_ types.FilterableContainer) bool { return true },
-		"test filter",
-		make(chan bool, 1),
-		false,
-		"@every 1h",
-		logging.WriteStartupMessage,
-		func(_ context.Context, _ types.Filter, _ types.UpdateParams) *metrics.Metric {
+	err := scheduling.RunUpgradesOnSchedule(schedCtx, scheduling.ScheduleDeps{
+		Filter:              func(_ types.FilterableContainer) bool { return true },
+		FilterDesc:          "test filter",
+		Lock:                make(chan bool, 1),
+		ScheduleSpec:        "@every 1h",
+		WriteStartupMessage: logging.WriteStartupMessage,
+		RunUpdate: func(_ context.Context, _ types.Filter, _ types.UpdateParams) *metrics.Metric {
 			return &metrics.Metric{}
 		},
-		nil,
-		"",
-		nil,
-		"",
-		false,
-		false,
-		false,
-		nil,
-		true,
-		false,
-		false, // reviveStopped
-		false, // useComposeDependsOn
-	)
+		Client:                     nil,
+		Scope:                      "",
+		Notifier:                   nil,
+		MetaVersion:                "",
+		UpdateOnStart:              false,
+		SkipFirstRun:               false,
+		CurrentWatchtowerContainer: nil,
+		StartupMessageSent:         true,
+		BaseParams: types.UpdateParams{
+			Cleanup:             false,
+			MonitorOnly:         false,
+			EphemeralSelfUpdate: false,
+			ReviveStopped:       false,
+			UseComposeDependsOn: false,
+		},
+	})
 	require.NoError(t, err, "RunUpgradesOnSchedule should run concurrently after SetupAndStartAPI returns")
 }
 
@@ -689,13 +688,15 @@ func TestIntegration_UpdateHonorsReviveStoppedAndComposeDependsOn(t *testing.T) 
 	app := api.New(testLogger(), 60, api.ProxyConfig{}, api.CORSConfig{}, false)
 
 	opts := config.Options{
-		Token:               "test-token",
-		EnableUpdateAPI:     true,
-		UnblockHTTPAPI:      true,
-		ReviveStopped:       true,
-		UseComposeDependsOn: true,
-		Client:              makeListContainersMock(t),
-		Filter:              makeFilter(t),
+		Token:           "test-token",
+		EnableUpdateAPI: true,
+		UnblockHTTPAPI:  true,
+		BaseParams: types.UpdateParams{
+			ReviveStopped:       true,
+			UseComposeDependsOn: true,
+		},
+		Client: makeListContainersMock(t),
+		Filter: makeFilter(t),
 		RunUpdatesWithNotifications: func(_ context.Context, _ types.Filter, params types.UpdateParams) *metrics.Metric {
 			captured = params
 

--- a/internal/api/config/config.go
+++ b/internal/api/config/config.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/middleware/timeout"
-	"github.com/spf13/cobra"
 
 	"github.com/nicholas-fedor/watchtower/internal/api/handlers/events"
+	"github.com/nicholas-fedor/watchtower/internal/logging"
 	mt "github.com/nicholas-fedor/watchtower/internal/metrics"
 	"github.com/nicholas-fedor/watchtower/pkg/container"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
@@ -50,58 +50,88 @@ const (
 	DefaultUpdateTimeout = 10 * time.Minute
 )
 
-// Options holds all configuration for SetupAndStartAPI.
+// Options holds transport and runtime configuration for SetupAndStartAPI.
 type Options struct {
-	Host                         string
-	Port                         string
-	Token                        string
-	EventsToken                  string
-	RateLimit                    int
-	EnableUpdateAPI              bool
-	EnableMetricsAPI             bool
-	EnableContainersAPI          bool
-	EnableCheckAPI               bool
-	EnableSwaggerAPI             bool
-	EnableHealthAPI              bool
-	EnableHistoryAPI             bool
-	EnableImagesAPI              bool
-	EnableConfigAPI              bool
-	EnableEventsAPI              bool
-	UnblockHTTPAPI               bool
-	NoStartupMessage             bool
-	TLSCertPath                  string
-	TLSKeyPath                   string
-	CORSAllowedOrigins           []string
-	TrustedProxies               []string
-	ProxyHeader                  string
-	Filter                       types.Filter
-	Command                      *cobra.Command
-	FilterDesc                   string
-	UpdateLock                   chan bool
-	Cleanup                      bool
-	MonitorOnly                  bool
-	NoPull                       bool
-	NoRestart                    bool
-	RollingRestart               bool
-	IncludeStopped               bool
-	IncludeRestarting            bool
-	LifecycleHooks               bool
-	LabelEnable                  bool
-	LabelPrecedence              bool
-	CooldownDelay                time.Duration
-	SkipSelfUpdate               bool
-	ReviveStopped                bool
-	UseComposeDependsOn          bool
-	Client                       container.Client
-	Notifier                     types.Notifier
+	// Host is the HTTP bind host (empty means all interfaces).
+	Host string
+	// Port is the HTTP bind port.
+	Port string
+	// Token authenticates HTTP API requests.
+	Token string
+	// EventsToken authenticates the events SSE endpoint.
+	EventsToken string
+	// RateLimit is the maximum authentication requests per minute per IP.
+	RateLimit int
+	// EnableUpdateAPI enables the /v1/update endpoint.
+	EnableUpdateAPI bool
+	// EnableMetricsAPI enables the metrics endpoint.
+	EnableMetricsAPI bool
+	// EnableContainersAPI enables the containers listing endpoint.
+	EnableContainersAPI bool
+	// EnableCheckAPI enables the /v1/check endpoint.
+	EnableCheckAPI bool
+	// EnableSwaggerAPI enables the Swagger UI endpoint.
+	EnableSwaggerAPI bool
+	// EnableHealthAPI enables health probe endpoints.
+	EnableHealthAPI bool
+	// EnableHistoryAPI enables the history endpoint.
+	EnableHistoryAPI bool
+	// EnableImagesAPI enables the images endpoint.
+	EnableImagesAPI bool
+	// EnableConfigAPI enables the config inspection endpoint.
+	EnableConfigAPI bool
+	// EnableEventsAPI enables the events SSE endpoint.
+	EnableEventsAPI bool
+	// UnblockHTTPAPI keeps scheduled polls running when the HTTP API is enabled.
+	UnblockHTTPAPI bool
+	// NoStartupMessage suppresses startup logs and notifications.
+	NoStartupMessage bool
+	// TLSCertPath is the path to the TLS certificate file.
+	TLSCertPath string
+	// TLSKeyPath is the path to the TLS key file.
+	TLSKeyPath string
+	// CORSAllowedOrigins lists allowed CORS origins.
+	CORSAllowedOrigins []string
+	// TrustedProxies lists trusted proxy IPs or CIDRs.
+	TrustedProxies []string
+	// ProxyHeader is the header used for the real client IP behind a reverse proxy.
+	ProxyHeader string
+	// Filter is the process-wide container filter predicate.
+	Filter types.Filter
+	// FilterDesc is a human-readable description of the filter for startup messaging.
+	FilterDesc string
+	// UpdateLock serializes concurrent update sessions.
+	UpdateLock chan bool
+	// BaseParams is the complete update policy snapshot from config.UpdateParams.
+	BaseParams types.UpdateParams
+	// IncludeStopped is exposed on the config API (client list option).
+	IncludeStopped bool
+	// IncludeRestarting is exposed on the config API (client list option).
+	IncludeRestarting bool
+	// LabelEnable is exposed on the config API (filter option).
+	LabelEnable bool
+	// Client is the Docker client used by API handlers.
+	Client container.Client
+	// Notifier sends update and check status messages.
+	Notifier types.Notifier
+	// NotificationSplitByContainer sends one notification per updated container when true.
 	NotificationSplitByContainer bool
-	Scope                        string
-	Version                      string
-	RunUpdatesWithNotifications  func(context.Context, types.Filter, types.UpdateParams) *mt.Metric
-	FilterByImage                func([]string, types.Filter) types.Filter
-	DefaultMetrics               func() *mt.Metrics
-	WriteStartupMessage          func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool)
-	EventBroadcaster             *events.Broadcaster
+	// Scope limits operations to containers matching this Watchtower scope.
+	Scope string
+	// Version is the Watchtower version string used in startup messaging.
+	Version string
+	// Startup holds resolved values for blocking-mode startup messaging.
+	Startup logging.StartupParams
+	// RunUpdatesWithNotifications runs the scan-and-update pipeline for HTTP update requests.
+	RunUpdatesWithNotifications func(context.Context, types.Filter, types.UpdateParams) *mt.Metric
+	// FilterByImage builds an image-scoped filter for update and check requests.
+	FilterByImage func([]string, types.Filter) types.Filter
+	// DefaultMetrics returns the process metrics store.
+	DefaultMetrics func() *mt.Metrics
+	// WriteStartupMessage writes the blocking-mode startup message when the update API starts.
+	WriteStartupMessage func(logging.StartupParams)
+	// EventBroadcaster publishes action events to SSE subscribers.
+	EventBroadcaster *events.Broadcaster
 	// OnUnexpectedServerStop is invoked when the HTTP server exits with an
 	// unexpected error while running in non-blocking mode. Callers typically
 	// cancel the process context so scheduling shuts down with the API.
@@ -114,9 +144,10 @@ type Options struct {
 	UpdateTimeout time.Duration
 }
 
-// BuildUpdateParams constructs UpdateParams for HTTP-triggered updates from
-// the resolved CLI/API options. Fields match those used by scheduled and
-// run-once paths so HTTP updates honor the same operational flags.
+// BuildUpdateParams returns the complete UpdateParams snapshot for HTTP-triggered updates.
+//
+// Policy fields come only from BaseParams so HTTP, schedule, and run-once paths share the
+// same config.UpdateParams construction. RunOnce is forced false for HTTP sessions.
 //
 // Parameters:
 //   - opts: API configuration options.
@@ -124,20 +155,15 @@ type Options struct {
 // Returns:
 //   - types.UpdateParams: Parameters for the update pipeline.
 func BuildUpdateParams(opts Options) types.UpdateParams {
-	return types.UpdateParams{
-		Cleanup:             opts.Cleanup,
-		NoRestart:           opts.NoRestart,
-		ReviveStopped:       opts.ReviveStopped,
-		MonitorOnly:         opts.MonitorOnly,
-		NoPull:              opts.NoPull,
-		LifecycleHooks:      opts.LifecycleHooks,
-		RollingRestart:      opts.RollingRestart,
-		LabelPrecedence:     opts.LabelPrecedence,
-		RunOnce:             false,
-		UseComposeDependsOn: opts.UseComposeDependsOn,
-		SkipSelfUpdate:      opts.SkipSelfUpdate,
-		CooldownDelay:       opts.CooldownDelay,
+	params := opts.BaseParams
+	params.RunOnce = false
+
+	// Fall back to the process-wide filter when BaseParams did not carry one.
+	if params.Filter == nil {
+		params.Filter = opts.Filter
 	}
+
+	return params
 }
 
 // ValidateUpdateOptions validates that all required update options are set.

--- a/internal/api/config/config_test.go
+++ b/internal/api/config/config_test.go
@@ -84,17 +84,20 @@ func TestBuildUpdateParams(t *testing.T) {
 	t.Parallel()
 
 	opts := Options{
-		Cleanup:             true,
-		NoRestart:           true,
-		ReviveStopped:       true,
-		MonitorOnly:         true,
-		NoPull:              true,
-		LifecycleHooks:      true,
-		RollingRestart:      true,
-		LabelPrecedence:     true,
-		UseComposeDependsOn: true,
-		SkipSelfUpdate:      true,
-		CooldownDelay:       24 * time.Hour,
+		BaseParams: types.UpdateParams{
+			Cleanup:             true,
+			NoRestart:           true,
+			ReviveStopped:       true,
+			MonitorOnly:         true,
+			NoPull:              true,
+			LifecycleHooks:      true,
+			RollingRestart:      true,
+			LabelPrecedence:     true,
+			UseComposeDependsOn: true,
+			SkipSelfUpdate:      true,
+			CooldownDelay:       24 * time.Hour,
+			RunOnce:             true, // must be cleared for HTTP path
+		},
 	}
 
 	params := BuildUpdateParams(opts)

--- a/internal/api/lifecycle_test.go
+++ b/internal/api/lifecycle_test.go
@@ -7,15 +7,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nicholas-fedor/watchtower/internal/api/config"
 	"github.com/nicholas-fedor/watchtower/internal/api/handlers/events"
+	"github.com/nicholas-fedor/watchtower/internal/logging"
 	"github.com/nicholas-fedor/watchtower/internal/metrics"
-	"github.com/nicholas-fedor/watchtower/pkg/container"
 	mockContainer "github.com/nicholas-fedor/watchtower/pkg/container/mocks"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
@@ -336,7 +335,7 @@ func TestRegisterUpdateRoute_UnblockHTTPAPI(t *testing.T) {
 		DefaultMetrics: func() *metrics.Metrics {
 			return &metrics.Metrics{}
 		},
-		WriteStartupMessage: func(_ *cobra.Command, _ time.Time, _, _ string, _ container.Client, _ types.Notifier, _ string, _ *bool) {
+		WriteStartupMessage: func(_ logging.StartupParams) {
 			startupCalled.Add(1)
 		},
 	})
@@ -548,7 +547,7 @@ func TestRunServer_BlockingUntilCancel(t *testing.T) {
 		},
 		FilterByImage:  func(_ []string, f types.Filter) types.Filter { return f },
 		DefaultMetrics: func() *metrics.Metrics { return testMetrics },
-		WriteStartupMessage: func(_ *cobra.Command, _ time.Time, _, _ string, _ container.Client, _ types.Notifier, _ string, _ *bool) {
+		WriteStartupMessage: func(_ logging.StartupParams) {
 		},
 	})
 

--- a/internal/api/routes/check.go
+++ b/internal/api/routes/check.go
@@ -24,12 +24,7 @@ func registerCheckRoute(app *fiber.App, auth fiber.Handler, opts config.Options)
 
 	handler := check.New(
 		func(ctx context.Context, images, names []string) ([]check.ContainerCheck, error) {
-			params := types.UpdateParams{
-				MonitorOnly:     opts.MonitorOnly,
-				NoPull:          opts.NoPull,
-				LabelPrecedence: opts.LabelPrecedence,
-				CooldownDelay:   opts.CooldownDelay,
-			}
+			params := config.BuildUpdateParams(opts)
 
 			imageFilter := opts.FilterByImage(images, opts.Filter)
 			containerFilter := update.ContainerFilter(names)

--- a/internal/api/routes/check_test.go
+++ b/internal/api/routes/check_test.go
@@ -4,15 +4,13 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/nicholas-fedor/watchtower/internal/api/config"
 	"github.com/nicholas-fedor/watchtower/internal/api/handlers/events"
+	"github.com/nicholas-fedor/watchtower/internal/logging"
 	"github.com/nicholas-fedor/watchtower/internal/metrics"
-	"github.com/nicholas-fedor/watchtower/pkg/container"
 	mockContainer "github.com/nicholas-fedor/watchtower/pkg/container/mocks"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
@@ -103,7 +101,7 @@ func TestRegisterUpdateRoute_WriteStartupMessage(t *testing.T) {
 		},
 		FilterByImage:  func(_ []string, f types.Filter) types.Filter { return f },
 		DefaultMetrics: func() *metrics.Metrics { return testMetrics },
-		WriteStartupMessage: func(_ *cobra.Command, _ time.Time, _, _ string, _ container.Client, _ types.Notifier, _ string, _ *bool) {
+		WriteStartupMessage: func(_ logging.StartupParams) {
 		},
 	}
 

--- a/internal/api/routes/config.go
+++ b/internal/api/routes/config.go
@@ -12,14 +12,14 @@ import (
 func registerConfigRoute(app *fiber.App, auth fiber.Handler, opts apiconfig.Options) {
 	handler := config.New(func(_ context.Context) (config.ConfigData, error) {
 		return config.ConfigData{
-			MonitorOnly:       opts.MonitorOnly,
-			Cleanup:           opts.Cleanup,
-			NoPull:            opts.NoPull,
-			NoRestart:         opts.NoRestart,
-			RollingRestart:    opts.RollingRestart,
+			MonitorOnly:       opts.BaseParams.MonitorOnly,
+			Cleanup:           opts.BaseParams.Cleanup,
+			NoPull:            opts.BaseParams.NoPull,
+			NoRestart:         opts.BaseParams.NoRestart,
+			RollingRestart:    opts.BaseParams.RollingRestart,
 			IncludeStopped:    opts.IncludeStopped,
 			IncludeRestarting: opts.IncludeRestarting,
-			LifecycleHooks:    opts.LifecycleHooks,
+			LifecycleHooks:    opts.BaseParams.LifecycleHooks,
 			LabelEnable:       opts.LabelEnable,
 			FilterDesc:        opts.FilterDesc,
 			Scope:             opts.Scope,

--- a/internal/api/routes/containers.go
+++ b/internal/api/routes/containers.go
@@ -8,7 +8,6 @@ import (
 	"github.com/nicholas-fedor/watchtower/internal/api/config"
 	"github.com/nicholas-fedor/watchtower/internal/api/handlers/containers"
 	"github.com/nicholas-fedor/watchtower/internal/api/handlers/containers/details"
-	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
 func registerContainersRoute(app *fiber.App, auth fiber.Handler, opts config.Options) {
@@ -27,11 +26,7 @@ func registerContainersDetailsRoute(app *fiber.App, auth fiber.Handler, opts con
 		return
 	}
 
-	detailsParams := types.UpdateParams{
-		MonitorOnly:     opts.MonitorOnly,
-		NoPull:          opts.NoPull,
-		LabelPrecedence: opts.LabelPrecedence,
-	}
+	detailsParams := config.BuildUpdateParams(opts)
 	handler := details.New(func(ctx context.Context, name, image string) ([]details.ContainerDetails, error) {
 		return details.GetContainerDetails(ctx, opts.Client, opts.Filter, name, image, detailsParams)
 	})

--- a/internal/api/routes/update.go
+++ b/internal/api/routes/update.go
@@ -39,10 +39,15 @@ func registerUpdateRoute(ctx context.Context, app *fiber.App, auth fiber.Handler
 		Timeout: updateTimeout,
 	}))
 
+	// In blocking HTTP API mode, emit the startup message once when the update route registers.
 	if !opts.UnblockHTTPAPI && opts.WriteStartupMessage != nil {
-		opts.WriteStartupMessage(
-			opts.Command, time.Time{}, opts.FilterDesc, opts.Scope,
-			opts.Client, opts.Notifier, opts.Version, nil,
-		)
+		startup := opts.Startup
+		startup.Sched = time.Time{}
+		startup.Filtering = opts.FilterDesc
+		startup.Scope = opts.Scope
+		startup.Client = opts.Client
+		startup.Notifier = opts.Notifier
+		startup.Version = opts.Version
+		opts.WriteStartupMessage(startup)
 	}
 }

--- a/internal/api/routes/update_test.go
+++ b/internal/api/routes/update_test.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/nicholas-fedor/watchtower/internal/api/config"
+	"github.com/nicholas-fedor/watchtower/internal/logging"
 	"github.com/nicholas-fedor/watchtower/internal/metrics"
-	"github.com/nicholas-fedor/watchtower/pkg/container"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
@@ -52,18 +50,20 @@ func TestRegisterUpdateRoute_BuildsFullUpdateParams(t *testing.T) {
 	var got types.UpdateParams
 
 	opts := config.Options{
-		EnableUpdateAPI:     true,
-		UnblockHTTPAPI:      true,
-		Cleanup:             true,
-		ReviveStopped:       true,
-		UseComposeDependsOn: true,
-		NoPull:              true,
-		NoRestart:           true,
-		LifecycleHooks:      true,
-		RollingRestart:      true,
-		LabelPrecedence:     true,
-		SkipSelfUpdate:      true,
-		Filter:              func(_ types.FilterableContainer) bool { return true },
+		EnableUpdateAPI: true,
+		UnblockHTTPAPI:  true,
+		BaseParams: types.UpdateParams{
+			Cleanup:             true,
+			ReviveStopped:       true,
+			UseComposeDependsOn: true,
+			NoPull:              true,
+			NoRestart:           true,
+			LifecycleHooks:      true,
+			RollingRestart:      true,
+			LabelPrecedence:     true,
+			SkipSelfUpdate:      true,
+		},
+		Filter: func(_ types.FilterableContainer) bool { return true },
 		RunUpdatesWithNotifications: func(_ context.Context, _ types.Filter, params types.UpdateParams) *metrics.Metric {
 			got = params
 
@@ -126,15 +126,7 @@ func TestRegisterUpdateRoute_WriteStartupMessageCalledWhenBlocking(t *testing.T)
 		},
 		FilterByImage:  func(_ []string, f types.Filter) types.Filter { return f },
 		DefaultMetrics: func() *metrics.Metrics { return testMetrics },
-		WriteStartupMessage: func(
-			_ *cobra.Command,
-			_ time.Time,
-			_, _ string,
-			_ container.Client,
-			_ types.Notifier,
-			_ string,
-			_ *bool,
-		) {
+		WriteStartupMessage: func(_ logging.StartupParams) {
 			called = true
 		},
 	}

--- a/internal/config/api/api.go
+++ b/internal/config/api/api.go
@@ -1,0 +1,52 @@
+// Package api holds HTTP API transport and endpoint settings.
+package api
+
+import "time"
+
+// API holds HTTP API server configuration.
+type API struct {
+	// Endpoints lists enabled endpoint names, or contains "all".
+	Endpoints []string
+	// LegacyUpdate enables the legacy http-api-update flag behavior.
+	LegacyUpdate bool
+	// LegacyMetrics enables the legacy http-api-metrics flag behavior.
+	LegacyMetrics bool
+	// LegacyContainers enables the legacy http-api-containers flag behavior.
+	LegacyContainers bool
+	// Host is the bind host.
+	Host string
+	// HostChanged is true when the host flag was explicitly set.
+	HostChanged bool
+	// Port is the bind port.
+	Port string
+	// PortChanged is true when the port flag was explicitly set.
+	PortChanged bool
+	// Token is the API authentication token.
+	Token string
+	// EventsToken is the events SSE authentication token.
+	EventsToken string
+	// PeriodicPolls keeps scheduled polls when the HTTP API is enabled.
+	PeriodicPolls bool
+	// RateLimit is max auth requests per minute per IP.
+	RateLimit int
+	// RateLimitChanged is true when the rate-limit flag was explicitly set.
+	RateLimitChanged bool
+	// TLSCert is the path to the TLS certificate file.
+	TLSCert string
+	// TLSKey is the path to the TLS key file.
+	TLSKey string
+	// TrustedProxies lists trusted proxy CIDRs or IPs.
+	TrustedProxies []string
+	// ProxyHeader is the header used for the real client IP.
+	ProxyHeader string
+	// CORSOrigins lists allowed CORS origins.
+	CORSOrigins []string
+	// CheckTimeout is the max duration for /v1/check.
+	CheckTimeout time.Duration
+	// CheckTimeoutChanged is true when the check-timeout flag was explicitly set.
+	CheckTimeoutChanged bool
+	// UpdateTimeout is the max duration for /v1/update.
+	UpdateTimeout time.Duration
+	// UpdateTimeoutChanged is true when the update-timeout flag was explicitly set.
+	UpdateTimeoutChanged bool
+}

--- a/internal/config/client/client.go
+++ b/internal/config/client/client.go
@@ -1,0 +1,29 @@
+// Package client holds Docker client construction options derived from flags.
+//
+// Projected into container.ClientOptions via config.ClientOptions.
+package client
+
+// Client holds options passed to container.NewClient.
+type Client struct {
+	// IncludeStopped includes created and exited containers in updates
+	// (--include-stopped / WATCHTOWER_INCLUDE_STOPPED).
+	IncludeStopped bool
+	// IncludeRestarting includes containers that are restarting
+	// (--include-restarting / WATCHTOWER_INCLUDE_RESTARTING).
+	IncludeRestarting bool
+	// ReviveStopped starts stopped containers after update when IncludeStopped is active
+	// (--revive-stopped / WATCHTOWER_REVIVE_STOPPED).
+	ReviveStopped bool
+	// RemoveVolumes removes attached volumes before updating
+	// (--remove-volumes / WATCHTOWER_REMOVE_VOLUMES).
+	RemoveVolumes bool
+	// DisableMemorySwappiness clears memory swappiness when recreating containers
+	// for Podman compatibility (--disable-memory-swappiness).
+	DisableMemorySwappiness bool
+	// CPUCopyMode controls CPU settings when recreating containers
+	// (--cpu-copy-mode / WATCHTOWER_CPU_COPY_MODE: auto, full, none).
+	CPUCopyMode string
+	// WarnOnHeadFailure is the HEAD pull failure warning strategy
+	// (--warn-on-head-failure / WATCHTOWER_WARN_ON_HEAD_FAILURE: always, auto, never).
+	WarnOnHeadFailure string
+}

--- a/internal/config/client_opts.go
+++ b/internal/config/client_opts.go
@@ -18,8 +18,9 @@ func (c Config) ClientOptions() container.ClientOptions {
 		ReviveStopped:           c.Client.ReviveStopped,
 		RemoveVolumes:           c.Client.RemoveVolumes,
 		DisableMemorySwappiness: c.Client.DisableMemorySwappiness || c.Compatibility.DisableMemorySwappiness,
-		CPUCopyMode:             firstNonEmpty(c.Client.CPUCopyMode, c.Compatibility.CPUCopyMode),
-		WarnOnHeadFailed:        container.WarningStrategy(c.Client.WarnOnHeadFailure),
+		// Prefer Compatibility, then Client — same order as UpdateParams.
+		CPUCopyMode:      firstNonEmpty(c.Compatibility.CPUCopyMode, c.Client.CPUCopyMode),
+		WarnOnHeadFailed: container.WarningStrategy(c.Client.WarnOnHeadFailure),
 	}
 }
 

--- a/internal/config/client_opts.go
+++ b/internal/config/client_opts.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"github.com/nicholas-fedor/watchtower/pkg/container"
+)
+
+// ClientOptions builds container.ClientOptions from the resolved Config.
+//
+// Parameters:
+//   - none (receiver Config).
+//
+// Returns:
+//   - container.ClientOptions: Options for container.NewClient.
+func (c Config) ClientOptions() container.ClientOptions {
+	return container.ClientOptions{
+		IncludeStopped:          c.Client.IncludeStopped,
+		IncludeRestarting:       c.Client.IncludeRestarting,
+		ReviveStopped:           c.Client.ReviveStopped,
+		RemoveVolumes:           c.Client.RemoveVolumes,
+		DisableMemorySwappiness: c.Client.DisableMemorySwappiness || c.Compatibility.DisableMemorySwappiness,
+		CPUCopyMode:             firstNonEmpty(c.Client.CPUCopyMode, c.Compatibility.CPUCopyMode),
+		WarnOnHeadFailed:        container.WarningStrategy(c.Client.WarnOnHeadFailure),
+	}
+}
+
+// firstNonEmpty returns a if non-empty, otherwise b.
+//
+// Parameters:
+//   - a: Preferred string.
+//   - b: Fallback string.
+//
+// Returns:
+//   - string: First non-empty value, or empty if both are empty.
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+
+	return b
+}

--- a/internal/config/compatibility/compatibility.go
+++ b/internal/config/compatibility/compatibility.go
@@ -1,0 +1,10 @@
+// Package compatibility holds runtime compatibility settings (for example Podman).
+package compatibility
+
+// Compatibility holds container recreate compatibility options.
+type Compatibility struct {
+	// DisableMemorySwappiness clears memory swappiness when recreating containers.
+	DisableMemorySwappiness bool
+	// CPUCopyMode controls CPU settings when recreating containers.
+	CPUCopyMode string
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"github.com/nicholas-fedor/watchtower/internal/config/api"
+	"github.com/nicholas-fedor/watchtower/internal/config/client"
+	"github.com/nicholas-fedor/watchtower/internal/config/compatibility"
+	"github.com/nicholas-fedor/watchtower/internal/config/docker"
+	"github.com/nicholas-fedor/watchtower/internal/config/filter"
+	"github.com/nicholas-fedor/watchtower/internal/config/lifecycle"
+	"github.com/nicholas-fedor/watchtower/internal/config/logging"
+	"github.com/nicholas-fedor/watchtower/internal/config/mode"
+	"github.com/nicholas-fedor/watchtower/internal/config/notify"
+	"github.com/nicholas-fedor/watchtower/internal/config/registry"
+	"github.com/nicholas-fedor/watchtower/internal/config/schedule"
+	"github.com/nicholas-fedor/watchtower/internal/config/update"
+)
+
+// Config is the immutable process configuration snapshot produced by Load.
+//
+// Each field is a domain group aligned with internal/flags/<domain> registration.
+// Use UpdateParams and ClientOptions to project this snapshot into the DTOs
+// consumed by the update pipeline and Docker client construction.
+type Config struct {
+	// Docker holds Docker daemon connection settings (host, TLS, API version, cert path).
+	Docker docker.Docker
+	// Client holds options passed to container.NewClient (include-stopped, revive-stopped, etc.).
+	Client client.Client
+	// Schedule holds poll interval, cron spec, and update-on-start.
+	Schedule schedule.Schedule
+	// Mode holds process entry shape (run-once, health-check, porcelain, orchestrator).
+	Mode mode.Mode
+	// Update holds container update policy (cleanup, no-pull, compose depends-on, timeouts).
+	Update update.Update
+	// Lifecycle holds pre/post update lifecycle hook defaults (enable, UID, GID).
+	Lifecycle lifecycle.Lifecycle
+	// Filter holds container selection inputs and the resolved predicate.
+	Filter filter.Filter
+	// Registry holds registry TLS settings.
+	Registry registry.Registry
+	// Compatibility holds runtime compatibility options (for example Podman CPU/memory).
+	Compatibility compatibility.Compatibility
+	// API holds HTTP API transport, auth, and endpoint settings.
+	API api.API
+	// Notify holds notification URLs and related options for notifications.NewNotifier.
+	Notify notify.Notify
+	// Logging holds console log format and level settings.
+	Logging logging.Logging
+}

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -1,0 +1,23 @@
+// Package config resolves process configuration into a single immutable Config.
+//
+// Flags are declared in internal/flags. This package is the only production site
+// that should construct types.UpdateParams and container.ClientOptions for
+// run-once, scheduled, and HTTP API update paths.
+//
+// Domain settings live under internal/config/<domain>. Placement rules:
+//
+//   - Update policy (stop/start/pull/restart) belongs on Update and flows through UpdateParams.
+//   - Container selection belongs on Filter (including label-enable, name lists, and scope).
+//   - Schedule and Mode control when the process runs (interval/cron, run-once, health-check).
+//   - Client construction options (include-stopped, revive-stopped, remove-volumes, etc.)
+//     are projected via ClientOptions.
+//   - Notify holds notification settings; notifications.NewNotifier takes Config.Notify.
+//   - API holds HTTP API transport and endpoint settings.
+//
+// Per-run deltas use RunOverrides only (filter override, run-once, skip self-update,
+// current container ID). Do not rebuild partial UpdateParams in consumers.
+//
+// Load expects flag registration, ProcessFlagAliases, SetupLogging, and GetSecretsFromFiles
+// to have already run. All domains bind through a process-local Viper instance
+// (flag > env > static default) via FlagSpec rows.
+package config

--- a/internal/config/docker/docker.go
+++ b/internal/config/docker/docker.go
@@ -1,0 +1,14 @@
+// Package docker holds Docker API connection settings.
+package docker
+
+// Docker holds Docker daemon connection settings.
+type Docker struct {
+	// Host is the Docker daemon socket or host URL.
+	Host string
+	// TLSVerify enables TLS verification for remote daemons.
+	TLSVerify bool
+	// APIVersion is the Docker API version, or empty for negotiation.
+	APIVersion string
+	// CertPath is the path to TLS certificates.
+	CertPath string
+}

--- a/internal/config/filter/filter.go
+++ b/internal/config/filter/filter.go
@@ -1,0 +1,28 @@
+// Package filter holds container selection inputs and the resolved filter.
+package filter
+
+import "github.com/nicholas-fedor/watchtower/pkg/types"
+
+// Filter holds raw filter inputs and the resolved predicate.
+type Filter struct {
+	// LabelEnable restricts watching to containers with the enable label.
+	LabelEnable bool
+	// DisableContainers lists container names to exclude.
+	DisableContainers []string
+	// MonitorImageNames lists image name patterns to include.
+	MonitorImageNames []string
+	// SkipImageNames lists image name patterns to exclude.
+	SkipImageNames []string
+	// EnableContainersByLabel lists key=value pairs that must match.
+	EnableContainersByLabel []string
+	// DisableContainersByLabel lists key=value pairs that exclude matches.
+	DisableContainersByLabel []string
+	// Scope is the Watchtower monitoring scope label value.
+	Scope string
+	// Names are positional container name arguments.
+	Names []string
+	// Predicate is the resolved container filter function.
+	Predicate types.Filter
+	// Desc is a human-readable description of the filter.
+	Desc string
+}

--- a/internal/config/lifecycle/lifecycle.go
+++ b/internal/config/lifecycle/lifecycle.go
@@ -1,0 +1,12 @@
+// Package lifecycle holds pre/post update lifecycle hook settings.
+package lifecycle
+
+// Lifecycle holds lifecycle hook configuration.
+type Lifecycle struct {
+	// Enabled turns on pre- and post-update lifecycle hooks.
+	Enabled bool
+	// UID is the default UID for lifecycle hook commands.
+	UID int
+	// GID is the default GID for lifecycle hook commands.
+	GID int
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1,0 +1,431 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/nicholas-fedor/watchtower/internal/config/api"
+	"github.com/nicholas-fedor/watchtower/internal/config/client"
+	"github.com/nicholas-fedor/watchtower/internal/config/compatibility"
+	"github.com/nicholas-fedor/watchtower/internal/config/docker"
+	"github.com/nicholas-fedor/watchtower/internal/config/filter"
+	"github.com/nicholas-fedor/watchtower/internal/config/lifecycle"
+	"github.com/nicholas-fedor/watchtower/internal/config/logging"
+	"github.com/nicholas-fedor/watchtower/internal/config/mode"
+	"github.com/nicholas-fedor/watchtower/internal/config/notify"
+	"github.com/nicholas-fedor/watchtower/internal/config/registry"
+	"github.com/nicholas-fedor/watchtower/internal/config/schedule"
+	"github.com/nicholas-fedor/watchtower/internal/config/update"
+	"github.com/nicholas-fedor/watchtower/internal/flags"
+	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
+	"github.com/nicholas-fedor/watchtower/internal/util"
+	"github.com/nicholas-fedor/watchtower/pkg/filters"
+)
+
+var (
+	// ErrNegativeStopTimeout indicates stop-timeout was set to a negative duration.
+	ErrNegativeStopTimeout = errors.New("stop-timeout must be non-negative")
+	// ErrNegativeCooldownDelay indicates cooldown-delay was set to a negative duration.
+	ErrNegativeCooldownDelay = errors.New("cooldown-delay must be non-negative")
+	// ErrRollingRestartWithMonitorOnly indicates incompatible rolling-restart and monitor-only flags.
+	ErrRollingRestartWithMonitorOnly = errors.New(
+		"rolling-restart and monitor-only cannot both be enabled",
+	)
+)
+
+// Load reads resolved settings from a parsed Cobra command into Config.
+//
+// Callers must run flag registration, ProcessFlagAliases, SetupLogging, and
+// GetSecretsFromFiles before Load. Load does not re-parse CLI arguments.
+//
+// Values are resolved through a process-local Viper instance (flag > env >
+// static default) using FlagSpec metadata from every domain.
+//
+// Parameters:
+//   - cmd: Parsed root command with persistent flags populated.
+//   - args: Positional container name arguments for filtering.
+//
+// Returns:
+//   - Config: Immutable configuration snapshot.
+//   - error: Non-nil when required flags are missing or values are invalid.
+func Load(cmd *cobra.Command, args []string) (Config, error) {
+	flagSet := cmd.PersistentFlags()
+
+	vip := viper.New()
+
+	err := flags.BindAll(vip, flagSet, flags.AllSpecs())
+	if err != nil {
+		return Config{}, fmt.Errorf("bind configuration: %w", err)
+	}
+
+	cfg := Config{}
+
+	cfg.Docker = loadDocker(vip)
+	cfg.Client = loadClient(vip)
+	cfg.Compatibility = loadCompat(vip)
+
+	// Keep client and compat CPU/memory fields aligned for projections.
+	if cfg.Client.CPUCopyMode == "" {
+		cfg.Client.CPUCopyMode = cfg.Compatibility.CPUCopyMode
+	}
+
+	if !cfg.Client.DisableMemorySwappiness {
+		cfg.Client.DisableMemorySwappiness = cfg.Compatibility.DisableMemorySwappiness
+	}
+
+	cfg.Schedule = loadSchedule(vip)
+	cfg.Mode = loadMode(vip)
+
+	cfg.Update, err = loadUpdate(vip, flagSet)
+	if err != nil {
+		return Config{}, err
+	}
+
+	cfg.Lifecycle = loadLifecycle(vip)
+
+	cfg.Filter, err = loadFilter(vip, flagSet, args)
+	if err != nil {
+		return Config{}, err
+	}
+
+	cfg.Registry = loadRegistry(vip)
+	cfg.API = loadAPI(vip, flagSet)
+	cfg.Notify = loadNotify(vip, flagSet)
+	cfg.Logging = loadLogging(vip)
+
+	err = validate(cfg)
+	if err != nil {
+		return Config{}, err
+	}
+
+	return cfg, nil
+}
+
+// loadDocker reads Docker connection settings from Viper after BindAll.
+func loadDocker(v *viper.Viper) docker.Docker {
+	return docker.Docker{
+		Host:       v.GetString("host"),
+		TLSVerify:  v.GetBool("tlsverify"),
+		APIVersion: strings.Trim(v.GetString("api-version"), "\""),
+		CertPath:   v.GetString("cert-path"),
+	}
+}
+
+// loadClient reads Docker client construction settings from Viper.
+func loadClient(vip *viper.Viper) client.Client {
+	return client.Client{
+		IncludeStopped:    vip.GetBool("include-stopped"),
+		IncludeRestarting: vip.GetBool("include-restarting"),
+		ReviveStopped:     vip.GetBool("revive-stopped"),
+		RemoveVolumes:     vip.GetBool("remove-volumes"),
+		WarnOnHeadFailure: vip.GetString("warn-on-head-failure"),
+	}
+}
+
+// loadCompat reads runtime compatibility settings from Viper.
+func loadCompat(vip *viper.Viper) compatibility.Compatibility {
+	return compatibility.Compatibility{
+		DisableMemorySwappiness: vip.GetBool("disable-memory-swappiness"),
+		CPUCopyMode:             vip.GetString("cpu-copy-mode"),
+	}
+}
+
+// loadSchedule reads schedule settings from Viper.
+func loadSchedule(vip *viper.Viper) schedule.Schedule {
+	return schedule.Schedule{
+		IntervalSeconds: vip.GetInt("interval"),
+		Spec:            vip.GetString("schedule"),
+		UpdateOnStart:   vip.GetBool("update-on-start"),
+	}
+}
+
+// loadMode reads process mode settings from Viper.
+func loadMode(vip *viper.Viper) mode.Mode {
+	return mode.Mode{
+		RunOnce:                vip.GetBool("run-once"),
+		HealthCheck:            vip.GetBool("health-check"),
+		Porcelain:              vip.GetString("porcelain"),
+		SelfUpdateOrchestrator: vip.GetBool("self-update-orchestrator"),
+		NoStartupMessage:       vip.GetBool("no-startup-message"),
+	}
+}
+
+// loadUpdate reads update policy settings from Viper.
+func loadUpdate(vip *viper.Viper, flagSet *pflag.FlagSet) (update.Update, error) {
+	stopTimeout := durationValue(vip, flagSet, "stop-timeout", []string{"WATCHTOWER_TIMEOUT"})
+
+	if stopTimeout < 0 {
+		return update.Update{}, ErrNegativeStopTimeout
+	}
+
+	if stopTimeout > 0 && stopTimeout < time.Second {
+		logrus.WithField("timeout", stopTimeout).
+			Warn("WATCHTOWER_TIMEOUT is less than 1 second")
+	}
+
+	cooldownStr := vip.GetString("cooldown-delay")
+
+	var cooldown time.Duration
+
+	if cooldownStr != "" {
+		parsed, err := util.ParseDuration(cooldownStr)
+		if err != nil {
+			return update.Update{}, fmt.Errorf("cooldown-delay: %w", err)
+		}
+
+		if parsed < 0 {
+			return update.Update{}, ErrNegativeCooldownDelay
+		}
+
+		cooldown = parsed
+	}
+
+	return update.Update{
+		Cleanup:             vip.GetBool("cleanup"),
+		NoPull:              vip.GetBool("no-pull"),
+		NoRestart:           vip.GetBool("no-restart"),
+		MonitorOnly:         vip.GetBool("monitor-only"),
+		RollingRestart:      vip.GetBool("rolling-restart"),
+		StopTimeout:         stopTimeout,
+		CooldownDelay:       cooldown,
+		UseComposeDependsOn: vip.GetBool("use-compose-depends-on"),
+		LabelPrecedence:     vip.GetBool("label-take-precedence"),
+		EphemeralSelfUpdate: vip.GetBool("ephemeral-self-update"),
+	}, nil
+}
+
+// loadLifecycle reads lifecycle hook settings from Viper.
+func loadLifecycle(vip *viper.Viper) lifecycle.Lifecycle {
+	return lifecycle.Lifecycle{
+		Enabled: vip.GetBool("enable-lifecycle-hooks"),
+		UID:     vip.GetInt("lifecycle-uid"),
+		GID:     vip.GetInt("lifecycle-gid"),
+	}
+}
+
+// loadFilter reads filter settings, normalizes names, and builds the predicate.
+func loadFilter(vip *viper.Viper, flagSet *pflag.FlagSet, args []string) (filter.Filter, error) {
+	labelEnable := vip.GetBool("label-enable")
+
+	disableContainers := stringSliceValue(
+		vip, flagSet, "disable-containers",
+		[]string{"WATCHTOWER_DISABLE_CONTAINERS"},
+		spec.ListCommaOrSpace,
+	)
+	for i := range disableContainers {
+		disableContainers[i] = util.NormalizeContainerName(disableContainers[i])
+	}
+
+	monitorImages := stringSliceValue(
+		vip, flagSet, "monitor-image-names",
+		[]string{"WATCHTOWER_MONITOR_IMAGE_NAMES"},
+		spec.ListCommaOrSpace,
+	)
+	for i := range monitorImages {
+		monitorImages[i] = strings.TrimSpace(monitorImages[i])
+	}
+
+	skipImages := stringSliceValue(
+		vip, flagSet, "skip-image-names",
+		[]string{"WATCHTOWER_SKIP_IMAGE_NAMES"},
+		spec.ListCommaOrSpace,
+	)
+	for i := range skipImages {
+		skipImages[i] = strings.TrimSpace(skipImages[i])
+	}
+
+	enableByLabel := stringSliceValue(
+		vip, flagSet, "enable-containers-by-label",
+		[]string{"WATCHTOWER_ENABLE_CONTAINERS_BY_LABEL"},
+		spec.ListCommaOnly,
+	)
+
+	disableByLabel := stringSliceValue(
+		vip, flagSet, "disable-containers-by-label",
+		[]string{"WATCHTOWER_DISABLE_CONTAINERS_BY_LABEL"},
+		spec.ListCommaOnly,
+	)
+
+	scope := vip.GetString("scope")
+
+	names := make([]string, len(args))
+	for i, name := range args {
+		names[i] = util.NormalizeContainerName(name)
+	}
+
+	predicate, desc, err := filters.BuildFilter(
+		names,
+		disableContainers,
+		monitorImages,
+		skipImages,
+		enableByLabel,
+		disableByLabel,
+		labelEnable,
+		scope,
+	)
+	if err != nil {
+		return filter.Filter{}, fmt.Errorf("build filter: %w", err)
+	}
+
+	return filter.Filter{
+		LabelEnable:              labelEnable,
+		DisableContainers:        disableContainers,
+		MonitorImageNames:        monitorImages,
+		SkipImageNames:           skipImages,
+		EnableContainersByLabel:  enableByLabel,
+		DisableContainersByLabel: disableByLabel,
+		Scope:                    scope,
+		Names:                    names,
+		Predicate:                predicate,
+		Desc:                     desc,
+	}, nil
+}
+
+// loadRegistry reads registry TLS settings from Viper.
+func loadRegistry(vip *viper.Viper) registry.Registry {
+	return registry.Registry{
+		TLSSkip:       vip.GetBool("registry-tls-skip"),
+		TLSMinVersion: vip.GetString("registry-tls-min-version"),
+	}
+}
+
+// loadAPI reads HTTP API settings from Viper.
+func loadAPI(vip *viper.Viper, flagSet *pflag.FlagSet) api.API {
+	return api.API{
+		Endpoints: stringSliceValue(
+			vip, flagSet, "http-api-endpoints",
+			[]string{"WATCHTOWER_HTTP_API_ENDPOINTS"},
+			spec.ListCommaOrSpace,
+		),
+		LegacyUpdate:     vip.GetBool("http-api-update"),
+		LegacyMetrics:    vip.GetBool("http-api-metrics"),
+		LegacyContainers: vip.GetBool("http-api-containers"),
+		Host:             vip.GetString("http-api-host"),
+		HostChanged:      flagChanged(flagSet, "http-api-host"),
+		Port:             vip.GetString("http-api-port"),
+		PortChanged:      flagChanged(flagSet, "http-api-port"),
+		Token:            vip.GetString("http-api-token"),
+		EventsToken:      vip.GetString("http-api-events-token"),
+		PeriodicPolls:    vip.GetBool("http-api-periodic-polls"),
+		RateLimit:        vip.GetInt("http-api-rate-limit"),
+		RateLimitChanged: flagChanged(flagSet, "http-api-rate-limit"),
+		TLSCert:          vip.GetString("http-api-tls-cert"),
+		TLSKey:           vip.GetString("http-api-tls-key"),
+		TrustedProxies: stringSliceValue(
+			vip, flagSet, "http-api-trusted-proxies",
+			[]string{"WATCHTOWER_HTTP_API_TRUSTED_PROXIES"},
+			spec.ListCommaOrSpace,
+		),
+		ProxyHeader: vip.GetString("http-api-proxy-header"),
+		CORSOrigins: stringSliceValue(
+			vip, flagSet, "http-api-cors-origins",
+			[]string{"WATCHTOWER_HTTP_API_CORS_ORIGINS"},
+			spec.ListCommaOrSpace,
+		),
+		CheckTimeout: durationValue(
+			vip, flagSet, "http-api-check-timeout",
+			[]string{"WATCHTOWER_HTTP_API_CHECK_TIMEOUT"},
+		),
+		CheckTimeoutChanged: flagChanged(flagSet, "http-api-check-timeout"),
+		UpdateTimeout: durationValue(
+			vip, flagSet, "http-api-update-timeout",
+			[]string{"WATCHTOWER_HTTP_API_UPDATE_TIMEOUT"},
+		),
+		UpdateTimeoutChanged: flagChanged(flagSet, "http-api-update-timeout"),
+	}
+}
+
+// loadNotify reads notification settings from Viper.
+func loadNotify(vip *viper.Viper, flagSet *pflag.FlagSet) notify.Notify {
+	return notify.Notify{
+		URLs: stringSliceValue(
+			vip, flagSet, "notification-url",
+			[]string{"WATCHTOWER_NOTIFICATION_URL"},
+			spec.ListNotificationURLs,
+		),
+		LegacyTypes: stringSliceValue(
+			vip, flagSet, "notifications",
+			[]string{"WATCHTOWER_NOTIFICATIONS"},
+			spec.ListCommaOrSpace,
+		),
+		Level:            vip.GetString("notifications-level"),
+		Template:         vip.GetString("notification-template"),
+		TemplateFile:     vip.GetString("notification-template-file"),
+		Report:           vip.GetBool("notification-report"),
+		SplitByContainer: vip.GetBool("notification-split-by-container"),
+		SkipTitle:        vip.GetBool("notification-skip-title"),
+		LogStdout:        vip.GetBool("notification-log-stdout"),
+		DelaySeconds:     vip.GetInt("notifications-delay"),
+		Hostname:         vip.GetString("notifications-hostname"),
+		TitleTag:         vip.GetString("notification-title-tag"),
+		EmailSubjectTag:  vip.GetString("notification-email-subjecttag"),
+		Legacy: notify.Legacy{
+			EmailFrom:           vip.GetString("notification-email-from"),
+			EmailTo:             vip.GetString("notification-email-to"),
+			EmailServer:         vip.GetString("notification-email-server"),
+			EmailUser:           vip.GetString("notification-email-server-user"),
+			EmailPassword:       vip.GetString("notification-email-server-password"),
+			EmailPort:           vip.GetInt("notification-email-server-port"),
+			EmailTLSSkipVerify:  vip.GetBool("notification-email-server-tls-skip-verify"),
+			EmailDelay:          vip.GetInt("notification-email-delay"),
+			SlackHookURL:        vip.GetString("notification-slack-hook-url"),
+			SlackIdentifier:     vip.GetString("notification-slack-identifier"),
+			SlackChannel:        vip.GetString("notification-slack-channel"),
+			SlackIconEmoji:      vip.GetString("notification-slack-icon-emoji"),
+			SlackIconURL:        vip.GetString("notification-slack-icon-url"),
+			MSTeamsHook:         vip.GetString("notification-msteams-hook"),
+			GotifyURL:           vip.GetString("notification-gotify-url"),
+			GotifyToken:         vip.GetString("notification-gotify-token"),
+			GotifyTLSSkipVerify: vip.GetBool("notification-gotify-tls-skip-verify"),
+		},
+	}
+}
+
+// loadLogging reads logging settings from Viper.
+func loadLogging(vip *viper.Viper) logging.Logging {
+	format := vip.GetString("log-format")
+	if format == "" {
+		format = "auto"
+	}
+
+	return logging.Logging{
+		Level:   vip.GetString("log-level"),
+		Format:  format,
+		Debug:   vip.GetBool("debug"),
+		Trace:   vip.GetBool("trace"),
+		NoColor: vip.GetBool("no-color"),
+	}
+}
+
+// validate checks cross-flag constraints that Load can enforce without side effects.
+func validate(cfg Config) error {
+	if cfg.Update.RollingRestart && cfg.Update.MonitorOnly {
+		return ErrRollingRestartWithMonitorOnly
+	}
+
+	if cfg.Update.MonitorOnly && cfg.Update.NoPull {
+		logrus.WithFields(logrus.Fields{
+			"monitor_only": cfg.Update.MonitorOnly,
+			"no_pull":      cfg.Update.NoPull,
+		}).Warn("Combining monitor-only and no-pull might result in no updates")
+	}
+
+	return nil
+}
+
+// flagChanged reports whether a flag was set on the command line.
+func flagChanged(flagSet *pflag.FlagSet, name string) bool {
+	flag := flagSet.Lookup(name)
+	if flag == nil {
+		return false
+	}
+
+	return flag.Changed
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -210,36 +210,58 @@ func loadLifecycle(vip *viper.Viper) lifecycle.Lifecycle {
 	}
 }
 
+// normalizedStringSlice loads a list flag/env value and applies normalize to each element.
+//
+// Parameters:
+//   - vip: Bound Viper instance.
+//   - flagSet: Parsed flag set.
+//   - name: Flag name.
+//   - envKeys: Environment variable aliases.
+//   - parse: List parse strategy.
+//   - normalize: Per-element transform (for example TrimSpace or NormalizeContainerName).
+//
+// Returns:
+//   - []string: Normalized list (empty when unset).
+func normalizedStringSlice(
+	vip *viper.Viper,
+	flagSet *pflag.FlagSet,
+	name string,
+	envKeys []string,
+	parse spec.ListParseKind,
+	normalize func(string) string,
+) []string {
+	values := stringSliceValue(vip, flagSet, name, envKeys, parse)
+	for i := range values {
+		values[i] = normalize(values[i])
+	}
+
+	return values
+}
+
 // loadFilter reads filter settings, normalizes names, and builds the predicate.
 func loadFilter(vip *viper.Viper, flagSet *pflag.FlagSet, args []string) (filter.Filter, error) {
 	labelEnable := vip.GetBool("label-enable")
 
-	disableContainers := stringSliceValue(
+	disableContainers := normalizedStringSlice(
 		vip, flagSet, "disable-containers",
 		[]string{"WATCHTOWER_DISABLE_CONTAINERS"},
 		spec.ListCommaOrSpace,
+		util.NormalizeContainerName,
 	)
-	for i := range disableContainers {
-		disableContainers[i] = util.NormalizeContainerName(disableContainers[i])
-	}
 
-	monitorImages := stringSliceValue(
+	monitorImages := normalizedStringSlice(
 		vip, flagSet, "monitor-image-names",
 		[]string{"WATCHTOWER_MONITOR_IMAGE_NAMES"},
 		spec.ListCommaOrSpace,
+		strings.TrimSpace,
 	)
-	for i := range monitorImages {
-		monitorImages[i] = strings.TrimSpace(monitorImages[i])
-	}
 
-	skipImages := stringSliceValue(
+	skipImages := normalizedStringSlice(
 		vip, flagSet, "skip-image-names",
 		[]string{"WATCHTOWER_SKIP_IMAGE_NAMES"},
 		spec.ListCommaOrSpace,
+		strings.TrimSpace,
 	)
-	for i := range skipImages {
-		skipImages[i] = strings.TrimSpace(skipImages[i])
-	}
 
 	enableByLabel := stringSliceValue(
 		vip, flagSet, "enable-containers-by-label",

--- a/internal/config/logging/logging.go
+++ b/internal/config/logging/logging.go
@@ -1,0 +1,16 @@
+// Package logging holds console logging settings.
+package logging
+
+// Logging holds log format and level settings.
+type Logging struct {
+	// Level is the maximum log level written to stderr.
+	Level string
+	// Format is the console log format (auto, logfmt, pretty, json).
+	Format string
+	// Debug enables debug logging.
+	Debug bool
+	// Trace enables trace logging.
+	Trace bool
+	// NoColor disables ANSI color codes.
+	NoColor bool
+}

--- a/internal/config/mode/mode.go
+++ b/internal/config/mode/mode.go
@@ -1,0 +1,16 @@
+// Package mode holds process entry-shape settings.
+package mode
+
+// Mode holds how the process enters its main loop.
+type Mode struct {
+	// RunOnce performs one update cycle and exits.
+	RunOnce bool
+	// HealthCheck runs a health check and exits.
+	HealthCheck bool
+	// Porcelain is the porcelain output version, or empty when disabled.
+	Porcelain string
+	// SelfUpdateOrchestrator runs the ephemeral self-update orchestrator path.
+	SelfUpdateOrchestrator bool
+	// NoStartupMessage suppresses the startup notification.
+	NoStartupMessage bool
+}

--- a/internal/config/notify/notify.go
+++ b/internal/config/notify/notify.go
@@ -1,0 +1,94 @@
+// Package notify holds notification settings for the config domain.
+package notify
+
+// Notify holds resolved notification configuration for the process.
+//
+// Values come from CLI flags and environment variables. Pass this value to
+// notifications.NewNotifier to build the client used for update status messages.
+type Notify struct {
+	// URLs are Shoutrrr notification service URLs (--notification-url / WATCHTOWER_NOTIFICATION_URL).
+	URLs []string
+	// LegacyTypes are deprecated notification type names: email, slack, msteams, gotify
+	// (--notifications / WATCHTOWER_NOTIFICATIONS). Prefer Shoutrrr URLs instead.
+	LegacyTypes []string
+	// Level is the log level used for sending notifications
+	// (--notifications-level / WATCHTOWER_NOTIFICATIONS_LEVEL).
+	Level string
+	// Template is the Shoutrrr text/template for messages
+	// (--notification-template / WATCHTOWER_NOTIFICATION_TEMPLATE).
+	Template string
+	// TemplateFile is an optional path to a template file; when set it overrides Template
+	// (--notification-template-file / WATCHTOWER_NOTIFICATION_TEMPLATE_FILE).
+	TemplateFile string
+	// Report enables report-based notification templates
+	// (--notification-report / WATCHTOWER_NOTIFICATION_REPORT).
+	Report bool
+	// SplitByContainer sends a separate notification for each updated container
+	// (--notification-split-by-container / WATCHTOWER_NOTIFICATION_SPLIT_BY_CONTAINER).
+	SplitByContainer bool
+	// SkipTitle omits the title parameter for services that support it
+	// (--notification-skip-title / WATCHTOWER_NOTIFICATION_SKIP_TITLE).
+	SkipTitle bool
+	// LogStdout writes notification logs to stdout instead of logging to stderr
+	// (--notification-log-stdout / WATCHTOWER_NOTIFICATION_LOG_STDOUT).
+	LogStdout bool
+	// DelaySeconds is the delay before sending notifications, in seconds
+	// (--notifications-delay / WATCHTOWER_NOTIFICATIONS_DELAY).
+	DelaySeconds int
+	// Hostname overrides the system hostname in notification titles
+	// (--notifications-hostname / WATCHTOWER_NOTIFICATIONS_HOSTNAME).
+	Hostname string
+	// TitleTag prefixes the notification title
+	// (--notification-title-tag / WATCHTOWER_NOTIFICATION_TITLE_TAG).
+	TitleTag string
+	// EmailSubjectTag is the deprecated email subject tag fallback when TitleTag is empty
+	// (--notification-email-subjecttag / WATCHTOWER_NOTIFICATION_EMAIL_SUBJECTTAG).
+	EmailSubjectTag string
+	// Legacy holds deprecated per-type notification settings used only when LegacyTypes is set.
+	Legacy Legacy
+}
+
+// Legacy holds deprecated notification-type-specific settings.
+//
+// These fields support the legacy email, Slack, MSTeams, and Gotify flag sets.
+// Prefer --notification-url with the appropriate Shoutrrr scheme instead.
+//
+// TODO: Remove Legacy when legacy notification types are removed in v2.
+//
+//nolint:godox
+type Legacy struct {
+	// EmailFrom is the SMTP From address (--notification-email-from).
+	EmailFrom string
+	// EmailTo is the SMTP To address (--notification-email-to).
+	EmailTo string
+	// EmailServer is the SMTP server host (--notification-email-server).
+	EmailServer string
+	// EmailUser is the SMTP username (--notification-email-server-user).
+	EmailUser string
+	// EmailPassword is the SMTP password (--notification-email-server-password).
+	EmailPassword string
+	// EmailPort is the SMTP server port (--notification-email-server-port).
+	EmailPort int
+	// EmailTLSSkipVerify skips SMTP TLS verification (--notification-email-server-tls-skip-verify).
+	EmailTLSSkipVerify bool
+	// EmailDelay is the legacy email send delay in seconds (--notification-email-delay).
+	EmailDelay int
+	// SlackHookURL is the Slack/Discord webhook URL (--notification-slack-hook-url).
+	SlackHookURL string
+	// SlackIdentifier identifies this Watchtower instance in Slack messages.
+	SlackIdentifier string
+	// SlackChannel overrides the webhook default channel (--notification-slack-channel).
+	SlackChannel string
+	// SlackIconEmoji is an emoji code for the message icon (--notification-slack-icon-emoji).
+	SlackIconEmoji string
+	// SlackIconURL is an image URL for the message icon (--notification-slack-icon-url).
+	SlackIconURL string
+	// MSTeamsHook is the Microsoft Teams webhook URL (--notification-msteams-hook).
+	MSTeamsHook string
+	// GotifyURL is the Gotify server URL (--notification-gotify-url).
+	GotifyURL string
+	// GotifyToken is the Gotify application token (--notification-gotify-token).
+	GotifyToken string
+	// GotifyTLSSkipVerify skips Gotify TLS verification (--notification-gotify-tls-skip-verify).
+	GotifyTLSSkipVerify bool
+}

--- a/internal/config/overrides.go
+++ b/internal/config/overrides.go
@@ -1,0 +1,18 @@
+package config
+
+import "github.com/nicholas-fedor/watchtower/pkg/types"
+
+// RunOverrides holds per-invocation deltas applied on top of process-wide Config.
+//
+// Process-wide policy always comes from Config. Only fields that can differ per
+// run-once, schedule tick, or API request belong here.
+type RunOverrides struct {
+	// Filter replaces Config.Filter.Predicate when non-nil.
+	Filter types.Filter
+	// RunOnce marks a one-shot update session.
+	RunOnce bool
+	// SkipSelfUpdate disables Watchtower self-update for this invocation.
+	SkipSelfUpdate bool
+	// CurrentContainerID is the running Watchtower container ID when known.
+	CurrentContainerID types.ContainerID
+}

--- a/internal/config/precedence_test.go
+++ b/internal/config/precedence_test.go
@@ -1,0 +1,176 @@
+package config_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nicholas-fedor/watchtower/internal/config"
+	"github.com/nicholas-fedor/watchtower/internal/flags"
+)
+
+// newLoadedCommand registers flags, applies env, parses args, and loads config.
+func newLoadedCommand(t *testing.T, env map[string]string, args ...string) config.Config {
+	t.Helper()
+
+	for k, v := range env {
+		t.Setenv(k, v)
+	}
+
+	cmd := &cobra.Command{Use: "watchtower"}
+
+	flags.SetDefaults()
+	flags.RegisterAll(cmd)
+	require.NoError(t, cmd.ParseFlags(args))
+
+	flagSet := cmd.PersistentFlags()
+	require.NoError(t, flags.ApplyEnvToFlags(flagSet, flags.AllSpecs()))
+	flags.ProcessFlagAliases(flagSet)
+
+	cfg, err := config.Load(cmd, nil)
+	require.NoError(t, err)
+
+	return cfg
+}
+
+func TestLoad_FlagOverridesEnv(t *testing.T) {
+	cfg := newLoadedCommand(t,
+		map[string]string{
+			"WATCHTOWER_CLEANUP":      "false",
+			"WATCHTOWER_MONITOR_ONLY": "true",
+			"WATCHTOWER_TIMEOUT":      "30",
+		},
+		"--cleanup",
+		"--monitor-only=false",
+		"--stop-timeout", "10s",
+	)
+
+	assert.True(t, cfg.Update.Cleanup, "flag must override env for cleanup")
+	assert.False(t, cfg.Update.MonitorOnly, "flag must override env for monitor-only")
+	assert.Equal(t, 10*time.Second, cfg.Update.StopTimeout, "flag must override env for timeout")
+}
+
+func TestLoad_EnvOverridesDefault(t *testing.T) {
+	cfg := newLoadedCommand(t, map[string]string{
+		"WATCHTOWER_CLEANUP":       "true",
+		"WATCHTOWER_NO_PULL":       "true",
+		"WATCHTOWER_TIMEOUT":       "45",
+		"WATCHTOWER_POLL_INTERVAL": "120",
+	})
+
+	assert.True(t, cfg.Update.Cleanup)
+	assert.True(t, cfg.Update.NoPull)
+	assert.Equal(t, 45*time.Second, cfg.Update.StopTimeout, "bare-second env duration")
+	assert.Equal(t, 120, cfg.Schedule.IntervalSeconds)
+}
+
+func TestLoad_DefaultWhenUnset(t *testing.T) {
+	cfg := newLoadedCommand(t, nil)
+
+	assert.False(t, cfg.Update.Cleanup)
+	assert.False(t, cfg.Update.MonitorOnly)
+	assert.False(t, cfg.Update.NoPull)
+	assert.Equal(t, 30*time.Second, cfg.Update.StopTimeout)
+}
+
+func TestLoad_ListParseStrategies(t *testing.T) {
+	t.Run("comma or space disable-containers", func(t *testing.T) {
+		cfg := newLoadedCommand(t, map[string]string{
+			"WATCHTOWER_DISABLE_CONTAINERS": "a,b c",
+		})
+		assert.ElementsMatch(t, []string{"a", "b", "c"}, cfg.Filter.DisableContainers)
+	})
+
+	t.Run("comma only label values keep spaces", func(t *testing.T) {
+		cfg := newLoadedCommand(t, map[string]string{
+			"WATCHTOWER_ENABLE_CONTAINERS_BY_LABEL": "env=prod east,env=prod west",
+		})
+		assert.Equal(t, []string{"env=prod east", "env=prod west"}, cfg.Filter.EnableContainersByLabel)
+	})
+
+	t.Run("notification urls preserve embedded commas", func(t *testing.T) {
+		cfg := newLoadedCommand(t, map[string]string{
+			"WATCHTOWER_NOTIFICATION_URL": "teams://token@tenant/group/id?host=host,title=Hello discord://token",
+		})
+		require.Len(t, cfg.Notify.URLs, 2)
+		assert.Contains(t, cfg.Notify.URLs[0], "host,title=Hello")
+		assert.Contains(t, cfg.Notify.URLs[1], "discord://")
+	})
+}
+
+func TestLoad_CooldownExtendedUnits(t *testing.T) {
+	cfg := newLoadedCommand(t, map[string]string{
+		"WATCHTOWER_COOLDOWN_DELAY": "3d",
+	})
+	assert.Equal(t, 72*time.Hour, cfg.Update.CooldownDelay)
+}
+
+func TestUpdateParams_CompleteSnapshot(t *testing.T) {
+	cfg := newLoadedCommand(t, map[string]string{
+		"WATCHTOWER_CLEANUP":                "true",
+		"WATCHTOWER_REVIVE_STOPPED":         "true",
+		"WATCHTOWER_USE_COMPOSE_DEPENDS_ON": "true",
+		"WATCHTOWER_LIFECYCLE_HOOKS":        "true",
+		"WATCHTOWER_LABEL_TAKE_PRECEDENCE":  "true",
+	})
+
+	params := cfg.UpdateParams(config.RunOverrides{})
+	assert.True(t, params.Cleanup)
+	assert.True(t, params.ReviveStopped, "ReviveStopped projects from Client domain")
+	assert.True(t, params.UseComposeDependsOn)
+	assert.True(t, params.LifecycleHooks)
+	assert.True(t, params.LabelPrecedence)
+	assert.NotNil(t, params.Filter)
+	assert.True(t, cfg.Client.ReviveStopped)
+}
+
+// TestLoad_APIChangedReflectsCLIOnly verifies env-only API transport settings do not
+// set *Changed fields (avoids false "API config set without endpoints" warnings).
+func TestLoad_APIChangedReflectsCLIOnly(t *testing.T) {
+	t.Run("env only leaves Changed false", func(t *testing.T) {
+		cfg := newLoadedCommand(t, map[string]string{
+			"WATCHTOWER_HTTP_API_HOST":           "127.0.0.1",
+			"WATCHTOWER_HTTP_API_PORT":           "9090",
+			"WATCHTOWER_HTTP_API_RATE_LIMIT":     "30",
+			"WATCHTOWER_HTTP_API_CHECK_TIMEOUT":  "2m",
+			"WATCHTOWER_HTTP_API_UPDATE_TIMEOUT": "3m",
+		})
+
+		assert.Equal(t, "127.0.0.1", cfg.API.Host)
+		assert.Equal(t, "9090", cfg.API.Port)
+		assert.Equal(t, 30, cfg.API.RateLimit)
+		assert.Equal(t, 2*time.Minute, cfg.API.CheckTimeout)
+		assert.Equal(t, 3*time.Minute, cfg.API.UpdateTimeout)
+
+		assert.False(t, cfg.API.HostChanged)
+		assert.False(t, cfg.API.PortChanged)
+		assert.False(t, cfg.API.RateLimitChanged)
+		assert.False(t, cfg.API.CheckTimeoutChanged)
+		assert.False(t, cfg.API.UpdateTimeoutChanged)
+
+		run, err := cfg.BuildRunConfig(config.RunConfigInput{})
+		require.NoError(t, err)
+		assert.False(t, config.AnyHTTPAPIConfig(run),
+			"env-only host/port/rate/timeouts must not trip the no-endpoint warning")
+	})
+
+	t.Run("CLI sets Changed true", func(t *testing.T) {
+		cfg := newLoadedCommand(t, nil,
+			"--http-api-host", "127.0.0.1",
+			"--http-api-port", "9090",
+			"--http-api-rate-limit", "30",
+		)
+
+		assert.True(t, cfg.API.HostChanged)
+		assert.True(t, cfg.API.PortChanged)
+		assert.True(t, cfg.API.RateLimitChanged)
+
+		run, err := cfg.BuildRunConfig(config.RunConfigInput{})
+		require.NoError(t, err)
+		assert.True(t, config.AnyHTTPAPIConfig(run),
+			"CLI host/port/rate-limit should still trip the no-endpoint warning")
+	})
+}

--- a/internal/config/registry/registry.go
+++ b/internal/config/registry/registry.go
@@ -1,0 +1,10 @@
+// Package registry holds registry TLS settings.
+package registry
+
+// Registry holds registry connection security settings.
+type Registry struct {
+	// TLSSkip disables TLS verification for registry connections.
+	TLSSkip bool
+	// TLSMinVersion is the minimum TLS version for registry connections.
+	TLSMinVersion string
+}

--- a/internal/config/run_config.go
+++ b/internal/config/run_config.go
@@ -111,10 +111,12 @@ func (c Config) BuildRunConfig(input RunConfigInput) (types.RunConfig, error) {
 //   - logging.StartupParams: Mode and HTTP API values for startup messaging.
 func (c Config) StartupParams(run types.RunConfig) logging.StartupParams {
 	return logging.StartupParams{
-		NoStartupMessage:     c.Mode.NoStartupMessage,
-		RunOnce:              c.Mode.RunOnce,
-		HTTPAPIUpdate:        run.EnableUpdateAPI,
-		HTTPAPIPeriodicPolls: run.UnblockHTTPAPI,
+		NoStartupMessage: c.Mode.NoStartupMessage,
+		ScheduleInfo: logging.ScheduleInfo{
+			RunOnce:              c.Mode.RunOnce,
+			HTTPAPIUpdate:        run.EnableUpdateAPI,
+			HTTPAPIPeriodicPolls: run.UnblockHTTPAPI,
+		},
 	}
 }
 

--- a/internal/config/run_config.go
+++ b/internal/config/run_config.go
@@ -1,0 +1,169 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/spf13/cobra"
+
+	apiConfig "github.com/nicholas-fedor/watchtower/internal/api/config"
+	"github.com/nicholas-fedor/watchtower/internal/logging"
+	"github.com/nicholas-fedor/watchtower/pkg/types"
+)
+
+// errInvalidAPIHost indicates http-api-host is neither empty nor a valid IP.
+var errInvalidAPIHost = errors.New(
+	"invalid http-api-host: must be empty or a valid IP address (IPv4 or IPv6)",
+)
+
+// RunConfigInput supplies runtime values needed to project Config into types.RunConfig.
+type RunConfigInput struct {
+	// Command is the cobra command retained on types.RunConfig for callers that still
+	// carry a command reference through orchestration (not used for policy flag reads).
+	Command *cobra.Command
+	// Names are normalized container names for filtering display.
+	Names []string
+}
+
+// BuildRunConfig projects Config into types.RunConfig for process orchestration.
+//
+// It applies API port and rate-limit defaults, validates the API host, resolves
+// endpoint enablement from cfg.API, and returns a complete RunConfig snapshot.
+//
+// Parameters:
+//   - input: Runtime inputs (command pointer and normalized names).
+//
+// Returns:
+//   - types.RunConfig: Orchestration snapshot for runMain.
+//   - error: Non-nil when API host or endpoint configuration is invalid.
+func (c Config) BuildRunConfig(input RunConfigInput) (types.RunConfig, error) {
+	// Default port when unset so HTTP API bind always has a concrete value.
+	apiPort := c.API.Port
+	if apiPort == "" {
+		apiPort = "8080"
+	}
+
+	// Default rate limit when unset or invalid.
+	apiRateLimit := c.API.RateLimit
+	if apiRateLimit <= 0 {
+		apiRateLimit = 60
+	}
+
+	err := ValidateAPIHost(c.API.Host)
+	if err != nil {
+		return types.RunConfig{}, err
+	}
+
+	endpointSet, err := apiConfig.ResolveEndpoints(
+		c.API.Endpoints,
+		c.API.LegacyUpdate,
+		c.API.LegacyMetrics,
+		c.API.LegacyContainers,
+	)
+	if err != nil {
+		return types.RunConfig{}, fmt.Errorf("invalid HTTP API endpoint configuration: %w", err)
+	}
+
+	cfg := types.RunConfig{
+		Command:                 input.Command,
+		Names:                   append([]string(nil), input.Names...),
+		Filter:                  c.Filter.Predicate,
+		FilterDesc:              c.Filter.Desc,
+		RunOnce:                 c.Mode.RunOnce,
+		UpdateOnStart:           c.Schedule.UpdateOnStart,
+		TLSCertPath:             c.API.TLSCert,
+		TLSKeyPath:              c.API.TLSKey,
+		CORSAllowedOrigins:      append([]string(nil), c.API.CORSOrigins...),
+		TrustedProxies:          append([]string(nil), c.API.TrustedProxies...),
+		ProxyHeader:             c.API.ProxyHeader,
+		UnblockHTTPAPI:          c.API.PeriodicPolls,
+		NoStartupMessage:        c.Mode.NoStartupMessage,
+		APIToken:                c.API.Token,
+		APIEventsToken:          c.API.EventsToken,
+		APIHost:                 c.API.Host,
+		APIHostChanged:          c.API.HostChanged,
+		APIPort:                 apiPort,
+		APIPortChanged:          c.API.PortChanged,
+		APIRateLimit:            apiRateLimit,
+		APIRateLimitChanged:     c.API.RateLimitChanged,
+		CheckAPITimeout:         c.API.CheckTimeout,
+		CheckAPITimeoutChanged:  c.API.CheckTimeoutChanged,
+		UpdateAPITimeout:        c.API.UpdateTimeout,
+		UpdateAPITimeoutChanged: c.API.UpdateTimeoutChanged,
+	}
+
+	// Map resolved endpoint names onto Enable* fields on RunConfig.
+	apiConfig.SetEndpointConfig(endpointSet, &cfg)
+
+	return cfg, nil
+}
+
+// StartupParams builds logging.StartupParams from Config and RunConfig endpoint state.
+//
+// Runtime fields such as Sched, Filtering, Client, Notifier, and Version are left for
+// callers to fill when invoking WriteStartupMessage.
+//
+// Parameters:
+//   - run: RunConfig with resolved endpoint enablement.
+//
+// Returns:
+//   - logging.StartupParams: Mode and HTTP API values for startup messaging.
+func (c Config) StartupParams(run types.RunConfig) logging.StartupParams {
+	return logging.StartupParams{
+		NoStartupMessage:     c.Mode.NoStartupMessage,
+		RunOnce:              c.Mode.RunOnce,
+		HTTPAPIUpdate:        run.EnableUpdateAPI,
+		HTTPAPIPeriodicPolls: run.UnblockHTTPAPI,
+	}
+}
+
+// AnyHTTPAPIConfig reports whether any HTTP API-related settings are present
+// without enabled endpoints, so operators can be warned about a no-op config.
+func AnyHTTPAPIConfig(cfg types.RunConfig) bool {
+	return cfg.APIToken != "" ||
+		cfg.APIEventsToken != "" ||
+		cfg.TLSCertPath != "" ||
+		cfg.TLSKeyPath != "" ||
+		len(cfg.CORSAllowedOrigins) > 0 ||
+		len(cfg.TrustedProxies) > 0 ||
+		cfg.ProxyHeader != "" ||
+		cfg.APIHostChanged ||
+		cfg.APIPortChanged ||
+		cfg.APIRateLimitChanged ||
+		cfg.CheckAPITimeoutChanged ||
+		cfg.UpdateAPITimeoutChanged
+}
+
+// HTTPAPIEndpointsEnabled reports whether any HTTP API endpoint is enabled.
+func HTTPAPIEndpointsEnabled(cfg types.RunConfig) bool {
+	return cfg.EnableUpdateAPI ||
+		cfg.EnableMetricsAPI ||
+		cfg.EnableContainersAPI ||
+		cfg.EnableCheckAPI ||
+		cfg.EnableSwaggerAPI ||
+		cfg.EnableHealthAPI ||
+		cfg.EnableHistoryAPI ||
+		cfg.EnableImagesAPI ||
+		cfg.EnableConfigAPI ||
+		cfg.EnableEventsAPI
+}
+
+// ValidateAPIHost ensures http-api-host is empty (all interfaces) or a valid IP.
+//
+// Parameters:
+//   - host: Value of the http-api-host setting.
+//
+// Returns:
+//   - error: Non-nil when host is a non-empty non-IP string (for example a hostname).
+func ValidateAPIHost(host string) error {
+	if host == "" {
+		return nil
+	}
+
+	if net.ParseIP(host) == nil {
+		return fmt.Errorf("%w: %q", errInvalidAPIHost, host)
+	}
+
+	return nil
+}

--- a/internal/config/schedule/schedule.go
+++ b/internal/config/schedule/schedule.go
@@ -1,0 +1,12 @@
+// Package schedule holds poll interval and cron schedule settings.
+package schedule
+
+// Schedule holds when periodic updates run.
+type Schedule struct {
+	// IntervalSeconds is the poll interval in seconds when not using a cron expression.
+	IntervalSeconds int
+	// Spec is the cron schedule expression (may be derived from IntervalSeconds).
+	Spec string
+	// UpdateOnStart runs an update check immediately on startup.
+	UpdateOnStart bool
+}

--- a/internal/config/timeout_test.go
+++ b/internal/config/timeout_test.go
@@ -1,0 +1,76 @@
+package config_test
+
+import (
+	"math"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nicholas-fedor/watchtower/internal/config"
+	"github.com/nicholas-fedor/watchtower/internal/flags"
+)
+
+// TestStopTimeout_LegacyBareNumberAsSeconds verifies bare numeric WATCHTOWER_TIMEOUT
+// values are interpreted as seconds at Load time.
+func TestStopTimeout_LegacyBareNumberAsSeconds(t *testing.T) {
+	tests := []struct {
+		name      string
+		envValue  string
+		expected  time.Duration
+		wantError bool
+	}{
+		{name: "default (no env) is 30s", envValue: "", expected: 30 * time.Second},
+		{name: "bare integer as seconds", envValue: "60", expected: 60 * time.Second},
+		{name: "larger bare integer", envValue: "300", expected: 300 * time.Second},
+		{name: "bare float seconds", envValue: "1.5", expected: 1500 * time.Millisecond},
+		{name: "with explicit unit s", envValue: "45s", expected: 45 * time.Second},
+		{name: "with unit m", envValue: "2m", expected: 2 * time.Minute},
+		{name: "zero value", envValue: "0", expected: 0},
+		{name: "negative rejected", envValue: "-10", wantError: true},
+		{name: "invalid non-numeric falls back to default", envValue: "abc", expected: 30 * time.Second},
+		{name: "invalid multi-decimal falls back to default", envValue: "12.34.56", expected: 30 * time.Second},
+		{name: "positive sign prefix", envValue: "+10", expected: 10 * time.Second},
+		{name: "whitespace trimmed", envValue: "  30  ", expected: 30 * time.Second},
+		{
+			name:     "unparseable huge integer treated as zero bare seconds",
+			envValue: "1" + strings.Repeat("0", 1000),
+			expected: 0,
+		},
+		{
+			name:     "overflow clamps to max int64",
+			envValue: "9223372038",
+			expected: time.Duration(math.MaxInt64),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envValue != "" {
+				t.Setenv("WATCHTOWER_TIMEOUT", tc.envValue)
+			} else {
+				_ = os.Unsetenv("WATCHTOWER_TIMEOUT")
+			}
+
+			flags.SetDefaults()
+
+			cmd := &cobra.Command{}
+			flags.RegisterAll(cmd)
+			require.NoError(t, cmd.ParseFlags([]string{}))
+
+			cfg, err := config.Load(cmd, nil)
+			if tc.wantError {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, cfg.Update.StopTimeout)
+		})
+	}
+}

--- a/internal/config/timeout_test.go
+++ b/internal/config/timeout_test.go
@@ -37,9 +37,9 @@ func TestStopTimeout_LegacyBareNumberAsSeconds(t *testing.T) {
 		{name: "positive sign prefix", envValue: "+10", expected: 10 * time.Second},
 		{name: "whitespace trimmed", envValue: "  30  ", expected: 30 * time.Second},
 		{
-			name:     "unparseable huge integer treated as zero bare seconds",
+			name:     "unparseable huge integer falls back to default",
 			envValue: "1" + strings.Repeat("0", 1000),
-			expected: 0,
+			expected: 30 * time.Second,
 		},
 		{
 			name:     "overflow clamps to max int64",

--- a/internal/config/update/update.go
+++ b/internal/config/update/update.go
@@ -1,0 +1,44 @@
+// Package update holds container update policy settings.
+//
+// These values flow into types.UpdateParams via config.UpdateParams for every
+// run-once, scheduled, and HTTP API update path.
+package update
+
+import "time"
+
+// Update holds process-wide container update policy.
+type Update struct {
+	// Cleanup removes previously used images after updating
+	// (--cleanup / WATCHTOWER_CLEANUP).
+	Cleanup bool
+	// NoPull skips pulling new images from the registry
+	// (--no-pull / WATCHTOWER_NO_PULL).
+	NoPull bool
+	// NoRestart prevents containers from being restarted after an update
+	// (--no-restart / WATCHTOWER_NO_RESTART).
+	NoRestart bool
+	// MonitorOnly monitors for new images without updating containers
+	// (--monitor-only / WATCHTOWER_MONITOR_ONLY).
+	MonitorOnly bool
+	// RollingRestart updates containers sequentially rather than all at once
+	// (--rolling-restart / WATCHTOWER_ROLLING_RESTART).
+	RollingRestart bool
+	// StopTimeout is the maximum duration for container stop before a forceful kill
+	// (--stop-timeout / WATCHTOWER_TIMEOUT).
+	StopTimeout time.Duration
+	// CooldownDelay is the minimum age a new image must have before an update is allowed,
+	// reducing risk from freshly pushed images (--cooldown-delay / WATCHTOWER_COOLDOWN_DELAY).
+	// Supports extended units such as d, w, and M via util.ParseDuration.
+	CooldownDelay time.Duration
+	// UseComposeDependsOn honors Docker Compose depends_on labels for stop/start order
+	// (--use-compose-depends-on / WATCHTOWER_USE_COMPOSE_DEPENDS_ON).
+	UseComposeDependsOn bool
+	// LabelPrecedence gives container label settings priority over global flags
+	// (--label-take-precedence / WATCHTOWER_LABEL_TAKE_PRECEDENCE).
+	LabelPrecedence bool
+	// EphemeralSelfUpdate uses a short-lived orchestrator container for Watchtower self-update
+	// (--ephemeral-self-update / WATCHTOWER_EPHEMERAL_SELF_UPDATE).
+	EphemeralSelfUpdate bool
+	// PullFailureDelay is the delay after a failed Watchtower self-update pull.
+	PullFailureDelay time.Duration
+}

--- a/internal/config/update_params.go
+++ b/internal/config/update_params.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"github.com/nicholas-fedor/watchtower/pkg/types"
+)
+
+// UpdateParams builds a complete types.UpdateParams from Config and per-run overrides.
+//
+// This is the only production constructor for update policy DTOs. Every field on
+// types.UpdateParams is assigned here so scheduled and run-once paths cannot omit policy.
+//
+// Parameters:
+//   - overrides: Per-invocation overrides (filter, run-once, skip self-update, current container ID).
+//
+// Returns:
+//   - types.UpdateParams: Complete update policy for the actions pipeline.
+func (c Config) UpdateParams(overrides RunOverrides) types.UpdateParams {
+	filterFn := c.Filter.Predicate
+	if overrides.Filter != nil {
+		filterFn = overrides.Filter
+	}
+
+	cpuCopyMode := c.Compatibility.CPUCopyMode
+	if cpuCopyMode == "" {
+		cpuCopyMode = c.Client.CPUCopyMode
+	}
+
+	return types.UpdateParams{
+		Filter:              filterFn,
+		Cleanup:             c.Update.Cleanup,
+		NoRestart:           c.Update.NoRestart,
+		ReviveStopped:       c.Client.ReviveStopped,
+		Timeout:             c.Update.StopTimeout,
+		MonitorOnly:         c.Update.MonitorOnly,
+		NoPull:              c.Update.NoPull,
+		LifecycleHooks:      c.Lifecycle.Enabled,
+		RollingRestart:      c.Update.RollingRestart,
+		LabelPrecedence:     c.Update.LabelPrecedence,
+		PullFailureDelay:    c.Update.PullFailureDelay,
+		LifecycleUID:        c.Lifecycle.UID,
+		LifecycleGID:        c.Lifecycle.GID,
+		CPUCopyMode:         cpuCopyMode,
+		RunOnce:             overrides.RunOnce || c.Mode.RunOnce,
+		CurrentContainerID:  overrides.CurrentContainerID,
+		UseComposeDependsOn: c.Update.UseComposeDependsOn,
+		SkipSelfUpdate:      overrides.SkipSelfUpdate,
+		EphemeralSelfUpdate: c.Update.EphemeralSelfUpdate,
+		CooldownDelay:       c.Update.CooldownDelay,
+	}
+}

--- a/internal/config/update_params_test.go
+++ b/internal/config/update_params_test.go
@@ -1,0 +1,154 @@
+package config_test
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nicholas-fedor/watchtower/internal/config"
+	"github.com/nicholas-fedor/watchtower/internal/config/client"
+	"github.com/nicholas-fedor/watchtower/internal/config/compatibility"
+	"github.com/nicholas-fedor/watchtower/internal/config/filter"
+	"github.com/nicholas-fedor/watchtower/internal/config/lifecycle"
+	"github.com/nicholas-fedor/watchtower/internal/config/mode"
+	"github.com/nicholas-fedor/watchtower/internal/config/update"
+	"github.com/nicholas-fedor/watchtower/pkg/filters"
+	"github.com/nicholas-fedor/watchtower/pkg/types"
+)
+
+// TestUpdateParamsAssignsEveryField ensures UpdateParams sets every exported
+// field on types.UpdateParams so scheduled and run-once paths cannot omit policy.
+func TestUpdateParamsAssignsEveryField(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		Client: client.Client{
+			ReviveStopped: true,
+			CPUCopyMode:   "full",
+		},
+		Compatibility: compatibility.Compatibility{
+			CPUCopyMode: "auto",
+		},
+		Mode: mode.Mode{
+			RunOnce: false,
+		},
+		Update: update.Update{
+			Cleanup:             true,
+			NoPull:              true,
+			NoRestart:           true,
+			MonitorOnly:         true,
+			RollingRestart:      false,
+			StopTimeout:         30 * time.Second,
+			CooldownDelay:       24 * time.Hour,
+			UseComposeDependsOn: true,
+			LabelPrecedence:     true,
+			EphemeralSelfUpdate: true,
+			PullFailureDelay:    5 * time.Second,
+		},
+		Lifecycle: lifecycle.Lifecycle{
+			Enabled: true,
+			UID:     1000,
+			GID:     1000,
+		},
+		Filter: filter.Filter{
+			Predicate: filters.NoFilter,
+			Desc:      "all",
+		},
+	}
+
+	ov := config.RunOverrides{
+		RunOnce:            true,
+		SkipSelfUpdate:     true,
+		CurrentContainerID: types.ContainerID("abc123"),
+	}
+
+	params := cfg.UpdateParams(ov)
+
+	assert.NotNil(t, params.Filter)
+	assert.True(t, params.Cleanup)
+	assert.True(t, params.NoRestart)
+	assert.True(t, params.ReviveStopped)
+	assert.Equal(t, 30*time.Second, params.Timeout)
+	assert.True(t, params.MonitorOnly)
+	assert.True(t, params.NoPull)
+	assert.True(t, params.LifecycleHooks)
+	assert.False(t, params.RollingRestart)
+	assert.True(t, params.LabelPrecedence)
+	assert.Equal(t, 5*time.Second, params.PullFailureDelay)
+	assert.Equal(t, 1000, params.LifecycleUID)
+	assert.Equal(t, 1000, params.LifecycleGID)
+	assert.Equal(t, "auto", params.CPUCopyMode)
+	assert.True(t, params.RunOnce)
+	assert.Equal(t, types.ContainerID("abc123"), params.CurrentContainerID)
+	assert.True(t, params.UseComposeDependsOn)
+	assert.True(t, params.SkipSelfUpdate)
+	assert.True(t, params.EphemeralSelfUpdate)
+	assert.Equal(t, 24*time.Hour, params.CooldownDelay)
+
+	// Exhaustiveness: every exported field must be non-zero in this fixture
+	// (Filter is a func; RunOnce and SkipSelfUpdate come from overrides).
+	val := reflect.ValueOf(params)
+	typ := val.Type()
+
+	for i := range val.NumField() {
+		field := typ.Field(i)
+		fv := val.Field(i)
+
+		switch field.Name {
+		case "RollingRestart":
+			// Intentionally false in fixture to prove false is set, not omitted.
+			assert.False(t, fv.Bool())
+		case "Filter":
+			assert.False(t, fv.IsNil(), "Filter must be assigned")
+		default:
+			assert.False(t, fv.IsZero(), "field %s must be assigned by UpdateParams", field.Name)
+		}
+	}
+}
+
+// TestUpdateParamsOverrideFilter replaces the config filter when provided.
+func TestUpdateParamsOverrideFilter(t *testing.T) {
+	t.Parallel()
+
+	override := func(types.FilterableContainer) bool { return false }
+
+	cfg := config.Config{
+		Filter:        filter.Filter{Predicate: filters.NoFilter},
+		Compatibility: compatibility.Compatibility{CPUCopyMode: "none"},
+	}
+
+	params := cfg.UpdateParams(config.RunOverrides{Filter: override})
+	require.NotNil(t, params.Filter)
+	assert.False(t, params.Filter(nil))
+}
+
+// TestClientOptionsMapsClientAndCompat projects client construction options.
+func TestClientOptionsMapsClientAndCompat(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		Client: client.Client{
+			IncludeStopped:    true,
+			IncludeRestarting: true,
+			ReviveStopped:     true,
+			RemoveVolumes:     true,
+			WarnOnHeadFailure: "always",
+		},
+		Compatibility: compatibility.Compatibility{
+			DisableMemorySwappiness: true,
+			CPUCopyMode:             "full",
+		},
+	}
+
+	opts := cfg.ClientOptions()
+	assert.True(t, opts.IncludeStopped)
+	assert.True(t, opts.IncludeRestarting)
+	assert.True(t, opts.ReviveStopped)
+	assert.True(t, opts.RemoveVolumes)
+	assert.True(t, opts.DisableMemorySwappiness)
+	assert.Equal(t, "full", opts.CPUCopyMode)
+	assert.Equal(t, "always", string(opts.WarnOnHeadFailed))
+}

--- a/internal/config/update_params_test.go
+++ b/internal/config/update_params_test.go
@@ -136,10 +136,11 @@ func TestClientOptionsMapsClientAndCompat(t *testing.T) {
 			ReviveStopped:     true,
 			RemoveVolumes:     true,
 			WarnOnHeadFailure: "always",
+			CPUCopyMode:       "full",
 		},
 		Compatibility: compatibility.Compatibility{
 			DisableMemorySwappiness: true,
-			CPUCopyMode:             "full",
+			CPUCopyMode:             "auto",
 		},
 	}
 
@@ -149,6 +150,11 @@ func TestClientOptionsMapsClientAndCompat(t *testing.T) {
 	assert.True(t, opts.ReviveStopped)
 	assert.True(t, opts.RemoveVolumes)
 	assert.True(t, opts.DisableMemorySwappiness)
-	assert.Equal(t, "full", opts.CPUCopyMode)
+	// Compatibility wins over Client when both are non-empty (matches UpdateParams).
+	assert.Equal(t, "auto", opts.CPUCopyMode)
 	assert.Equal(t, "always", string(opts.WarnOnHeadFailed))
+
+	// Client is used when Compatibility is empty.
+	cfg.Compatibility.CPUCopyMode = ""
+	assert.Equal(t, "full", cfg.ClientOptions().CPUCopyMode)
 }

--- a/internal/config/viper_get.go
+++ b/internal/config/viper_get.go
@@ -1,0 +1,156 @@
+package config
+
+import (
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
+	"github.com/nicholas-fedor/watchtower/internal/flags/utils"
+)
+
+// durationValue reads a duration from Viper with bare-second env support.
+//
+// When the flag was not changed on the CLI and the bound env value is a pure
+// number, it is treated as seconds (legacy WATCHTOWER_TIMEOUT behavior).
+//
+// Parameters:
+//   - v: Bound Viper instance.
+//   - flagSet: Parsed flag set (for Changed checks).
+//   - name: Flag name.
+//   - envKeys: Environment keys bound to this flag.
+//
+// Returns:
+//   - time.Duration: Resolved duration.
+func durationValue(
+	vip *viper.Viper,
+	flagSet *pflag.FlagSet,
+	name string,
+	envKeys []string,
+) time.Duration {
+	if flagSet.Changed(name) {
+		d, err := flagSet.GetDuration(name)
+		if err == nil {
+			return d
+		}
+	}
+
+	envSeen := false
+
+	for _, envKey := range envKeys {
+		raw := strings.TrimSpace(os.Getenv(envKey))
+		if raw == "" {
+			continue
+		}
+
+		envSeen = true
+
+		if utils.IsPureNumeric(raw) {
+			return bareSeconds(raw)
+		}
+
+		d, err := time.ParseDuration(raw)
+		if err == nil {
+			return d
+		}
+	}
+
+	// Invalid env values fall back to the static pflag default, not zero.
+	if envSeen {
+		d, err := flagSet.GetDuration(name)
+		if err == nil {
+			return d
+		}
+	}
+
+	return vip.GetDuration(name)
+}
+
+// bareSeconds parses a pure numeric string as seconds.
+func bareSeconds(raw string) time.Duration {
+	val, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0
+	}
+
+	nanos := val * float64(time.Second)
+
+	if nanos > float64(math.MaxInt64) {
+		return time.Duration(math.MaxInt64)
+	}
+
+	if nanos < float64(math.MinInt64) {
+		return time.Duration(math.MinInt64)
+	}
+
+	return time.Duration(nanos)
+}
+
+// stringSliceValue reads a string list using the FlagSpec ListParse strategy.
+//
+// Parameters:
+//   - v: Bound Viper instance.
+//   - flagSet: Parsed flag set.
+//   - name: Flag name.
+//   - envKeys: Environment keys bound to this flag.
+//   - parse: List parse strategy.
+//
+// Returns:
+//   - []string: Resolved list (never nil).
+func stringSliceValue(
+	vip *viper.Viper,
+	flagSet *pflag.FlagSet,
+	name string,
+	envKeys []string,
+	parse spec.ListParseKind,
+) []string {
+	if flagSet.Changed(name) {
+		switch parse {
+		case spec.ListNotificationURLs:
+			vals, err := flagSet.GetStringArray(name)
+			if err == nil {
+				return vals
+			}
+		case spec.ListNone, spec.ListCommaOrSpace, spec.ListCommaOnly, spec.ListNative:
+			vals, err := flagSet.GetStringSlice(name)
+			if err == nil {
+				return vals
+			}
+		}
+	}
+
+	for _, envKey := range envKeys {
+		raw := os.Getenv(envKey)
+		if raw == "" {
+			continue
+		}
+
+		return parseList(raw, parse)
+	}
+
+	vals := vip.GetStringSlice(name)
+	if vals == nil {
+		return []string{}
+	}
+
+	return vals
+}
+
+// parseList applies a ListParseKind to a raw env/default string.
+func parseList(raw string, parse spec.ListParseKind) []string {
+	switch parse {
+	case spec.ListCommaOnly:
+		return utils.SplitCommaOnly(raw)
+	case spec.ListNotificationURLs:
+		return utils.FilterEmptyStrings(utils.SplitNotificationValues(raw))
+	case spec.ListCommaOrSpace, spec.ListNative, spec.ListNone:
+		return utils.SplitCommaOrSpace(raw)
+	default:
+		return utils.SplitCommaOrSpace(raw)
+	}
+}

--- a/internal/config/viper_get.go
+++ b/internal/config/viper_get.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -72,23 +71,15 @@ func durationValue(
 }
 
 // bareSeconds parses a pure numeric string as seconds.
+//
+// Invalid input yields zero. Overflow is clamped via utils.DurationFromSeconds.
 func bareSeconds(raw string) time.Duration {
 	val, err := strconv.ParseFloat(raw, 64)
 	if err != nil {
 		return 0
 	}
 
-	nanos := val * float64(time.Second)
-
-	if nanos > float64(math.MaxInt64) {
-		return time.Duration(math.MaxInt64)
-	}
-
-	if nanos < float64(math.MinInt64) {
-		return time.Duration(math.MinInt64)
-	}
-
-	return time.Duration(nanos)
+	return utils.DurationFromSeconds(val)
 }
 
 // stringSliceValue reads a string list using the FlagSpec ListParse strategy.

--- a/internal/config/viper_get.go
+++ b/internal/config/viper_get.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -50,7 +51,14 @@ func durationValue(
 		envSeen = true
 
 		if utils.IsPureNumeric(raw) {
-			return bareSeconds(raw)
+			d, err := bareSeconds(raw)
+			if err == nil {
+				return d
+			}
+
+			// Unparseable bare number (for example out-of-range float): same as
+			// other invalid env values — fall back to the pflag default below.
+			break
 		}
 
 		d, err := time.ParseDuration(raw)
@@ -72,14 +80,22 @@ func durationValue(
 
 // bareSeconds parses a pure numeric string as seconds.
 //
-// Invalid input yields zero. Overflow is clamped via utils.DurationFromSeconds.
-func bareSeconds(raw string) time.Duration {
+// Overflow is clamped via utils.DurationFromSeconds. Invalid input returns an error
+// so callers can fall back to the static default.
+//
+// Parameters:
+//   - raw: Pure numeric string (no duration unit suffix).
+//
+// Returns:
+//   - time.Duration: Parsed duration in seconds when successful.
+//   - error: Non-nil when raw cannot be parsed as a float.
+func bareSeconds(raw string) (time.Duration, error) {
 	val, err := strconv.ParseFloat(raw, 64)
 	if err != nil {
-		return 0
+		return 0, fmt.Errorf("parse bare seconds: %w", err)
 	}
 
-	return utils.DurationFromSeconds(val)
+	return utils.DurationFromSeconds(val), nil
 }
 
 // stringSliceValue reads a string list using the FlagSpec ListParse strategy.

--- a/internal/config/viper_get.go
+++ b/internal/config/viper_get.go
@@ -121,7 +121,7 @@ func stringSliceValue(
 			continue
 		}
 
-		return parseList(raw, parse)
+		return spec.ParseList(raw, parse)
 	}
 
 	vals := vip.GetStringSlice(name)
@@ -130,18 +130,4 @@ func stringSliceValue(
 	}
 
 	return vals
-}
-
-// parseList applies a ListParseKind to a raw env/default string.
-func parseList(raw string, parse spec.ListParseKind) []string {
-	switch parse {
-	case spec.ListCommaOnly:
-		return utils.SplitCommaOnly(raw)
-	case spec.ListNotificationURLs:
-		return utils.FilterEmptyStrings(utils.SplitNotificationValues(raw))
-	case spec.ListCommaOrSpace, spec.ListNative, spec.ListNone:
-		return utils.SplitCommaOrSpace(raw)
-	default:
-		return utils.SplitCommaOrSpace(raw)
-	}
 }

--- a/internal/flags/api/register.go
+++ b/internal/flags/api/register.go
@@ -1,0 +1,156 @@
+// Package api registers HTTP API transport and endpoint flags.
+package api
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
+)
+
+// DefaultRateLimit is the static default HTTP API rate limit per minute per IP.
+const DefaultRateLimit = 60
+
+// Specs returns API domain flag metadata with static defaults.
+//
+// Returns:
+//   - []spec.FlagSpec: API flag specifications.
+func Specs() []spec.FlagSpec {
+	return []spec.FlagSpec{
+		{
+			Name:      "http-api-endpoints",
+			Kind:      spec.KindStringSlice,
+			Default:   []string{},
+			EnvKeys:   []string{"WATCHTOWER_HTTP_API_ENDPOINTS"},
+			ListParse: spec.ListCommaOrSpace,
+			Help:      "HTTP API endpoints to enable (health, update, metrics, containers, check, history, images, config, events, swagger), or \"all\". Comma- or space-separated. Empty disables the HTTP API.",
+		},
+
+		{
+			Name:       "http-api-update",
+			Kind:       spec.KindBool,
+			Default:    false,
+			EnvKeys:    []string{"WATCHTOWER_HTTP_API_UPDATE"},
+			Deprecated: "Use the http-api-endpoints configuration option instead.",
+			Help:       "Runs Watchtower in HTTP API mode, so that image updates must be triggered by a request",
+		},
+		{
+			Name:       "http-api-metrics",
+			Kind:       spec.KindBool,
+			Default:    false,
+			EnvKeys:    []string{"WATCHTOWER_HTTP_API_METRICS"},
+			Deprecated: "Use the http-api-endpoints configuration option instead.",
+			Help:       "Runs Watchtower with the Prometheus metrics API enabled",
+		},
+		{
+			Name:       "http-api-containers",
+			Kind:       spec.KindBool,
+			Default:    false,
+			EnvKeys:    []string{"WATCHTOWER_HTTP_API_CONTAINERS"},
+			Deprecated: "Use the http-api-endpoints configuration option instead.",
+			Help:       "Runs Watchtower with the read-only containers API enabled, exposing each watched container's current image digest",
+		},
+		{
+			Name:    "http-api-host",
+			Kind:    spec.KindString,
+			Default: "",
+			EnvKeys: []string{"WATCHTOWER_HTTP_API_HOST"},
+			Help:    "Host to bind the HTTP API to (default: empty, binds to all interfaces; allows empty or valid IP address)",
+		},
+		{
+			Name:    "http-api-port",
+			Kind:    spec.KindString,
+			Default: "8080",
+			EnvKeys: []string{"WATCHTOWER_HTTP_API_PORT"},
+			Help:    "Port to bind the HTTP API to (default: 8080)",
+		},
+		{
+			Name:    "http-api-token",
+			Kind:    spec.KindString,
+			Default: "",
+			EnvKeys: []string{"WATCHTOWER_HTTP_API_TOKEN"},
+			Help:    "Sets an authentication token for HTTP API requests (required when any non-health endpoint is enabled)",
+		},
+		{
+			Name:    "http-api-events-token",
+			Kind:    spec.KindString,
+			Default: "",
+			EnvKeys: []string{"WATCHTOWER_HTTP_API_EVENTS_TOKEN"},
+			Help:    "Sets an authentication token for the events SSE endpoint. Required when the events endpoint is enabled. Supports Bearer header and query parameter access_token (for browser EventSource)",
+		},
+		{
+			Name:    "http-api-periodic-polls",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_HTTP_API_PERIODIC_POLLS"},
+			Help:    "Also run periodic updates (specified with --interval and --schedule) if HTTP API is enabled",
+		},
+		{
+			Name:    "http-api-rate-limit",
+			Kind:    spec.KindInt,
+			Default: DefaultRateLimit,
+			EnvKeys: []string{"WATCHTOWER_HTTP_API_RATE_LIMIT"},
+			Help:    "Maximum authentication requests per minute per IP address for the HTTP API (default: 60)",
+		},
+		{
+			Name:    "http-api-tls-cert",
+			Kind:    spec.KindString,
+			Default: "",
+			EnvKeys: []string{"WATCHTOWER_HTTP_API_TLS_CERT"},
+			Help:    "Path to TLS certificate file for the HTTP API",
+		},
+		{
+			Name:    "http-api-tls-key",
+			Kind:    spec.KindString,
+			Default: "",
+			EnvKeys: []string{"WATCHTOWER_HTTP_API_TLS_KEY"},
+			Help:    "Path to TLS key file for the HTTP API",
+		},
+		{
+			Name:      "http-api-trusted-proxies",
+			Kind:      spec.KindStringSlice,
+			Default:   []string{},
+			EnvKeys:   []string{"WATCHTOWER_HTTP_API_TRUSTED_PROXIES"},
+			ListParse: spec.ListCommaOrSpace,
+			Help:      "Comma-separated list of trusted proxy IP addresses or CIDR ranges for reverse proxy support (e.g. 10.0.0.0/8,172.16.0.0/12). When set, enables proxy header processing for client IP and scheme detection",
+		},
+		{
+			Name:    "http-api-proxy-header",
+			Kind:    spec.KindString,
+			Default: "",
+			EnvKeys: []string{"WATCHTOWER_HTTP_API_PROXY_HEADER"},
+			Help:    "Header to use for real client IP when behind a reverse proxy (default: X-Forwarded-For). Only used when http-api-trusted-proxies is set",
+		},
+		{
+			Name:      "http-api-cors-origins",
+			Kind:      spec.KindStringSlice,
+			Default:   []string{},
+			EnvKeys:   []string{"WATCHTOWER_HTTP_API_CORS_ORIGINS"},
+			ListParse: spec.ListCommaOrSpace,
+			Help:      "Comma-separated list of allowed CORS origins for cross-origin requests (e.g. https://app.example.com). If unset, CORS is disabled and only same-origin requests are allowed.",
+		},
+		{
+			Name:    "http-api-check-timeout",
+			Kind:    spec.KindDuration,
+			Default: time.Duration(0),
+			EnvKeys: []string{"WATCHTOWER_HTTP_API_CHECK_TIMEOUT"},
+			Help:    "Maximum duration for the /v1/check API endpoint (e.g. 30s, 2m, 5m). Default: 5m",
+		},
+		{
+			Name:    "http-api-update-timeout",
+			Kind:    spec.KindDuration,
+			Default: time.Duration(0),
+			EnvKeys: []string{"WATCHTOWER_HTTP_API_UPDATE_TIMEOUT"},
+			Help:    "Maximum duration for the /v1/update API endpoint (e.g. 1m, 10m, 30m). Default: 10m",
+		},
+	}
+}
+
+// Register adds HTTP API domain flags to the root command.
+//
+// Parameters:
+//   - rootCmd: Root Cobra command.
+func Register(rootCmd *cobra.Command) {
+	spec.MustRegister(rootCmd.PersistentFlags(), Specs())
+}

--- a/internal/flags/apply_env.go
+++ b/internal/flags/apply_env.go
@@ -62,7 +62,7 @@ func applyEnvValue(flagSet *pflag.FlagSet, flagSpec spec.FlagSpec, raw string) e
 
 	switch flagSpec.Kind {
 	case spec.KindStringSlice, spec.KindStringArray:
-		parts := parseEnvList(raw, flagSpec.ListParse)
+		parts := spec.ParseList(raw, flagSpec.ListParse)
 
 		sliceValue, ok := flag.Value.(pflag.SliceValue)
 		if !ok {
@@ -198,19 +198,5 @@ func formatEnvForFlag(flagSpec spec.FlagSpec, raw string) (string, error) {
 		return "", fmt.Errorf("%w: %s handled via Replace", ErrUnsupportedFlagKind, flagSpec.Name)
 	default:
 		return "", fmt.Errorf("%w: %s", ErrUnsupportedFlagKind, flagSpec.Name)
-	}
-}
-
-// parseEnvList splits a raw env list using FlagSpec ListParse.
-func parseEnvList(raw string, parse spec.ListParseKind) []string {
-	switch parse {
-	case spec.ListCommaOnly:
-		return utils.SplitCommaOnly(raw)
-	case spec.ListNotificationURLs:
-		return utils.FilterEmptyStrings(utils.SplitNotificationValues(raw))
-	case spec.ListCommaOrSpace, spec.ListNative, spec.ListNone:
-		return utils.SplitCommaOrSpace(raw)
-	default:
-		return utils.SplitCommaOrSpace(raw)
 	}
 }

--- a/internal/flags/apply_env.go
+++ b/internal/flags/apply_env.go
@@ -184,7 +184,8 @@ func formatEnvForFlag(flagSpec spec.FlagSpec, raw string) (string, error) {
 				return "", fmt.Errorf("parse duration seconds: %w", err)
 			}
 
-			return time.Duration(val * float64(time.Second)).String(), nil
+			// Clamp EnvDuration so huge bare-second values do not overflow.
+			return utils.DurationFromSeconds(val).String(), nil
 		}
 
 		d, err := time.ParseDuration(trimmed)

--- a/internal/flags/apply_env.go
+++ b/internal/flags/apply_env.go
@@ -1,0 +1,174 @@
+package flags
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
+	"github.com/nicholas-fedor/watchtower/internal/flags/utils"
+)
+
+// ApplyEnvToFlags copies bound environment values onto flags that were not set on the CLI.
+//
+// Call after Cobra parse and before ProcessFlagAliases / SetupLogging so those
+// helpers still see env-sourced values via flag Gets. Load continues to resolve
+// through Viper with flag > env > default precedence. Static pflag defaults are
+// never env-baked at registration time.
+//
+// Parameters:
+//   - flagSet: Parsed persistent flag set.
+//   - specs: Aggregated FlagSpec rows.
+//
+// Returns:
+//   - error: Non-nil when a flag cannot be set from env.
+func ApplyEnvToFlags(flagSet *pflag.FlagSet, specs []spec.FlagSpec) error {
+	for _, flagSpec := range specs {
+		if flagSet.Lookup(flagSpec.Name) == nil {
+			continue
+		}
+
+		if flagSet.Changed(flagSpec.Name) {
+			continue
+		}
+
+		raw, ok := firstEnv(flagSpec.EnvKeys)
+		if !ok {
+			continue
+		}
+
+		err := applyEnvValue(flagSet, flagSpec, raw)
+		if err != nil {
+			return fmt.Errorf("%s: %w", flagSpec.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// applyEnvValue sets one flag from a raw environment string without marking it Changed.
+//
+// Callers must only invoke this when the flag was not already Changed on the CLI.
+func applyEnvValue(flagSet *pflag.FlagSet, flagSpec spec.FlagSpec, raw string) error {
+	flag := flagSet.Lookup(flagSpec.Name)
+	if flag == nil {
+		return fmt.Errorf("%w: %q", ErrFlagNotRegistered, flagSpec.Name)
+	}
+
+	switch flagSpec.Kind {
+	case spec.KindStringSlice, spec.KindStringArray:
+		parts := parseEnvList(raw, flagSpec.ListParse)
+
+		sliceValue, ok := flag.Value.(pflag.SliceValue)
+		if !ok {
+			return fmt.Errorf("%w: %s is not a slice", ErrUnsupportedFlagKind, flagSpec.Name)
+		}
+
+		err := sliceValue.Replace(parts)
+		if err != nil {
+			return fmt.Errorf("replace %s: %w", flagSpec.Name, err)
+		}
+
+		// Replace must not count as a CLI change for *Changed consumers.
+		flag.Changed = false
+
+		return nil
+	case spec.KindBool, spec.KindString, spec.KindInt, spec.KindDuration:
+		value, err := formatEnvForFlag(flagSpec, raw)
+		if err != nil {
+			return err
+		}
+
+		// flagSet.Set marks Changed; clear it so env bridging stays CLI-neutral.
+		err = flagSet.Set(flagSpec.Name, value)
+		if err != nil {
+			return fmt.Errorf("set %s: %w", flagSpec.Name, err)
+		}
+
+		flag.Changed = false
+
+		return nil
+	default:
+		return fmt.Errorf("%w: %s", ErrUnsupportedFlagKind, flagSpec.Name)
+	}
+}
+
+// firstEnv returns the first non-empty environment value for the given keys.
+func firstEnv(envKeys []string) (string, bool) {
+	for _, key := range envKeys {
+		if raw, ok := os.LookupEnv(key); ok {
+			return raw, true
+		}
+	}
+
+	return "", false
+}
+
+// formatEnvForFlag converts a raw env string into a pflag.Set value string.
+func formatEnvForFlag(flagSpec spec.FlagSpec, raw string) (string, error) {
+	switch flagSpec.Kind {
+	case spec.KindBool:
+		// NO_COLOR and similar: presence alone means true when value is empty.
+		if raw == "" {
+			return "true", nil
+		}
+
+		b, err := strconv.ParseBool(raw)
+		if err != nil {
+			return "", fmt.Errorf("parse bool: %w", err)
+		}
+
+		return strconv.FormatBool(b), nil
+	case spec.KindString:
+		return raw, nil
+	case spec.KindInt:
+		// Allow bare integers only; pflag Set accepts decimal strings.
+		trimmed := strings.TrimSpace(raw)
+
+		_, err := strconv.Atoi(trimmed)
+		if err != nil {
+			return "", fmt.Errorf("parse int: %w", err)
+		}
+
+		return trimmed, nil
+	case spec.KindDuration:
+		trimmed := strings.TrimSpace(raw)
+		if utils.IsPureNumeric(trimmed) {
+			val, err := strconv.ParseFloat(trimmed, 64)
+			if err != nil {
+				return "", fmt.Errorf("parse duration seconds: %w", err)
+			}
+
+			return time.Duration(val * float64(time.Second)).String(), nil
+		}
+
+		d, err := time.ParseDuration(trimmed)
+		if err != nil {
+			return "", fmt.Errorf("parse duration: %w", err)
+		}
+
+		return d.String(), nil
+	case spec.KindStringSlice, spec.KindStringArray:
+		return "", fmt.Errorf("%w: %s handled via Replace", ErrUnsupportedFlagKind, flagSpec.Name)
+	default:
+		return "", fmt.Errorf("%w: %s", ErrUnsupportedFlagKind, flagSpec.Name)
+	}
+}
+
+// parseEnvList splits a raw env list using FlagSpec ListParse.
+func parseEnvList(raw string, parse spec.ListParseKind) []string {
+	switch parse {
+	case spec.ListCommaOnly:
+		return utils.SplitCommaOnly(raw)
+	case spec.ListNotificationURLs:
+		return utils.FilterEmptyStrings(utils.SplitNotificationValues(raw))
+	case spec.ListCommaOrSpace, spec.ListNative, spec.ListNone:
+		return utils.SplitCommaOrSpace(raw)
+	default:
+		return utils.SplitCommaOrSpace(raw)
+	}
+}

--- a/internal/flags/apply_env.go
+++ b/internal/flags/apply_env.go
@@ -3,6 +3,7 @@ package flags
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -97,22 +98,35 @@ func applyEnvValue(flagSet *pflag.FlagSet, flagSpec spec.FlagSpec, raw string) e
 	}
 }
 
-// presenceEmptyEnvKeys are env keys where presence with an empty value means true
-// (https://no-color.org/). All other keys treat empty as unset.
-var presenceEmptyEnvKeys = map[string]struct{}{
+// presenceEnvKeys are env keys where any presence enables the bound bool flag
+// (https://no-color.org/). Empty, "0", and "false" still mean enabled. Other
+// keys treat empty as unset and parse non-empty bools with strconv.ParseBool.
+var presenceEnvKeys = map[string]struct{}{
 	"NO_COLOR": {},
+}
+
+// IsPresenceEnvKey reports whether envKey uses presence-means-true semantics.
+func IsPresenceEnvKey(envKey string) bool {
+	_, ok := presenceEnvKeys[envKey]
+
+	return ok
+}
+
+// hasPresenceEnvKey reports whether any of flagSpec's env keys is presence-based.
+func hasPresenceEnvKey(flagSpec spec.FlagSpec) bool {
+	return slices.ContainsFunc(flagSpec.EnvKeys, IsPresenceEnvKey)
 }
 
 // firstEnv returns the first usable environment value for the given keys.
 //
-// Empty values are skipped unless the key is in presenceEmptyEnvKeys (NO_COLOR),
-// where presence alone is meaningful.
+// Empty values are skipped unless the key is in presenceEnvKeys (NO_COLOR),
+// where presence alone is meaningful (including empty, "0", and "false").
 //
 // Parameters:
 //   - envKeys: Candidate environment variable names in priority order.
 //
 // Returns:
-//   - string: Raw env value (may be empty only for presenceEmptyEnvKeys).
+//   - string: Raw env value (may be empty only for presenceEnvKeys).
 //   - bool: True when a usable entry was found.
 func firstEnv(envKeys []string) (string, bool) {
 	for _, key := range envKeys {
@@ -121,10 +135,8 @@ func firstEnv(envKeys []string) (string, bool) {
 			continue
 		}
 
-		if raw == "" {
-			if _, allowEmpty := presenceEmptyEnvKeys[key]; !allowEmpty {
-				continue
-			}
+		if raw == "" && !IsPresenceEnvKey(key) {
+			continue
 		}
 
 		return raw, true
@@ -135,14 +147,14 @@ func firstEnv(envKeys []string) (string, bool) {
 
 // formatEnvForFlag converts a raw env string into a pflag.Set value string.
 //
-// For bools, a non-empty value is parsed with strconv.ParseBool. An empty raw
-// value is only accepted for presenceEmptyEnvKeys (NO_COLOR) and means true;
-// firstEnv must not pass empty strings for other keys.
+// Presence-based bool flags (NO_COLOR) always become true when firstEnv found
+// the key. Other bools parse non-empty values with strconv.ParseBool; empty is
+// not passed for those keys.
 func formatEnvForFlag(flagSpec spec.FlagSpec, raw string) (string, error) {
 	switch flagSpec.Kind {
 	case spec.KindBool:
-		if raw == "" {
-			// Presence-means-true for NO_COLOR only (see firstEnv / presenceEmptyEnvKeys).
+		// Presence means true for NO_COLOR (empty, "0", "false", "1", …).
+		if hasPresenceEnvKey(flagSpec) {
 			return "true", nil
 		}
 

--- a/internal/flags/apply_env.go
+++ b/internal/flags/apply_env.go
@@ -97,23 +97,52 @@ func applyEnvValue(flagSet *pflag.FlagSet, flagSpec spec.FlagSpec, raw string) e
 	}
 }
 
-// firstEnv returns the first non-empty environment value for the given keys.
+// presenceEmptyEnvKeys are env keys where presence with an empty value means true
+// (https://no-color.org/). All other keys treat empty as unset.
+var presenceEmptyEnvKeys = map[string]struct{}{
+	"NO_COLOR": {},
+}
+
+// firstEnv returns the first usable environment value for the given keys.
+//
+// Empty values are skipped unless the key is in presenceEmptyEnvKeys (NO_COLOR),
+// where presence alone is meaningful.
+//
+// Parameters:
+//   - envKeys: Candidate environment variable names in priority order.
+//
+// Returns:
+//   - string: Raw env value (may be empty only for presenceEmptyEnvKeys).
+//   - bool: True when a usable entry was found.
 func firstEnv(envKeys []string) (string, bool) {
 	for _, key := range envKeys {
-		if raw, ok := os.LookupEnv(key); ok {
-			return raw, true
+		raw, ok := os.LookupEnv(key)
+		if !ok {
+			continue
 		}
+
+		if raw == "" {
+			if _, allowEmpty := presenceEmptyEnvKeys[key]; !allowEmpty {
+				continue
+			}
+		}
+
+		return raw, true
 	}
 
 	return "", false
 }
 
 // formatEnvForFlag converts a raw env string into a pflag.Set value string.
+//
+// For bools, a non-empty value is parsed with strconv.ParseBool. An empty raw
+// value is only accepted for presenceEmptyEnvKeys (NO_COLOR) and means true;
+// firstEnv must not pass empty strings for other keys.
 func formatEnvForFlag(flagSpec spec.FlagSpec, raw string) (string, error) {
 	switch flagSpec.Kind {
 	case spec.KindBool:
-		// NO_COLOR and similar: presence alone means true when value is empty.
 		if raw == "" {
+			// Presence-means-true for NO_COLOR only (see firstEnv / presenceEmptyEnvKeys).
 			return "true", nil
 		}
 

--- a/internal/flags/bind.go
+++ b/internal/flags/bind.go
@@ -49,17 +49,28 @@ func BindAll(vip *viper.Viper, flagSet *pflag.FlagSet, specs []spec.FlagSpec) er
 			return fmt.Errorf("bind flag %s: %w", flagSpec.Name, err)
 		}
 
+		// Bind all non-presence env aliases in one call so earlier EnvKeys keep precedence.
+		// Presence-only keys (NO_COLOR) are applied via ApplyEnvToFlags only.
+		envAliases := make([]string, 0, len(flagSpec.EnvKeys))
 		for _, envKey := range flagSpec.EnvKeys {
-			// Presence-only keys (NO_COLOR) are applied via ApplyEnvToFlags and must
-			// not BindEnv, or Viper would re-parse values like "0"/"false" as false.
 			if IsPresenceEnvKey(envKey) {
 				continue
 			}
 
-			err = vip.BindEnv(flagSpec.Name, envKey)
-			if err != nil {
-				return fmt.Errorf("bind env %s -> %s: %w", flagSpec.Name, envKey, err)
-			}
+			envAliases = append(envAliases, envKey)
+		}
+
+		if len(envAliases) == 0 {
+			continue
+		}
+
+		bindArgs := make([]string, 0, 1+len(envAliases))
+		bindArgs = append(bindArgs, flagSpec.Name)
+		bindArgs = append(bindArgs, envAliases...)
+
+		err = vip.BindEnv(bindArgs...)
+		if err != nil {
+			return fmt.Errorf("bind env %s -> %v: %w", flagSpec.Name, envAliases, err)
 		}
 	}
 

--- a/internal/flags/bind.go
+++ b/internal/flags/bind.go
@@ -51,6 +51,12 @@ func BindAll(vip *viper.Viper, flagSet *pflag.FlagSet, specs []spec.FlagSpec) er
 		}
 
 		for _, envKey := range flagSpec.EnvKeys {
+			// Presence-only keys (NO_COLOR) are applied via ApplyEnvToFlags and must
+			// not BindEnv, or Viper would re-parse values like "0"/"false" as false.
+			if IsPresenceEnvKey(envKey) {
+				continue
+			}
+
 			err = vip.BindEnv(flagSpec.Name, envKey)
 			if err != nil {
 				return fmt.Errorf("bind env %s -> %s: %w", flagSpec.Name, envKey, err)

--- a/internal/flags/bind.go
+++ b/internal/flags/bind.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
-	"github.com/nicholas-fedor/watchtower/internal/flags/utils"
 )
 
 var (
@@ -112,103 +111,6 @@ func applyDefault(vip *viper.Viper, flagSpec spec.FlagSpec) error {
 		}
 	default:
 		return fmt.Errorf("%w: %s", ErrUnsupportedFlagKind, flagSpec.Name)
-	}
-
-	return nil
-}
-
-// RegisterFromSpecs registers pflags from FlagSpec rows using static defaults only.
-//
-// Parameters:
-//   - flagSet: Target flag set.
-//   - specs: Domain flag specifications.
-//
-// Returns:
-//   - error: Non-nil when registration fails.
-func RegisterFromSpecs(flagSet *pflag.FlagSet, specs []spec.FlagSpec) error {
-	for _, flagSpec := range specs {
-		err := registerOne(flagSet, flagSpec)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// registerOne registers a single FlagSpec onto flagSet.
-//
-// Parameters:
-//   - flagSet: Target flag set.
-//   - flagSpec: Flag specification.
-//
-// Returns:
-//   - error: Non-nil when the kind/default is invalid.
-func registerOne(flagSet *pflag.FlagSet, flagSpec spec.FlagSpec) error {
-	switch flagSpec.Kind {
-	case spec.KindBool:
-		def, _ := flagSpec.Default.(bool)
-		if flagSpec.Shorthand != "" {
-			flagSet.BoolP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
-		} else {
-			flagSet.Bool(flagSpec.Name, def, flagSpec.Help)
-		}
-	case spec.KindString:
-		def, _ := flagSpec.Default.(string)
-		if flagSpec.Shorthand != "" {
-			flagSet.StringP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
-		} else {
-			flagSet.String(flagSpec.Name, def, flagSpec.Help)
-		}
-	case spec.KindInt:
-		def, _ := flagSpec.Default.(int)
-		if flagSpec.Shorthand != "" {
-			flagSet.IntP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
-		} else {
-			flagSet.Int(flagSpec.Name, def, flagSpec.Help)
-		}
-	case spec.KindDuration:
-		def, _ := flagSpec.Default.(time.Duration)
-		if flagSpec.Shorthand != "" {
-			flagSet.DurationP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
-		} else {
-			flagSet.Duration(flagSpec.Name, def, flagSpec.Help)
-		}
-	case spec.KindStringSlice:
-		def, _ := flagSpec.Default.([]string)
-		if def == nil {
-			def = []string{}
-		}
-
-		if flagSpec.Shorthand != "" {
-			flagSet.StringSliceP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
-		} else {
-			flagSet.StringSlice(flagSpec.Name, def, flagSpec.Help)
-		}
-	case spec.KindStringArray:
-		def, _ := flagSpec.Default.([]string)
-		if def == nil {
-			def = []string{}
-		}
-
-		if flagSpec.Shorthand != "" {
-			flagSet.StringArrayP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
-		} else {
-			flagSet.StringArray(flagSpec.Name, def, flagSpec.Help)
-		}
-	default:
-		return fmt.Errorf("%w: %s", ErrUnsupportedFlagKind, flagSpec.Name)
-	}
-
-	if flagSpec.Deprecated != "" {
-		utils.MarkFlagDeprecated(flagSet, flagSpec.Name, flagSpec.Deprecated)
-	}
-
-	if flagSpec.Hidden {
-		err := flagSet.MarkHidden(flagSpec.Name)
-		if err != nil {
-			return fmt.Errorf("hide %s: %w", flagSpec.Name, err)
-		}
 	}
 
 	return nil

--- a/internal/flags/bind.go
+++ b/internal/flags/bind.go
@@ -1,0 +1,226 @@
+package flags
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
+	"github.com/nicholas-fedor/watchtower/internal/flags/utils"
+)
+
+var (
+	// ErrFlagNotRegistered indicates a FlagSpec name was not found on the flag set.
+	ErrFlagNotRegistered = errors.New("flag not registered")
+	// ErrInvalidFlagDefault indicates a FlagSpec default value has the wrong type.
+	ErrInvalidFlagDefault = errors.New("invalid flag default")
+	// ErrUnsupportedFlagKind indicates a FlagSpec kind is not supported.
+	ErrUnsupportedFlagKind = errors.New("unsupported flag kind")
+)
+
+// BindAll applies Viper defaults, flag binds, and env binds from FlagSpec rows.
+//
+// Call after Cobra has parsed flags. Static flag defaults come from Specs;
+// env values participate through BindEnv without baking into pflag defaults.
+//
+// Parameters:
+//   - vip: Local Viper instance for this process load.
+//   - flagSet: Parsed persistent flag set.
+//   - specs: Aggregated domain flag specifications.
+//
+// Returns:
+//   - error: Non-nil when a bind or default application fails.
+func BindAll(vip *viper.Viper, flagSet *pflag.FlagSet, specs []spec.FlagSpec) error {
+	for _, flagSpec := range specs {
+		err := applyDefault(vip, flagSpec)
+		if err != nil {
+			return fmt.Errorf("default %s: %w", flagSpec.Name, err)
+		}
+
+		flag := flagSet.Lookup(flagSpec.Name)
+		if flag == nil {
+			return fmt.Errorf("%w: %q", ErrFlagNotRegistered, flagSpec.Name)
+		}
+
+		err = vip.BindPFlag(flagSpec.Name, flag)
+		if err != nil {
+			return fmt.Errorf("bind flag %s: %w", flagSpec.Name, err)
+		}
+
+		for _, envKey := range flagSpec.EnvKeys {
+			err = vip.BindEnv(flagSpec.Name, envKey)
+			if err != nil {
+				return fmt.Errorf("bind env %s -> %s: %w", flagSpec.Name, envKey, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// applyDefault sets the Viper default for a FlagSpec.
+//
+// Parameters:
+//   - vip: Viper instance.
+//   - flagSpec: Flag specification.
+//
+// Returns:
+//   - error: Non-nil when the default type is unsupported.
+func applyDefault(vip *viper.Viper, flagSpec spec.FlagSpec) error {
+	switch flagSpec.Kind {
+	case spec.KindBool:
+		b, ok := flagSpec.Default.(bool)
+		if !ok && flagSpec.Default != nil {
+			return fmt.Errorf("%w: bool %s", ErrInvalidFlagDefault, flagSpec.Name)
+		}
+
+		vip.SetDefault(flagSpec.Name, b)
+	case spec.KindString:
+		str, _ := flagSpec.Default.(string)
+		vip.SetDefault(flagSpec.Name, str)
+	case spec.KindInt:
+		n, ok := flagSpec.Default.(int)
+		if !ok && flagSpec.Default != nil {
+			return fmt.Errorf("%w: int %s", ErrInvalidFlagDefault, flagSpec.Name)
+		}
+
+		vip.SetDefault(flagSpec.Name, n)
+	case spec.KindDuration:
+		d, ok := flagSpec.Default.(time.Duration)
+		if !ok && flagSpec.Default != nil {
+			return fmt.Errorf("%w: duration %s", ErrInvalidFlagDefault, flagSpec.Name)
+		}
+
+		vip.SetDefault(flagSpec.Name, d)
+	case spec.KindStringSlice, spec.KindStringArray:
+		switch typed := flagSpec.Default.(type) {
+		case []string:
+			vip.SetDefault(flagSpec.Name, typed)
+		case nil:
+			vip.SetDefault(flagSpec.Name, []string{})
+		default:
+			return fmt.Errorf("%w: string slice %s", ErrInvalidFlagDefault, flagSpec.Name)
+		}
+	default:
+		return fmt.Errorf("%w: %s", ErrUnsupportedFlagKind, flagSpec.Name)
+	}
+
+	return nil
+}
+
+// RegisterFromSpecs registers pflags from FlagSpec rows using static defaults only.
+//
+// Parameters:
+//   - flagSet: Target flag set.
+//   - specs: Domain flag specifications.
+//
+// Returns:
+//   - error: Non-nil when registration fails.
+func RegisterFromSpecs(flagSet *pflag.FlagSet, specs []spec.FlagSpec) error {
+	for _, flagSpec := range specs {
+		err := registerOne(flagSet, flagSpec)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// registerOne registers a single FlagSpec onto flagSet.
+//
+// Parameters:
+//   - flagSet: Target flag set.
+//   - flagSpec: Flag specification.
+//
+// Returns:
+//   - error: Non-nil when the kind/default is invalid.
+func registerOne(flagSet *pflag.FlagSet, flagSpec spec.FlagSpec) error {
+	switch flagSpec.Kind {
+	case spec.KindBool:
+		def, _ := flagSpec.Default.(bool)
+		if flagSpec.Shorthand != "" {
+			flagSet.BoolP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
+		} else {
+			flagSet.Bool(flagSpec.Name, def, flagSpec.Help)
+		}
+	case spec.KindString:
+		def, _ := flagSpec.Default.(string)
+		if flagSpec.Shorthand != "" {
+			flagSet.StringP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
+		} else {
+			flagSet.String(flagSpec.Name, def, flagSpec.Help)
+		}
+	case spec.KindInt:
+		def, _ := flagSpec.Default.(int)
+		if flagSpec.Shorthand != "" {
+			flagSet.IntP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
+		} else {
+			flagSet.Int(flagSpec.Name, def, flagSpec.Help)
+		}
+	case spec.KindDuration:
+		def, _ := flagSpec.Default.(time.Duration)
+		if flagSpec.Shorthand != "" {
+			flagSet.DurationP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
+		} else {
+			flagSet.Duration(flagSpec.Name, def, flagSpec.Help)
+		}
+	case spec.KindStringSlice:
+		def, _ := flagSpec.Default.([]string)
+		if def == nil {
+			def = []string{}
+		}
+
+		if flagSpec.Shorthand != "" {
+			flagSet.StringSliceP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
+		} else {
+			flagSet.StringSlice(flagSpec.Name, def, flagSpec.Help)
+		}
+	case spec.KindStringArray:
+		def, _ := flagSpec.Default.([]string)
+		if def == nil {
+			def = []string{}
+		}
+
+		if flagSpec.Shorthand != "" {
+			flagSet.StringArrayP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
+		} else {
+			flagSet.StringArray(flagSpec.Name, def, flagSpec.Help)
+		}
+	default:
+		return fmt.Errorf("%w: %s", ErrUnsupportedFlagKind, flagSpec.Name)
+	}
+
+	if flagSpec.Deprecated != "" {
+		utils.MarkFlagDeprecated(flagSet, flagSpec.Name, flagSpec.Deprecated)
+	}
+
+	if flagSpec.Hidden {
+		err := flagSet.MarkHidden(flagSpec.Name)
+		if err != nil {
+			return fmt.Errorf("hide %s: %w", flagSpec.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// CollectSpecs aggregates FlagSpec rows from domain Specs functions.
+//
+// Parameters:
+//   - groups: Domain Specs() results.
+//
+// Returns:
+//   - []spec.FlagSpec: Combined specification list.
+func CollectSpecs(groups ...[]spec.FlagSpec) []spec.FlagSpec {
+	var all []spec.FlagSpec
+
+	for _, group := range groups {
+		all = append(all, group...)
+	}
+
+	return all
+}

--- a/internal/flags/client/register.go
+++ b/internal/flags/client/register.go
@@ -1,0 +1,61 @@
+// Package client registers Docker client construction flags.
+package client
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
+)
+
+// Specs returns client domain flag metadata with static defaults.
+//
+// Returns:
+//   - []spec.FlagSpec: Client flag specifications.
+func Specs() []spec.FlagSpec {
+	return []spec.FlagSpec{
+		{
+			Name:      "include-stopped",
+			Shorthand: "S",
+			Kind:      spec.KindBool,
+			Default:   false,
+			EnvKeys:   []string{"WATCHTOWER_INCLUDE_STOPPED"},
+			Help:      "Will also include created and exited containers",
+		},
+		{
+			Name:    "include-restarting",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_INCLUDE_RESTARTING"},
+			Help:    "Will also include restarting containers",
+		},
+		{
+			Name:    "revive-stopped",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_REVIVE_STOPPED"},
+			Help:    "Will also start stopped containers that were updated, if include-stopped is active",
+		},
+		{
+			Name:    "remove-volumes",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_REMOVE_VOLUMES"},
+			Help:    "Remove attached volumes before updating",
+		},
+		{
+			Name:    "warn-on-head-failure",
+			Kind:    spec.KindString,
+			Default: "",
+			EnvKeys: []string{"WATCHTOWER_WARN_ON_HEAD_FAILURE"},
+			Help:    "When to warn about HEAD pull requests failing. Possible values: always, auto or never",
+		},
+	}
+}
+
+// Register adds client domain flags to the root command.
+//
+// Parameters:
+//   - rootCmd: Root Cobra command.
+func Register(rootCmd *cobra.Command) {
+	spec.MustRegister(rootCmd.PersistentFlags(), Specs())
+}

--- a/internal/flags/compat/register.go
+++ b/internal/flags/compat/register.go
@@ -1,0 +1,39 @@
+// Package compat registers runtime compatibility flags.
+package compat
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
+)
+
+// Specs returns compat domain flag metadata with static defaults.
+//
+// Returns:
+//   - []spec.FlagSpec: Compat flag specifications.
+func Specs() []spec.FlagSpec {
+	return []spec.FlagSpec{
+		{
+			Name:    "disable-memory-swappiness",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_DISABLE_MEMORY_SWAPPINESS"},
+			Help:    "Label used for setting memory swappiness as nil when recreating the container, used for compatibility with podman",
+		},
+		{
+			Name:    "cpu-copy-mode",
+			Kind:    spec.KindString,
+			Default: "auto",
+			EnvKeys: []string{"WATCHTOWER_CPU_COPY_MODE"},
+			Help:    "CPU copy mode for container recreation, used for compatibility with Podman. Options: auto, full, none",
+		},
+	}
+}
+
+// Register adds compatibility domain flags to the root command.
+//
+// Parameters:
+//   - rootCmd: Root Cobra command.
+func Register(rootCmd *cobra.Command) {
+	spec.MustRegister(rootCmd.PersistentFlags(), Specs())
+}

--- a/internal/flags/doc.go
+++ b/internal/flags/doc.go
@@ -19,8 +19,9 @@
 //   - ProcessFlagAliases / GetSecretsFromFiles: Pre-load transforms (porcelain, interval→schedule, secrets).
 //   - EnvConfig: Maps Docker client flags into DOCKER_* process environment variables.
 //
-// Domains that expose FlagSpec use static pflag defaults and BindAll (flag > env >
-// default). Remaining domains still register with env-baked defaults until converted.
+// Every domain exposes FlagSpec with static pflag defaults. BindAll and Load
+// resolve values as flag > env > default; ApplyEnvToFlags bridges env onto unset
+// flags for pre-load helpers without baking env into registration defaults.
 //
 // Usage example:
 //

--- a/internal/flags/doc.go
+++ b/internal/flags/doc.go
@@ -1,21 +1,39 @@
 // Package flags manages command-line flags and environment variables for Watchtower configuration.
-// It configures Docker connections, system behavior, and notifications via Cobra and Viper.
+// It configures Docker connections, operational behavior, and notifications via Cobra and Viper.
+//
+// Layout:
+//   - internal/flags/spec — FlagSpec metadata (static defaults, env keys, list parse kind)
+//   - internal/flags/<domain> — Specs() and/or Register per subsystem
+//   - internal/flags/utils — list parsers, env helpers, deprecation
+//   - RegisterAll / BindAll / AllSpecs — parent façade
+//
+// Domain packages match the config taxonomy:
+// docker, client, schedule, mode, update, lifecycle, filter, registry, compat,
+// api, notify, logging.
 //
 // Key components:
-//   - RegisterDockerFlags: Adds Docker API client flags.
-//   - RegisterSystemFlags: Adds operational control flags.
-//   - RegisterNotificationFlags: Adds notification settings.
+//   - RegisterAll: Registers every domain's flags on the root command.
+//   - RegisterDockerFlags / RegisterSystemFlags / RegisterNotificationFlags: Domain-group helpers for tests.
+//   - BindAll: Applies Viper defaults, BindPFlag, and BindEnv from FlagSpec rows.
 //   - SetupLogging: Configures logrus based on flags.
+//   - ProcessFlagAliases / GetSecretsFromFiles: Pre-load transforms (porcelain, interval→schedule, secrets).
+//   - EnvConfig: Maps Docker client flags into DOCKER_* process environment variables.
+//
+// Domains that expose FlagSpec use static pflag defaults and BindAll (flag > env >
+// default). Remaining domains still register with env-baked defaults until converted.
 //
 // Usage example:
 //
 //	cmd := &cobra.Command{}
-//	flags.RegisterSystemFlags(cmd)
 //	flags.SetDefaults()
+//	flags.RegisterAll(cmd)
 //	err := flags.SetupLogging(cmd.PersistentFlags())
 //	if err != nil {
 //	    logrus.WithError(err).Fatal("Logging setup failed")
 //	}
+//
+// Resolved process policy belongs in internal/config via config.Load. This package
+// only declares and binds flags; it does not own update policy DTOs.
 //
 // The package integrates with Cobra for flag parsing, Viper for environment variable binding,
 // and logrus for logging configuration errors.

--- a/internal/flags/docker/register.go
+++ b/internal/flags/docker/register.go
@@ -1,0 +1,65 @@
+// Package docker registers Docker API client flags.
+package docker
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
+)
+
+// Specs returns Docker domain flag metadata with static defaults.
+//
+// Returns:
+//   - []spec.FlagSpec: Docker flag specifications.
+func Specs() []spec.FlagSpec {
+	return []spec.FlagSpec{
+		{
+			Name:      "host",
+			Shorthand: "H",
+			Kind:      spec.KindString,
+			Default:   "unix:///var/run/docker.sock",
+			EnvKeys:   []string{"DOCKER_HOST"},
+			Help:      "daemon socket to connect to",
+		},
+		{
+			Name:      "tlsverify",
+			Shorthand: "v",
+			Kind:      spec.KindBool,
+			Default:   false,
+			EnvKeys:   []string{"DOCKER_TLS_VERIFY"},
+			Help:      "use TLS and verify the remote",
+		},
+		{
+			Name:      "api-version",
+			Shorthand: "a",
+			Kind:      spec.KindString,
+			Default:   "",
+			EnvKeys:   []string{"DOCKER_API_VERSION"},
+			Help:      "api version to use by docker client (omit for autonegotiation)",
+		},
+		{
+			Name:    "cert-path",
+			Kind:    spec.KindString,
+			Default: "",
+			EnvKeys: []string{"DOCKER_CERT_PATH"},
+			Help:    "Path to TLS certificates",
+		},
+	}
+}
+
+// Register adds Docker API client flags using static defaults from Specs.
+//
+// Parameters:
+//   - rootCmd: Root Cobra command.
+func Register(rootCmd *cobra.Command) {
+	RegisterOn(rootCmd.PersistentFlags())
+}
+
+// RegisterOn registers Docker flags onto an arbitrary flag set.
+//
+// Parameters:
+//   - flagSet: Target flag set.
+func RegisterOn(flagSet *pflag.FlagSet) {
+	spec.MustRegister(flagSet, Specs())
+}

--- a/internal/flags/filter/register.go
+++ b/internal/flags/filter/register.go
@@ -1,0 +1,81 @@
+// Package filter registers container selection flags.
+package filter
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
+)
+
+// Specs returns filter domain flag metadata with static defaults.
+//
+// Returns:
+//   - []spec.FlagSpec: Filter flag specifications.
+func Specs() []spec.FlagSpec {
+	return []spec.FlagSpec{
+		{
+			Name:      "label-enable",
+			Shorthand: "e",
+			Kind:      spec.KindBool,
+			Default:   false,
+			EnvKeys:   []string{"WATCHTOWER_LABEL_ENABLE"},
+			Help:      "Watch containers where the com.centurylinklabs.watchtower.enable label is true",
+		},
+		{
+			Name:      "disable-containers",
+			Shorthand: "x",
+			Kind:      spec.KindStringSlice,
+			Default:   []string{},
+			EnvKeys:   []string{"WATCHTOWER_DISABLE_CONTAINERS"},
+			ListParse: spec.ListCommaOrSpace,
+			Help:      "Comma-separated list of containers to explicitly exclude from watching.",
+		},
+		{
+			Name:      "monitor-image-names",
+			Kind:      spec.KindStringSlice,
+			Default:   []string{},
+			EnvKeys:   []string{"WATCHTOWER_MONITOR_IMAGE_NAMES"},
+			ListParse: spec.ListCommaOrSpace,
+			Help:      "Comma-separated list of image names to monitor.",
+		},
+		{
+			Name:      "skip-image-names",
+			Kind:      spec.KindStringSlice,
+			Default:   []string{},
+			EnvKeys:   []string{"WATCHTOWER_SKIP_IMAGE_NAMES"},
+			ListParse: spec.ListCommaOrSpace,
+			Help:      "Comma-separated list of image names to explicitly exclude from monitoring.",
+		},
+		{
+			Name:      "enable-containers-by-label",
+			Kind:      spec.KindStringSlice,
+			Default:   []string{},
+			EnvKeys:   []string{"WATCHTOWER_ENABLE_CONTAINERS_BY_LABEL"},
+			ListParse: spec.ListCommaOnly,
+			Help:      "Comma-separated list of key=value label pairs to restrict monitoring to matching containers.",
+		},
+		{
+			Name:      "disable-containers-by-label",
+			Kind:      spec.KindStringSlice,
+			Default:   []string{},
+			EnvKeys:   []string{"WATCHTOWER_DISABLE_CONTAINERS_BY_LABEL"},
+			ListParse: spec.ListCommaOnly,
+			Help:      "Comma-separated list of key=value label pairs to exclude matching containers from monitoring.",
+		},
+		{
+			Name:    "scope",
+			Kind:    spec.KindString,
+			Default: "",
+			EnvKeys: []string{"WATCHTOWER_SCOPE"},
+			Help:    "Defines a monitoring scope for the Watchtower instance.",
+		},
+	}
+}
+
+// Register adds filter domain flags to the root command.
+//
+// Parameters:
+//   - rootCmd: Root Cobra command.
+func Register(rootCmd *cobra.Command) {
+	spec.MustRegister(rootCmd.PersistentFlags(), Specs())
+}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -4,34 +4,32 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"math"
 	"net/url"
 	"os"
-	"regexp"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/api"
+	"github.com/nicholas-fedor/watchtower/internal/flags/client"
+	"github.com/nicholas-fedor/watchtower/internal/flags/compat"
+	"github.com/nicholas-fedor/watchtower/internal/flags/docker"
+	"github.com/nicholas-fedor/watchtower/internal/flags/filter"
+	"github.com/nicholas-fedor/watchtower/internal/flags/lifecycle"
+	"github.com/nicholas-fedor/watchtower/internal/flags/logging"
+	"github.com/nicholas-fedor/watchtower/internal/flags/mode"
+	"github.com/nicholas-fedor/watchtower/internal/flags/notify"
+	"github.com/nicholas-fedor/watchtower/internal/flags/registry"
+	"github.com/nicholas-fedor/watchtower/internal/flags/schedule"
+	"github.com/nicholas-fedor/watchtower/internal/flags/update"
+	"github.com/nicholas-fedor/watchtower/internal/flags/utils"
 )
 
 // DockerAPIMinVersion sets the minimum Docker API version supported by Watchtower.
 const DockerAPIMinVersion string = "1.24"
-
-// defaultPollIntervalSeconds sets the default polling interval (24 hours).
-const defaultPollIntervalSeconds = 86400 // 24 * 60 * 60 seconds
-
-// defaultStopTimeoutSeconds sets the default container stop timeout (30 seconds).
-const defaultStopTimeoutSeconds = 30
-
-// defaultEmailServerPort sets the default SMTP port (25).
-const defaultEmailServerPort = 25
-
-// defaultAPIRateLimitPerMinute sets the default HTTP API rate limit (60 requests per minute per IP).
-const defaultAPIRateLimitPerMinute = 60
 
 // Errors for flag and environment configuration.
 var (
@@ -59,914 +57,59 @@ var (
 
 // RegisterDockerFlags adds Docker API client flags to the root command.
 //
+// Prefer RegisterAll when registering the full flag set.
+//
 // Parameters:
 //   - rootCmd: Root Cobra command.
 func RegisterDockerFlags(rootCmd *cobra.Command) {
-	flags := rootCmd.PersistentFlags()
-	flags.StringP("host", "H", envString("DOCKER_HOST"), "daemon socket to connect to")
-	flags.BoolP("tlsverify", "v", envBool("DOCKER_TLS_VERIFY"), "use TLS and verify the remote")
-	flags.StringP(
-		"api-version",
-		"a",
-		strings.Trim(envString("DOCKER_API_VERSION"), "\""),
-		"api version to use by docker client (omit for autonegotiation)",
-	)
-	flags.StringP("cert-path", "", envString("DOCKER_CERT_PATH"), "Path to TLS certificates")
+	docker.Register(rootCmd)
 }
 
-// RegisterSystemFlags adds Watchtower flow control flags to the root command.
+// RegisterSystemFlags registers non-Docker, non-notification domain flags.
+//
+// Prefer RegisterAll. Kept for tests that call domain groups separately.
 //
 // Parameters:
 //   - rootCmd: Root Cobra command.
 func RegisterSystemFlags(rootCmd *cobra.Command) {
-	flags := rootCmd.PersistentFlags()
-	flags.IntP(
-		"interval",
-		"i",
-		envInt("WATCHTOWER_POLL_INTERVAL"),
-		"Poll interval (in seconds)")
-
-	flags.StringP(
-		"schedule",
-		"s",
-		envString("WATCHTOWER_SCHEDULE"),
-		"The cron expression which defines when to update")
-
-	flags.DurationP(
-		"stop-timeout",
-		"t",
-		envDuration("WATCHTOWER_TIMEOUT"),
-		"Timeout before a container is forcefully stopped (e.g., 30s, 1m, 5m)")
-
-	flags.StringP(
-		"cooldown-delay",
-		"",
-		envString("WATCHTOWER_COOLDOWN_DELAY"),
-		"Minimum time since image creation before allowing updates. Supports h, m, s, d (days), w (weeks), M (months) (e.g., 24h, 3d, 1w, 1M)")
-
-	flags.BoolP(
-		"no-pull",
-		"",
-		envBool("WATCHTOWER_NO_PULL"),
-		"Do not pull any new images")
-
-	flags.BoolP(
-		"no-restart",
-		"",
-		envBool("WATCHTOWER_NO_RESTART"),
-		"Do not restart any containers")
-
-	flags.BoolP(
-		"no-startup-message",
-		"",
-		envBool("WATCHTOWER_NO_STARTUP_MESSAGE"),
-		"Prevents watchtower from sending a startup message")
-
-	flags.BoolP(
-		"cleanup",
-		"c",
-		envBool("WATCHTOWER_CLEANUP"),
-		"Remove previously used images after updating")
-
-	flags.BoolP(
-		"remove-volumes",
-		"",
-		envBool("WATCHTOWER_REMOVE_VOLUMES"),
-		"Remove attached volumes before updating")
-
-	flags.BoolP(
-		"label-enable",
-		"e",
-		envBool("WATCHTOWER_LABEL_ENABLE"),
-		"Watch containers where the com.centurylinklabs.watchtower.enable label is true")
-
-	flags.StringSliceP(
-		"disable-containers",
-		"x",
-		filterEmptyStrings(
-			regexp.MustCompile("[, ]+").Split(envString("WATCHTOWER_DISABLE_CONTAINERS"), -1),
-		),
-		"Comma-separated list of containers to explicitly exclude from watching.")
-
-	flags.StringSlice(
-		"monitor-image-names",
-		filterEmptyStrings(
-			regexp.MustCompile("[, ]+").Split(envString("WATCHTOWER_MONITOR_IMAGE_NAMES"), -1),
-		),
-		"Comma-separated list of image names to monitor.")
-
-	flags.StringSlice(
-		"skip-image-names",
-		filterEmptyStrings(
-			regexp.MustCompile("[, ]+").Split(envString("WATCHTOWER_SKIP_IMAGE_NAMES"), -1),
-		),
-		"Comma-separated list of image names to explicitly exclude from monitoring.")
-
-	flags.StringSlice(
-		"enable-containers-by-label",
-		filterEmptyStrings(
-			regexp.MustCompile(",").Split(envString("WATCHTOWER_ENABLE_CONTAINERS_BY_LABEL"), -1),
-		),
-		"Comma-separated list of key=value label pairs to restrict monitoring to matching containers.")
-
-	flags.StringSlice(
-		"disable-containers-by-label",
-		filterEmptyStrings(
-			regexp.MustCompile(",").Split(envString("WATCHTOWER_DISABLE_CONTAINERS_BY_LABEL"), -1),
-		),
-		"Comma-separated list of key=value label pairs to exclude matching containers from monitoring.")
-
-	flags.StringP(
-		"log-format",
-		"l",
-		viper.GetString("WATCHTOWER_LOG_FORMAT"),
-		"Sets what logging format to use for console output. Possible values: Auto, LogFmt, Pretty, JSON",
-	)
-
-	flags.BoolP(
-		"debug",
-		"d",
-		envBool("WATCHTOWER_DEBUG"),
-		"Enable debug mode with verbose logging")
-
-	flags.BoolP(
-		"trace",
-		"",
-		envBool("WATCHTOWER_TRACE"),
-		"Enable trace mode with very verbose logging - caution, exposes credentials")
-
-	flags.BoolP(
-		"monitor-only",
-		"m",
-		envBool("WATCHTOWER_MONITOR_ONLY"),
-		"Will only monitor for new images, not update the containers")
-
-	flags.BoolP(
-		"run-once",
-		"R",
-		envBool("WATCHTOWER_RUN_ONCE"),
-		"Run once now and exit")
-
-	flags.BoolP(
-		"update-on-start",
-		"",
-		envBool("WATCHTOWER_UPDATE_ON_START"),
-		"Perform an update check on startup, then continue with periodic updates")
-
-	flags.BoolP(
-		"include-restarting",
-		"",
-		envBool("WATCHTOWER_INCLUDE_RESTARTING"),
-		"Will also include restarting containers")
-
-	flags.BoolP(
-		"include-stopped",
-		"S",
-		envBool("WATCHTOWER_INCLUDE_STOPPED"),
-		"Will also include created and exited containers")
-
-	flags.BoolP(
-		"revive-stopped",
-		"",
-		envBool("WATCHTOWER_REVIVE_STOPPED"),
-		"Will also start stopped containers that were updated, if include-stopped is active")
-
-	flags.BoolP(
-		"enable-lifecycle-hooks",
-		"",
-		envBool("WATCHTOWER_LIFECYCLE_HOOKS"),
-		"Enable the execution of commands triggered by pre- and post-update lifecycle hooks")
-
-	flags.BoolP(
-		"rolling-restart",
-		"",
-		envBool("WATCHTOWER_ROLLING_RESTART"),
-		"Restart containers one at a time")
-
-	flags.StringSliceP(
-		"http-api-endpoints",
-		"",
-		filterEmptyStrings(
-			regexp.MustCompile("[, ]+").Split(envString("WATCHTOWER_HTTP_API_ENDPOINTS"), -1),
-		),
-		"HTTP API endpoints to enable (health, update, metrics, containers, check, history, images, config, events, swagger), or \"all\". Comma- or space-separated. Empty disables the HTTP API.")
-
-	//nolint:godox
-	// TODO: Remove legacy HTTP API enable flags below for the v2 release.
-	// They are kept for backwards compatibility but are deprecated.
-	// Use http-api-endpoints instead.
-
-	flags.BoolP(
-		"http-api-update",
-		"",
-		envBool("WATCHTOWER_HTTP_API_UPDATE"),
-		"Runs Watchtower in HTTP API mode, so that image updates must be triggered by a request")
-	flags.BoolP(
-		"http-api-metrics",
-		"",
-		envBool("WATCHTOWER_HTTP_API_METRICS"),
-		"Runs Watchtower with the Prometheus metrics API enabled")
-	flags.BoolP(
-		"http-api-containers",
-		"",
-		envBool("WATCHTOWER_HTTP_API_CONTAINERS"),
-		"Runs Watchtower with the read-only containers API enabled, exposing each watched container's current image digest")
-
-	//nolint:godox
-	// TODO: Remove just before v2 Release.
-	// Mark legacy HTTP API enable flags as deprecated.
-	// These flags are still functional but will be removed in the v2 release.
-	// Users should migrate to use the http-api-endpoints configuration option instead.
-	markFlagDeprecated(flags, "http-api-update", "Use the http-api-endpoints configuration option instead.")
-	markFlagDeprecated(flags, "http-api-metrics", "Use the http-api-endpoints configuration option instead.")
-	markFlagDeprecated(flags, "http-api-containers", "Use the http-api-endpoints configuration option instead.")
-
-	flags.StringP(
-		"http-api-host",
-		"",
-		envString("WATCHTOWER_HTTP_API_HOST"),
-		"Host to bind the HTTP API to (default: empty, binds to all interfaces; allows empty or valid IP address)",
-	)
-
-	flags.StringP(
-		"http-api-port",
-		"",
-		envString("WATCHTOWER_HTTP_API_PORT"),
-		"Port to bind the HTTP API to (default: 8080)")
-
-	flags.StringP(
-		"http-api-token",
-		"",
-		envString("WATCHTOWER_HTTP_API_TOKEN"),
-		"Sets an authentication token for HTTP API requests (required when any non-health endpoint is enabled)")
-
-	flags.StringP(
-		"http-api-events-token",
-		"",
-		envString("WATCHTOWER_HTTP_API_EVENTS_TOKEN"),
-		"Sets an authentication token for the events SSE endpoint. Required when the events endpoint is enabled. Supports Bearer header and query parameter access_token (for browser EventSource)")
-
-	flags.BoolP(
-		"http-api-periodic-polls",
-		"",
-		envBool("WATCHTOWER_HTTP_API_PERIODIC_POLLS"),
-		"Also run periodic updates (specified with --interval and --schedule) if HTTP API is enabled",
-	)
-
-	flags.IntP(
-		"http-api-rate-limit",
-		"",
-		envInt("WATCHTOWER_HTTP_API_RATE_LIMIT"),
-		"Maximum authentication requests per minute per IP address for the HTTP API (default: 60)",
-	)
-
-	flags.StringP(
-		"http-api-tls-cert",
-		"",
-		envString("WATCHTOWER_HTTP_API_TLS_CERT"),
-		"Path to TLS certificate file for the HTTP API")
-
-	flags.StringP(
-		"http-api-tls-key",
-		"",
-		envString("WATCHTOWER_HTTP_API_TLS_KEY"),
-		"Path to TLS key file for the HTTP API")
-
-	flags.StringSliceP(
-		"http-api-trusted-proxies",
-		"",
-		filterEmptyStrings(
-			regexp.MustCompile("[, ]+").Split(envString("WATCHTOWER_HTTP_API_TRUSTED_PROXIES"), -1),
-		),
-		"Comma-separated list of trusted proxy IP addresses or CIDR ranges for reverse proxy support (e.g. 10.0.0.0/8,172.16.0.0/12). When set, enables proxy header processing for client IP and scheme detection",
-	)
-
-	flags.StringP(
-		"http-api-proxy-header",
-		"",
-		envString("WATCHTOWER_HTTP_API_PROXY_HEADER"),
-		"Header to use for real client IP when behind a reverse proxy (default: X-Forwarded-For). Only used when http-api-trusted-proxies is set")
-
-	flags.StringSliceP(
-		"http-api-cors-origins",
-		"",
-		filterEmptyStrings(
-			regexp.MustCompile("[, ]+").Split(envString("WATCHTOWER_HTTP_API_CORS_ORIGINS"), -1),
-		),
-		"Comma-separated list of allowed CORS origins for cross-origin requests (e.g. https://app.example.com). If unset, CORS is disabled and only same-origin requests are allowed.")
-
-	flags.DurationP(
-		"http-api-check-timeout",
-		"",
-		envDuration("WATCHTOWER_HTTP_API_CHECK_TIMEOUT"),
-		"Maximum duration for the /v1/check API endpoint (e.g. 30s, 2m, 5m). Default: 5m",
-	)
-
-	flags.DurationP(
-		"http-api-update-timeout",
-		"",
-		envDuration("WATCHTOWER_HTTP_API_UPDATE_TIMEOUT"),
-		"Maximum duration for the /v1/update API endpoint (e.g. 1m, 10m, 30m). Default: 10m",
-	)
-
-	// https://no-color.org/
-	flags.BoolP(
-		"no-color",
-		"",
-		viper.IsSet("NO_COLOR"),
-		"Disable ANSI color escape codes in log output")
-
-	flags.StringP(
-		"scope",
-		"",
-		envString("WATCHTOWER_SCOPE"),
-		"Defines a monitoring scope for the Watchtower instance.")
-
-	flags.StringP(
-		"porcelain",
-		"P",
-		envString("WATCHTOWER_PORCELAIN"),
-		`Write session results to stdout using a stable versioned format. Supported values: "v1"`)
-
-	flags.String(
-		"log-level",
-		envString("WATCHTOWER_LOG_LEVEL"),
-		"The maximum log level that will be written to STDERR. Possible values: panic, fatal, error, warn, info, debug or trace",
-	)
-
-	flags.BoolP(
-		"health-check",
-		"",
-		false,
-		"Do health check and exit")
-
-	flags.BoolP(
-		"label-take-precedence",
-		"",
-		envBool("WATCHTOWER_LABEL_TAKE_PRECEDENCE"),
-		"Label applied to containers take precedence over arguments")
-
-	flags.BoolP(
-		"use-compose-depends-on",
-		"",
-		envBool("WATCHTOWER_USE_COMPOSE_DEPENDS_ON"),
-		"Include Docker Compose depends_on label when determining container update order")
-
-	flags.BoolP(
-		"disable-memory-swappiness",
-		"",
-		envBool("WATCHTOWER_DISABLE_MEMORY_SWAPPINESS"),
-		"Label used for setting memory swappiness as nil when recreating the container, used for compatibility with podman",
-	)
-
-	flags.StringP(
-		"cpu-copy-mode",
-		"",
-		envString("WATCHTOWER_CPU_COPY_MODE"),
-		"CPU copy mode for container recreation, used for compatibility with Podman. Options: auto, full, none",
-	)
-
-	flags.BoolP(
-		"ephemeral-self-update",
-		"",
-		envBool("WATCHTOWER_EPHEMERAL_SELF_UPDATE"),
-		"Use an ephemeral container to orchestrate Watchtower self-updates (experimental)",
-	)
-
-	flags.Bool(
-		"self-update-orchestrator",
-		false,
-		"Internal: Run as ephemeral orchestrator for self-update (not for direct use)",
-	)
-	// Hide the orchestrator flag from help output since it's internal.
-	err := flags.MarkHidden("self-update-orchestrator")
-	if err != nil {
-		logrus.WithError(err).Debug("Failed to hide self-update-orchestrator flag")
-	}
-
-	flags.IntP(
-		"lifecycle-uid",
-		"",
-		envInt("WATCHTOWER_LIFECYCLE_UID"),
-		"Default UID to run lifecycle hooks as (can be overridden by container labels)",
-	)
-
-	flags.IntP(
-		"lifecycle-gid",
-		"",
-		envInt("WATCHTOWER_LIFECYCLE_GID"),
-		"Default GID to run lifecycle hooks as (can be overridden by container labels)",
-	)
-
-	flags.Bool(
-		"registry-tls-skip",
-		envBool("WATCHTOWER_REGISTRY_TLS_SKIP"),
-		"Disable TLS verification for registry connections; allows HTTP or insecure TLS registries (use with caution)",
-	)
-	viper.MustBindEnv("WATCHTOWER_REGISTRY_TLS_SKIP")
-
-	flags.String(
-		"registry-tls-min-version",
-		envString("WATCHTOWER_REGISTRY_TLS_MIN_VERSION"),
-		"Minimum TLS version for registry connections (e.g., TLS1.0, TLS1.1, TLS1.2, TLS1.3); default is TLS1.2",
-	)
-	viper.MustBindEnv("WATCHTOWER_REGISTRY_TLS_MIN_VERSION")
+	client.Register(rootCmd)
+	schedule.Register(rootCmd)
+	mode.Register(rootCmd)
+	update.Register(rootCmd)
+	lifecycle.Register(rootCmd)
+	filter.Register(rootCmd)
+	registry.Register(rootCmd)
+	compat.Register(rootCmd)
+	api.Register(rootCmd)
+	logging.Register(rootCmd)
 }
 
 // RegisterNotificationFlags adds notification flags to the root command.
 //
+// Prefer RegisterAll when registering the full flag set.
+//
 // Parameters:
 //   - rootCmd: Root Cobra command.
 func RegisterNotificationFlags(rootCmd *cobra.Command) {
-	flags := rootCmd.PersistentFlags()
-
-	flags.StringArray(
-		"notification-url",
-		filterEmptyStrings(splitNotificationValues(envString("WATCHTOWER_NOTIFICATION_URL"))),
-		"The shoutrrr URL to send notifications to",
-	)
-
-	flags.String(
-		"notifications-level",
-		envString("WATCHTOWER_NOTIFICATIONS_LEVEL"),
-		"The log level used for sending notifications. Possible values: panic, fatal, error, warn, info or debug",
-	)
-
-	flags.IntP(
-		"notifications-delay",
-		"",
-		envInt("WATCHTOWER_NOTIFICATIONS_DELAY"),
-		"Delay before sending notifications, expressed in seconds")
-
-	flags.StringP(
-		"notifications-hostname",
-		"",
-		envString("WATCHTOWER_NOTIFICATIONS_HOSTNAME"),
-		"Custom hostname for notification titles")
-
-	flags.String(
-		"notification-template",
-		envString("WATCHTOWER_NOTIFICATION_TEMPLATE"),
-		"The shoutrrr text/template for the messages")
-
-	flags.String(
-		"notification-template-file",
-		envString("WATCHTOWER_NOTIFICATION_TEMPLATE_FILE"),
-		"Path to a file containing the Shoutrrr text/template for the messages")
-
-	flags.Bool("notification-report",
-		envBool("WATCHTOWER_NOTIFICATION_REPORT"),
-		"Use the session report as the notification template data")
-
-	flags.StringP(
-		"notification-title-tag",
-		"",
-		envString("WATCHTOWER_NOTIFICATION_TITLE_TAG"),
-		"Title prefix tag for notifications")
-
-	flags.Bool("notification-skip-title",
-		envBool("WATCHTOWER_NOTIFICATION_SKIP_TITLE"),
-		"Do not pass the title param to notifications")
-
-	flags.String(
-		"warn-on-head-failure",
-		envString("WATCHTOWER_WARN_ON_HEAD_FAILURE"),
-		"When to warn about HEAD pull requests failing. Possible values: always, auto or never")
-
-	flags.Bool(
-		"notification-log-stdout",
-		envBool("WATCHTOWER_NOTIFICATION_LOG_STDOUT"),
-		"Write notification logs to stdout instead of logging (to stderr)")
-
-	flags.BoolP(
-		"notification-split-by-container",
-		"",
-		envBool("WATCHTOWER_NOTIFICATION_SPLIT_BY_CONTAINER"),
-		"Send separate notifications for each updated container instead of grouping them")
-
-	//nolint:godox
-	// TODO: Remove legacy notification flags below for the v2 release.
-	// They are kept for backwards compatibility but are deprecated.
-	// Use --notification-url instead.
-
-	flags.StringSliceP(
-		"notifications",
-		"n",
-		filterEmptyStrings(
-			regexp.MustCompile("[, ]+").Split(envString("WATCHTOWER_NOTIFICATIONS"), -1),
-		),
-		"Notification types to send [legacy types (email, slack, msteams, gotify).",
-	)
-
-	flags.StringP(
-		"notification-email-from",
-		"",
-		envString("WATCHTOWER_NOTIFICATION_EMAIL_FROM"),
-		"Address to send notification emails from")
-
-	flags.StringP(
-		"notification-email-to",
-		"",
-		envString("WATCHTOWER_NOTIFICATION_EMAIL_TO"),
-		"Address to send notification emails to")
-
-	flags.IntP(
-		"notification-email-delay",
-		"",
-		envInt("WATCHTOWER_NOTIFICATION_EMAIL_DELAY"),
-		"Delay before sending notifications, expressed in seconds")
-
-	flags.StringP(
-		"notification-email-server",
-		"",
-		envString("WATCHTOWER_NOTIFICATION_EMAIL_SERVER"),
-		"SMTP server to send notification emails through")
-
-	flags.IntP(
-		"notification-email-server-port",
-		"",
-		envInt("WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT"),
-		"SMTP server port to send notification emails through")
-
-	flags.BoolP(
-		"notification-email-server-tls-skip-verify",
-		"",
-		envBool("WATCHTOWER_NOTIFICATION_EMAIL_SERVER_TLS_SKIP_VERIFY"),
-		"Controls whether watchtower verifies the SMTP server's certificate chain and host name. Should only be used for testing.",
-	)
-
-	flags.StringP(
-		"notification-email-server-user",
-		"",
-		envString("WATCHTOWER_NOTIFICATION_EMAIL_SERVER_USER"),
-		"SMTP server user for sending notifications")
-
-	flags.StringP(
-		"notification-email-server-password",
-		"",
-		envString("WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD"),
-		"SMTP server password for sending notifications")
-
-	flags.StringP(
-		"notification-email-subjecttag",
-		"",
-		envString("WATCHTOWER_NOTIFICATION_EMAIL_SUBJECTTAG"),
-		"Subject prefix tag for notifications via mail")
-
-	flags.StringP(
-		"notification-slack-hook-url",
-		"",
-		envString("WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL"),
-		"The Slack Hook URL to send notifications to")
-
-	flags.StringP(
-		"notification-slack-identifier",
-		"",
-		envString("WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER"),
-		"A string which will be used to identify the messages coming from this watchtower instance")
-
-	flags.StringP(
-		"notification-slack-channel",
-		"",
-		envString("WATCHTOWER_NOTIFICATION_SLACK_CHANNEL"),
-		"A string which overrides the webhook's default channel. Example: #my-custom-channel")
-
-	flags.StringP(
-		"notification-slack-icon-emoji",
-		"",
-		envString("WATCHTOWER_NOTIFICATION_SLACK_ICON_EMOJI"),
-		"An emoji code string to use in place of the default icon")
-
-	flags.StringP(
-		"notification-slack-icon-url",
-		"",
-		envString("WATCHTOWER_NOTIFICATION_SLACK_ICON_URL"),
-		"An icon image URL string to use in place of the default icon")
-
-	flags.StringP(
-		"notification-msteams-hook",
-		"",
-		envString("WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL"),
-		"The MSTeams WebHook URL to send notifications to")
-
-	flags.StringP(
-		"notification-gotify-url",
-		"",
-		envString("WATCHTOWER_NOTIFICATION_GOTIFY_URL"),
-		"The Gotify URL to send notifications to")
-
-	flags.StringP(
-		"notification-gotify-token",
-		"",
-		envString("WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN"),
-		"The Gotify Application required to query the Gotify API")
-
-	flags.BoolP(
-		"notification-gotify-tls-skip-verify",
-		"",
-		envBool("WATCHTOWER_NOTIFICATION_GOTIFY_TLS_SKIP_VERIFY"),
-		"Controls whether watchtower verifies the Gotify server's certificate chain and host name. Should only be used for testing.",
-	)
-
-	//nolint:godox
-	// TODO: Remove just before v2 Release.
-	// Mark legacy notification flags as deprecated.
-	// These flags are still functional but will be removed in the v2 release.
-	// Users should migrate to --notification-url instead.
-	markFlagDeprecated(flags, "notification-email-from", "Use --notification-url with an smtp:// URL.")
-	markFlagDeprecated(flags, "notification-email-to", "Use --notification-url with an smtp:// URL.")
-	markFlagDeprecated(flags, "notification-email-delay", "Use --notifications-delay instead.")
-	markFlagDeprecated(flags, "notification-email-server", "Use --notification-url with an smtp:// URL.")
-	markFlagDeprecated(flags, "notification-email-server-port", "Use --notification-url with an smtp:// URL.")
-	markFlagDeprecated(flags, "notification-email-server-tls-skip-verify", "Use --notification-url with an smtp:// URL.")
-	markFlagDeprecated(flags, "notification-email-server-user", "Use --notification-url with an smtp:// URL.")
-	markFlagDeprecated(flags, "notification-email-server-password", "Use --notification-url with an smtp:// URL.")
-	markFlagDeprecated(flags, "notification-email-subjecttag", "Use --notification-title-tag instead.")
-	markFlagDeprecated(flags, "notification-slack-hook-url", "Use --notification-url with a slack:// or discord:// URL.")
-	markFlagDeprecated(flags, "notification-slack-identifier", "Use --notification-url with a slack:// or discord:// URL.")
-	markFlagDeprecated(flags, "notification-slack-channel", "Use --notification-url with a slack:// or discord:// URL.")
-	markFlagDeprecated(flags, "notification-slack-icon-emoji", "Use --notification-url with a slack:// or discord:// URL.")
-	markFlagDeprecated(flags, "notification-slack-icon-url", "Use --notification-url with a slack:// or discord:// URL.")
-	markFlagDeprecated(flags, "notification-msteams-hook", "Use --notification-url with a teams:// URL.")
-	markFlagDeprecated(flags, "notification-gotify-url", "Use --notification-url with a gotify:// URL.")
-	markFlagDeprecated(flags, "notification-gotify-token", "Use --notification-url with a gotify:// URL.")
-	markFlagDeprecated(flags, "notification-gotify-tls-skip-verify", "Use --notification-url with a gotify:// URL.")
-	markFlagDeprecated(flags, "notifications", "Use --notification-url with the appropriate Shoutrrr URL scheme instead.")
+	notify.Register(rootCmd)
 }
 
-// markFlagDeprecated marks a pflag as deprecated with a migration hint.
-//
-// Parameters:
-//   - flags: Flag set containing the flag.
-//   - name: Flag name.
-//   - hint: Migration hint message.
-//
-// TODO: Remove markFlagDeprecated and all legacy flags in the v2 release.
-//
-//nolint:godox
-func markFlagDeprecated(flags *pflag.FlagSet, name, hint string) {
-	if f := flags.Lookup(name); f != nil {
-		f.Deprecated = hint
-		f.Hidden = false // Keep visible so users see the hint in --help
-	}
+// filterEmptyStrings is a package-local alias for utils.FilterEmptyStrings (tests).
+func filterEmptyStrings(values []string) []string {
+	return utils.FilterEmptyStrings(values)
 }
 
-// Parameters:
-//   - key: Environment variable key.
-//
-// Returns:
-//   - string: Value or empty if unset.
-func envString(key string) string {
-	viper.MustBindEnv(key)
-
-	return viper.GetString(key)
-}
-
-// envInt fetches an integer from an environment variable.
-//
-// Parameters:
-//   - key: Environment variable key.
-//
-// Returns:
-//   - int: Value or 0 if unset.
-func envInt(key string) int {
-	viper.MustBindEnv(key)
-
-	return viper.GetInt(key)
-}
-
-// envBool fetches a boolean from an environment variable.
-//
-// Parameters:
-//   - key: Environment variable key.
-//
-// Returns:
-//   - bool: Value or false if unset.
-func envBool(key string) bool {
-	viper.MustBindEnv(key)
-
-	return viper.GetBool(key)
-}
-
-// envDuration fetches a duration from an environment variable.
-//
-// Bare values without a time unit are treated as seconds.
-//
-// Parameters:
-//   - key: Environment variable key.
-//
-// Returns:
-//   - time.Duration: Value or 0 if unset.
-func envDuration(key string) time.Duration {
-	viper.MustBindEnv(key)
-
-	// Check the raw env var so bare numbers are treated as seconds before
-	// viper/cast turns them into nanoseconds.
-	if raw := os.Getenv(key); raw != "" {
-		trimmed := strings.TrimSpace(raw)
-		if isPureNumeric(trimmed) {
-			val, err := strconv.ParseFloat(trimmed, 64)
-			if err == nil {
-				nanos := val * float64(time.Second)
-
-				if nanos > float64(math.MaxInt64) {
-					return time.Duration(math.MaxInt64)
-				}
-
-				if nanos < float64(math.MinInt64) {
-					return time.Duration(math.MinInt64)
-				}
-
-				return time.Duration(nanos)
-			}
-		}
-	}
-
-	return viper.GetDuration(key)
-}
-
-// isPureNumeric reports whether str is a bare number (integer or float,
-// possibly signed) with no duration unit characters.
+// isPureNumeric reports whether str is a bare number (tests and env duration helpers).
 func isPureNumeric(str string) bool {
-	if str == "" {
-		return false
-	}
-
-	sawDigit := false
-	sawDot := false
-
-	for i, char := range str {
-		switch {
-		case char >= '0' && char <= '9':
-			sawDigit = true
-		case char == '.':
-			if sawDot {
-				return false
-			}
-
-			sawDot = true
-		case char == '-' || char == '+':
-			if i != 0 {
-				return false
-			}
-		default:
-			return false
-		}
-	}
-
-	return sawDigit
+	return utils.IsPureNumeric(str)
 }
 
-// filterEmptyStrings removes empty or whitespace-only strings from a slice.
+// SetDefaults enables automatic environment lookup on the global Viper instance.
 //
-// Parameters:
-//   - ss: Slice of strings.
-//
-// Returns:
-//   - []string: Filtered slice without empty or whitespace-only strings.
-func filterEmptyStrings(ss []string) []string {
-	var res []string
-
-	for _, s := range ss {
-		if strings.TrimSpace(s) != "" {
-			res = append(res, s)
-		}
-	}
-
-	return res
-}
-
-// splitNotificationValues parses a string containing notification URLs separated by commas or spaces.
-//
-// Parameters:
-//   - value: A string containing one or more notification URLs separated by commas or spaces.
-//
-// Returns:
-//   - []string: A slice of parsed notification URLs. Invalid URLs are included in the result but logged as warnings.
-func splitNotificationValues(value string) []string {
-	// Define delimiter types to track how parts were separated (comma or space)
-	type delimiterType int
-
-	const (
-		delimiterComma delimiterType = iota
-		delimiterSpace
-	)
-
-	// Struct to hold a part and its delimiter type
-	type splitPart struct {
-		text      string
-		delimiter delimiterType
-	}
-
-	// Manual scanner to split on commas and spaces, tracking delimiter types
-	// Prepare variables for the manual scanning process
-	var (
-		parts   []splitPart
-		current strings.Builder
-	)
-
-	lastDelimiter := delimiterSpace // Default for first part
-
-	// Scan the input string character by character to identify delimiters and build parts
-	for _, char := range value {
-		switch char {
-		case ',':
-			// Encountered comma: finalize current part and set delimiter to comma
-			if current.Len() > 0 {
-				parts = append(parts, splitPart{text: current.String(), delimiter: lastDelimiter})
-				current.Reset()
-			}
-
-			lastDelimiter = delimiterComma
-		case ' ':
-			// Encountered space: finalize current part and set delimiter to space
-			// Note: consecutive spaces are handled by trimming later
-			if current.Len() > 0 {
-				parts = append(parts, splitPart{text: current.String(), delimiter: lastDelimiter})
-				current.Reset()
-			}
-
-			lastDelimiter = delimiterSpace
-		default:
-			// Append non-delimiter character to current part
-			current.WriteRune(char)
-		}
-	}
-
-	// Add the last part if any
-	if current.Len() > 0 {
-		parts = append(parts, splitPart{text: current.String(), delimiter: lastDelimiter})
-	}
-
-	// Process parts: trim spaces and handle recombination
-	// Initialize result slice to hold processed parts
-	var result []string
-
-	// Iterate through each split part to trim whitespace and apply recombination logic
-	for _, part := range parts {
-		part.text = strings.TrimSpace(part.text)
-		if part.text == "" {
-			continue
-		}
-
-		// Recombination logic: only for comma delimiters
-		// Conditionally recombine comma-delimited parts that don't contain '://'
-		// (indicating not a complete URL) with the previous part
-		if part.delimiter == delimiterComma && len(result) > 0 &&
-			!strings.Contains(part.text, "://") {
-			result[len(result)-1] = result[len(result)-1] + "," + part.text
-		} else {
-			result = append(result, part.text)
-		}
-	}
-
-	// Validate URLs and log warnings for invalid ones
-	// Prepare final result slice with capacity for all results
-	final := make([]string, 0, len(result))
-	// Validate each URL string using net/url.Parse
-	for _, urlStr := range result {
-		_, err := url.Parse(urlStr)
-		if err != nil {
-			logrus.Warnf("Invalid notification URL '%s': %v", urlStr, err)
-		}
-
-		final = append(final, urlStr)
-	}
-
-	return final
-}
-
-// SetDefaults sets default environment variable values.
-//
-// It configures fallback values for unset flags.
-//
-//nolint:godox
+// Flag static defaults and process Load bind live on FlagSpec rows. This remains
+// for tests and helpers that still touch the global Viper (for example EnvDuration).
 func SetDefaults() {
 	viper.AutomaticEnv()
-	viper.SetDefault("DOCKER_HOST", "unix:///var/run/docker.sock")
-	viper.SetDefault("WATCHTOWER_POLL_INTERVAL", defaultPollIntervalSeconds)
-	viper.SetDefault("WATCHTOWER_TIMEOUT", time.Second*defaultStopTimeoutSeconds)
-	viper.SetDefault("WATCHTOWER_COOLDOWN_DELAY", "")
-	viper.SetDefault("WATCHTOWER_HTTP_API_HOST", "")
-	viper.SetDefault("WATCHTOWER_HTTP_API_PORT", "8080")
-	viper.SetDefault("WATCHTOWER_HTTP_API_RATE_LIMIT", defaultAPIRateLimitPerMinute)
-	// TODO: Remove just before v2 Release.
-	viper.SetDefault("WATCHTOWER_NOTIFICATIONS", []string{})
-	viper.SetDefault("WATCHTOWER_NOTIFICATIONS_LEVEL", "info")
-	// TODO: Remove just before v2 Release.
-	viper.SetDefault("WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT", defaultEmailServerPort)
-	// TODO: Remove just before v2 Release.
-	viper.SetDefault("WATCHTOWER_NOTIFICATION_EMAIL_SUBJECTTAG", "")
-	// TODO: Remove just before v2 Release.
-	viper.SetDefault("WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER", "watchtower")
-	// TODO: Remove just before v2 Release.
-	viper.SetDefault("WATCHTOWER_LOG_LEVEL", "info")
-	viper.SetDefault("WATCHTOWER_LOG_FORMAT", "auto")
-	viper.SetDefault("WATCHTOWER_DISABLE_MEMORY_SWAPPINESS", false)
-	viper.SetDefault("WATCHTOWER_CPU_COPY_MODE", "auto")
-	viper.SetDefault("WATCHTOWER_USE_COMPOSE_DEPENDS_ON", true)
-	viper.SetDefault("WATCHTOWER_REGISTRY_TLS_SKIP", false)
-	viper.SetDefault("WATCHTOWER_REGISTRY_TLS_MIN_VERSION", "TLS1.2")
 }
 
 // EnvConfig sets Docker environment variables from flags.
@@ -977,45 +120,27 @@ func SetDefaults() {
 // Returns:
 //   - error: Non-nil if flag retrieval fails, nil on success.
 func EnvConfig(cmd *cobra.Command) error {
-	flags := cmd.PersistentFlags()
+	flagSet := cmd.PersistentFlags()
 
-	// Fetch Docker flags.
-	host, err := flags.GetString("host")
+	// Resolve Docker settings via Viper (flag > env > static default) after BindAll.
+	vip := viper.New()
+
+	err := BindAll(vip, flagSet, docker.Specs())
 	if err != nil {
-		logrus.WithError(err).WithField("flag", "host").Debug("Failed to get host flag")
-
-		return fmt.Errorf("%w: %w", errSetFlagFailed, err)
+		return fmt.Errorf("bind docker flags: %w", err)
 	}
 
-	tls, err := flags.GetBool("tlsverify")
-	if err != nil {
-		logrus.WithError(err).WithField("flag", "tlsverify").Debug("Failed to get tlsverify flag")
+	host := vip.GetString("host")
+	tls := vip.GetBool("tlsverify")
+	version := strings.Trim(vip.GetString("api-version"), "\"")
+	certPath := vip.GetString("cert-path")
 
-		return fmt.Errorf("%w: %w", errSetFlagFailed, err)
-	}
-
-	version, err := flags.GetString("api-version")
-	if err != nil {
-		logrus.WithError(err).
-			WithField("flag", "api-version").
-			Debug("Failed to get api-version flag")
-
-		return fmt.Errorf("%w: %w", errSetFlagFailed, err)
-	}
-
-	certPath, err := flags.GetString("cert-path")
-	if err != nil {
-		logrus.WithError(err).WithField("flag", "cert-path").Debug("Failed to get cert-path flag")
-
-		return fmt.Errorf("%w: %w", errSetFlagFailed, err)
-	}
-
-	// Convert tcp:// to https:// when TLS is enabled
+	// Convert tcp:// to https:// when TLS is enabled.
 	if tls && strings.HasPrefix(host, "tcp://") {
 		host = strings.Replace(host, "tcp://", "https://", 1)
 	}
 
-	// Warn about mismatched TLS settings
+	// Warn about mismatched TLS settings.
 	if tls {
 		if strings.HasPrefix(host, "http://") {
 			logrus.Warn(
@@ -1057,58 +182,6 @@ func EnvConfig(cmd *cobra.Command) error {
 	}).Debug("Configured Docker environment variables")
 
 	return nil
-}
-
-// ReadFlags retrieves key operational flags.
-//
-// Parameters:
-//   - cmd: Cobra command with flags.
-//
-// Returns:
-//   - bool: Cleanup setting.
-//   - bool: No-restart setting.
-//   - bool: Monitor-only setting.
-//   - time.Duration: Stop timeout.
-func ReadFlags(cmd *cobra.Command) (bool, bool, bool, time.Duration) {
-	flags := cmd.PersistentFlags()
-
-	// Fetch flags, fatal on error.
-	cleanup, err := flags.GetBool("cleanup")
-	if err != nil {
-		logrus.WithField("flag", "cleanup").
-			WithError(err).
-			Fatal("Failed to get cleanup flag")
-	}
-
-	noRestart, err := flags.GetBool("no-restart")
-	if err != nil {
-		logrus.WithField("flag", "no-restart").
-			WithError(err).
-			Fatal("Failed to get no-restart flag")
-	}
-
-	monitorOnly, err := flags.GetBool("monitor-only")
-	if err != nil {
-		logrus.WithField("flag", "monitor-only").
-			WithError(err).
-			Fatal("Failed to get monitor-only flag")
-	}
-
-	timeout, err := flags.GetDuration("stop-timeout")
-	if err != nil {
-		logrus.WithField("flag", "stop-timeout").
-			WithError(err).
-			Fatal("Failed to get stop-timeout flag")
-	}
-
-	logrus.WithFields(logrus.Fields{
-		"cleanup":      cleanup,
-		"no_restart":   noRestart,
-		"monitor_only": monitorOnly,
-		"timeout":      timeout,
-	}).Debug("Retrieved operational flags")
-
-	return cleanup, noRestart, monitorOnly, timeout
 }
 
 // setEnvOptStr sets an environment variable if needed.
@@ -1322,11 +395,21 @@ func isFilePath(path string) bool {
 	return !errors.Is(err, os.ErrNotExist)
 }
 
-// ProcessFlagAliases syncs flag values based on aliases.
+// ProcessFlagAliases applies environment values then syncs flag aliases.
+//
+// It bridges env onto unset flags, then applies porcelain mode, interval versus
+// schedule conflicts, and debug/trace log-level forcing. Call after Cobra parse
+// and before SetupLogging / secrets expansion / config.Load.
 //
 // Parameters:
-//   - flags: Flag set.
+//   - flags: Parsed persistent flag set.
 func ProcessFlagAliases(flags *pflag.FlagSet) {
+	// Ensure env-sourced values are visible to alias logic via flag Gets.
+	err := ApplyEnvToFlags(flags, AllSpecs())
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to apply environment configuration")
+	}
+
 	// Handle porcelain mode.
 	porcelain, err := flags.GetString("porcelain")
 	if err != nil {
@@ -1361,7 +444,7 @@ func ProcessFlagAliases(flags *pflag.FlagSet) {
 		scheduleChanged = true
 	}
 
-	if val, _ := flags.GetInt("interval"); val != defaultPollIntervalSeconds {
+	if val, _ := flags.GetInt("interval"); val != schedule.DefaultPollIntervalSeconds {
 		intervalChanged = true
 	}
 

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -3,12 +3,10 @@ package flags
 import (
 	"errors"
 	"fmt"
-	"math"
 	"os"
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -16,6 +14,8 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/utils"
 )
 
 //nolint:godox
@@ -33,6 +33,54 @@ func newTestCommand() *cobra.Command {
 	RegisterNotificationFlags(cmd)
 
 	return cmd
+}
+
+// parseWithEnv parses flags then applies environment values (mirrors production preRun).
+func parseWithEnv(t *testing.T, cmd *cobra.Command, args ...string) {
+	t.Helper()
+
+	require.NoError(t, cmd.ParseFlags(args))
+	require.NoError(t, ApplyEnvToFlags(cmd.PersistentFlags(), AllSpecs()))
+}
+
+// TestApplyEnvToFlags_DoesNotMarkChanged ensures env bridging leaves pflag.Changed false
+// so API *Changed fields only reflect CLI overrides.
+func TestApplyEnvToFlags_DoesNotMarkChanged(t *testing.T) {
+	t.Setenv("WATCHTOWER_HTTP_API_HOST", "127.0.0.1")
+	t.Setenv("WATCHTOWER_HTTP_API_PORT", "9090")
+	t.Setenv("WATCHTOWER_HTTP_API_RATE_LIMIT", "30")
+	t.Setenv("WATCHTOWER_TIMEOUT", "45")
+	t.Setenv("WATCHTOWER_NOTIFICATION_URL", "slack://hook discord://token")
+
+	cmd := newTestCommand()
+	parseWithEnv(t, cmd)
+
+	flagSet := cmd.PersistentFlags()
+
+	assert.False(t, flagSet.Changed("http-api-host"), "env must not mark host Changed")
+	assert.False(t, flagSet.Changed("http-api-port"), "env must not mark port Changed")
+	assert.False(t, flagSet.Changed("http-api-rate-limit"), "env must not mark rate-limit Changed")
+	assert.False(t, flagSet.Changed("stop-timeout"), "env must not mark stop-timeout Changed")
+	assert.False(t, flagSet.Changed("notification-url"), "env must not mark slice Changed")
+
+	host, err := flagSet.GetString("http-api-host")
+	require.NoError(t, err)
+	assert.Equal(t, "127.0.0.1", host)
+
+	port, err := flagSet.GetString("http-api-port")
+	require.NoError(t, err)
+	assert.Equal(t, "9090", port)
+
+	// CLI still marks Changed and wins over env.
+	t.Setenv("WATCHTOWER_HTTP_API_HOST", "10.0.0.1")
+
+	cmdCLI := newTestCommand()
+	parseWithEnv(t, cmdCLI, "--http-api-host", "192.168.1.1")
+
+	assert.True(t, cmdCLI.PersistentFlags().Changed("http-api-host"))
+	cliHost, err := cmdCLI.PersistentFlags().GetString("http-api-host")
+	require.NoError(t, err)
+	assert.Equal(t, "192.168.1.1", cliHost)
 }
 
 // TestEnvConfig tests EnvConfig functionality with various configurations.
@@ -286,7 +334,15 @@ func TestEnvConfig(t *testing.T) {
 
 			if tc.expectError {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "failed to set flag value")
+				// Partial flag registration fails during BindAll (flag not registered)
+				// or when setting Docker env vars.
+				errMsg := err.Error()
+				assert.True(t,
+					strings.Contains(errMsg, "failed to set flag value") ||
+						strings.Contains(errMsg, "not registered") ||
+						strings.Contains(errMsg, "bind docker"),
+					"unexpected error: %s", errMsg,
+				)
 
 				return
 			}
@@ -719,23 +775,6 @@ func TestFlagsArePresentInDocumentation(t *testing.T) {
 	}
 }
 
-// TestReadFlags_FlagErrors tests error handling in ReadFlags with mocked logrus.Fatal.
-func TestReadFlags_FlagErrors(t *testing.T) {
-	originalExit := logrus.StandardLogger().ExitFunc
-
-	defer func() { logrus.StandardLogger().ExitFunc = originalExit }()
-
-	logrus.StandardLogger().ExitFunc = func(_ int) { panic("FATAL") }
-
-	cmd := new(cobra.Command)
-
-	SetDefaults()
-	// Don't register flags to force retrieval errors
-	assert.PanicsWithValue(t, "FATAL", func() {
-		ReadFlags(cmd)
-	})
-}
-
 // TestSetEnvOptStr_Error tests error handling in setEnvOptStr.
 // Note: This test is limited without mocking os.Setenv; real failure requires system-specific conditions.
 func TestSetEnvOptStr_Error(t *testing.T) {
@@ -869,22 +908,6 @@ func TestGetSecretFromFile_ParameterlessLoggerAndMockURLs(t *testing.T) {
 	assert.Equal(t, []string{"logger://", "mock://", "discord://token@webhookid"}, urls)
 }
 
-func TestReadFlags_Errors(t *testing.T) {
-	originalExit := logrus.StandardLogger().ExitFunc
-
-	defer func() { logrus.StandardLogger().ExitFunc = originalExit }()
-
-	logrus.StandardLogger().ExitFunc = func(_ int) { panic("FATAL") }
-
-	cmd := new(cobra.Command)
-
-	SetDefaults()
-	// Don't register flags to force errors
-	assert.PanicsWithValue(t, "FATAL", func() {
-		ReadFlags(cmd)
-	})
-}
-
 // TestGetSecretFromFile_CloseError tests file closing errors (simplified without full mocking).
 func TestGetSecretFromFile_CloseError(t *testing.T) {
 	cmd := new(cobra.Command)
@@ -1013,7 +1036,7 @@ func testGetSecretsFromFiles(t *testing.T, flagName, expected string, args ...st
 	SetDefaults()
 	RegisterSystemFlags(cmd)
 	RegisterNotificationFlags(cmd)
-	require.NoError(t, cmd.ParseFlags(args))
+	parseWithEnv(t, cmd, args...)
 	GetSecretsFromFiles(cmd)
 	flag := cmd.PersistentFlags().Lookup(flagName)
 	require.NotNil(t, flag)
@@ -1070,9 +1093,7 @@ func TestUpdateOnStart(t *testing.T) {
 
 			SetDefaults()
 			RegisterSystemFlags(cmd)
-
-			err := cmd.ParseFlags(tc.flags)
-			require.NoError(t, err)
+			parseWithEnv(t, cmd, tc.flags...)
 
 			updateOnStart, err := cmd.PersistentFlags().GetBool("update-on-start")
 			require.NoError(t, err)
@@ -1090,9 +1111,7 @@ func TestWatchtowerNotificationsEnvironmentVariable(t *testing.T) {
 
 	SetDefaults()
 	RegisterNotificationFlags(cmd)
-
-	err := cmd.ParseFlags([]string{})
-	require.NoError(t, err)
+	parseWithEnv(t, cmd)
 
 	notifications, err := cmd.PersistentFlags().GetStringSlice("notifications")
 	require.NoError(t, err)
@@ -1109,9 +1128,7 @@ func TestWatchtowerNotificationURLEnvironmentVariable(t *testing.T) {
 
 	SetDefaults()
 	RegisterNotificationFlags(cmd)
-
-	err := cmd.ParseFlags([]string{})
-	require.NoError(t, err)
+	parseWithEnv(t, cmd)
 
 	urls, err := cmd.PersistentFlags().GetStringArray("notification-url")
 	require.NoError(t, err)
@@ -1132,9 +1149,7 @@ func TestNotificationEnvVarsDoNotAffectContainerFiltering(t *testing.T) {
 	SetDefaults()
 	RegisterSystemFlags(cmd)
 	RegisterNotificationFlags(cmd)
-
-	err := cmd.ParseFlags([]string{})
-	require.NoError(t, err)
+	parseWithEnv(t, cmd)
 
 	disableContainers, err := cmd.PersistentFlags().GetStringSlice("disable-containers")
 	require.NoError(t, err)
@@ -1212,9 +1227,7 @@ func TestNotificationsConfigurationFromEnvVarsVsFlags(t *testing.T) {
 
 			SetDefaults()
 			RegisterNotificationFlags(cmd)
-
-			err := cmd.ParseFlags(tc.flagArgs)
-			require.NoError(t, err)
+			parseWithEnv(t, cmd, tc.flagArgs...)
 
 			notifications, err := cmd.PersistentFlags().GetStringSlice("notifications")
 			require.NoError(t, err)
@@ -1237,9 +1250,7 @@ func TestNotificationURLParsingWithMixedSeparators(t *testing.T) {
 
 	SetDefaults()
 	RegisterNotificationFlags(cmd)
-
-	err := cmd.ParseFlags([]string{})
-	require.NoError(t, err)
+	parseWithEnv(t, cmd)
 
 	urls, err := cmd.PersistentFlags().GetStringArray("notification-url")
 	require.NoError(t, err)
@@ -1256,9 +1267,7 @@ func TestNotificationURLParsingWithInvalidValues(t *testing.T) {
 
 	SetDefaults()
 	RegisterNotificationFlags(cmd)
-
-	err := cmd.ParseFlags([]string{})
-	require.NoError(t, err)
+	parseWithEnv(t, cmd)
 
 	urls, err := cmd.PersistentFlags().GetStringArray("notification-url")
 	require.NoError(t, err)
@@ -1275,9 +1284,7 @@ func TestNotificationURLParsingWithEmptyValues(t *testing.T) {
 
 	SetDefaults()
 	RegisterNotificationFlags(cmd)
-
-	err := cmd.ParseFlags([]string{})
-	require.NoError(t, err)
+	parseWithEnv(t, cmd)
 
 	urls, err := cmd.PersistentFlags().GetStringArray("notification-url")
 	require.NoError(t, err)
@@ -1295,9 +1302,7 @@ func TestNotificationParsingEmptyEnvVar(t *testing.T) {
 
 	SetDefaults()
 	RegisterNotificationFlags(cmd)
-
-	err := cmd.ParseFlags([]string{})
-	require.NoError(t, err)
+	parseWithEnv(t, cmd)
 
 	notifications, err := cmd.PersistentFlags().GetStringSlice("notifications")
 	require.NoError(t, err)
@@ -1313,9 +1318,7 @@ func TestNotificationParsingWhitespaceOnly(t *testing.T) {
 
 	SetDefaults()
 	RegisterNotificationFlags(cmd)
-
-	err := cmd.ParseFlags([]string{})
-	require.NoError(t, err)
+	parseWithEnv(t, cmd)
 
 	notifications, err := cmd.PersistentFlags().GetStringSlice("notifications")
 	require.NoError(t, err)
@@ -1334,9 +1337,7 @@ func TestNotificationParsingSpecialCharsInURLs(t *testing.T) {
 
 	SetDefaults()
 	RegisterNotificationFlags(cmd)
-
-	err := cmd.ParseFlags([]string{})
-	require.NoError(t, err)
+	parseWithEnv(t, cmd)
 
 	urls, err := cmd.PersistentFlags().GetStringArray("notification-url")
 	require.NoError(t, err)
@@ -1357,9 +1358,7 @@ func TestNotificationParsingLongURLs(t *testing.T) {
 
 	SetDefaults()
 	RegisterNotificationFlags(cmd)
-
-	err := cmd.ParseFlags([]string{})
-	require.NoError(t, err)
+	parseWithEnv(t, cmd)
 
 	urls, err := cmd.PersistentFlags().GetStringArray("notification-url")
 	require.NoError(t, err)
@@ -1798,121 +1797,9 @@ func TestNotificationURLParsingComprehensive(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("WATCHTOWER_NOTIFICATION_URL", tc.envValue)
-
-			cmd := new(cobra.Command)
-
-			SetDefaults()
-			RegisterNotificationFlags(cmd)
-
-			err := cmd.ParseFlags([]string{})
-			require.NoError(t, err)
-
-			urls, err := cmd.PersistentFlags().GetStringArray("notification-url")
-			require.NoError(t, err)
-
+			// List parse is applied at Load from env; unit-test the parser here.
+			urls := utils.FilterEmptyStrings(utils.SplitNotificationValues(tc.envValue))
 			assert.Equal(t, tc.expected, urls)
-		})
-	}
-}
-
-// TestEnvDuration_LegacyBareNumberAsSeconds verifies that bare numeric
-// values supplied for WATCHTOWER_TIMEOUT are interpreted as seconds.
-func TestEnvDuration_LegacyBareNumberAsSeconds(t *testing.T) {
-	tests := []struct {
-		name     string
-		envValue string // "" means ensure unset for default case
-		expected time.Duration
-	}{
-		{
-			name:     "default (no env) is 30s",
-			envValue: "",
-			expected: 30 * time.Second,
-		},
-		{
-			name:     "bare integer as seconds (common legacy)",
-			envValue: "60",
-			expected: 60 * time.Second,
-		},
-		{
-			name:     "larger bare integer",
-			envValue: "300",
-			expected: 300 * time.Second,
-		},
-		{
-			name:     "bare float seconds",
-			envValue: "1.5",
-			expected: 1500 * time.Millisecond,
-		},
-		{
-			name:     "with explicit unit s",
-			envValue: "45s",
-			expected: 45 * time.Second,
-		},
-		{
-			name:     "with unit m",
-			envValue: "2m",
-			expected: 2 * time.Minute,
-		},
-		{
-			name:     "zero value",
-			envValue: "0",
-			expected: 0,
-		},
-		{
-			name:     "negative (parsed as negative; validation in preRun will fatal)",
-			envValue: "-10",
-			expected: -10 * time.Second,
-		},
-		{
-			name:     "invalid non-numeric (viper fallback to zero)",
-			envValue: "abc",
-			expected: 0,
-		},
-		{
-			name:     "invalid multiple decimal points (viper fallback to zero)",
-			envValue: "12.34.56",
-			expected: 0,
-		},
-		{
-			name:     "positive sign prefix",
-			envValue: "+10",
-			expected: 10 * time.Second,
-		},
-		{
-			name:     "whitespace trimmed by envDuration",
-			envValue: "  30  ",
-			expected: 30 * time.Second,
-		},
-		{
-			name:     "very large integer (out of range, viper fallback to zero)",
-			envValue: "1" + strings.Repeat("0", 1000),
-			expected: 0,
-		},
-		{
-			name:     "overflow clamps to max int64",
-			envValue: "9223372038",
-			expected: time.Duration(math.MaxInt64),
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if tc.envValue != "" {
-				t.Setenv("WATCHTOWER_TIMEOUT", tc.envValue)
-			} else {
-				_ = os.Unsetenv("WATCHTOWER_TIMEOUT")
-			}
-
-			// Register (with t.Setenv isolation) to capture value via (patched) envDuration at flag creation time
-			SetDefaults()
-
-			cmd := &cobra.Command{}
-			RegisterSystemFlags(cmd)
-
-			got, err := cmd.PersistentFlags().GetDuration("stop-timeout")
-			require.NoError(t, err)
-			assert.Equal(t, tc.expected, got)
 		})
 	}
 }

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -68,6 +68,37 @@ func TestApplyEnvToFlags_EmptyBoolEnvDoesNotEnable(t *testing.T) {
 	assert.True(t, noColor, "NO_COLOR presence (empty value) must enable no-color")
 }
 
+// TestApplyEnvToFlags_NOColorPresenceAlwaysEnables verifies NO_COLOR uses
+// presence semantics (including 0/false) and a static false default.
+func TestApplyEnvToFlags_NOColorPresenceAlwaysEnables(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{name: "empty", value: ""},
+		{name: "zero", value: "0"},
+		{name: "false", value: "false"},
+		{name: "true", value: "true"},
+		{name: "one", value: "1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("NO_COLOR", tc.value)
+
+			cmd := newTestCommand()
+			// Static default must be false before env apply.
+			defaultNoColor, err := cmd.PersistentFlags().GetBool("no-color")
+			require.NoError(t, err)
+			assert.False(t, defaultNoColor)
+
+			parseWithEnv(t, cmd)
+
+			noColor, err := cmd.PersistentFlags().GetBool("no-color")
+			require.NoError(t, err)
+			assert.True(t, noColor, "NO_COLOR=%q must enable no-color", tc.value)
+		})
+	}
+}
+
 // TestApplyEnvToFlags_DoesNotMarkChanged ensures env bridging leaves pflag.Changed false
 // so API *Changed fields only reflect CLI overrides.
 func TestApplyEnvToFlags_DoesNotMarkChanged(t *testing.T) {

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/nicholas-fedor/watchtower/internal/flags/utils"
 )
 
 //nolint:godox
@@ -1524,282 +1522,26 @@ func TestRegexpSplittingLogic(t *testing.T) {
 	}
 }
 
-// TestNotificationURLParsingComprehensive tests comprehensive URL parsing for various Shoutrrr services
-// with different separator combinations and edge cases.
-func TestNotificationURLParsingComprehensive(t *testing.T) {
+// TestNotificationURLEnvToFlagWiring verifies WATCHTOWER_NOTIFICATION_URL reaches
+// notification-url via ApplyEnvToFlags and ListNotificationURLs parsing for
+// representative comma-in-query and mixed-separator cases.
+//
+// Full SplitNotificationValues coverage lives in internal/flags/utils.
+func TestNotificationURLEnvToFlagWiring(t *testing.T) {
 	testCases := []struct {
 		name     string
 		envValue string
 		expected []string
 	}{
-		// SMTP service tests
 		{
-			name:     "SMTP single URL",
-			envValue: "smtp://user:pass@host:port/?from=test@example.com&to=recipient@example.com",
-			expected: []string{
-				"smtp://user:pass@host:port/?from=test@example.com&to=recipient@example.com",
-			},
-		},
-		{
-			name:     "SMTP multiple recipients with comma in query",
-			envValue: "smtp://user:pass@host:port/?from=test@example.com&to=recipient1@example.com,recipient2@example.com",
-			expected: []string{
-				"smtp://user:pass@host:port/?from=test@example.com&to=recipient1@example.com,recipient2@example.com",
-			},
-		},
-		{
-			name:     "SMTP space separator",
-			envValue: "smtp://user:pass@host1:port smtp://user:pass@host2:port",
-			expected: []string{"smtp://user:pass@host1:port", "smtp://user:pass@host2:port"},
-		},
-		{
-			name:     "SMTP comma-space separator",
-			envValue: "smtp://user:pass@host1:port, smtp://user:pass@host2:port",
-			expected: []string{"smtp://user:pass@host1:port", "smtp://user:pass@host2:port"},
-		},
-
-		// Slack service tests
-		{
-			name:     "Slack single URL",
-			envValue: "slack://botname@token-a/token-b/token-c",
-			expected: []string{"slack://botname@token-a/token-b/token-c"},
-		},
-		{
-			name:     "Slack space separator",
-			envValue: "slack://token1@channel1 slack://token2@channel2",
-			expected: []string{"slack://token1@channel1", "slack://token2@channel2"},
-		},
-		{
-			name:     "Slack comma-space separator",
-			envValue: "slack://token1@channel1, slack://token2@channel2",
-			expected: []string{"slack://token1@channel1", "slack://token2@channel2"},
-		},
-
-		// Gotify service tests
-		{
-			name:     "Gotify single URL",
-			envValue: "gotify://gotify-host/token",
-			expected: []string{"gotify://gotify-host/token"},
-		},
-		{
-			name:     "Gotify space separator",
-			envValue: "gotify://host1/token1 gotify://host2/token2",
-			expected: []string{"gotify://host1/token1", "gotify://host2/token2"},
-		},
-		{
-			name:     "Gotify comma-space separator",
-			envValue: "gotify://host1/token1, gotify://host2/token2",
-			expected: []string{"gotify://host1/token1", "gotify://host2/token2"},
-		},
-
-		// Discord service tests
-		{
-			name:     "Discord single URL",
-			envValue: "discord://token@123456789",
-			expected: []string{"discord://token@123456789"},
-		},
-		{
-			name:     "Discord space separator",
-			envValue: "discord://token1@123 discord://token2@456",
-			expected: []string{"discord://token1@123", "discord://token2@456"},
-		},
-		{
-			name:     "Discord comma-space separator",
-			envValue: "discord://token1@123, discord://token2@456",
-			expected: []string{"discord://token1@123", "discord://token2@456"},
-		},
-
-		// Teams service tests
-		{
-			name:     "Teams single URL",
-			envValue: "teams://group@tenant/altId/groupOwner?host=organization.webhook.office.com",
-			expected: []string{
-				"teams://group@tenant/altId/groupOwner?host=organization.webhook.office.com",
-			},
-		},
-		{
-			name:     "Teams space separator",
-			envValue: "teams://group1@tenant1/id1/owner1?host=host1 teams://group2@tenant2/id2/owner2?host=host2",
-			expected: []string{
-				"teams://group1@tenant1/id1/owner1?host=host1",
-				"teams://group2@tenant2/id2/owner2?host=host2",
-			},
-		},
-		{
-			name:     "Teams comma-space separator",
-			envValue: "teams://group1@tenant1/id1/owner1?host=host1, teams://group2@tenant2/id2/owner2?host=host2",
-			expected: []string{
-				"teams://group1@tenant1/id1/owner1?host=host1",
-				"teams://group2@tenant2/id2/owner2?host=host2",
-			},
-		},
-
-		// Telegram service tests
-		{
-			name:     "Telegram single URL",
-			envValue: "telegram://1234567890:AAEJ_AAAAABBBBBccccccccdddddddd@telegram/?channels=123456789&parseMode=html",
-			expected: []string{
-				"telegram://1234567890:AAEJ_AAAAABBBBBccccccccdddddddd@telegram/?channels=123456789&parseMode=html",
-			},
-		},
-		{
-			name:     "Telegram space separator",
-			envValue: "telegram://1234567890:AAEJ_AAAAABBBBBccccccccdddddddd@telegram/?channels=123456789&parseMode=html telegram://another@telegram",
-			expected: []string{
-				"telegram://1234567890:AAEJ_AAAAABBBBBccccccccdddddddd@telegram/?channels=123456789&parseMode=html",
-				"telegram://another@telegram",
-			},
-		},
-		{
-			name:     "Telegram comma-space separator",
-			envValue: "telegram://1234567890:AAEJ_AAAAABBBBBccccccccdddddddd@telegram/?channels=123456789&parseMode=html, telegram://another@telegram",
-			expected: []string{
-				"telegram://1234567890:AAEJ_AAAAABBBBBccccccccdddddddd@telegram/?channels=123456789&parseMode=html",
-				"telegram://another@telegram",
-			},
-		},
-
-		// Generic webhook tests
-		{
-			name:     "Generic webhook single URL",
-			envValue: "generic+https://webhook.example.com/hook?token=abc123",
-			expected: []string{"generic+https://webhook.example.com/hook?token=abc123"},
-		},
-		{
-			name:     "Generic webhook space separator",
-			envValue: "generic+https://hook1.example.com generic+https://hook2.example.com",
-			expected: []string{
-				"generic+https://hook1.example.com",
-				"generic+https://hook2.example.com",
-			},
-		},
-		{
-			name:     "Generic webhook comma-space separator",
-			envValue: "generic+https://hook1.example.com, generic+https://hook2.example.com",
-			expected: []string{
-				"generic+https://hook1.example.com",
-				"generic+https://hook2.example.com",
-			},
-		},
-
-		// Edge cases
-		{
-			name:     "URL with comma in query parameter",
-			envValue: "https://api.example.com/webhook?param=value,with,commas https://api2.example.com/webhook",
-			expected: []string{
-				"https://api.example.com/webhook?param=value,with,commas",
-				"https://api2.example.com/webhook",
-			},
-		},
-		{
-			name:     "Multiple URLs with mixed separators",
-			envValue: "smtp://test1 smtp://test2 slack://test3 slack://test4 gotify://test5",
-			expected: []string{
-				"smtp://test1",
-				"smtp://test2",
-				"slack://test3",
-				"slack://test4",
-				"gotify://test5",
-			},
-		},
-		{
-			name:     "Empty values filtered out",
-			envValue: "smtp://test1 smtp://test2 slack://test3",
-			expected: []string{"smtp://test1", "smtp://test2", "slack://test3"},
-		},
-		{
-			name:     "Malformed URL handling",
-			envValue: "not-a-url smtp://valid@example.com invalid://missing-parts",
-			expected: []string{"not-a-url", "smtp://valid@example.com", "invalid://missing-parts"},
-		},
-		{
-			name:     "URLs with special characters",
-			envValue: "smtp://user%40domain:pass%40word@host:587 slack://token@channel",
-			expected: []string{
-				"smtp://user%40domain:pass%40word@host:587",
-				"slack://token@channel",
-			},
-		},
-		{
-			name: "Very long URL",
-			envValue: "https://very-long-domain-name-with-many-subdomains.example.com/path/to/webhook?param1=" + strings.Repeat(
-				"a",
-				1000,
-			),
-			expected: []string{
-				"https://very-long-domain-name-with-many-subdomains.example.com/path/to/webhook?param1=" + strings.Repeat(
-					"a",
-					1000,
-				),
-			},
-		},
-		// Test cases from issues and bug reports
-		{
-			name:     "URL with comma in query parameter should not be split",
+			name:     "comma in query must not split URL",
 			envValue: "smtp://user:pass@host:port/?to=recipient1@example.com,recipient2@example.com",
 			expected: []string{
 				"smtp://user:pass@host:port/?to=recipient1@example.com,recipient2@example.com",
 			},
 		},
 		{
-			name:     "Multiple URLs with comma in second URL query",
-			envValue: "smtp://test1 smtp://test2?param=value,with,commas",
-			expected: []string{"smtp://test1", "smtp://test2?param=value,with,commas"},
-		},
-		{
-			name:     "Complex URL with commas in path and query",
-			envValue: "https://api.example.com/webhook?param=value,with,commas https://api2.example.com/webhook",
-			expected: []string{
-				"https://api.example.com/webhook?param=value,with,commas",
-				"https://api2.example.com/webhook",
-			},
-		},
-		{
-			name:     "Teams URL with comma in tenant ID",
-			envValue: "teams://group@tenant,id.with,commas/altId/groupOwner?host=organization.webhook.office.com",
-			expected: []string{
-				"teams://group@tenant,id.with,commas/altId/groupOwner?host=organization.webhook.office.com",
-			},
-		},
-
-		// Additional edge cases
-		{
-			name:     "URL with multiple commas in query parameters",
-			envValue: "smtp://user:pass@host:port/?to=recipient1@example.com,recipient2@example.com,recipient3@example.com",
-			expected: []string{
-				"smtp://user:pass@host:port/?to=recipient1@example.com,recipient2@example.com,recipient3@example.com",
-			},
-		},
-		{
-			name:     "URL with encoded commas",
-			envValue: "smtp://user:pass@host:port/?to=recipient1%2Crecipient2%2Crecipient3@example.com",
-			expected: []string{
-				"smtp://user:pass@host:port/?to=recipient1%2Crecipient2%2Crecipient3@example.com",
-			},
-		},
-		{
-			name:     "IPv6 address in URL",
-			envValue: "smtp://[::1]:587/?from=test@example.com",
-			expected: []string{
-				"smtp://[::1]:587/?from=test@example.com",
-			},
-		},
-		{
-			name:     "Complex authentication with encoded characters",
-			envValue: "smtp://user%40domain:pass%40word@host:587",
-			expected: []string{
-				"smtp://user%40domain:pass%40word@host:587",
-			},
-		},
-		{
-			name:     "URL with special characters in query",
-			envValue: "generic+https://api.example.com/webhook?param=value&special=!@#$%^&*()",
-			expected: []string{
-				"generic+https://api.example.com/webhook?param=value&special=!@#$%^&*()",
-			},
-		},
-		{
-			name:     "Multiple URLs with commas in different positions",
+			name:     "space separator with comma in second URL query",
 			envValue: "smtp://test1 smtp://test2?param=value,with,commas gotify://host/token",
 			expected: []string{
 				"smtp://test1",
@@ -1808,49 +1550,7 @@ func TestNotificationURLParsingComprehensive(t *testing.T) {
 			},
 		},
 		{
-			name:     "Multiple IPv6 URLs",
-			envValue: "smtp://[::1]:587 smtp://[2001:db8::1]:587",
-			expected: []string{
-				"smtp://[::1]:587",
-				"smtp://[2001:db8::1]:587",
-			},
-		},
-		{
-			name:     "URL with encoded special characters in path",
-			envValue: "slack://token@channel?text=Hello%20World%21",
-			expected: []string{
-				"slack://token@channel?text=Hello%20World%21",
-			},
-		},
-		{
-			name:     "Teams URL with complex tenant and commas",
-			envValue: "teams://group@tenant.with.dots.and,commas,more/altId/groupOwner?host=organization.webhook.office.com",
-			expected: []string{
-				"teams://group@tenant.with.dots.and,commas,more/altId/groupOwner?host=organization.webhook.office.com",
-			},
-		},
-		{
-			name: "Very long URL with multiple commas",
-			envValue: "https://very-long-domain-name-with-many-subdomains.example.com/path/to/webhook?param1=" + strings.Repeat(
-				"a,b,c,",
-				50,
-			) + "end",
-			expected: []string{
-				"https://very-long-domain-name-with-many-subdomains.example.com/path/to/webhook?param1=" + strings.Repeat(
-					"a,b,c,",
-					50,
-				) + "end",
-			},
-		},
-		{
-			name:     "URL with authentication and IPv6",
-			envValue: "smtp://user:pass@[2001:db8::1]:587/?from=test@example.com",
-			expected: []string{
-				"smtp://user:pass@[2001:db8::1]:587/?from=test@example.com",
-			},
-		},
-		{
-			name:     "Mixed separators with complex URLs",
+			name:     "mixed separators with complex URLs",
 			envValue: "smtp://test1, smtp://test2?param=value,with,commas gotify://host/token slack://token@channel",
 			expected: []string{
 				"smtp://test1",
@@ -1859,12 +1559,32 @@ func TestNotificationURLParsingComprehensive(t *testing.T) {
 				"slack://token@channel",
 			},
 		},
+		{
+			name:     "teams tenant commas preserved",
+			envValue: "teams://group@tenant,id.with,commas/altId/groupOwner?host=organization.webhook.office.com",
+			expected: []string{
+				"teams://group@tenant,id.with,commas/altId/groupOwner?host=organization.webhook.office.com",
+			},
+		},
+		{
+			name:     "comma-space separator between full URLs",
+			envValue: "slack://token1@channel1, slack://token2@channel2",
+			expected: []string{"slack://token1@channel1", "slack://token2@channel2"},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// List parse is applied at Load from env; unit-test the parser here.
-			urls := utils.FilterEmptyStrings(utils.SplitNotificationValues(tc.envValue))
+			t.Setenv("WATCHTOWER_NOTIFICATION_URL", tc.envValue)
+
+			cmd := new(cobra.Command)
+
+			SetDefaults()
+			RegisterNotificationFlags(cmd)
+			parseWithEnv(t, cmd)
+
+			urls, err := cmd.PersistentFlags().GetStringArray("notification-url")
+			require.NoError(t, err)
 			assert.Equal(t, tc.expected, urls)
 		})
 	}

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -43,6 +43,31 @@ func parseWithEnv(t *testing.T, cmd *cobra.Command, args ...string) {
 	require.NoError(t, ApplyEnvToFlags(cmd.PersistentFlags(), AllSpecs()))
 }
 
+// TestApplyEnvToFlags_EmptyBoolEnvDoesNotEnable verifies empty non-NO_COLOR bool
+// env vars are treated as unset, while NO_COLOR presence still enables no-color.
+func TestApplyEnvToFlags_EmptyBoolEnvDoesNotEnable(t *testing.T) {
+	t.Setenv("WATCHTOWER_CLEANUP", "")
+	t.Setenv("WATCHTOWER_DEBUG", "")
+	t.Setenv("NO_COLOR", "")
+
+	cmd := newTestCommand()
+	parseWithEnv(t, cmd)
+
+	flagSet := cmd.PersistentFlags()
+
+	cleanup, err := flagSet.GetBool("cleanup")
+	require.NoError(t, err)
+	assert.False(t, cleanup, "empty WATCHTOWER_CLEANUP must not enable cleanup")
+
+	debug, err := flagSet.GetBool("debug")
+	require.NoError(t, err)
+	assert.False(t, debug, "empty WATCHTOWER_DEBUG must not enable debug")
+
+	noColor, err := flagSet.GetBool("no-color")
+	require.NoError(t, err)
+	assert.True(t, noColor, "NO_COLOR presence (empty value) must enable no-color")
+}
+
 // TestApplyEnvToFlags_DoesNotMarkChanged ensures env bridging leaves pflag.Changed false
 // so API *Changed fields only reflect CLI overrides.
 func TestApplyEnvToFlags_DoesNotMarkChanged(t *testing.T) {

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -126,6 +127,15 @@ func TestApplyEnvToFlags_DoesNotMarkChanged(t *testing.T) {
 	port, err := flagSet.GetString("http-api-port")
 	require.NoError(t, err)
 	assert.Equal(t, "9090", port)
+
+	timeout, err := flagSet.GetDuration("stop-timeout")
+	require.NoError(t, err)
+	assert.Equal(t, 45*time.Second, timeout, "bare-second WATCHTOWER_TIMEOUT must bridge to stop-timeout")
+
+	urls, err := flagSet.GetStringArray("notification-url")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"slack://hook", "discord://token"}, urls,
+		"space-separated WATCHTOWER_NOTIFICATION_URL must bridge to two entries")
 
 	// CLI still marks Changed and wins over env.
 	t.Setenv("WATCHTOWER_HTTP_API_HOST", "10.0.0.1")

--- a/internal/flags/lifecycle/register.go
+++ b/internal/flags/lifecycle/register.go
@@ -1,0 +1,46 @@
+// Package lifecycle registers pre/post update lifecycle hook flags.
+package lifecycle
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
+)
+
+// Specs returns lifecycle domain flag metadata with static defaults.
+//
+// Returns:
+//   - []spec.FlagSpec: Lifecycle flag specifications.
+func Specs() []spec.FlagSpec {
+	return []spec.FlagSpec{
+		{
+			Name:    "enable-lifecycle-hooks",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_LIFECYCLE_HOOKS"},
+			Help:    "Enable the execution of commands triggered by pre- and post-update lifecycle hooks",
+		},
+		{
+			Name:    "lifecycle-uid",
+			Kind:    spec.KindInt,
+			Default: 0,
+			EnvKeys: []string{"WATCHTOWER_LIFECYCLE_UID"},
+			Help:    "Default UID to run lifecycle hooks as (can be overridden by container labels)",
+		},
+		{
+			Name:    "lifecycle-gid",
+			Kind:    spec.KindInt,
+			Default: 0,
+			EnvKeys: []string{"WATCHTOWER_LIFECYCLE_GID"},
+			Help:    "Default GID to run lifecycle hooks as (can be overridden by container labels)",
+		},
+	}
+}
+
+// Register adds lifecycle domain flags to the root command.
+//
+// Parameters:
+//   - rootCmd: Root Cobra command.
+func Register(rootCmd *cobra.Command) {
+	spec.MustRegister(rootCmd.PersistentFlags(), Specs())
+}

--- a/internal/flags/logging/register.go
+++ b/internal/flags/logging/register.go
@@ -2,8 +2,6 @@
 package logging
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 
 	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
@@ -11,14 +9,14 @@ import (
 
 // Specs returns logging domain flag metadata with static defaults.
 //
-// NO_COLOR is applied at registration time per https://no-color.org/ (presence of
-// the variable, not WATCHTOWER_* naming).
+// NO_COLOR is listed in EnvKeys so ApplyEnvToFlags can apply presence-based
+// semantics (https://no-color.org/). The pflag default stays false; env is not
+// baked into registration-time defaults. BindAll skips BindEnv for NO_COLOR so
+// Viper does not re-parse "0"/"false" as false after presence apply.
 //
 // Returns:
 //   - []spec.FlagSpec: Logging flag specifications.
 func Specs() []spec.FlagSpec {
-	_, noColorSet := os.LookupEnv("NO_COLOR")
-
 	return []spec.FlagSpec{
 		{
 			Name:      "log-format",
@@ -53,7 +51,7 @@ func Specs() []spec.FlagSpec {
 		{
 			Name:    "no-color",
 			Kind:    spec.KindBool,
-			Default: noColorSet,
+			Default: false,
 			EnvKeys: []string{"NO_COLOR"},
 			Help:    "Disable ANSI color escape codes in log output",
 		},

--- a/internal/flags/logging/register.go
+++ b/internal/flags/logging/register.go
@@ -1,0 +1,69 @@
+// Package logging registers console logging flags.
+package logging
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
+)
+
+// Specs returns logging domain flag metadata with static defaults.
+//
+// NO_COLOR is applied at registration time per https://no-color.org/ (presence of
+// the variable, not WATCHTOWER_* naming).
+//
+// Returns:
+//   - []spec.FlagSpec: Logging flag specifications.
+func Specs() []spec.FlagSpec {
+	_, noColorSet := os.LookupEnv("NO_COLOR")
+
+	return []spec.FlagSpec{
+		{
+			Name:      "log-format",
+			Shorthand: "l",
+			Kind:      spec.KindString,
+			Default:   "auto",
+			EnvKeys:   []string{"WATCHTOWER_LOG_FORMAT"},
+			Help:      "Sets what logging format to use for console output. Possible values: Auto, LogFmt, Pretty, JSON",
+		},
+		{
+			Name:    "log-level",
+			Kind:    spec.KindString,
+			Default: "info",
+			EnvKeys: []string{"WATCHTOWER_LOG_LEVEL"},
+			Help:    "The maximum log level that will be written to STDERR. Possible values: panic, fatal, error, warn, info, debug or trace",
+		},
+		{
+			Name:      "debug",
+			Shorthand: "d",
+			Kind:      spec.KindBool,
+			Default:   false,
+			EnvKeys:   []string{"WATCHTOWER_DEBUG"},
+			Help:      "Enable debug mode with verbose logging",
+		},
+		{
+			Name:    "trace",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_TRACE"},
+			Help:    "Enable trace mode with very verbose logging - caution, exposes credentials",
+		},
+		{
+			Name:    "no-color",
+			Kind:    spec.KindBool,
+			Default: noColorSet,
+			EnvKeys: []string{"NO_COLOR"},
+			Help:    "Disable ANSI color escape codes in log output",
+		},
+	}
+}
+
+// Register adds logging domain flags to the root command.
+//
+// Parameters:
+//   - rootCmd: Root Cobra command.
+func Register(rootCmd *cobra.Command) {
+	spec.MustRegister(rootCmd.PersistentFlags(), Specs())
+}

--- a/internal/flags/mode/register.go
+++ b/internal/flags/mode/register.go
@@ -1,0 +1,61 @@
+// Package mode registers process entry-shape flags.
+package mode
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
+)
+
+// Specs returns mode domain flag metadata with static defaults.
+//
+// Returns:
+//   - []spec.FlagSpec: Mode flag specifications.
+func Specs() []spec.FlagSpec {
+	return []spec.FlagSpec{
+		{
+			Name:      "run-once",
+			Shorthand: "R",
+			Kind:      spec.KindBool,
+			Default:   false,
+			EnvKeys:   []string{"WATCHTOWER_RUN_ONCE"},
+			Help:      "Run once now and exit",
+		},
+		{
+			Name:    "health-check",
+			Kind:    spec.KindBool,
+			Default: false,
+			Help:    "Do health check and exit",
+		},
+		{
+			Name:      "porcelain",
+			Shorthand: "P",
+			Kind:      spec.KindString,
+			Default:   "",
+			EnvKeys:   []string{"WATCHTOWER_PORCELAIN"},
+			Help:      `Write session results to stdout using a stable versioned format. Supported values: "v1"`,
+		},
+		{
+			Name:    "no-startup-message",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_NO_STARTUP_MESSAGE"},
+			Help:    "Prevents watchtower from sending a startup message",
+		},
+		{
+			Name:    "self-update-orchestrator",
+			Kind:    spec.KindBool,
+			Default: false,
+			Hidden:  true,
+			Help:    "Internal: Run as ephemeral orchestrator for self-update (not for direct use)",
+		},
+	}
+}
+
+// Register adds mode domain flags to the root command.
+//
+// Parameters:
+//   - rootCmd: Root Cobra command.
+func Register(rootCmd *cobra.Command) {
+	spec.MustRegister(rootCmd.PersistentFlags(), Specs())
+}

--- a/internal/flags/notify/register.go
+++ b/internal/flags/notify/register.go
@@ -103,7 +103,7 @@ func Specs() []spec.FlagSpec {
 			EnvKeys:    []string{"WATCHTOWER_NOTIFICATIONS"},
 			ListParse:  spec.ListCommaOrSpace,
 			Deprecated: "Use --notification-url with the appropriate Shoutrrr URL scheme instead.",
-			Help:       "Notification types to send [legacy types (email, slack, msteams, gotify).",
+			Help:       "Notification types to send [legacy types (email, slack, msteams, gotify)].",
 		},
 		{
 			Name:       "notification-email-from",

--- a/internal/flags/notify/register.go
+++ b/internal/flags/notify/register.go
@@ -1,0 +1,261 @@
+// Package notify registers notification-related CLI and environment flags.
+package notify
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
+)
+
+// DefaultEmailServerPort is the static default SMTP port.
+const DefaultEmailServerPort = 25
+
+// Specs returns notify domain flag metadata with static defaults.
+//
+// Returns:
+//   - []spec.FlagSpec: Notify flag specifications.
+func Specs() []spec.FlagSpec {
+	return []spec.FlagSpec{
+		{
+			Name:      "notification-url",
+			Kind:      spec.KindStringArray,
+			Default:   []string{},
+			EnvKeys:   []string{"WATCHTOWER_NOTIFICATION_URL"},
+			ListParse: spec.ListNotificationURLs,
+			Help:      "The shoutrrr URL to send notifications to",
+		},
+		{
+			Name:    "notifications-level",
+			Kind:    spec.KindString,
+			Default: "info",
+			EnvKeys: []string{"WATCHTOWER_NOTIFICATIONS_LEVEL"},
+			Help:    "The log level used for sending notifications. Possible values: panic, fatal, error, warn, info or debug",
+		},
+		{
+			Name:    "notifications-delay",
+			Kind:    spec.KindInt,
+			Default: 0,
+			EnvKeys: []string{"WATCHTOWER_NOTIFICATIONS_DELAY"},
+			Help:    "Delay before sending notifications, expressed in seconds",
+		},
+		{
+			Name:    "notifications-hostname",
+			Kind:    spec.KindString,
+			Default: "",
+			EnvKeys: []string{"WATCHTOWER_NOTIFICATIONS_HOSTNAME"},
+			Help:    "Custom hostname for notification titles",
+		},
+		{
+			Name:    "notification-template",
+			Kind:    spec.KindString,
+			Default: "",
+			EnvKeys: []string{"WATCHTOWER_NOTIFICATION_TEMPLATE"},
+			Help:    "The shoutrrr text/template for the messages",
+		},
+		{
+			Name:    "notification-template-file",
+			Kind:    spec.KindString,
+			Default: "",
+			EnvKeys: []string{"WATCHTOWER_NOTIFICATION_TEMPLATE_FILE"},
+			Help:    "Path to a file containing the Shoutrrr text/template for the messages",
+		},
+		{
+			Name:    "notification-report",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_NOTIFICATION_REPORT"},
+			Help:    "Use the session report as the notification template data",
+		},
+		{
+			Name:    "notification-title-tag",
+			Kind:    spec.KindString,
+			Default: "",
+			EnvKeys: []string{"WATCHTOWER_NOTIFICATION_TITLE_TAG"},
+			Help:    "Title prefix tag for notifications",
+		},
+		{
+			Name:    "notification-skip-title",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_NOTIFICATION_SKIP_TITLE"},
+			Help:    "Do not pass the title param to notifications",
+		},
+		{
+			Name:    "notification-log-stdout",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_NOTIFICATION_LOG_STDOUT"},
+			Help:    "Write notification logs to stdout instead of logging (to stderr)",
+		},
+		{
+			Name:    "notification-split-by-container",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_NOTIFICATION_SPLIT_BY_CONTAINER"},
+			Help:    "Send separate notifications for each updated container instead of grouping them",
+		},
+
+		{
+			Name:       "notifications",
+			Shorthand:  "n",
+			Kind:       spec.KindStringSlice,
+			Default:    []string{},
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATIONS"},
+			ListParse:  spec.ListCommaOrSpace,
+			Deprecated: "Use --notification-url with the appropriate Shoutrrr URL scheme instead.",
+			Help:       "Notification types to send [legacy types (email, slack, msteams, gotify).",
+		},
+		{
+			Name:       "notification-email-from",
+			Kind:       spec.KindString,
+			Default:    "",
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATION_EMAIL_FROM"},
+			Deprecated: "Use --notification-url with an smtp:// URL.",
+			Help:       "Address to send notification emails from",
+		},
+		{
+			Name:       "notification-email-to",
+			Kind:       spec.KindString,
+			Default:    "",
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATION_EMAIL_TO"},
+			Deprecated: "Use --notification-url with an smtp:// URL.",
+			Help:       "Address to send notification emails to",
+		},
+		{
+			Name:       "notification-email-delay",
+			Kind:       spec.KindInt,
+			Default:    0,
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATION_EMAIL_DELAY"},
+			Deprecated: "Use --notifications-delay instead.",
+			Help:       "Delay before sending notifications, expressed in seconds",
+		},
+		{
+			Name:       "notification-email-server",
+			Kind:       spec.KindString,
+			Default:    "",
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATION_EMAIL_SERVER"},
+			Deprecated: "Use --notification-url with an smtp:// URL.",
+			Help:       "SMTP server to send notification emails through",
+		},
+		{
+			Name:       "notification-email-server-port",
+			Kind:       spec.KindInt,
+			Default:    DefaultEmailServerPort,
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT"},
+			Deprecated: "Use --notification-url with an smtp:// URL.",
+			Help:       "SMTP server port to send notification emails through",
+		},
+		{
+			Name:       "notification-email-server-tls-skip-verify",
+			Kind:       spec.KindBool,
+			Default:    false,
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATION_EMAIL_SERVER_TLS_SKIP_VERIFY"},
+			Deprecated: "Use --notification-url with an smtp:// URL.",
+			Help:       "Controls whether watchtower verifies the SMTP server's certificate chain and host name. Should only be used for testing.",
+		},
+		{
+			Name:       "notification-email-server-user",
+			Kind:       spec.KindString,
+			Default:    "",
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATION_EMAIL_SERVER_USER"},
+			Deprecated: "Use --notification-url with an smtp:// URL.",
+			Help:       "SMTP server user for sending notifications",
+		},
+		{
+			Name:       "notification-email-server-password",
+			Kind:       spec.KindString,
+			Default:    "",
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD"},
+			Deprecated: "Use --notification-url with an smtp:// URL.",
+			Help:       "SMTP server password for sending notifications",
+		},
+		{
+			Name:       "notification-email-subjecttag",
+			Kind:       spec.KindString,
+			Default:    "",
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATION_EMAIL_SUBJECTTAG"},
+			Deprecated: "Use --notification-title-tag instead.",
+			Help:       "Subject prefix tag for notifications via mail",
+		},
+		{
+			Name:       "notification-slack-hook-url",
+			Kind:       spec.KindString,
+			Default:    "",
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL"},
+			Deprecated: "Use --notification-url with a slack:// or discord:// URL.",
+			Help:       "The Slack Hook URL to send notifications to",
+		},
+		{
+			Name:       "notification-slack-identifier",
+			Kind:       spec.KindString,
+			Default:    "watchtower",
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER"},
+			Deprecated: "Use --notification-url with a slack:// or discord:// URL.",
+			Help:       "A string which will be used to identify the messages coming from this watchtower instance",
+		},
+		{
+			Name:       "notification-slack-channel",
+			Kind:       spec.KindString,
+			Default:    "",
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATION_SLACK_CHANNEL"},
+			Deprecated: "Use --notification-url with a slack:// or discord:// URL.",
+			Help:       "A string which overrides the webhook's default channel. Example: #my-custom-channel",
+		},
+		{
+			Name:       "notification-slack-icon-emoji",
+			Kind:       spec.KindString,
+			Default:    "",
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATION_SLACK_ICON_EMOJI"},
+			Deprecated: "Use --notification-url with a slack:// or discord:// URL.",
+			Help:       "An emoji code string to use in place of the default icon",
+		},
+		{
+			Name:       "notification-slack-icon-url",
+			Kind:       spec.KindString,
+			Default:    "",
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATION_SLACK_ICON_URL"},
+			Deprecated: "Use --notification-url with a slack:// or discord:// URL.",
+			Help:       "An icon image URL string to use in place of the default icon",
+		},
+		{
+			Name:       "notification-msteams-hook",
+			Kind:       spec.KindString,
+			Default:    "",
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL"},
+			Deprecated: "Use --notification-url with a teams:// URL.",
+			Help:       "The MSTeams WebHook URL to send notifications to",
+		},
+		{
+			Name:       "notification-gotify-url",
+			Kind:       spec.KindString,
+			Default:    "",
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATION_GOTIFY_URL"},
+			Deprecated: "Use --notification-url with a gotify:// URL.",
+			Help:       "The Gotify URL to send notifications to",
+		},
+		{
+			Name:       "notification-gotify-token",
+			Kind:       spec.KindString,
+			Default:    "",
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN"},
+			Deprecated: "Use --notification-url with a gotify:// URL.",
+			Help:       "The Gotify Application required to query the Gotify API",
+		},
+		{
+			Name:       "notification-gotify-tls-skip-verify",
+			Kind:       spec.KindBool,
+			Default:    false,
+			EnvKeys:    []string{"WATCHTOWER_NOTIFICATION_GOTIFY_TLS_SKIP_VERIFY"},
+			Deprecated: "Use --notification-url with a gotify:// URL.",
+			Help:       "Controls whether watchtower verifies the Gotify server's certificate chain and host name. Should only be used for testing.",
+		},
+	}
+}
+
+// Register adds notification flags to the root command.
+//
+// Parameters:
+//   - rootCmd: Root Cobra command.
+func Register(rootCmd *cobra.Command) {
+	spec.MustRegister(rootCmd.PersistentFlags(), Specs())
+}

--- a/internal/flags/register.go
+++ b/internal/flags/register.go
@@ -1,0 +1,62 @@
+package flags
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/api"
+	"github.com/nicholas-fedor/watchtower/internal/flags/client"
+	"github.com/nicholas-fedor/watchtower/internal/flags/compat"
+	"github.com/nicholas-fedor/watchtower/internal/flags/docker"
+	"github.com/nicholas-fedor/watchtower/internal/flags/filter"
+	"github.com/nicholas-fedor/watchtower/internal/flags/lifecycle"
+	"github.com/nicholas-fedor/watchtower/internal/flags/logging"
+	"github.com/nicholas-fedor/watchtower/internal/flags/mode"
+	"github.com/nicholas-fedor/watchtower/internal/flags/notify"
+	"github.com/nicholas-fedor/watchtower/internal/flags/registry"
+	"github.com/nicholas-fedor/watchtower/internal/flags/schedule"
+	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
+	"github.com/nicholas-fedor/watchtower/internal/flags/update"
+)
+
+// RegisterAll registers every domain's flags on the root command.
+//
+// Domain packages match the config taxonomy: docker, client, schedule, mode,
+// update, lifecycle, filter, registry, compat, api, notify, logging.
+//
+// Parameters:
+//   - rootCmd: Root Cobra command.
+func RegisterAll(rootCmd *cobra.Command) {
+	docker.Register(rootCmd)
+	client.Register(rootCmd)
+	schedule.Register(rootCmd)
+	mode.Register(rootCmd)
+	update.Register(rootCmd)
+	lifecycle.Register(rootCmd)
+	filter.Register(rootCmd)
+	registry.Register(rootCmd)
+	compat.Register(rootCmd)
+	api.Register(rootCmd)
+	notify.Register(rootCmd)
+	logging.Register(rootCmd)
+}
+
+// AllSpecs returns aggregated FlagSpec rows from every domain.
+//
+// Returns:
+//   - []spec.FlagSpec: Flag metadata for BindAll.
+func AllSpecs() []spec.FlagSpec {
+	return CollectSpecs(
+		docker.Specs(),
+		client.Specs(),
+		schedule.Specs(),
+		mode.Specs(),
+		update.Specs(),
+		lifecycle.Specs(),
+		filter.Specs(),
+		registry.Specs(),
+		compat.Specs(),
+		api.Specs(),
+		notify.Specs(),
+		logging.Specs(),
+	)
+}

--- a/internal/flags/registry/register.go
+++ b/internal/flags/registry/register.go
@@ -1,0 +1,39 @@
+// Package registry registers registry TLS flags.
+package registry
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
+)
+
+// Specs returns registry domain flag metadata with static defaults.
+//
+// Returns:
+//   - []spec.FlagSpec: Registry flag specifications.
+func Specs() []spec.FlagSpec {
+	return []spec.FlagSpec{
+		{
+			Name:    "registry-tls-skip",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_REGISTRY_TLS_SKIP"},
+			Help:    "Disable TLS verification for registry connections; allows HTTP or insecure TLS registries (use with caution)",
+		},
+		{
+			Name:    "registry-tls-min-version",
+			Kind:    spec.KindString,
+			Default: "TLS1.2",
+			EnvKeys: []string{"WATCHTOWER_REGISTRY_TLS_MIN_VERSION"},
+			Help:    "Minimum TLS version for registry connections (e.g., TLS1.0, TLS1.1, TLS1.2, TLS1.3); default is TLS1.2",
+		},
+	}
+}
+
+// Register adds registry domain flags to the root command.
+//
+// Parameters:
+//   - rootCmd: Root Cobra command.
+func Register(rootCmd *cobra.Command) {
+	spec.MustRegister(rootCmd.PersistentFlags(), Specs())
+}

--- a/internal/flags/schedule/register.go
+++ b/internal/flags/schedule/register.go
@@ -1,0 +1,51 @@
+// Package schedule registers poll interval and cron schedule flags.
+package schedule
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
+)
+
+// DefaultPollIntervalSeconds is the static default poll interval (24 hours).
+const DefaultPollIntervalSeconds = 86400
+
+// Specs returns schedule domain flag metadata with static defaults.
+//
+// Returns:
+//   - []spec.FlagSpec: Schedule flag specifications.
+func Specs() []spec.FlagSpec {
+	return []spec.FlagSpec{
+		{
+			Name:      "interval",
+			Shorthand: "i",
+			Kind:      spec.KindInt,
+			Default:   DefaultPollIntervalSeconds,
+			EnvKeys:   []string{"WATCHTOWER_POLL_INTERVAL"},
+			Help:      "Poll interval (in seconds)",
+		},
+		{
+			Name:      "schedule",
+			Shorthand: "s",
+			Kind:      spec.KindString,
+			Default:   "",
+			EnvKeys:   []string{"WATCHTOWER_SCHEDULE"},
+			Help:      "The cron expression which defines when to update",
+		},
+		{
+			Name:    "update-on-start",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_UPDATE_ON_START"},
+			Help:    "Perform an update check on startup, then continue with periodic updates",
+		},
+	}
+}
+
+// Register adds schedule domain flags to the root command.
+//
+// Parameters:
+//   - rootCmd: Root Cobra command.
+func Register(rootCmd *cobra.Command) {
+	spec.MustRegister(rootCmd.PersistentFlags(), Specs())
+}

--- a/internal/flags/spec/listparse.go
+++ b/internal/flags/spec/listparse.go
@@ -1,0 +1,24 @@
+package spec
+
+import "github.com/nicholas-fedor/watchtower/internal/flags/utils"
+
+// ParseList splits a raw list string using the FlagSpec ListParse strategy.
+//
+// Parameters:
+//   - raw: Raw env or default list string.
+//   - parse: List parse kind from FlagSpec.
+//
+// Returns:
+//   - []string: Parsed tokens for the given strategy.
+func ParseList(raw string, parse ListParseKind) []string {
+	switch parse {
+	case ListCommaOnly:
+		return utils.SplitCommaOnly(raw)
+	case ListNotificationURLs:
+		return utils.FilterEmptyStrings(utils.SplitNotificationValues(raw))
+	case ListCommaOrSpace, ListNative, ListNone:
+		return utils.SplitCommaOrSpace(raw)
+	default:
+		return utils.SplitCommaOrSpace(raw)
+	}
+}

--- a/internal/flags/spec/register.go
+++ b/internal/flags/spec/register.go
@@ -10,17 +10,20 @@ import (
 	"github.com/nicholas-fedor/watchtower/internal/flags/utils"
 )
 
-// ErrUnsupportedFlagKind indicates a FlagSpec kind is not supported.
+// ErrUnsupportedFlagKind indicates a FlagSpec kind is not supported for registration.
 var ErrUnsupportedFlagKind = errors.New("unsupported flag kind")
 
 // Register registers pflags from FlagSpec rows using static defaults only.
 //
+// Environment values are not baked into pflag defaults; ApplyEnvToFlags and
+// Viper bind resolve env after parse.
+//
 // Parameters:
-//   - flagSet: Target flag set.
-//   - specs: Domain flag specifications.
+//   - flagSet: Target flag set that receives the registered flags.
+//   - specs: Domain flag specifications to register in order.
 //
 // Returns:
-//   - error: Non-nil when registration fails.
+//   - error: Non-nil when a kind is unsupported or a flag cannot be marked hidden.
 func Register(flagSet *pflag.FlagSet, specs []FlagSpec) error {
 	for _, flagSpec := range specs {
 		err := registerOne(flagSet, flagSpec)
@@ -32,11 +35,11 @@ func Register(flagSet *pflag.FlagSet, specs []FlagSpec) error {
 	return nil
 }
 
-// MustRegister registers FlagSpec rows and panics on failure.
+// MustRegister registers FlagSpec rows and panics when registration fails.
 //
 // Parameters:
-//   - flagSet: Target flag set.
-//   - specs: Domain flag specifications.
+//   - flagSet: Target flag set that receives the registered flags.
+//   - specs: Domain flag specifications to register in order.
 func MustRegister(flagSet *pflag.FlagSet, specs []FlagSpec) {
 	err := Register(flagSet, specs)
 	if err != nil {
@@ -44,58 +47,30 @@ func MustRegister(flagSet *pflag.FlagSet, specs []FlagSpec) {
 	}
 }
 
+// registerOne registers a single FlagSpec onto flagSet.
+//
+// It dispatches by kind, then applies deprecation and hidden metadata when set.
+//
+// Parameters:
+//   - flagSet: Target flag set.
+//   - flagSpec: Flag specification to register.
+//
+// Returns:
+//   - error: Non-nil when the kind is unsupported or MarkHidden fails.
 func registerOne(flagSet *pflag.FlagSet, flagSpec FlagSpec) error {
 	switch flagSpec.Kind {
 	case KindBool:
-		def, _ := flagSpec.Default.(bool)
-		if flagSpec.Shorthand != "" {
-			flagSet.BoolP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
-		} else {
-			flagSet.Bool(flagSpec.Name, def, flagSpec.Help)
-		}
+		registerBool(flagSet, flagSpec)
 	case KindString:
-		def, _ := flagSpec.Default.(string)
-		if flagSpec.Shorthand != "" {
-			flagSet.StringP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
-		} else {
-			flagSet.String(flagSpec.Name, def, flagSpec.Help)
-		}
+		registerString(flagSet, flagSpec)
 	case KindInt:
-		def, _ := flagSpec.Default.(int)
-		if flagSpec.Shorthand != "" {
-			flagSet.IntP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
-		} else {
-			flagSet.Int(flagSpec.Name, def, flagSpec.Help)
-		}
+		registerInt(flagSet, flagSpec)
 	case KindDuration:
-		def, _ := flagSpec.Default.(time.Duration)
-		if flagSpec.Shorthand != "" {
-			flagSet.DurationP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
-		} else {
-			flagSet.Duration(flagSpec.Name, def, flagSpec.Help)
-		}
+		registerDuration(flagSet, flagSpec)
 	case KindStringSlice:
-		def, _ := flagSpec.Default.([]string)
-		if def == nil {
-			def = []string{}
-		}
-
-		if flagSpec.Shorthand != "" {
-			flagSet.StringSliceP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
-		} else {
-			flagSet.StringSlice(flagSpec.Name, def, flagSpec.Help)
-		}
+		registerStringSlice(flagSet, flagSpec)
 	case KindStringArray:
-		def, _ := flagSpec.Default.([]string)
-		if def == nil {
-			def = []string{}
-		}
-
-		if flagSpec.Shorthand != "" {
-			flagSet.StringArrayP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
-		} else {
-			flagSet.StringArray(flagSpec.Name, def, flagSpec.Help)
-		}
+		registerStringArray(flagSet, flagSpec)
 	default:
 		return fmt.Errorf("%w: %s", ErrUnsupportedFlagKind, flagSpec.Name)
 	}
@@ -112,4 +87,123 @@ func registerOne(flagSet *pflag.FlagSet, flagSpec FlagSpec) error {
 	}
 
 	return nil
+}
+
+// stringSliceDefault returns def, or an empty non-nil slice when def is nil.
+//
+// Parameters:
+//   - def: Slice default from FlagSpec, which may be nil.
+//
+// Returns:
+//   - []string: A non-nil slice suitable for pflag StringSlice/StringArray defaults.
+func stringSliceDefault(def []string) []string {
+	if def == nil {
+		return []string{}
+	}
+
+	return def
+}
+
+// registerBool registers a boolean flag from flagSpec.
+//
+// Parameters:
+//   - flagSet: Target flag set.
+//   - flagSpec: Boolean flag specification (Default must be bool).
+func registerBool(flagSet *pflag.FlagSet, flagSpec FlagSpec) {
+	def, _ := flagSpec.Default.(bool)
+	if flagSpec.Shorthand != "" {
+		flagSet.BoolP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
+
+		return
+	}
+
+	flagSet.Bool(flagSpec.Name, def, flagSpec.Help)
+}
+
+// registerString registers a string flag from flagSpec.
+//
+// Parameters:
+//   - flagSet: Target flag set.
+//   - flagSpec: String flag specification (Default must be string).
+func registerString(flagSet *pflag.FlagSet, flagSpec FlagSpec) {
+	def, _ := flagSpec.Default.(string)
+	if flagSpec.Shorthand != "" {
+		flagSet.StringP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
+
+		return
+	}
+
+	flagSet.String(flagSpec.Name, def, flagSpec.Help)
+}
+
+// registerInt registers an int flag from flagSpec.
+//
+// Parameters:
+//   - flagSet: Target flag set.
+//   - flagSpec: Int flag specification (Default must be int).
+func registerInt(flagSet *pflag.FlagSet, flagSpec FlagSpec) {
+	def, _ := flagSpec.Default.(int)
+	if flagSpec.Shorthand != "" {
+		flagSet.IntP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
+
+		return
+	}
+
+	flagSet.Int(flagSpec.Name, def, flagSpec.Help)
+}
+
+// registerDuration registers a duration flag from flagSpec.
+//
+// Parameters:
+//   - flagSet: Target flag set.
+//   - flagSpec: Duration flag specification (Default must be time.Duration).
+func registerDuration(flagSet *pflag.FlagSet, flagSpec FlagSpec) {
+	def, _ := flagSpec.Default.(time.Duration)
+	if flagSpec.Shorthand != "" {
+		flagSet.DurationP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
+
+		return
+	}
+
+	flagSet.Duration(flagSpec.Name, def, flagSpec.Help)
+}
+
+// registerStringSlice registers a string-slice flag from flagSpec.
+//
+// A nil Default becomes an empty non-nil slice so pflag receives a stable default.
+//
+// Parameters:
+//   - flagSet: Target flag set.
+//   - flagSpec: String-slice flag specification (Default must be []string or nil).
+func registerStringSlice(flagSet *pflag.FlagSet, flagSpec FlagSpec) {
+	def, _ := flagSpec.Default.([]string)
+	def = stringSliceDefault(def)
+
+	if flagSpec.Shorthand != "" {
+		flagSet.StringSliceP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
+
+		return
+	}
+
+	flagSet.StringSlice(flagSpec.Name, def, flagSpec.Help)
+}
+
+// registerStringArray registers a string-array flag from flagSpec.
+//
+// A nil Default becomes an empty non-nil slice so pflag receives a stable default.
+//
+// Parameters:
+//   - flagSet: Target flag set.
+//   - flagSpec: String-array flag specification (Default must be []string or nil).
+func registerStringArray(flagSet *pflag.FlagSet, flagSpec FlagSpec) {
+	def, _ := flagSpec.Default.([]string)
+	def = stringSliceDefault(def)
+
+	if flagSpec.Shorthand != "" {
+		flagSet.StringArrayP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
+
+		return
+	}
+
+	flagSet.StringArray(flagSpec.Name, def, flagSpec.Help)
 }

--- a/internal/flags/spec/register.go
+++ b/internal/flags/spec/register.go
@@ -1,0 +1,115 @@
+package spec
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/utils"
+)
+
+// ErrUnsupportedFlagKind indicates a FlagSpec kind is not supported.
+var ErrUnsupportedFlagKind = errors.New("unsupported flag kind")
+
+// Register registers pflags from FlagSpec rows using static defaults only.
+//
+// Parameters:
+//   - flagSet: Target flag set.
+//   - specs: Domain flag specifications.
+//
+// Returns:
+//   - error: Non-nil when registration fails.
+func Register(flagSet *pflag.FlagSet, specs []FlagSpec) error {
+	for _, flagSpec := range specs {
+		err := registerOne(flagSet, flagSpec)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// MustRegister registers FlagSpec rows and panics on failure.
+//
+// Parameters:
+//   - flagSet: Target flag set.
+//   - specs: Domain flag specifications.
+func MustRegister(flagSet *pflag.FlagSet, specs []FlagSpec) {
+	err := Register(flagSet, specs)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func registerOne(flagSet *pflag.FlagSet, flagSpec FlagSpec) error {
+	switch flagSpec.Kind {
+	case KindBool:
+		def, _ := flagSpec.Default.(bool)
+		if flagSpec.Shorthand != "" {
+			flagSet.BoolP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
+		} else {
+			flagSet.Bool(flagSpec.Name, def, flagSpec.Help)
+		}
+	case KindString:
+		def, _ := flagSpec.Default.(string)
+		if flagSpec.Shorthand != "" {
+			flagSet.StringP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
+		} else {
+			flagSet.String(flagSpec.Name, def, flagSpec.Help)
+		}
+	case KindInt:
+		def, _ := flagSpec.Default.(int)
+		if flagSpec.Shorthand != "" {
+			flagSet.IntP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
+		} else {
+			flagSet.Int(flagSpec.Name, def, flagSpec.Help)
+		}
+	case KindDuration:
+		def, _ := flagSpec.Default.(time.Duration)
+		if flagSpec.Shorthand != "" {
+			flagSet.DurationP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
+		} else {
+			flagSet.Duration(flagSpec.Name, def, flagSpec.Help)
+		}
+	case KindStringSlice:
+		def, _ := flagSpec.Default.([]string)
+		if def == nil {
+			def = []string{}
+		}
+
+		if flagSpec.Shorthand != "" {
+			flagSet.StringSliceP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
+		} else {
+			flagSet.StringSlice(flagSpec.Name, def, flagSpec.Help)
+		}
+	case KindStringArray:
+		def, _ := flagSpec.Default.([]string)
+		if def == nil {
+			def = []string{}
+		}
+
+		if flagSpec.Shorthand != "" {
+			flagSet.StringArrayP(flagSpec.Name, flagSpec.Shorthand, def, flagSpec.Help)
+		} else {
+			flagSet.StringArray(flagSpec.Name, def, flagSpec.Help)
+		}
+	default:
+		return fmt.Errorf("%w: %s", ErrUnsupportedFlagKind, flagSpec.Name)
+	}
+
+	if flagSpec.Deprecated != "" {
+		utils.MarkFlagDeprecated(flagSet, flagSpec.Name, flagSpec.Deprecated)
+	}
+
+	if flagSpec.Hidden {
+		err := flagSet.MarkHidden(flagSpec.Name)
+		if err != nil {
+			return fmt.Errorf("hide %s: %w", flagSpec.Name, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/flags/spec/spec.go
+++ b/internal/flags/spec/spec.go
@@ -1,0 +1,63 @@
+// Package spec defines shared flag metadata used by domain registration and Viper bind.
+//
+// Domain packages depend on this package only (no import of parent flags), avoiding cycles.
+package spec
+
+// ListParseKind selects how multi-value env/default strings become []string.
+type ListParseKind int
+
+const (
+	// ListNone is a scalar flag (not a list).
+	ListNone ListParseKind = iota
+	// ListCommaOrSpace splits on commas and/or spaces.
+	ListCommaOrSpace
+	// ListCommaOnly splits on commas only.
+	ListCommaOnly
+	// ListNotificationURLs uses notification URL parsing (embedded commas preserved).
+	ListNotificationURLs
+	// ListNative uses pflag native StringSlice/StringArray semantics only.
+	ListNative
+)
+
+// FlagKind is the pflag value kind for registration.
+type FlagKind int
+
+const (
+	// KindBool is a boolean flag.
+	KindBool FlagKind = iota
+	// KindString is a string flag.
+	KindString
+	// KindInt is an int flag.
+	KindInt
+	// KindDuration is a time.Duration flag.
+	KindDuration
+	// KindStringSlice is a string slice flag.
+	KindStringSlice
+	// KindStringArray is a string array flag (repeatable, no CSV split by pflag).
+	KindStringArray
+)
+
+// FlagSpec is the single metadata row for one CLI/env setting.
+//
+// Default must be the static default (not env-baked). EnvKeys lists explicit
+// environment variable names (supports irregular mappings).
+type FlagSpec struct {
+	// Name is the long flag name (e.g. "stop-timeout").
+	Name string
+	// Shorthand is an optional single-letter flag.
+	Shorthand string
+	// Kind selects the pflag type.
+	Kind FlagKind
+	// Default is the static default value.
+	Default any
+	// EnvKeys are environment variable names bound to this flag.
+	EnvKeys []string
+	// Help is the flag help text.
+	Help string
+	// Deprecated is a non-empty migration hint when the flag is deprecated.
+	Deprecated string
+	// Hidden hides the flag from help when true.
+	Hidden bool
+	// ListParse selects multi-value parsing for string list kinds.
+	ListParse ListParseKind
+}

--- a/internal/flags/update/register.go
+++ b/internal/flags/update/register.go
@@ -1,0 +1,103 @@
+// Package update registers container update policy flags.
+package update
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
+)
+
+// DefaultStopTimeout is the static default container stop timeout.
+const DefaultStopTimeout = 30 * time.Second
+
+// Specs returns update domain flag metadata with static defaults.
+//
+// Returns:
+//   - []spec.FlagSpec: Update flag specifications.
+func Specs() []spec.FlagSpec {
+	return []spec.FlagSpec{
+		{
+			Name:      "cleanup",
+			Shorthand: "c",
+			Kind:      spec.KindBool,
+			Default:   false,
+			EnvKeys:   []string{"WATCHTOWER_CLEANUP"},
+			Help:      "Remove previously used images after updating",
+		},
+		{
+			Name:    "no-pull",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_NO_PULL"},
+			Help:    "Do not pull any new images",
+		},
+		{
+			Name:    "no-restart",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_NO_RESTART"},
+			Help:    "Do not restart any containers",
+		},
+		{
+			Name:      "monitor-only",
+			Shorthand: "m",
+			Kind:      spec.KindBool,
+			Default:   false,
+			EnvKeys:   []string{"WATCHTOWER_MONITOR_ONLY"},
+			Help:      "Will only monitor for new images, not update the containers",
+		},
+		{
+			Name:    "rolling-restart",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_ROLLING_RESTART"},
+			Help:    "Restart containers one at a time",
+		},
+		{
+			Name:      "stop-timeout",
+			Shorthand: "t",
+			Kind:      spec.KindDuration,
+			Default:   DefaultStopTimeout,
+			EnvKeys:   []string{"WATCHTOWER_TIMEOUT"},
+			Help:      "Timeout before a container is forcefully stopped (e.g., 30s, 1m, 5m)",
+		},
+		{
+			Name:    "cooldown-delay",
+			Kind:    spec.KindString,
+			Default: "",
+			EnvKeys: []string{"WATCHTOWER_COOLDOWN_DELAY"},
+			Help:    "Minimum time since image creation before allowing updates. Supports h, m, s, d (days), w (weeks), M (months) (e.g., 24h, 3d, 1w, 1M)",
+		},
+		{
+			Name:    "use-compose-depends-on",
+			Kind:    spec.KindBool,
+			Default: true,
+			EnvKeys: []string{"WATCHTOWER_USE_COMPOSE_DEPENDS_ON"},
+			Help:    "Include Docker Compose depends_on label when determining container update order",
+		},
+		{
+			Name:    "label-take-precedence",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_LABEL_TAKE_PRECEDENCE"},
+			Help:    "Label applied to containers take precedence over arguments",
+		},
+		{
+			Name:    "ephemeral-self-update",
+			Kind:    spec.KindBool,
+			Default: false,
+			EnvKeys: []string{"WATCHTOWER_EPHEMERAL_SELF_UPDATE"},
+			Help:    "Use an ephemeral container to orchestrate Watchtower self-updates (experimental)",
+		},
+	}
+}
+
+// Register adds update policy flags to the root command.
+//
+// Parameters:
+//   - rootCmd: Root Cobra command.
+func Register(rootCmd *cobra.Command) {
+	spec.MustRegister(rootCmd.PersistentFlags(), Specs())
+}

--- a/internal/flags/utils/deprecate.go
+++ b/internal/flags/utils/deprecate.go
@@ -1,0 +1,20 @@
+package utils
+
+import "github.com/spf13/pflag"
+
+// MarkFlagDeprecated marks a pflag as deprecated with a migration hint.
+//
+// Parameters:
+//   - flagSet: Flag set containing the flag.
+//   - name: Flag name.
+//   - hint: Migration hint message.
+//
+// TODO: Remove MarkFlagDeprecated and all legacy flags in the v2 release.
+//
+//nolint:godox
+func MarkFlagDeprecated(flagSet *pflag.FlagSet, name, hint string) {
+	if flag := flagSet.Lookup(name); flag != nil {
+		flag.Deprecated = hint
+		flag.Hidden = false // Keep visible so users see the hint in --help.
+	}
+}

--- a/internal/flags/utils/env.go
+++ b/internal/flags/utils/env.go
@@ -1,0 +1,117 @@
+package utils
+
+import (
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+// EnvString fetches a string from an environment variable via Viper.
+//
+// Parameters:
+//   - key: Environment variable key.
+//
+// Returns:
+//   - string: Value or empty if unset.
+func EnvString(key string) string {
+	viper.MustBindEnv(key)
+
+	return viper.GetString(key)
+}
+
+// EnvInt fetches an integer from an environment variable via Viper.
+//
+// Parameters:
+//   - key: Environment variable key.
+//
+// Returns:
+//   - int: Value or 0 if unset.
+func EnvInt(key string) int {
+	viper.MustBindEnv(key)
+
+	return viper.GetInt(key)
+}
+
+// EnvBool fetches a boolean from an environment variable via Viper.
+//
+// Parameters:
+//   - key: Environment variable key.
+//
+// Returns:
+//   - bool: Value or false if unset.
+func EnvBool(key string) bool {
+	viper.MustBindEnv(key)
+
+	return viper.GetBool(key)
+}
+
+// EnvDuration fetches a duration from an environment variable.
+//
+// Bare values without a time unit are treated as seconds.
+//
+// Parameters:
+//   - key: Environment variable key.
+//
+// Returns:
+//   - time.Duration: Value or 0 if unset.
+func EnvDuration(key string) time.Duration {
+	viper.MustBindEnv(key)
+
+	if raw := os.Getenv(key); raw != "" {
+		trimmed := strings.TrimSpace(raw)
+		if IsPureNumeric(trimmed) {
+			val, err := strconv.ParseFloat(trimmed, 64)
+			if err == nil {
+				nanos := val * float64(time.Second)
+
+				if nanos > float64(math.MaxInt64) {
+					return time.Duration(math.MaxInt64)
+				}
+
+				if nanos < float64(math.MinInt64) {
+					return time.Duration(math.MinInt64)
+				}
+
+				return time.Duration(nanos)
+			}
+		}
+	}
+
+	return viper.GetDuration(key)
+}
+
+// IsPureNumeric reports whether str is a bare number (integer or float,
+// possibly signed) with no duration unit characters.
+func IsPureNumeric(str string) bool {
+	if str == "" {
+		return false
+	}
+
+	sawDigit := false
+	sawDot := false
+
+	for i, char := range str {
+		switch {
+		case char >= '0' && char <= '9':
+			sawDigit = true
+		case char == '.':
+			if sawDot {
+				return false
+			}
+
+			sawDot = true
+		case char == '-' || char == '+':
+			if i != 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+
+	return sawDigit
+}

--- a/internal/flags/utils/env.go
+++ b/internal/flags/utils/env.go
@@ -49,6 +49,30 @@ func EnvBool(key string) bool {
 	return viper.GetBool(key)
 }
 
+// DurationFromSeconds converts a floating-point second count to time.Duration.
+//
+// The nanosecond product is clamped to MaxInt64/MinInt64 when it would overflow
+// time.Duration's integer range.
+//
+// Parameters:
+//   - seconds: Duration length in seconds (may be fractional).
+//
+// Returns:
+//   - time.Duration: Clamped duration value.
+func DurationFromSeconds(seconds float64) time.Duration {
+	nanos := seconds * float64(time.Second)
+
+	if nanos > float64(math.MaxInt64) {
+		return time.Duration(math.MaxInt64)
+	}
+
+	if nanos < float64(math.MinInt64) {
+		return time.Duration(math.MinInt64)
+	}
+
+	return time.Duration(nanos)
+}
+
 // EnvDuration fetches a duration from an environment variable.
 //
 // Bare values without a time unit are treated as seconds.
@@ -66,17 +90,7 @@ func EnvDuration(key string) time.Duration {
 		if IsPureNumeric(trimmed) {
 			val, err := strconv.ParseFloat(trimmed, 64)
 			if err == nil {
-				nanos := val * float64(time.Second)
-
-				if nanos > float64(math.MaxInt64) {
-					return time.Duration(math.MaxInt64)
-				}
-
-				if nanos < float64(math.MinInt64) {
-					return time.Duration(math.MinInt64)
-				}
-
-				return time.Duration(nanos)
+				return DurationFromSeconds(val)
 			}
 		}
 	}

--- a/internal/flags/utils/listparse.go
+++ b/internal/flags/utils/listparse.go
@@ -1,0 +1,142 @@
+// Package utils provides shared helpers for flag registration and value parsing.
+package utils
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	// commaOrSpace splits on commas, spaces, or runs of either.
+	commaOrSpace = regexp.MustCompile("[, ]+")
+	// commaOnly splits on commas only (spaces inside tokens are kept).
+	commaOnly = regexp.MustCompile(",")
+)
+
+// FilterEmptyStrings removes empty or whitespace-only strings from a slice.
+//
+// Parameters:
+//   - values: Slice of strings.
+//
+// Returns:
+//   - []string: Filtered slice without empty or whitespace-only strings.
+func FilterEmptyStrings(values []string) []string {
+	var result []string
+
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			result = append(result, value)
+		}
+	}
+
+	return result
+}
+
+// SplitCommaOrSpace splits on commas and/or spaces and drops empty tokens.
+//
+// Parameters:
+//   - value: Raw list string from env or defaults.
+//
+// Returns:
+//   - []string: Parsed non-empty tokens.
+func SplitCommaOrSpace(value string) []string {
+	return FilterEmptyStrings(commaOrSpace.Split(value, -1))
+}
+
+// SplitCommaOnly splits on commas only and drops empty tokens.
+//
+// Parameters:
+//   - value: Raw list string from env or defaults.
+//
+// Returns:
+//   - []string: Parsed non-empty tokens.
+func SplitCommaOnly(value string) []string {
+	return FilterEmptyStrings(commaOnly.Split(value, -1))
+}
+
+// SplitNotificationValues parses notification URLs separated by commas or spaces.
+//
+// Comma-delimited fragments without "://" are recombined so commas inside URLs
+// (query params, tenant IDs) are preserved.
+//
+// Parameters:
+//   - value: A string containing one or more notification URLs.
+//
+// Returns:
+//   - []string: Parsed notification URLs. Invalid URLs are included but logged.
+func SplitNotificationValues(value string) []string {
+	type delimiterType int
+
+	const (
+		delimiterComma delimiterType = iota
+		delimiterSpace
+	)
+
+	type splitPart struct {
+		text      string
+		delimiter delimiterType
+	}
+
+	var (
+		parts   []splitPart
+		current strings.Builder
+	)
+
+	lastDelimiter := delimiterSpace
+
+	for _, char := range value {
+		switch char {
+		case ',':
+			if current.Len() > 0 {
+				parts = append(parts, splitPart{text: current.String(), delimiter: lastDelimiter})
+				current.Reset()
+			}
+
+			lastDelimiter = delimiterComma
+		case ' ':
+			if current.Len() > 0 {
+				parts = append(parts, splitPart{text: current.String(), delimiter: lastDelimiter})
+				current.Reset()
+			}
+
+			lastDelimiter = delimiterSpace
+		default:
+			current.WriteRune(char)
+		}
+	}
+
+	if current.Len() > 0 {
+		parts = append(parts, splitPart{text: current.String(), delimiter: lastDelimiter})
+	}
+
+	var result []string
+
+	for _, part := range parts {
+		part.text = strings.TrimSpace(part.text)
+		if part.text == "" {
+			continue
+		}
+
+		if part.delimiter == delimiterComma && len(result) > 0 &&
+			!strings.Contains(part.text, "://") {
+			result[len(result)-1] = result[len(result)-1] + "," + part.text
+		} else {
+			result = append(result, part.text)
+		}
+	}
+
+	final := make([]string, 0, len(result))
+	for _, urlStr := range result {
+		_, err := url.Parse(urlStr)
+		if err != nil {
+			logrus.Warnf("Invalid notification URL '%s': %v", urlStr, err)
+		}
+
+		final = append(final, urlStr)
+	}
+
+	return final
+}

--- a/internal/flags/utils/listparse.go
+++ b/internal/flags/utils/listparse.go
@@ -132,7 +132,8 @@ func SplitNotificationValues(value string) []string {
 	for _, urlStr := range result {
 		_, err := url.Parse(urlStr)
 		if err != nil {
-			logrus.Warnf("Invalid notification URL '%s': %v", urlStr, err)
+			// Do not log urlStr; notification URLs often embed tokens.
+			logrus.WithError(err).Warn("Invalid notification URL in list")
 		}
 
 		final = append(final, urlStr)

--- a/internal/flags/utils/listparse_test.go
+++ b/internal/flags/utils/listparse_test.go
@@ -1,0 +1,353 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSplitNotificationValuesComprehensive exercises SplitNotificationValues for Shoutrrr
+// URL lists with separators and commas inside query/tenant segments.
+func TestSplitNotificationValuesComprehensive(t *testing.T) {
+	testCases := []struct {
+		name     string
+		envValue string
+		expected []string
+	}{
+		// SMTP service tests
+		{
+			name:     "SMTP single URL",
+			envValue: "smtp://user:pass@host:port/?from=test@example.com&to=recipient@example.com",
+			expected: []string{
+				"smtp://user:pass@host:port/?from=test@example.com&to=recipient@example.com",
+			},
+		},
+		{
+			name:     "SMTP multiple recipients with comma in query",
+			envValue: "smtp://user:pass@host:port/?from=test@example.com&to=recipient1@example.com,recipient2@example.com",
+			expected: []string{
+				"smtp://user:pass@host:port/?from=test@example.com&to=recipient1@example.com,recipient2@example.com",
+			},
+		},
+		{
+			name:     "SMTP space separator",
+			envValue: "smtp://user:pass@host1:port smtp://user:pass@host2:port",
+			expected: []string{"smtp://user:pass@host1:port", "smtp://user:pass@host2:port"},
+		},
+		{
+			name:     "SMTP comma-space separator",
+			envValue: "smtp://user:pass@host1:port, smtp://user:pass@host2:port",
+			expected: []string{"smtp://user:pass@host1:port", "smtp://user:pass@host2:port"},
+		},
+
+		// Slack service tests
+		{
+			name:     "Slack single URL",
+			envValue: "slack://botname@token-a/token-b/token-c",
+			expected: []string{"slack://botname@token-a/token-b/token-c"},
+		},
+		{
+			name:     "Slack space separator",
+			envValue: "slack://token1@channel1 slack://token2@channel2",
+			expected: []string{"slack://token1@channel1", "slack://token2@channel2"},
+		},
+		{
+			name:     "Slack comma-space separator",
+			envValue: "slack://token1@channel1, slack://token2@channel2",
+			expected: []string{"slack://token1@channel1", "slack://token2@channel2"},
+		},
+
+		// Gotify service tests
+		{
+			name:     "Gotify single URL",
+			envValue: "gotify://gotify-host/token",
+			expected: []string{"gotify://gotify-host/token"},
+		},
+		{
+			name:     "Gotify space separator",
+			envValue: "gotify://host1/token1 gotify://host2/token2",
+			expected: []string{"gotify://host1/token1", "gotify://host2/token2"},
+		},
+		{
+			name:     "Gotify comma-space separator",
+			envValue: "gotify://host1/token1, gotify://host2/token2",
+			expected: []string{"gotify://host1/token1", "gotify://host2/token2"},
+		},
+
+		// Discord service tests
+		{
+			name:     "Discord single URL",
+			envValue: "discord://token@123456789",
+			expected: []string{"discord://token@123456789"},
+		},
+		{
+			name:     "Discord space separator",
+			envValue: "discord://token1@123 discord://token2@456",
+			expected: []string{"discord://token1@123", "discord://token2@456"},
+		},
+		{
+			name:     "Discord comma-space separator",
+			envValue: "discord://token1@123, discord://token2@456",
+			expected: []string{"discord://token1@123", "discord://token2@456"},
+		},
+
+		// Teams service tests
+		{
+			name:     "Teams single URL",
+			envValue: "teams://group@tenant/altId/groupOwner?host=organization.webhook.office.com",
+			expected: []string{
+				"teams://group@tenant/altId/groupOwner?host=organization.webhook.office.com",
+			},
+		},
+		{
+			name:     "Teams space separator",
+			envValue: "teams://group1@tenant1/id1/owner1?host=host1 teams://group2@tenant2/id2/owner2?host=host2",
+			expected: []string{
+				"teams://group1@tenant1/id1/owner1?host=host1",
+				"teams://group2@tenant2/id2/owner2?host=host2",
+			},
+		},
+		{
+			name:     "Teams comma-space separator",
+			envValue: "teams://group1@tenant1/id1/owner1?host=host1, teams://group2@tenant2/id2/owner2?host=host2",
+			expected: []string{
+				"teams://group1@tenant1/id1/owner1?host=host1",
+				"teams://group2@tenant2/id2/owner2?host=host2",
+			},
+		},
+
+		// Telegram service tests
+		{
+			name:     "Telegram single URL",
+			envValue: "telegram://1234567890:AAEJ_AAAAABBBBBccccccccdddddddd@telegram/?channels=123456789&parseMode=html",
+			expected: []string{
+				"telegram://1234567890:AAEJ_AAAAABBBBBccccccccdddddddd@telegram/?channels=123456789&parseMode=html",
+			},
+		},
+		{
+			name:     "Telegram space separator",
+			envValue: "telegram://1234567890:AAEJ_AAAAABBBBBccccccccdddddddd@telegram/?channels=123456789&parseMode=html telegram://another@telegram",
+			expected: []string{
+				"telegram://1234567890:AAEJ_AAAAABBBBBccccccccdddddddd@telegram/?channels=123456789&parseMode=html",
+				"telegram://another@telegram",
+			},
+		},
+		{
+			name:     "Telegram comma-space separator",
+			envValue: "telegram://1234567890:AAEJ_AAAAABBBBBccccccccdddddddd@telegram/?channels=123456789&parseMode=html, telegram://another@telegram",
+			expected: []string{
+				"telegram://1234567890:AAEJ_AAAAABBBBBccccccccdddddddd@telegram/?channels=123456789&parseMode=html",
+				"telegram://another@telegram",
+			},
+		},
+
+		// Generic webhook tests
+		{
+			name:     "Generic webhook single URL",
+			envValue: "generic+https://webhook.example.com/hook?token=abc123",
+			expected: []string{"generic+https://webhook.example.com/hook?token=abc123"},
+		},
+		{
+			name:     "Generic webhook space separator",
+			envValue: "generic+https://hook1.example.com generic+https://hook2.example.com",
+			expected: []string{
+				"generic+https://hook1.example.com",
+				"generic+https://hook2.example.com",
+			},
+		},
+		{
+			name:     "Generic webhook comma-space separator",
+			envValue: "generic+https://hook1.example.com, generic+https://hook2.example.com",
+			expected: []string{
+				"generic+https://hook1.example.com",
+				"generic+https://hook2.example.com",
+			},
+		},
+
+		// Edge cases
+		{
+			name:     "URL with comma in query parameter",
+			envValue: "https://api.example.com/webhook?param=value,with,commas https://api2.example.com/webhook",
+			expected: []string{
+				"https://api.example.com/webhook?param=value,with,commas",
+				"https://api2.example.com/webhook",
+			},
+		},
+		{
+			name:     "Multiple URLs with mixed separators",
+			envValue: "smtp://test1 smtp://test2 slack://test3 slack://test4 gotify://test5",
+			expected: []string{
+				"smtp://test1",
+				"smtp://test2",
+				"slack://test3",
+				"slack://test4",
+				"gotify://test5",
+			},
+		},
+		{
+			name:     "Empty values filtered out",
+			envValue: "smtp://test1 smtp://test2 slack://test3",
+			expected: []string{"smtp://test1", "smtp://test2", "slack://test3"},
+		},
+		{
+			name:     "Malformed URL handling",
+			envValue: "not-a-url smtp://valid@example.com invalid://missing-parts",
+			expected: []string{"not-a-url", "smtp://valid@example.com", "invalid://missing-parts"},
+		},
+		{
+			name:     "URLs with special characters",
+			envValue: "smtp://user%40domain:pass%40word@host:587 slack://token@channel",
+			expected: []string{
+				"smtp://user%40domain:pass%40word@host:587",
+				"slack://token@channel",
+			},
+		},
+		{
+			name: "Very long URL",
+			envValue: "https://very-long-domain-name-with-many-subdomains.example.com/path/to/webhook?param1=" + strings.Repeat(
+				"a",
+				1000,
+			),
+			expected: []string{
+				"https://very-long-domain-name-with-many-subdomains.example.com/path/to/webhook?param1=" + strings.Repeat(
+					"a",
+					1000,
+				),
+			},
+		},
+		// Test cases from issues and bug reports
+		{
+			name:     "URL with comma in query parameter should not be split",
+			envValue: "smtp://user:pass@host:port/?to=recipient1@example.com,recipient2@example.com",
+			expected: []string{
+				"smtp://user:pass@host:port/?to=recipient1@example.com,recipient2@example.com",
+			},
+		},
+		{
+			name:     "Multiple URLs with comma in second URL query",
+			envValue: "smtp://test1 smtp://test2?param=value,with,commas",
+			expected: []string{"smtp://test1", "smtp://test2?param=value,with,commas"},
+		},
+		{
+			name:     "Complex URL with commas in path and query",
+			envValue: "https://api.example.com/webhook?param=value,with,commas https://api2.example.com/webhook",
+			expected: []string{
+				"https://api.example.com/webhook?param=value,with,commas",
+				"https://api2.example.com/webhook",
+			},
+		},
+		{
+			name:     "Teams URL with comma in tenant ID",
+			envValue: "teams://group@tenant,id.with,commas/altId/groupOwner?host=organization.webhook.office.com",
+			expected: []string{
+				"teams://group@tenant,id.with,commas/altId/groupOwner?host=organization.webhook.office.com",
+			},
+		},
+
+		// Additional edge cases
+		{
+			name:     "URL with multiple commas in query parameters",
+			envValue: "smtp://user:pass@host:port/?to=recipient1@example.com,recipient2@example.com,recipient3@example.com",
+			expected: []string{
+				"smtp://user:pass@host:port/?to=recipient1@example.com,recipient2@example.com,recipient3@example.com",
+			},
+		},
+		{
+			name:     "URL with encoded commas",
+			envValue: "smtp://user:pass@host:port/?to=recipient1%2Crecipient2%2Crecipient3@example.com",
+			expected: []string{
+				"smtp://user:pass@host:port/?to=recipient1%2Crecipient2%2Crecipient3@example.com",
+			},
+		},
+		{
+			name:     "IPv6 address in URL",
+			envValue: "smtp://[::1]:587/?from=test@example.com",
+			expected: []string{
+				"smtp://[::1]:587/?from=test@example.com",
+			},
+		},
+		{
+			name:     "Complex authentication with encoded characters",
+			envValue: "smtp://user%40domain:pass%40word@host:587",
+			expected: []string{
+				"smtp://user%40domain:pass%40word@host:587",
+			},
+		},
+		{
+			name:     "URL with special characters in query",
+			envValue: "generic+https://api.example.com/webhook?param=value&special=!@#$%^&*()",
+			expected: []string{
+				"generic+https://api.example.com/webhook?param=value&special=!@#$%^&*()",
+			},
+		},
+		{
+			name:     "Multiple URLs with commas in different positions",
+			envValue: "smtp://test1 smtp://test2?param=value,with,commas gotify://host/token",
+			expected: []string{
+				"smtp://test1",
+				"smtp://test2?param=value,with,commas",
+				"gotify://host/token",
+			},
+		},
+		{
+			name:     "Multiple IPv6 URLs",
+			envValue: "smtp://[::1]:587 smtp://[2001:db8::1]:587",
+			expected: []string{
+				"smtp://[::1]:587",
+				"smtp://[2001:db8::1]:587",
+			},
+		},
+		{
+			name:     "URL with encoded special characters in path",
+			envValue: "slack://token@channel?text=Hello%20World%21",
+			expected: []string{
+				"slack://token@channel?text=Hello%20World%21",
+			},
+		},
+		{
+			name:     "Teams URL with complex tenant and commas",
+			envValue: "teams://group@tenant.with.dots.and,commas,more/altId/groupOwner?host=organization.webhook.office.com",
+			expected: []string{
+				"teams://group@tenant.with.dots.and,commas,more/altId/groupOwner?host=organization.webhook.office.com",
+			},
+		},
+		{
+			name: "Very long URL with multiple commas",
+			envValue: "https://very-long-domain-name-with-many-subdomains.example.com/path/to/webhook?param1=" + strings.Repeat(
+				"a,b,c,",
+				50,
+			) + "end",
+			expected: []string{
+				"https://very-long-domain-name-with-many-subdomains.example.com/path/to/webhook?param1=" + strings.Repeat(
+					"a,b,c,",
+					50,
+				) + "end",
+			},
+		},
+		{
+			name:     "URL with authentication and IPv6",
+			envValue: "smtp://user:pass@[2001:db8::1]:587/?from=test@example.com",
+			expected: []string{
+				"smtp://user:pass@[2001:db8::1]:587/?from=test@example.com",
+			},
+		},
+		{
+			name:     "Mixed separators with complex URLs",
+			envValue: "smtp://test1, smtp://test2?param=value,with,commas gotify://host/token slack://token@channel",
+			expected: []string{
+				"smtp://test1",
+				"smtp://test2?param=value,with,commas",
+				"gotify://host/token",
+				"slack://token@channel",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			urls := FilterEmptyStrings(SplitNotificationValues(tc.envValue))
+			assert.Equal(t, tc.expected, urls)
+		})
+	}
+}

--- a/internal/logging/startup.go
+++ b/internal/logging/startup.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/nicholas-fedor/watchtower/internal/util"
 	"github.com/nicholas-fedor/watchtower/pkg/container"
-	"github.com/nicholas-fedor/watchtower/pkg/notifications"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
@@ -51,13 +50,13 @@ type StartupParams struct {
 // Parameters:
 //   - params: Resolved startup messaging inputs from config.Load (no CLI flag reads).
 func WriteStartupMessage(params StartupParams) {
-	// If startup messages are suppressed, skip all logging.
+	// If startup messages are suppressed, skip all logging and notifier batching.
 	if params.NoStartupMessage {
 		return
 	}
 
-	// Configure the logger based on whether startup messages should be suppressed.
-	startupLog := SetupStartupLogger(params.NoStartupMessage, params.Notifier)
+	// Batch startup lines through the notifier when present (suppression already returned).
+	startupLog := SetupStartupLogger(params.Notifier)
 
 	var apiVersion string
 	if params.Client != nil {
@@ -104,22 +103,18 @@ func WriteStartupMessage(params StartupParams) {
 	}
 }
 
-// SetupStartupLogger configures the logger for startup messages based on message suppression settings.
+// SetupStartupLogger configures a log entry for startup messages and starts notifier batching.
 //
-// It uses a local log entry if messages are suppressed (--no-startup-message), otherwise batches messages
-// via the notifier for consolidated delivery, ensuring flexibility in how startup info is presented.
+// Callers that suppress startup messages must return before invoking this helper.
+// When notifier is non-nil, StartNotification batches subsequent startup lines for
+// a single SendNotification.
 //
 // Parameters:
-//   - noStartupMessage: A boolean indicating whether startup messages should be logged locally only.
-//   - notifier: The notification system instance for batching messages.
+//   - notifier: The notification system instance for batching messages, or nil.
 //
 // Returns:
 //   - *logrus.Entry: A configured log entry for writing startup messages.
-func SetupStartupLogger(noStartupMessage bool, notifier types.Notifier) *logrus.Entry {
-	if noStartupMessage {
-		return notifications.LocalLog
-	}
-
+func SetupStartupLogger(notifier types.Notifier) *logrus.Entry {
 	log := logrus.NewEntry(logrus.StandardLogger())
 
 	if notifier != nil {

--- a/internal/logging/startup.go
+++ b/internal/logging/startup.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 
 	"github.com/nicholas-fedor/watchtower/internal/util"
 	"github.com/nicholas-fedor/watchtower/pkg/container"
@@ -15,70 +14,86 @@ import (
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
-// WriteStartupMessage logs or notifies startup information based on configuration flags.
+// StartupParams holds resolved process values for startup messaging.
+//
+// Callers must populate these from config.Load output. Do not read CLI flags here.
+type StartupParams struct {
+	// NoStartupMessage suppresses all startup logs and notifications when true.
+	NoStartupMessage bool
+	// RunOnce indicates a single update run then exit.
+	RunOnce bool
+	// UpdateOnStart is the effective update-on-start value for this invocation.
+	// When nil, update-on-start messaging is omitted (treated as false).
+	UpdateOnStart *bool
+	// HTTPAPIUpdate is true when the HTTP update API endpoint is enabled.
+	HTTPAPIUpdate bool
+	// HTTPAPIPeriodicPolls is true when scheduled polls run alongside the HTTP API.
+	HTTPAPIPeriodicPolls bool
+	// Sched is the time of the first scheduled run, or zero if none.
+	Sched time.Time
+	// Filtering is a human-readable description of the container filter.
+	Filtering string
+	// Scope is the operational scope name, or empty when unset.
+	Scope string
+	// Client is the Docker client used for API version reporting.
+	Client container.Client
+	// Notifier sends batched startup messages when not suppressed.
+	Notifier types.Notifier
+	// Version is the Watchtower version string.
+	Version string
+}
+
+// WriteStartupMessage logs or notifies startup information from resolved configuration.
 //
 // It reports Watchtower's version, notification setup, container filtering details, scheduling information,
 // and HTTP API status, providing users with a comprehensive overview of the application's initial state.
 //
 // Parameters:
-//   - c: The cobra.Command instance, providing access to flags like --no-startup-message.
-//   - sched: The time.Time of the first scheduled run, or zero if no schedule is set.
-//   - filtering: A string describing the container filter applied (e.g., "Watching all containers").
-//   - scope: The scope name for structured logging, empty string if no scope is set.
-//   - client: The Docker client instance used to retrieve API version information.
-//   - notifier: The notification system instance for sending startup messages.
-//   - watchtowerVersion: The version string of Watchtower to include in startup messages.
-//   - updateOnStart: The actual update-on-start value, or nil to read from flags.
-func WriteStartupMessage(
-	c *cobra.Command,
-	sched time.Time,
-	filtering string,
-	scope string,
-	client container.Client,
-	notifier types.Notifier,
-	watchtowerVersion string,
-	updateOnStart *bool,
-) {
-	// Retrieve flags controlling startup message behavior.
-	noStartupMessage, _ := c.PersistentFlags().GetBool("no-startup-message")
-
-	// If startup messages are suppressed, skip all logging
-	if noStartupMessage {
+//   - params: Resolved startup messaging inputs from config.Load (no CLI flag reads).
+func WriteStartupMessage(params StartupParams) {
+	// If startup messages are suppressed, skip all logging.
+	if params.NoStartupMessage {
 		return
 	}
 
 	// Configure the logger based on whether startup messages should be suppressed.
-	startupLog := SetupStartupLogger(noStartupMessage, notifier)
+	startupLog := SetupStartupLogger(params.NoStartupMessage, params.Notifier)
 
 	var apiVersion string
-	if client != nil {
-		apiVersion = client.GetVersion()
+	if params.Client != nil {
+		apiVersion = params.Client.GetVersion()
 	}
 
-	startupLog.Info("Watchtower ", watchtowerVersion, " using Docker API v", apiVersion)
+	startupLog.Info("Watchtower ", params.Version, " using Docker API v", apiVersion)
 
 	// Log details about configured notifiers or lack thereof.
 	var notifierNames []string
-	if notifier != nil {
-		notifierNames = notifier.GetNames()
+	if params.Notifier != nil {
+		notifierNames = params.Notifier.GetNames()
 	}
 
 	LogNotifierInfo(startupLog, notifierNames)
 
-	// Log filtering information, using structured logging for scope when set
-	if scope != "" {
-		startupLog.WithField("scope", scope).
+	// Log filtering information, using structured logging for scope when set.
+	if params.Scope != "" {
+		startupLog.WithField("scope", params.Scope).
 			Info("Only checking containers in scope")
 	} else {
-		startupLog.Debug(filtering)
+		startupLog.Debug(params.Filtering)
 	}
 
 	// Log scheduling or run mode information based on configuration.
-	LogScheduleInfo(startupLog, c, sched, updateOnStart)
+	LogScheduleInfo(startupLog, ScheduleInfo{
+		RunOnce:              params.RunOnce,
+		UpdateOnStart:        params.UpdateOnStart,
+		HTTPAPIUpdate:        params.HTTPAPIUpdate,
+		HTTPAPIPeriodicPolls: params.HTTPAPIPeriodicPolls,
+		Sched:                params.Sched,
+	})
 
 	// Send batched notifications if not suppressed, ensuring startup info reaches users.
-	if !noStartupMessage && notifier != nil {
-		notifier.SendNotification(nil)
+	if params.Notifier != nil {
+		params.Notifier.SendNotification(nil)
 	}
 
 	// Warn about trace-level logging if enabled, as it may expose sensitive data.
@@ -130,32 +145,41 @@ func LogNotifierInfo(log *logrus.Entry, notifierNames []string) {
 	}
 }
 
+// ScheduleInfo holds resolved schedule and mode values for startup schedule messaging.
+//
+// Values come from config.Load projections rather than CLI flag reads.
+type ScheduleInfo struct {
+	// RunOnce indicates a single update run then exit.
+	RunOnce bool
+	// UpdateOnStart is the effective update-on-start value, or nil when unset or false.
+	UpdateOnStart *bool
+	// HTTPAPIUpdate is true when the HTTP update API is enabled.
+	HTTPAPIUpdate bool
+	// HTTPAPIPeriodicPolls is true when scheduled polls run with the HTTP API.
+	HTTPAPIPeriodicPolls bool
+	// Sched is the time of the first scheduled run, or zero if none.
+	Sched time.Time
+}
+
 // LogScheduleInfo logs information about the scheduling or run mode configuration.
 //
 // It handles scheduled runs with timing details, one-time updates, or indicates no periodic runs,
 // ensuring users understand when and how updates will occur. It also warns about flag conflicts
-// such as when both --run-once and --update-on-start are enabled.
+// such as when both run-once and update-on-start are enabled.
 //
 // Parameters:
 //   - log: The logrus.Entry used to write the schedule information.
-//   - c: The cobra.Command instance, providing access to flags like --run-once.
-//   - sched: The time.Time of the first scheduled run, or zero if no schedule is set.
-//   - updateOnStart: The actual update-on-start value, or nil to read from flags.
-func LogScheduleInfo(log *logrus.Entry, c *cobra.Command, sched time.Time, updateOnStart *bool) {
-	// Obtain flag values for run-once.
-	runOnce, _ := c.PersistentFlags().GetBool("run-once")
-
-	// Use provided updateOnStart value if not nil, otherwise read from flags.
+//   - info: Resolved schedule and mode values (no flag reads).
+func LogScheduleInfo(log *logrus.Entry, info ScheduleInfo) {
+	// Use provided update-on-start value when set; otherwise treat as disabled.
 	var updateOnStartVal bool
-	if updateOnStart != nil {
-		updateOnStartVal = *updateOnStart
-	} else {
-		updateOnStartVal, _ = c.PersistentFlags().GetBool("update-on-start")
+	if info.UpdateOnStart != nil {
+		updateOnStartVal = *info.UpdateOnStart
 	}
 
 	// Check if run-once is enabled.
-	if runOnce {
-		// Warn if disregarding update-on-start when already performing on-time update
+	if info.RunOnce {
+		// Warn if disregarding update-on-start when already performing a one-time update.
 		if updateOnStartVal {
 			log.Warn("Run once mode: Disregarding update on start")
 		} else {
@@ -172,13 +196,9 @@ func LogScheduleInfo(log *logrus.Entry, c *cobra.Command, sched time.Time, updat
 		)
 	}
 
-	// Retrieve HTTP API related flags.
-	httpAPI, _ := c.PersistentFlags().GetBool("http-api-update")
-	periodicPolls, _ := c.PersistentFlags().GetBool("http-api-periodic-polls")
-
 	// Handle HTTP API update configurations.
-	if httpAPI {
-		if periodicPolls {
+	if info.HTTPAPIUpdate {
+		if info.HTTPAPIPeriodicPolls {
 			log.Info("HTTP API and periodic updates enabled")
 		} else {
 			log.Info("HTTP API enabled and periodic updates disabled")
@@ -188,18 +208,18 @@ func LogScheduleInfo(log *logrus.Entry, c *cobra.Command, sched time.Time, updat
 	}
 
 	// Log details of the next scheduled run if scheduling is active.
-	if !sched.IsZero() {
-		until := util.FormatDuration(time.Until(sched))
+	if !info.Sched.IsZero() {
+		until := util.FormatDuration(time.Until(info.Sched))
 		// Example: Next scheduled run: 2025-10-22 00:31:25 MST in 24 hours.
 		log.Info(
-			"Next scheduled run: " + sched.Format(
+			"Next scheduled run: " + info.Sched.Format(
 				"2006-01-02 15:04:05 MST",
 			) + " in " + until,
 		)
 	}
 
 	// Default periodic updates are enabled.
-	if !updateOnStartVal && !httpAPI && sched.IsZero() {
+	if !updateOnStartVal && !info.HTTPAPIUpdate && info.Sched.IsZero() {
 		log.Info("Periodic updates are enabled with default schedule")
 	}
 }

--- a/internal/logging/startup.go
+++ b/internal/logging/startup.go
@@ -16,20 +16,13 @@ import (
 // StartupParams holds resolved process values for startup messaging.
 //
 // Callers must populate these from config.Load output. Do not read CLI flags here.
+// Schedule and mode fields live on the embedded ScheduleInfo (single source of truth).
 type StartupParams struct {
+	// ScheduleInfo holds run-once, update-on-start, HTTP API, and next-run schedule values.
+	ScheduleInfo
+
 	// NoStartupMessage suppresses all startup logs and notifications when true.
 	NoStartupMessage bool
-	// RunOnce indicates a single update run then exit.
-	RunOnce bool
-	// UpdateOnStart is the effective update-on-start value for this invocation.
-	// When nil, update-on-start messaging is omitted (treated as false).
-	UpdateOnStart *bool
-	// HTTPAPIUpdate is true when the HTTP update API endpoint is enabled.
-	HTTPAPIUpdate bool
-	// HTTPAPIPeriodicPolls is true when scheduled polls run alongside the HTTP API.
-	HTTPAPIPeriodicPolls bool
-	// Sched is the time of the first scheduled run, or zero if none.
-	Sched time.Time
 	// Filtering is a human-readable description of the container filter.
 	Filtering string
 	// Scope is the operational scope name, or empty when unset.
@@ -82,13 +75,7 @@ func WriteStartupMessage(params StartupParams) {
 	}
 
 	// Log scheduling or run mode information based on configuration.
-	LogScheduleInfo(startupLog, ScheduleInfo{
-		RunOnce:              params.RunOnce,
-		UpdateOnStart:        params.UpdateOnStart,
-		HTTPAPIUpdate:        params.HTTPAPIUpdate,
-		HTTPAPIPeriodicPolls: params.HTTPAPIPeriodicPolls,
-		Sched:                params.Sched,
-	})
+	LogScheduleInfo(startupLog, params.ScheduleInfo)
 
 	// Send batched notifications if not suppressed, ensuring startup info reaches users.
 	if params.Notifier != nil {

--- a/internal/logging/startup_test.go
+++ b/internal/logging/startup_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 
 	mockActions "github.com/nicholas-fedor/watchtower/internal/actions/mocks"
 	"github.com/nicholas-fedor/watchtower/internal/logging"
@@ -22,13 +21,11 @@ func TestStartupLogging(t *testing.T) {
 
 var _ = ginkgo.Describe("WriteStartupMessage", func() {
 	var (
-		cmd    *cobra.Command
 		client mockActions.MockClient
 		buffer *bytes.Buffer
 	)
 
 	ginkgo.BeforeEach(func() {
-		cmd = &cobra.Command{}
 		client = mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
 		buffer = &bytes.Buffer{}
 		logrus.SetOutput(buffer)
@@ -39,21 +36,12 @@ var _ = ginkgo.Describe("WriteStartupMessage", func() {
 	})
 
 	ginkgo.It("should log startup information with no notifier", func() {
-		cmd.PersistentFlags().Bool("no-startup-message", false, "")
-		cmd.PersistentFlags().Bool("http-api-update", true, "")
-		cmd.PersistentFlags().String("http-api-host", "", "")
-		cmd.PersistentFlags().String("http-api-port", "8080", "")
-
-		logging.WriteStartupMessage(
-			cmd,
-			time.Time{}, // no schedule
-			"Watching all containers",
-			"", // no scope
-			client,
-			nil, // no notifier
-			"v1.0.0",
-			nil, // read from flags
-		)
+		logging.WriteStartupMessage(logging.StartupParams{
+			HTTPAPIUpdate: true,
+			Filtering:     "Watching all containers",
+			Client:        client,
+			Version:       "v1.0.0",
+		})
 
 		output := buffer.String()
 		gomega.Expect(output).To(gomega.ContainSubstring("Watchtower v1.0.0"))
@@ -61,60 +49,38 @@ var _ = ginkgo.Describe("WriteStartupMessage", func() {
 	})
 
 	ginkgo.It("should suppress startup messages when flag is set", func() {
-		cmd.PersistentFlags().Bool("no-startup-message", true, "")
-		cmd.PersistentFlags().Bool("http-api-update", false, "")
+		logging.WriteStartupMessage(logging.StartupParams{
+			NoStartupMessage: true,
+			Filtering:        "Watching all containers",
+			Client:           client,
+			Version:          "v1.0.0",
+		})
 
-		logging.WriteStartupMessage(
-			cmd,
-			time.Time{},
-			"Watching all containers",
-			"",
-			client,
-			nil,
-			"v1.0.0",
-			nil, // read from flags
-		)
-
-		// Should not log to buffer when suppressed
 		gomega.Expect(buffer.String()).To(gomega.BeEmpty())
 	})
 
 	ginkgo.It(
 		"should suppress startup messages including HTTP API when no-startup-message is set",
 		func() {
-			cmd.PersistentFlags().Bool("no-startup-message", true, "")
-			cmd.PersistentFlags().Bool("http-api-update", true, "")
+			logging.WriteStartupMessage(logging.StartupParams{
+				NoStartupMessage: true,
+				HTTPAPIUpdate:    true,
+				Filtering:        "Watching all containers",
+				Client:           client,
+				Version:          "v1.0.0",
+			})
 
-			logging.WriteStartupMessage(
-				cmd,
-				time.Time{},
-				"Watching all containers",
-				"",
-				client,
-				nil,
-				"v1.0.0",
-				nil, // read from flags
-			)
-
-			// Should not log to buffer when suppressed, even with HTTP API enabled
 			gomega.Expect(buffer.String()).To(gomega.BeEmpty())
 		},
 	)
 
 	ginkgo.It("should log scope information when provided", func() {
-		cmd.PersistentFlags().Bool("no-startup-message", false, "")
-		cmd.PersistentFlags().Bool("http-api-update", false, "")
-
-		logging.WriteStartupMessage(
-			cmd,
-			time.Time{},
-			"Watching all containers",
-			"prod",
-			client,
-			nil,
-			"v1.0.0",
-			nil, // read from flags
-		)
+		logging.WriteStartupMessage(logging.StartupParams{
+			Filtering: "Watching all containers",
+			Scope:     "prod",
+			Client:    client,
+			Version:   "v1.0.0",
+		})
 
 		output := buffer.String()
 		gomega.Expect(output).To(gomega.ContainSubstring("Only checking containers in scope"))
@@ -126,19 +92,11 @@ var _ = ginkgo.Describe("WriteStartupMessage", func() {
 		logrus.SetLevel(logrus.TraceLevel)
 		defer logrus.SetLevel(originalLevel)
 
-		cmd.PersistentFlags().Bool("no-startup-message", false, "")
-		cmd.PersistentFlags().Bool("http-api-update", false, "")
-
-		logging.WriteStartupMessage(
-			cmd,
-			time.Time{},
-			"Watching all containers",
-			"",
-			client,
-			nil,
-			"v1.0.0",
-			nil, // read from flags
-		)
+		logging.WriteStartupMessage(logging.StartupParams{
+			Filtering: "Watching all containers",
+			Client:    client,
+			Version:   "v1.0.0",
+		})
 
 		output := buffer.String()
 		gomega.Expect(output).To(gomega.ContainSubstring("Trace-level logging enabled"))
@@ -148,11 +106,6 @@ var _ = ginkgo.Describe("WriteStartupMessage", func() {
 var _ = ginkgo.Describe("SetupStartupLogger", func() {
 	ginkgo.It("should return local log when startup messages are suppressed", func() {
 		logger := logging.SetupStartupLogger(true, nil)
-		gomega.Expect(logger).NotTo(gomega.BeNil())
-	})
-
-	ginkgo.It("should return logger when not suppressed", func() {
-		logger := logging.SetupStartupLogger(false, nil)
 		gomega.Expect(logger).NotTo(gomega.BeNil())
 	})
 })
@@ -169,16 +122,15 @@ var _ = ginkgo.Describe("LogNotifierInfo", func() {
 		logrus.SetOutput(logrus.StandardLogger().Out)
 	})
 
-	ginkgo.It("should log multiple notifiers", func() {
+	ginkgo.It("should log configured notifiers", func() {
 		logger := logrus.NewEntry(logrus.StandardLogger())
-		logging.LogNotifierInfo(logger, []string{"slack", "email", "webhook"})
+		logging.LogNotifierInfo(logger, []string{"email", "slack"})
 
 		output := buffer.String()
-		gomega.Expect(output).
-			To(gomega.ContainSubstring("Using notifications: slack, email, webhook"))
+		gomega.Expect(output).To(gomega.ContainSubstring("Using notifications: email, slack"))
 	})
 
-	ginkgo.It("should log no notifications when empty", func() {
+	ginkgo.It("should log when no notifiers are configured", func() {
 		logger := logrus.NewEntry(logrus.StandardLogger())
 		logging.LogNotifierInfo(logger, []string{})
 
@@ -188,13 +140,9 @@ var _ = ginkgo.Describe("LogNotifierInfo", func() {
 })
 
 var _ = ginkgo.Describe("LogScheduleInfo", func() {
-	var (
-		cmd    *cobra.Command
-		buffer *bytes.Buffer
-	)
+	var buffer *bytes.Buffer
 
 	ginkgo.BeforeEach(func() {
-		cmd = &cobra.Command{}
 		buffer = &bytes.Buffer{}
 		logrus.SetOutput(buffer)
 	})
@@ -207,30 +155,29 @@ var _ = ginkgo.Describe("LogScheduleInfo", func() {
 		logger := logrus.NewEntry(logrus.StandardLogger())
 		sched := time.Now().Add(time.Hour)
 
-		logging.LogScheduleInfo(logger, cmd, sched, nil)
+		logging.LogScheduleInfo(logger, logging.ScheduleInfo{Sched: sched})
 
 		output := buffer.String()
 		gomega.Expect(output).To(gomega.ContainSubstring("Next scheduled run"))
 	})
 
 	ginkgo.It("should log one-time update", func() {
-		cmd.PersistentFlags().Bool("run-once", true, "")
-
 		logger := logrus.NewEntry(logrus.StandardLogger())
 
-		logging.LogScheduleInfo(logger, cmd, time.Time{}, nil)
+		logging.LogScheduleInfo(logger, logging.ScheduleInfo{RunOnce: true})
 
 		output := buffer.String()
 		gomega.Expect(output).To(gomega.ContainSubstring("Running a one time update"))
 	})
 
 	ginkgo.It("should log flag conflict when both run-once and update-on-start are set", func() {
-		cmd.PersistentFlags().Bool("run-once", true, "")
-		cmd.PersistentFlags().Bool("update-on-start", true, "")
-
 		logger := logrus.NewEntry(logrus.StandardLogger())
+		updateOnStart := true
 
-		logging.LogScheduleInfo(logger, cmd, time.Time{}, nil)
+		logging.LogScheduleInfo(logger, logging.ScheduleInfo{
+			RunOnce:       true,
+			UpdateOnStart: &updateOnStart,
+		})
 
 		output := buffer.String()
 		gomega.Expect(output).
@@ -238,23 +185,19 @@ var _ = ginkgo.Describe("LogScheduleInfo", func() {
 	})
 
 	ginkgo.It("should log update on start", func() {
-		cmd.PersistentFlags().Bool("update-on-start", true, "")
-
 		logger := logrus.NewEntry(logrus.StandardLogger())
+		updateOnStart := true
 
-		logging.LogScheduleInfo(logger, cmd, time.Time{}, nil)
+		logging.LogScheduleInfo(logger, logging.ScheduleInfo{UpdateOnStart: &updateOnStart})
 
 		output := buffer.String()
 		gomega.Expect(output).To(gomega.ContainSubstring("Update on startup enabled"))
 	})
 
 	ginkgo.It("should log HTTP API without periodic polls", func() {
-		cmd.PersistentFlags().Bool("http-api-update", true, "")
-		cmd.PersistentFlags().Bool("http-api-periodic-polls", false, "")
-
 		logger := logrus.NewEntry(logrus.StandardLogger())
 
-		logging.LogScheduleInfo(logger, cmd, time.Time{}, nil)
+		logging.LogScheduleInfo(logger, logging.ScheduleInfo{HTTPAPIUpdate: true})
 
 		output := buffer.String()
 		gomega.Expect(output).
@@ -262,12 +205,12 @@ var _ = ginkgo.Describe("LogScheduleInfo", func() {
 	})
 
 	ginkgo.It("should log HTTP API with periodic polls", func() {
-		cmd.PersistentFlags().Bool("http-api-update", true, "")
-		cmd.PersistentFlags().Bool("http-api-periodic-polls", true, "")
-
 		logger := logrus.NewEntry(logrus.StandardLogger())
 
-		logging.LogScheduleInfo(logger, cmd, time.Time{}, nil)
+		logging.LogScheduleInfo(logger, logging.ScheduleInfo{
+			HTTPAPIUpdate:        true,
+			HTTPAPIPeriodicPolls: true,
+		})
 
 		output := buffer.String()
 		gomega.Expect(output).
@@ -277,7 +220,7 @@ var _ = ginkgo.Describe("LogScheduleInfo", func() {
 	ginkgo.It("should log default periodic updates", func() {
 		logger := logrus.NewEntry(logrus.StandardLogger())
 
-		logging.LogScheduleInfo(logger, cmd, time.Time{}, nil)
+		logging.LogScheduleInfo(logger, logging.ScheduleInfo{})
 
 		output := buffer.String()
 		gomega.Expect(output).

--- a/internal/logging/startup_test.go
+++ b/internal/logging/startup_test.go
@@ -104,9 +104,12 @@ var _ = ginkgo.Describe("WriteStartupMessage", func() {
 })
 
 var _ = ginkgo.Describe("SetupStartupLogger", func() {
-	ginkgo.It("should return a log entry when notifier is nil", func() {
+	ginkgo.It("should return a standard logger entry when notifier is nil", func() {
+		// Suppression is handled by WriteStartupMessage's early return; this helper
+		// always builds a StandardLogger entry (not notifications.LocalLog).
 		logger := logging.SetupStartupLogger(nil)
 		gomega.Expect(logger).NotTo(gomega.BeNil())
+		gomega.Expect(logger.Logger).To(gomega.Equal(logrus.StandardLogger()))
 	})
 })
 

--- a/internal/logging/startup_test.go
+++ b/internal/logging/startup_test.go
@@ -37,10 +37,10 @@ var _ = ginkgo.Describe("WriteStartupMessage", func() {
 
 	ginkgo.It("should log startup information with no notifier", func() {
 		logging.WriteStartupMessage(logging.StartupParams{
-			HTTPAPIUpdate: true,
-			Filtering:     "Watching all containers",
-			Client:        client,
-			Version:       "v1.0.0",
+			ScheduleInfo: logging.ScheduleInfo{HTTPAPIUpdate: true},
+			Filtering:    "Watching all containers",
+			Client:       client,
+			Version:      "v1.0.0",
 		})
 
 		output := buffer.String()
@@ -64,7 +64,7 @@ var _ = ginkgo.Describe("WriteStartupMessage", func() {
 		func() {
 			logging.WriteStartupMessage(logging.StartupParams{
 				NoStartupMessage: true,
-				HTTPAPIUpdate:    true,
+				ScheduleInfo:     logging.ScheduleInfo{HTTPAPIUpdate: true},
 				Filtering:        "Watching all containers",
 				Client:           client,
 				Version:          "v1.0.0",

--- a/internal/logging/startup_test.go
+++ b/internal/logging/startup_test.go
@@ -104,8 +104,8 @@ var _ = ginkgo.Describe("WriteStartupMessage", func() {
 })
 
 var _ = ginkgo.Describe("SetupStartupLogger", func() {
-	ginkgo.It("should return local log when startup messages are suppressed", func() {
-		logger := logging.SetupStartupLogger(true, nil)
+	ginkgo.It("should return a log entry when notifier is nil", func() {
+		logger := logging.SetupStartupLogger(nil)
 		gomega.Expect(logger).NotTo(gomega.BeNil())
 	})
 })

--- a/internal/scheduling/scheduling.go
+++ b/internal/scheduling/scheduling.go
@@ -108,24 +108,8 @@ type ScheduleDeps struct {
 // Returns:
 //   - error: An error if scheduling fails (e.g., invalid cron spec), nil on successful shutdown.
 func RunUpgradesOnSchedule(ctx context.Context, deps ScheduleDeps) error {
-	filter := deps.Filter
-	filtering := deps.FilterDesc
-	lock := deps.Lock
-	scheduleSpec := deps.ScheduleSpec
-	writeStartupMessage := deps.WriteStartupMessage
-	runUpdatesWithNotifications := deps.RunUpdate
-	client := deps.Client
-	scope := deps.Scope
-	notifier := deps.Notifier
-	metaVersion := deps.MetaVersion
-	updateOnStart := deps.UpdateOnStart
-	skipFirstRun := deps.SkipFirstRun
-	currentWatchtowerContainer := deps.CurrentWatchtowerContainer
-	startupMessageSent := deps.StartupMessageSent
-	baseParams := deps.BaseParams
-	ephemeralSelfUpdate := baseParams.EphemeralSelfUpdate
-
 	// Initialize lock if not provided, ensuring single-update concurrency.
+	lock := deps.Lock
 	if lock == nil {
 		lock = make(chan bool, 1)
 		lock <- true
@@ -150,9 +134,9 @@ func RunUpgradesOnSchedule(ctx context.Context, deps ScheduleDeps) error {
 	// while the new container tries to bind it, resulting in both containers being stopped.
 	// Ephemeral self-updates are exempt from this restriction because they remove
 	// the old container before creating the new one, avoiding port conflicts.
-	skipSelfUpdateForPorts := currentWatchtowerContainer != nil &&
-		currentWatchtowerContainer.HasExposedPorts() &&
-		!ephemeralSelfUpdate
+	skipSelfUpdateForPorts := deps.CurrentWatchtowerContainer != nil &&
+		deps.CurrentWatchtowerContainer.HasExposedPorts() &&
+		!deps.BaseParams.EphemeralSelfUpdate
 
 	// Define the update function to be used both for scheduled runs and immediate execution.
 	// skipWatchtowerSelfUpdate: whether to skip updating the Watchtower container itself
@@ -167,10 +151,10 @@ func RunUpgradesOnSchedule(ctx context.Context, deps ScheduleDeps) error {
 		}
 
 		// Skip update if this is a Watchtower parent container (from self-update chain)
-		if currentWatchtowerContainer != nil {
-			chain, _ := currentWatchtowerContainer.GetContainerChain()
+		if deps.CurrentWatchtowerContainer != nil {
+			chain, _ := deps.CurrentWatchtowerContainer.GetContainerChain()
 
-			if container.IsWatchtowerParent(currentWatchtowerContainer.ID(), chain) {
+			if container.IsWatchtowerParent(deps.CurrentWatchtowerContainer.ID(), chain) {
 				logrus.Debug("Skipping scheduled update for Watchtower parent container")
 
 				nextRuns := scheduler.Entries()
@@ -202,21 +186,21 @@ func RunUpgradesOnSchedule(ctx context.Context, deps ScheduleDeps) error {
 			}
 		}
 
-		params := baseParams
+		params := deps.BaseParams
 		params.RunOnce = false
 		params.SkipSelfUpdate = skipWatchtowerSelfUpdate
 
 		// One filter for this tick: schedule filter when set, else BaseParams.
 		// Keep params.Filter and the positional argument identical so
 		// runUpdatesWithNotifications cannot prefer a divergent source.
-		updateFilter := filter
+		updateFilter := deps.Filter
 		if updateFilter == nil {
 			updateFilter = params.Filter
 		}
 
 		params.Filter = updateFilter
 
-		metric := runUpdatesWithNotifications(ctx, updateFilter, params)
+		metric := deps.RunUpdate(ctx, updateFilter, params)
 		if metric != nil {
 			metrics.Default().RegisterScan(metric)
 		}
@@ -234,7 +218,7 @@ func RunUpgradesOnSchedule(ctx context.Context, deps ScheduleDeps) error {
 
 	// If Watchtower has performed a self-cleanup, then prevent Watchtower
 	// from self-updating during the first update cycle.
-	if skipFirstRun {
+	if deps.SkipFirstRun {
 		var firstRun atomic.Uint32 // atomic flag to track if this is the first run
 
 		scheduledUpdateFunc = func() {
@@ -253,9 +237,8 @@ func RunUpgradesOnSchedule(ctx context.Context, deps ScheduleDeps) error {
 	}
 
 	// Add the update function to the cron schedule, handling concurrency and metrics.
+	scheduleSpec := strings.Trim(deps.ScheduleSpec, `"'`)
 	if scheduleSpec != "" {
-		scheduleSpec = strings.Trim(scheduleSpec, `"'`)
-
 		_, err := scheduler.AddFunc(
 			scheduleSpec,
 			scheduledUpdateFunc)
@@ -273,20 +256,20 @@ func RunUpgradesOnSchedule(ctx context.Context, deps ScheduleDeps) error {
 
 	// Log startup message with the first scheduled run time.
 	// Skip if the startup message was already sent (for example by the HTTP API in blocking mode).
-	if !startupMessageSent && writeStartupMessage != nil {
+	if !deps.StartupMessageSent && deps.WriteStartupMessage != nil {
 		startup := deps.Startup
 		startup.Sched = nextRun
-		startup.Filtering = filtering
-		startup.Scope = scope
-		startup.Client = client
-		startup.Notifier = notifier
-		startup.Version = metaVersion
-		startup.UpdateOnStart = &updateOnStart
-		writeStartupMessage(startup)
+		startup.Filtering = deps.FilterDesc
+		startup.Scope = deps.Scope
+		startup.Client = deps.Client
+		startup.Notifier = deps.Notifier
+		startup.Version = deps.MetaVersion
+		startup.UpdateOnStart = &deps.UpdateOnStart
+		deps.WriteStartupMessage(startup)
 	}
 
 	// Check if update-on-start is enabled and trigger immediate update if so.
-	if updateOnStart {
+	if deps.UpdateOnStart {
 		updateFunc(false, false)
 	}
 
@@ -316,8 +299,8 @@ func RunUpgradesOnSchedule(ctx context.Context, deps ScheduleDeps) error {
 	WaitForRunningUpdate(ctx, lock)
 
 	// Close the notification system to clean up resources during shutdown.
-	if notifier != nil {
-		notifier.Close()
+	if deps.Notifier != nil {
+		deps.Notifier.Close()
 	}
 
 	logrus.Debug("Scheduler stopped and update completed.")

--- a/internal/scheduling/scheduling.go
+++ b/internal/scheduling/scheduling.go
@@ -202,6 +202,12 @@ func RunUpgradesOnSchedule(ctx context.Context, deps ScheduleDeps) error {
 
 		params.Filter = updateFilter
 
+		if deps.RunUpdate == nil {
+			logrus.Debug("Update skipped: RunUpdate hook is not configured")
+
+			return
+		}
+
 		metric := deps.RunUpdate(ctx, updateFilter, params)
 		if metric != nil {
 			metrics.Default().RegisterScan(metric)

--- a/internal/scheduling/scheduling.go
+++ b/internal/scheduling/scheduling.go
@@ -15,9 +15,8 @@ import (
 
 	"github.com/robfig/cron/v3"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
+	"github.com/nicholas-fedor/watchtower/internal/logging"
 	"github.com/nicholas-fedor/watchtower/internal/metrics"
 	"github.com/nicholas-fedor/watchtower/pkg/container"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
@@ -51,61 +50,81 @@ func WaitForRunningUpdate(ctx context.Context, lock chan bool) {
 	logrus.Debug("Lock check completed.")
 }
 
+// ScheduleDeps holds dependencies for scheduled update runs.
+//
+// BaseParams must be a complete types.UpdateParams snapshot from config.UpdateParams
+// (or an equivalent full construction).
+// Each tick copies BaseParams and applies only per-run fields such as SkipSelfUpdate.
+type ScheduleDeps struct {
+	// Filter determines which containers are updated.
+	Filter types.Filter
+	// FilterDesc is a human-readable description of the filter for startup messaging.
+	FilterDesc string
+	// Lock ensures only one update runs at a time, or nil to create a new one.
+	Lock chan bool
+	// ScheduleSpec is the cron-formatted schedule string for periodic updates.
+	ScheduleSpec string
+	// Startup holds resolved values for startup messaging (no flag reads).
+	Startup logging.StartupParams
+	// WriteStartupMessage writes the startup message with scheduling information.
+	WriteStartupMessage func(logging.StartupParams)
+	// RunUpdate performs container updates and sends notifications.
+	RunUpdate func(context.Context, types.Filter, types.UpdateParams) *metrics.Metric
+	// Client is the Docker client used for container operations.
+	Client container.Client
+	// Scope limits updates to containers matching this Watchtower scope.
+	Scope string
+	// Notifier sends update status messages.
+	Notifier types.Notifier
+	// MetaVersion is the Watchtower version string used in startup messaging.
+	MetaVersion string
+	// UpdateOnStart triggers an immediate update before the scheduler starts.
+	UpdateOnStart bool
+	// SkipFirstRun skips Watchtower self-update on the first scheduled run
+	// (useful after self-update cleanup of old instances).
+	SkipFirstRun bool
+	// CurrentWatchtowerContainer is the running Watchtower container for parent checking.
+	CurrentWatchtowerContainer types.Container
+	// StartupMessageSent is true when the startup message was already sent
+	// (for example by the HTTP API in blocking mode).
+	StartupMessageSent bool
+	// BaseParams is the complete update policy snapshot for every scheduled tick.
+	// Must include Cleanup, MonitorOnly, UseComposeDependsOn, ReviveStopped, and
+	// all other process-wide UpdateParams fields.
+	BaseParams types.UpdateParams
+}
+
 // RunUpgradesOnSchedule schedules and executes periodic container updates according to the cron specification.
 //
 // It sets up a cron scheduler, runs updates at specified intervals, and ensures graceful shutdown on interrupt
 // signals (SIGINT, SIGTERM) or context cancellation, handling concurrency with a lock channel.
 // If update-on-start is enabled, it triggers the first update immediately before starting the scheduler.
-// If skipFirstRun is true, it skips the first scheduled run (useful after self-update cleanup).
+// If SkipFirstRun is true, it skips Watchtower self-update on the first scheduled run (useful after self-update cleanup).
 //
 // Parameters:
 //   - ctx: The context controlling the scheduler's lifecycle, enabling shutdown on cancellation.
-//   - c: The cobra.Command instance, providing access to flags for startup messaging.
-//   - filter: The types.Filter determining which containers are updated.
-//   - filtering: A string describing the filter, used in startup messaging.
-//   - lock: A channel ensuring only one update runs at a time, or nil to create a new one.
-//   - cleanup: Boolean indicating whether to remove old images after updates.
-//   - scheduleSpec: The cron-formatted schedule string that dictates when periodic container updates occur.
-//   - writeStartupMessage: Function to write the startup message with scheduling information.
-//   - runUpdatesWithNotifications: Function to perform container updates and send notifications.
-//   - client: The Docker client instance used for container operations.
-//   - scope: Defines a specific operational scope for Watchtower, limiting updates to containers matching this scope.
-//   - notifier: The notification system instance responsible for sending update status messages.
-//   - metaVersion: The version string for Watchtower, used in startup messaging.
-//   - monitorOnly: Boolean indicating whether to monitor only without updating.
-//   - updateOnStart: Boolean indicating whether to perform an update immediately on startup.
-//   - skipFirstRun: Boolean indicating whether to skip the first scheduled run.
-//   - currentWatchtowerContainer: The current Watchtower container for parent checking.
-//   - startupMessageSent: Whether the startup message was already sent (e.g., by the HTTP API in blocking mode).
-//   - ephemeralSelfUpdate: Whether the self-update uses ephemeral mode (removes old container before creating new one).
-//   - reviveStopped: Whether to start stopped containers after update.
-//   - useComposeDependsOn: Whether to honor Docker Compose depends_on labels during updates.
+//   - deps: Schedule dependencies including a complete BaseParams policy snapshot.
 //
 // Returns:
 //   - error: An error if scheduling fails (e.g., invalid cron spec), nil on successful shutdown.
-func RunUpgradesOnSchedule(
-	ctx context.Context,
-	c *cobra.Command,
-	filter types.Filter,
-	filtering string,
-	lock chan bool,
-	cleanup bool,
-	scheduleSpec string,
-	writeStartupMessage func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool),
-	runUpdatesWithNotifications func(context.Context, types.Filter, types.UpdateParams) *metrics.Metric,
-	client container.Client,
-	scope string,
-	notifier types.Notifier,
-	metaVersion string,
-	monitorOnly bool,
-	updateOnStart bool,
-	skipFirstRun bool,
-	currentWatchtowerContainer types.Container,
-	startupMessageSent bool,
-	ephemeralSelfUpdate bool,
-	reviveStopped bool,
-	useComposeDependsOn bool,
-) error {
+func RunUpgradesOnSchedule(ctx context.Context, deps ScheduleDeps) error {
+	filter := deps.Filter
+	filtering := deps.FilterDesc
+	lock := deps.Lock
+	scheduleSpec := deps.ScheduleSpec
+	writeStartupMessage := deps.WriteStartupMessage
+	runUpdatesWithNotifications := deps.RunUpdate
+	client := deps.Client
+	scope := deps.Scope
+	notifier := deps.Notifier
+	metaVersion := deps.MetaVersion
+	updateOnStart := deps.UpdateOnStart
+	skipFirstRun := deps.SkipFirstRun
+	currentWatchtowerContainer := deps.CurrentWatchtowerContainer
+	startupMessageSent := deps.StartupMessageSent
+	baseParams := deps.BaseParams
+	ephemeralSelfUpdate := baseParams.EphemeralSelfUpdate
+
 	// Initialize lock if not provided, ensuring single-update concurrency.
 	if lock == nil {
 		lock = make(chan bool, 1)
@@ -183,13 +202,12 @@ func RunUpgradesOnSchedule(
 			}
 		}
 
-		params := types.UpdateParams{
-			Cleanup:             cleanup,
-			RunOnce:             false,
-			MonitorOnly:         monitorOnly,
-			SkipSelfUpdate:      skipWatchtowerSelfUpdate,
-			ReviveStopped:       reviveStopped,
-			UseComposeDependsOn: useComposeDependsOn,
+		params := baseParams
+		params.RunOnce = false
+
+		params.SkipSelfUpdate = skipWatchtowerSelfUpdate
+		if params.Filter == nil {
+			params.Filter = filter
 		}
 
 		metric := runUpdatesWithNotifications(ctx, filter, params)
@@ -247,8 +265,18 @@ func RunUpgradesOnSchedule(
 		nextRun = scheduler.Entries()[0].Schedule.Next(time.Now())
 	}
 
-	if !startupMessageSent {
-		writeStartupMessage(c, nextRun, filtering, scope, client, notifier, metaVersion, &updateOnStart)
+	// Log startup message with the first scheduled run time.
+	// Skip if the startup message was already sent (for example by the HTTP API in blocking mode).
+	if !startupMessageSent && writeStartupMessage != nil {
+		startup := deps.Startup
+		startup.Sched = nextRun
+		startup.Filtering = filtering
+		startup.Scope = scope
+		startup.Client = client
+		startup.Notifier = notifier
+		startup.Version = metaVersion
+		startup.UpdateOnStart = &updateOnStart
+		writeStartupMessage(startup)
 	}
 
 	// Check if update-on-start is enabled and trigger immediate update if so.
@@ -299,28 +327,22 @@ func RunUpgradesOnSchedule(
 //  2. The current container is present in the container chain label, indicating it is
 //     an ancestor in the self-update lineage.
 //
-// If either condition is true and the run-once flag is not set, the program should exit
+// If either condition is true and runOnce is false, the program should exit
 // to prevent an old Watchtower container from running.
 //
 // Parameters:
 //   - c: The current Watchtower container to check.
-//   - flags: The flag set to check for the run-once option.
+//   - runOnce: Whether the process is in run-once mode.
 //
 // Returns:
 //   - bool: True if the program should exit due to an invalid restart, false otherwise.
-func ShouldExitDueToInvalidRestart(
-	c types.Container,
-	flags *pflag.FlagSet,
-) bool {
+func ShouldExitDueToInvalidRestart(c types.Container, runOnce bool) bool {
 	if c == nil {
 		return false
 	}
 
-	if container.IsOldContainer(c.Name()) {
-		runOnce, _ := flags.GetBool("run-once")
-		if !runOnce {
-			return true
-		}
+	if container.IsOldContainer(c.Name()) && !runOnce {
+		return true
 	}
 
 	chain, present := c.GetContainerChain()
@@ -328,12 +350,5 @@ func ShouldExitDueToInvalidRestart(
 		return false
 	}
 
-	if container.IsWatchtowerParent(c.ID(), chain) {
-		runOnce, _ := flags.GetBool("run-once")
-		if !runOnce {
-			return true
-		}
-	}
-
-	return false
+	return container.IsWatchtowerParent(c.ID(), chain) && !runOnce
 }

--- a/internal/scheduling/scheduling.go
+++ b/internal/scheduling/scheduling.go
@@ -204,13 +204,19 @@ func RunUpgradesOnSchedule(ctx context.Context, deps ScheduleDeps) error {
 
 		params := baseParams
 		params.RunOnce = false
-
 		params.SkipSelfUpdate = skipWatchtowerSelfUpdate
-		if params.Filter == nil {
-			params.Filter = filter
+
+		// One filter for this tick: schedule filter when set, else BaseParams.
+		// Keep params.Filter and the positional argument identical so
+		// runUpdatesWithNotifications cannot prefer a divergent source.
+		updateFilter := filter
+		if updateFilter == nil {
+			updateFilter = params.Filter
 		}
 
-		metric := runUpdatesWithNotifications(ctx, filter, params)
+		params.Filter = updateFilter
+
+		metric := runUpdatesWithNotifications(ctx, updateFilter, params)
 		if metric != nil {
 			metrics.Default().RegisterScan(metric)
 		}

--- a/internal/scheduling/scheduling.go
+++ b/internal/scheduling/scheduling.go
@@ -65,18 +65,20 @@ type ScheduleDeps struct {
 	// ScheduleSpec is the cron-formatted schedule string for periodic updates.
 	ScheduleSpec string
 	// Startup holds resolved values for startup messaging (no flag reads).
+	// Callers must set Filtering, Scope, Client, Notifier, and Version on Startup.
+	// RunUpgradesOnSchedule only applies Sched and UpdateOnStart at send time.
 	Startup logging.StartupParams
 	// WriteStartupMessage writes the startup message with scheduling information.
 	WriteStartupMessage func(logging.StartupParams)
 	// RunUpdate performs container updates and sends notifications.
 	RunUpdate func(context.Context, types.Filter, types.UpdateParams) *metrics.Metric
-	// Client is the Docker client used for container operations.
+	// Client is retained for callers. Prefer Startup.Client for messaging.
 	Client container.Client
-	// Scope limits updates to containers matching this Watchtower scope.
+	// Scope is retained for callers. Prefer Startup.Scope for messaging.
 	Scope string
-	// Notifier sends update status messages.
+	// Notifier is closed on schedule shutdown. Prefer Startup.Notifier for messaging.
 	Notifier types.Notifier
-	// MetaVersion is the Watchtower version string used in startup messaging.
+	// MetaVersion is retained for callers. Prefer Startup.Version for messaging.
 	MetaVersion string
 	// UpdateOnStart triggers an immediate update before the scheduler starts.
 	UpdateOnStart bool
@@ -256,14 +258,11 @@ func RunUpgradesOnSchedule(ctx context.Context, deps ScheduleDeps) error {
 
 	// Log startup message with the first scheduled run time.
 	// Skip if the startup message was already sent (for example by the HTTP API in blocking mode).
+	// Startup is the single source of truth for messaging fields (Filtering, Scope, Client,
+	// Notifier, Version). Only apply scheduler-owned runtime values here.
 	if !deps.StartupMessageSent && deps.WriteStartupMessage != nil {
 		startup := deps.Startup
 		startup.Sched = nextRun
-		startup.Filtering = deps.FilterDesc
-		startup.Scope = deps.Scope
-		startup.Client = deps.Client
-		startup.Notifier = deps.Notifier
-		startup.Version = deps.MetaVersion
 		startup.UpdateOnStart = &deps.UpdateOnStart
 		deps.WriteStartupMessage(startup)
 	}

--- a/internal/scheduling/scheduling_test.go
+++ b/internal/scheduling/scheduling_test.go
@@ -8,8 +8,6 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -17,6 +15,7 @@ import (
 	dockerNetwork "github.com/moby/moby/api/types/network"
 
 	mockActions "github.com/nicholas-fedor/watchtower/internal/actions/mocks"
+	"github.com/nicholas-fedor/watchtower/internal/logging"
 	"github.com/nicholas-fedor/watchtower/internal/metrics"
 	"github.com/nicholas-fedor/watchtower/internal/scheduling"
 	"github.com/nicholas-fedor/watchtower/pkg/container"
@@ -107,46 +106,43 @@ func TestWaitForRunningUpdate(t *testing.T) {
 }
 
 func TestRunUpgradesOnSchedule_EmptySchedule(t *testing.T) {
-	cmd := &cobra.Command{}
 	client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
 
 	ctx := t.Context()
-
-	cmd.Flags().Bool("update-on-start", false, "")
 
 	runUpdatesWithNotifications := func(_ context.Context, _ types.Filter, _ types.UpdateParams) *metrics.Metric {
 		return &metrics.Metric{Scanned: 1, Updated: 0, Failed: 0}
 	}
 
-	writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {}
+	writeStartupMessage := func(logging.StartupParams) {}
 
 	// Use timeout to avoid hanging
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 	defer timeoutCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(
-		timeoutCtx,
-		cmd,
-		filters.NoFilter,
-		"test filter",
-		nil,   // no lock
-		false, // cleanup
-		"",    // empty schedule
-		writeStartupMessage,
-		runUpdatesWithNotifications,
-		client,
-		"",  // scope
-		nil, // no notifier
-		"v1.0.0",
-		false, // monitorOnly
-		false, // updateOnStart
-		false, // skipFirstRun
-		nil,   // currentWatchtowerContainer
-		false, // startupMessageSent
-		false, // ephemeralSelfUpdate
-		false, // reviveStopped
-		false, // useComposeDependsOn
-	)
+	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
+		Filter:                     filters.NoFilter,
+		FilterDesc:                 "test filter",
+		Lock:                       nil,
+		ScheduleSpec:               "",
+		WriteStartupMessage:        writeStartupMessage,
+		RunUpdate:                  runUpdatesWithNotifications,
+		Client:                     client,
+		Scope:                      "",
+		Notifier:                   nil,
+		MetaVersion:                "v1.0.0",
+		UpdateOnStart:              false,
+		SkipFirstRun:               false,
+		CurrentWatchtowerContainer: nil,
+		StartupMessageSent:         false,
+		BaseParams: types.UpdateParams{
+			Cleanup:             false,
+			MonitorOnly:         false,
+			EphemeralSelfUpdate: false,
+			ReviveStopped:       false,
+			UseComposeDependsOn: false,
+		},
+	})
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -154,12 +150,9 @@ func TestRunUpgradesOnSchedule_EmptySchedule(t *testing.T) {
 }
 
 func TestRunUpgradesOnSchedule_StartupMessageSuppressed(t *testing.T) {
-	cmd := &cobra.Command{}
 	client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
 
 	ctx := t.Context()
-
-	cmd.Flags().Bool("update-on-start", false, "")
 
 	runUpdatesWithNotifications := func(_ context.Context, _ types.Filter, _ types.UpdateParams) *metrics.Metric {
 		return &metrics.Metric{Scanned: 1, Updated: 0, Failed: 0}
@@ -167,7 +160,7 @@ func TestRunUpgradesOnSchedule_StartupMessageSuppressed(t *testing.T) {
 
 	// Spy closure to detect if writeStartupMessage is called
 	startupMessageCalled := false
-	writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {
+	writeStartupMessage := func(logging.StartupParams) {
 		startupMessageCalled = true
 	}
 
@@ -175,29 +168,29 @@ func TestRunUpgradesOnSchedule_StartupMessageSuppressed(t *testing.T) {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 	defer timeoutCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(
-		timeoutCtx,
-		cmd,
-		filters.NoFilter,
-		"test filter",
-		nil,   // no lock
-		false, // cleanup
-		"",    // empty schedule
-		writeStartupMessage,
-		runUpdatesWithNotifications,
-		client,
-		"",  // scope
-		nil, // no notifier
-		"v1.0.0",
-		false, // monitorOnly
-		false, // updateOnStart
-		false, // skipFirstRun
-		nil,   // currentWatchtowerContainer
-		true,  // startupMessageSent - suppress the startup message
-		false, // ephemeralSelfUpdate
-		false, // reviveStopped
-		false, // useComposeDependsOn
-	)
+	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
+		Filter:                     filters.NoFilter,
+		FilterDesc:                 "test filter",
+		Lock:                       nil,
+		ScheduleSpec:               "",
+		WriteStartupMessage:        writeStartupMessage,
+		RunUpdate:                  runUpdatesWithNotifications,
+		Client:                     client,
+		Scope:                      "",
+		Notifier:                   nil,
+		MetaVersion:                "v1.0.0",
+		UpdateOnStart:              false,
+		SkipFirstRun:               false,
+		CurrentWatchtowerContainer: nil,
+		StartupMessageSent:         true, // suppress the startup message
+		BaseParams: types.UpdateParams{
+			Cleanup:             false,
+			MonitorOnly:         false,
+			EphemeralSelfUpdate: false,
+			ReviveStopped:       false,
+			UseComposeDependsOn: false,
+		},
+	})
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -210,12 +203,9 @@ func TestRunUpgradesOnSchedule_StartupMessageSuppressed(t *testing.T) {
 }
 
 func TestRunUpgradesOnSchedule_UpdateOnStart(t *testing.T) {
-	cmd := &cobra.Command{}
 	client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
 
 	ctx := t.Context()
-
-	cmd.PersistentFlags().Bool("update-on-start", true, "")
 
 	updateCalled := false
 	runUpdatesWithNotifications := func(_ context.Context, _ types.Filter, _ types.UpdateParams) *metrics.Metric {
@@ -224,35 +214,35 @@ func TestRunUpgradesOnSchedule_UpdateOnStart(t *testing.T) {
 		return &metrics.Metric{Scanned: 1, Updated: 1, Failed: 0}
 	}
 
-	writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {}
+	writeStartupMessage := func(logging.StartupParams) {}
 
 	// Use timeout to avoid hanging
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 	defer timeoutCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(
-		timeoutCtx,
-		cmd,
-		filters.NoFilter,
-		"test filter",
-		nil,
-		false,
-		"", // no schedule
-		writeStartupMessage,
-		runUpdatesWithNotifications,
-		client,
-		"",
-		nil,
-		"v1.0.0",
-		false, // monitorOnly
-		true,  // updateOnStart
-		false, // skipFirstRun
-		nil,   // currentWatchtowerContainer
-		false, // startupMessageSent
-		false, // ephemeralSelfUpdate
-		false, // reviveStopped
-		false, // useComposeDependsOn
-	)
+	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
+		Filter:                     filters.NoFilter,
+		FilterDesc:                 "test filter",
+		Lock:                       nil,
+		ScheduleSpec:               "",
+		WriteStartupMessage:        writeStartupMessage,
+		RunUpdate:                  runUpdatesWithNotifications,
+		Client:                     client,
+		Scope:                      "",
+		Notifier:                   nil,
+		MetaVersion:                "v1.0.0",
+		UpdateOnStart:              true,
+		SkipFirstRun:               false,
+		CurrentWatchtowerContainer: nil,
+		StartupMessageSent:         false,
+		BaseParams: types.UpdateParams{
+			Cleanup:             false,
+			MonitorOnly:         false,
+			EphemeralSelfUpdate: false,
+			ReviveStopped:       false,
+			UseComposeDependsOn: false,
+		},
+	})
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
@@ -280,7 +270,6 @@ func TestWaitForRunningUpdate_NoUpdateRunning(t *testing.T) {
 }
 
 func TestRunUpgradesOnSchedule_InvalidCronSpec(t *testing.T) {
-	cmd := &cobra.Command{}
 	client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
 
 	ctx := t.Context()
@@ -289,31 +278,31 @@ func TestRunUpgradesOnSchedule_InvalidCronSpec(t *testing.T) {
 		return &metrics.Metric{Scanned: 0, Updated: 0, Failed: 0}
 	}
 
-	writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {}
+	writeStartupMessage := func(logging.StartupParams) {}
 
-	err := scheduling.RunUpgradesOnSchedule(
-		ctx,
-		cmd,
-		filters.NoFilter,
-		"test filter",
-		nil,
-		false,
-		"invalid cron spec",
-		writeStartupMessage,
-		runUpdatesWithNotifications,
-		client,
-		"",
-		nil,
-		"v1.0.0",
-		false, // monitorOnly
-		false, // updateOnStart
-		false, // skipFirstRun
-		nil,   // currentWatchtowerContainer
-		false, // startupMessageSent
-		false, // ephemeralSelfUpdate
-		false, // reviveStopped
-		false, // useComposeDependsOn
-	)
+	err := scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
+		Filter:                     filters.NoFilter,
+		FilterDesc:                 "test filter",
+		Lock:                       nil,
+		ScheduleSpec:               "invalid cron spec",
+		WriteStartupMessage:        writeStartupMessage,
+		RunUpdate:                  runUpdatesWithNotifications,
+		Client:                     client,
+		Scope:                      "",
+		Notifier:                   nil,
+		MetaVersion:                "v1.0.0",
+		UpdateOnStart:              false,
+		SkipFirstRun:               false,
+		CurrentWatchtowerContainer: nil,
+		StartupMessageSent:         false,
+		BaseParams: types.UpdateParams{
+			Cleanup:             false,
+			MonitorOnly:         false,
+			EphemeralSelfUpdate: false,
+			ReviveStopped:       false,
+			UseComposeDependsOn: false,
+		},
+	})
 	if err == nil {
 		t.Error("expected error")
 	}
@@ -363,7 +352,6 @@ func TestRunUpgradesOnSchedule_QuotedScheduleSpec(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := &cobra.Command{}
 			client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
 
 			ctx := t.Context()
@@ -372,34 +360,34 @@ func TestRunUpgradesOnSchedule_QuotedScheduleSpec(t *testing.T) {
 				return &metrics.Metric{Scanned: 0, Updated: 0, Failed: 0}
 			}
 
-			writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {}
+			writeStartupMessage := func(logging.StartupParams) {}
 
 			timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 			defer timeoutCancel()
 
-			err := scheduling.RunUpgradesOnSchedule(
-				timeoutCtx,
-				cmd,
-				filters.NoFilter,
-				"test filter",
-				nil,
-				false,
-				tt.scheduleSpec,
-				writeStartupMessage,
-				runUpdatesWithNotifications,
-				client,
-				"",
-				nil,
-				"v1.0.0",
-				false, // monitorOnly
-				false, // updateOnStart
-				true,  // skipFirstRun - should skip Watchtower self-update on first run
-				nil,   // currentWatchtowerContainer
-				false, // startupMessageSent
-				false, // ephemeralSelfUpdate
-				false, // reviveStopped
-				false, // useComposeDependsOn
-			)
+			err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
+				Filter:                     filters.NoFilter,
+				FilterDesc:                 "test filter",
+				Lock:                       nil,
+				ScheduleSpec:               tt.scheduleSpec,
+				WriteStartupMessage:        writeStartupMessage,
+				RunUpdate:                  runUpdatesWithNotifications,
+				Client:                     client,
+				Scope:                      "",
+				Notifier:                   nil,
+				MetaVersion:                "v1.0.0",
+				UpdateOnStart:              false,
+				SkipFirstRun:               true, // should skip Watchtower self-update on first run
+				CurrentWatchtowerContainer: nil,
+				StartupMessageSent:         false,
+				BaseParams: types.UpdateParams{
+					Cleanup:             false,
+					MonitorOnly:         false,
+					EphemeralSelfUpdate: false,
+					ReviveStopped:       false,
+					UseComposeDependsOn: false,
+				},
+			})
 
 			if tt.expectError {
 				if err == nil {
@@ -415,7 +403,6 @@ func TestRunUpgradesOnSchedule_QuotedScheduleSpec(t *testing.T) {
 }
 
 func TestRunUpgradesOnSchedule_ContextCancellation(t *testing.T) {
-	cmd := &cobra.Command{}
 	client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
 
 	ctx := t.Context()
@@ -424,35 +411,35 @@ func TestRunUpgradesOnSchedule_ContextCancellation(t *testing.T) {
 		return &metrics.Metric{Scanned: 0, Updated: 0, Failed: 0}
 	}
 
-	writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {}
+	writeStartupMessage := func(logging.StartupParams) {}
 
 	// Cancel immediately
 	canceledCtx, cancelFunc := context.WithCancel(ctx)
 	cancelFunc()
 
-	err := scheduling.RunUpgradesOnSchedule(
-		canceledCtx,
-		cmd,
-		filters.NoFilter,
-		"test filter",
-		nil,
-		false,
-		"",
-		writeStartupMessage,
-		runUpdatesWithNotifications,
-		client,
-		"",
-		nil,
-		"v1.0.0",
-		false, // monitorOnly
-		false, // updateOnStart
-		false, // skipFirstRun
-		nil,   // currentWatchtowerContainer
-		false, // startupMessageSent
-		false, // ephemeralSelfUpdate
-		false, // reviveStopped
-		false, // useComposeDependsOn
-	)
+	err := scheduling.RunUpgradesOnSchedule(canceledCtx, scheduling.ScheduleDeps{
+		Filter:                     filters.NoFilter,
+		FilterDesc:                 "test filter",
+		Lock:                       nil,
+		ScheduleSpec:               "",
+		WriteStartupMessage:        writeStartupMessage,
+		RunUpdate:                  runUpdatesWithNotifications,
+		Client:                     client,
+		Scope:                      "",
+		Notifier:                   nil,
+		MetaVersion:                "v1.0.0",
+		UpdateOnStart:              false,
+		SkipFirstRun:               false,
+		CurrentWatchtowerContainer: nil,
+		StartupMessageSent:         false,
+		BaseParams: types.UpdateParams{
+			Cleanup:             false,
+			MonitorOnly:         false,
+			EphemeralSelfUpdate: false,
+			ReviveStopped:       false,
+			UseComposeDependsOn: false,
+		},
+	})
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
@@ -478,7 +465,6 @@ func TestRunUpgradesOnSchedule_MonitorOnlyParameter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := &cobra.Command{}
 			client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
 
 			ctx := t.Context()
@@ -491,35 +477,35 @@ func TestRunUpgradesOnSchedule_MonitorOnlyParameter(t *testing.T) {
 				return &metrics.Metric{Scanned: 1, Updated: 0, Failed: 0}
 			}
 
-			writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {}
+			writeStartupMessage := func(logging.StartupParams) {}
 
 			// Use timeout to avoid hanging
 			timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 			defer timeoutCancel()
 
-			err := scheduling.RunUpgradesOnSchedule(
-				timeoutCtx,
-				cmd,
-				filters.NoFilter,
-				"test filter",
-				nil,   // no lock
-				false, // cleanup
-				"",    // empty schedule
-				writeStartupMessage,
-				runUpdatesWithNotifications,
-				client,
-				"",  // scope
-				nil, // no notifier
-				"v1.0.0",
-				tt.monitorOnly, // monitorOnly parameter
-				true,           // updateOnStart - trigger immediate update
-				false,          // skipFirstRun
-				nil,            // currentWatchtowerContainer
-				false,          // startupMessageSent
-				false,          // ephemeralSelfUpdate
-				false,          // reviveStopped
-				false,          // useComposeDependsOn
-			)
+			err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
+				Filter:                     filters.NoFilter,
+				FilterDesc:                 "test filter",
+				Lock:                       nil,
+				ScheduleSpec:               "",
+				WriteStartupMessage:        writeStartupMessage,
+				RunUpdate:                  runUpdatesWithNotifications,
+				Client:                     client,
+				Scope:                      "",
+				Notifier:                   nil,
+				MetaVersion:                "v1.0.0",
+				UpdateOnStart:              true, // trigger immediate update
+				SkipFirstRun:               false,
+				CurrentWatchtowerContainer: nil,
+				StartupMessageSent:         false,
+				BaseParams: types.UpdateParams{
+					Cleanup:             false,
+					MonitorOnly:         tt.monitorOnly,
+					EphemeralSelfUpdate: false,
+					ReviveStopped:       false,
+					UseComposeDependsOn: false,
+				},
+			})
 			if err != nil {
 				t.Errorf("expected no error, got %v", err)
 			}
@@ -596,14 +582,9 @@ func TestShouldExitDueToInvalidRestart(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create flag set
-			flagSet := &pflag.FlagSet{}
-			flagSet.Bool("run-once", tt.runOnceFlag, "")
-
-			// Test the function
 			shouldExit := scheduling.ShouldExitDueToInvalidRestart(
 				tt.container,
-				flagSet,
+				tt.runOnceFlag,
 			)
 
 			assert.Equal(t, tt.expectedExit, shouldExit)
@@ -612,7 +593,6 @@ func TestShouldExitDueToInvalidRestart(t *testing.T) {
 }
 
 func TestRunUpgradesOnSchedule_CronWithSeconds(t *testing.T) {
-	cmd := &cobra.Command{}
 	client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
 
 	ctx := t.Context()
@@ -624,7 +604,7 @@ func TestRunUpgradesOnSchedule_CronWithSeconds(t *testing.T) {
 		return &metrics.Metric{Scanned: 1, Updated: 0, Failed: 0}
 	}
 
-	writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {}
+	writeStartupMessage := func(logging.StartupParams) {}
 
 	// Use a 6-field cron spec that includes seconds (every 2 seconds)
 	scheduleSpec := "*/2 * * * * *"
@@ -633,29 +613,29 @@ func TestRunUpgradesOnSchedule_CronWithSeconds(t *testing.T) {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer timeoutCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(
-		timeoutCtx,
-		cmd,
-		filters.NoFilter,
-		"test filter",
-		nil,   // no lock
-		false, // cleanup
-		scheduleSpec,
-		writeStartupMessage,
-		runUpdatesWithNotifications,
-		client,
-		"",  // scope
-		nil, // no notifier
-		"v1.0.0",
-		false, // monitorOnly
-		false, // updateOnStart
-		false, // skipFirstRun
-		nil,   // currentWatchtowerContainer
-		false, // startupMessageSent
-		false, // ephemeralSelfUpdate
-		false, // reviveStopped
-		false, // useComposeDependsOn
-	)
+	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
+		Filter:                     filters.NoFilter,
+		FilterDesc:                 "test filter",
+		Lock:                       nil,
+		ScheduleSpec:               scheduleSpec,
+		WriteStartupMessage:        writeStartupMessage,
+		RunUpdate:                  runUpdatesWithNotifications,
+		Client:                     client,
+		Scope:                      "",
+		Notifier:                   nil,
+		MetaVersion:                "v1.0.0",
+		UpdateOnStart:              false,
+		SkipFirstRun:               false,
+		CurrentWatchtowerContainer: nil,
+		StartupMessageSent:         false,
+		BaseParams: types.UpdateParams{
+			Cleanup:             false,
+			MonitorOnly:         false,
+			EphemeralSelfUpdate: false,
+			ReviveStopped:       false,
+			UseComposeDependsOn: false,
+		},
+	})
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -668,7 +648,6 @@ func TestRunUpgradesOnSchedule_CronWithSeconds(t *testing.T) {
 }
 
 func TestRunUpgradesOnSchedule_SkipFirstRun_True(t *testing.T) {
-	cmd := &cobra.Command{}
 	client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
 
 	ctx := t.Context()
@@ -681,7 +660,7 @@ func TestRunUpgradesOnSchedule_SkipFirstRun_True(t *testing.T) {
 		return &metrics.Metric{Scanned: 1, Updated: 0, Failed: 0}
 	}
 
-	writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {}
+	writeStartupMessage := func(logging.StartupParams) {}
 
 	// Use a cron spec that runs every second
 	scheduleSpec := "* * * * * *"
@@ -690,29 +669,29 @@ func TestRunUpgradesOnSchedule_SkipFirstRun_True(t *testing.T) {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 3500*time.Millisecond)
 	defer timeoutCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(
-		timeoutCtx,
-		cmd,
-		filters.NoFilter,
-		"test filter",
-		nil,   // no lock
-		false, // cleanup
-		scheduleSpec,
-		writeStartupMessage,
-		runUpdatesWithNotifications,
-		client,
-		"",  // scope
-		nil, // no notifier
-		"v1.0.0",
-		false, // monitorOnly
-		false, // updateOnStart
-		true,  // skipFirstRun - should skip Watchtower self-update on first run
-		nil,   // currentWatchtowerContainer
-		false, // startupMessageSent
-		false, // ephemeralSelfUpdate
-		false, // reviveStopped
-		false, // useComposeDependsOn
-	)
+	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
+		Filter:                     filters.NoFilter,
+		FilterDesc:                 "test filter",
+		Lock:                       nil,
+		ScheduleSpec:               scheduleSpec,
+		WriteStartupMessage:        writeStartupMessage,
+		RunUpdate:                  runUpdatesWithNotifications,
+		Client:                     client,
+		Scope:                      "",
+		Notifier:                   nil,
+		MetaVersion:                "v1.0.0",
+		UpdateOnStart:              false,
+		SkipFirstRun:               true, // should skip Watchtower self-update on first run
+		CurrentWatchtowerContainer: nil,
+		StartupMessageSent:         false,
+		BaseParams: types.UpdateParams{
+			Cleanup:             false,
+			MonitorOnly:         false,
+			EphemeralSelfUpdate: false,
+			ReviveStopped:       false,
+			UseComposeDependsOn: false,
+		},
+	})
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -735,7 +714,6 @@ func TestRunUpgradesOnSchedule_SkipFirstRun_True(t *testing.T) {
 }
 
 func TestRunUpgradesOnSchedule_WatchtowerParent_Skipping(t *testing.T) {
-	cmd := &cobra.Command{}
 	client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
 
 	ctx := t.Context()
@@ -747,7 +725,7 @@ func TestRunUpgradesOnSchedule_WatchtowerParent_Skipping(t *testing.T) {
 		return &metrics.Metric{Scanned: 1, Updated: 0, Failed: 0}
 	}
 
-	writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {}
+	writeStartupMessage := func(logging.StartupParams) {}
 
 	// Create a mock Watchtower parent container
 	parentContainer := createTestContainer("test-container-id,parent-id")
@@ -759,29 +737,29 @@ func TestRunUpgradesOnSchedule_WatchtowerParent_Skipping(t *testing.T) {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 2500*time.Millisecond)
 	defer timeoutCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(
-		timeoutCtx,
-		cmd,
-		filters.NoFilter,
-		"test filter",
-		nil,   // no lock
-		false, // cleanup
-		scheduleSpec,
-		writeStartupMessage,
-		runUpdatesWithNotifications,
-		client,
-		"",  // scope
-		nil, // no notifier
-		"v1.0.0",
-		false,           // monitorOnly
-		false,           // updateOnStart
-		false,           // skipFirstRun
-		parentContainer, // currentWatchtowerContainer - should skip updates
-		false,           // startupMessageSent
-		false,           // ephemeralSelfUpdate
-		false,           // reviveStopped
-		false,           // useComposeDependsOn
-	)
+	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
+		Filter:                     filters.NoFilter,
+		FilterDesc:                 "test filter",
+		Lock:                       nil,
+		ScheduleSpec:               scheduleSpec,
+		WriteStartupMessage:        writeStartupMessage,
+		RunUpdate:                  runUpdatesWithNotifications,
+		Client:                     client,
+		Scope:                      "",
+		Notifier:                   nil,
+		MetaVersion:                "v1.0.0",
+		UpdateOnStart:              false,
+		SkipFirstRun:               false,
+		CurrentWatchtowerContainer: parentContainer, // should skip updates
+		StartupMessageSent:         false,
+		BaseParams: types.UpdateParams{
+			Cleanup:             false,
+			MonitorOnly:         false,
+			EphemeralSelfUpdate: false,
+			ReviveStopped:       false,
+			UseComposeDependsOn: false,
+		},
+	})
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -797,7 +775,6 @@ func TestRunUpgradesOnSchedule_WatchtowerParent_Skipping(t *testing.T) {
 }
 
 func TestRunUpgradesOnSchedule_ScheduledRuns_Execution(t *testing.T) {
-	cmd := &cobra.Command{}
 	client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
 
 	ctx := t.Context()
@@ -810,7 +787,7 @@ func TestRunUpgradesOnSchedule_ScheduledRuns_Execution(t *testing.T) {
 		return &metrics.Metric{Scanned: 1, Updated: 0, Failed: 0}
 	}
 
-	writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {}
+	writeStartupMessage := func(logging.StartupParams) {}
 
 	// Use a cron spec that runs every 1 second
 	scheduleSpec := "*/1 * * * * *"
@@ -821,29 +798,29 @@ func TestRunUpgradesOnSchedule_ScheduledRuns_Execution(t *testing.T) {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 2500*time.Millisecond)
 	defer timeoutCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(
-		timeoutCtx,
-		cmd,
-		filters.NoFilter,
-		"test filter",
-		nil,   // no lock
-		false, // cleanup
-		scheduleSpec,
-		writeStartupMessage,
-		runUpdatesWithNotifications,
-		client,
-		"",  // scope
-		nil, // no notifier
-		"v1.0.0",
-		false, // monitorOnly
-		false, // updateOnStart
-		false, // skipFirstRun
-		nil,   // currentWatchtowerContainer
-		false, // startupMessageSent
-		false, // ephemeralSelfUpdate
-		false, // reviveStopped
-		false, // useComposeDependsOn
-	)
+	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
+		Filter:                     filters.NoFilter,
+		FilterDesc:                 "test filter",
+		Lock:                       nil,
+		ScheduleSpec:               scheduleSpec,
+		WriteStartupMessage:        writeStartupMessage,
+		RunUpdate:                  runUpdatesWithNotifications,
+		Client:                     client,
+		Scope:                      "",
+		Notifier:                   nil,
+		MetaVersion:                "v1.0.0",
+		UpdateOnStart:              false,
+		SkipFirstRun:               false,
+		CurrentWatchtowerContainer: nil,
+		StartupMessageSent:         false,
+		BaseParams: types.UpdateParams{
+			Cleanup:             false,
+			MonitorOnly:         false,
+			EphemeralSelfUpdate: false,
+			ReviveStopped:       false,
+			UseComposeDependsOn: false,
+		},
+	})
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -876,7 +853,6 @@ func TestRunUpgradesOnSchedule_ScheduledRuns_Execution(t *testing.T) {
 // proceed because they remove the old container before creating the new one,
 // avoiding port conflicts.
 func TestRunUpgradesOnSchedule_EphemeralSelfUpdateWithExposedPorts(t *testing.T) {
-	cmd := &cobra.Command{}
 	client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
 
 	ctx := t.Context()
@@ -889,9 +865,7 @@ func TestRunUpgradesOnSchedule_EphemeralSelfUpdateWithExposedPorts(t *testing.T)
 		return &metrics.Metric{Scanned: 1, Updated: 0, Failed: 0}
 	}
 
-	writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {}
-
-	cmd.PersistentFlags().Bool("update-on-start", true, "")
+	writeStartupMessage := func(logging.StartupParams) {}
 
 	// Create a Watchtower container with exposed ports (host-bound port mappings).
 	containerWithPorts := createTestContainer("", withPortBindings())
@@ -903,29 +877,29 @@ func TestRunUpgradesOnSchedule_EphemeralSelfUpdateWithExposedPorts(t *testing.T)
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 	defer timeoutCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(
-		timeoutCtx,
-		cmd,
-		filters.NoFilter,
-		"test filter",
-		nil,   // no lock
-		false, // cleanup
-		"",    // empty schedule
-		writeStartupMessage,
-		runUpdatesWithNotifications,
-		client,
-		"",  // scope
-		nil, // no notifier
-		"v1.0.0",
-		false,              // monitorOnly
-		true,               // updateOnStart - triggers immediate update
-		false,              // skipFirstRun
-		containerWithPorts, // currentWatchtowerContainer with exposed ports
-		false,              // startupMessageSent
-		true,               // ephemeralSelfUpdate - bypasses port-conflict guard
-		false,              // reviveStopped
-		false,              // useComposeDependsOn
-	)
+	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
+		Filter:                     filters.NoFilter,
+		FilterDesc:                 "test filter",
+		Lock:                       nil,
+		ScheduleSpec:               "",
+		WriteStartupMessage:        writeStartupMessage,
+		RunUpdate:                  runUpdatesWithNotifications,
+		Client:                     client,
+		Scope:                      "",
+		Notifier:                   nil,
+		MetaVersion:                "v1.0.0",
+		UpdateOnStart:              true, // triggers immediate update
+		SkipFirstRun:               false,
+		CurrentWatchtowerContainer: containerWithPorts, // with exposed ports
+		StartupMessageSent:         false,
+		BaseParams: types.UpdateParams{
+			Cleanup:             false,
+			MonitorOnly:         false,
+			EphemeralSelfUpdate: true, // bypasses port-conflict guard
+			ReviveStopped:       false,
+			UseComposeDependsOn: false,
+		},
+	})
 	require.NoError(t, err)
 
 	// With ephemeralSelfUpdate=true, the port-conflict guard should be bypassed,
@@ -941,7 +915,6 @@ func TestRunUpgradesOnSchedule_EphemeralSelfUpdateWithExposedPorts(t *testing.T)
 // port-conflict guard forces SkipSelfUpdate to true to prevent the old container
 // from holding the port while the new container tries to bind it.
 func TestRunUpgradesOnSchedule_PortConflictGuard_SkipsSelfUpdate(t *testing.T) {
-	cmd := &cobra.Command{}
 	client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
 
 	ctx := t.Context()
@@ -954,9 +927,7 @@ func TestRunUpgradesOnSchedule_PortConflictGuard_SkipsSelfUpdate(t *testing.T) {
 		return &metrics.Metric{Scanned: 1, Updated: 0, Failed: 0}
 	}
 
-	writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {}
-
-	cmd.PersistentFlags().Bool("update-on-start", true, "")
+	writeStartupMessage := func(logging.StartupParams) {}
 
 	// Create a Watchtower container with exposed ports (host-bound port mappings).
 	containerWithPorts := createTestContainer("", withPortBindings())
@@ -968,29 +939,29 @@ func TestRunUpgradesOnSchedule_PortConflictGuard_SkipsSelfUpdate(t *testing.T) {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 	defer timeoutCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(
-		timeoutCtx,
-		cmd,
-		filters.NoFilter,
-		"test filter",
-		nil,   // lock (auto-created)
-		false, // cleanup
-		"",    // empty schedule
-		writeStartupMessage,
-		runUpdatesWithNotifications,
-		client,
-		"",  // scope
-		nil, // no notifier
-		"v1.0.0",
-		false,              // monitorOnly
-		true,               // updateOnStart - triggers immediate update
-		false,              // skipFirstRun
-		containerWithPorts, // currentWatchtowerContainer with exposed ports
-		false,              // startupMessageSent
-		false,              // ephemeralSelfUpdate - port-conflict guard is active
-		false,              // reviveStopped
-		false,              // useComposeDependsOn
-	)
+	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
+		Filter:                     filters.NoFilter,
+		FilterDesc:                 "test filter",
+		Lock:                       nil,
+		ScheduleSpec:               "",
+		WriteStartupMessage:        writeStartupMessage,
+		RunUpdate:                  runUpdatesWithNotifications,
+		Client:                     client,
+		Scope:                      "",
+		Notifier:                   nil,
+		MetaVersion:                "v1.0.0",
+		UpdateOnStart:              true, // triggers immediate update
+		SkipFirstRun:               false,
+		CurrentWatchtowerContainer: containerWithPorts, // with exposed ports
+		StartupMessageSent:         false,
+		BaseParams: types.UpdateParams{
+			Cleanup:             false,
+			MonitorOnly:         false,
+			EphemeralSelfUpdate: false, // port-conflict guard is active
+			ReviveStopped:       false,
+			UseComposeDependsOn: false,
+		},
+	})
 	require.NoError(t, err)
 
 	// With ephemeralSelfUpdate=false and exposed ports, the port-conflict guard
@@ -1021,7 +992,6 @@ func TestRunUpgradesOnSchedule_NoExposedPorts_AllowsSelfUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := &cobra.Command{}
 			client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
 
 			ctx := t.Context()
@@ -1034,9 +1004,7 @@ func TestRunUpgradesOnSchedule_NoExposedPorts_AllowsSelfUpdate(t *testing.T) {
 				return &metrics.Metric{Scanned: 1, Updated: 0, Failed: 0}
 			}
 
-			writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {}
-
-			cmd.PersistentFlags().Bool("update-on-start", true, "")
+			writeStartupMessage := func(logging.StartupParams) {}
 
 			// Create a Watchtower container WITHOUT exposed ports.
 			containerNoPorts := createTestContainer("")
@@ -1048,29 +1016,29 @@ func TestRunUpgradesOnSchedule_NoExposedPorts_AllowsSelfUpdate(t *testing.T) {
 			timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 			defer timeoutCancel()
 
-			err := scheduling.RunUpgradesOnSchedule(
-				timeoutCtx,
-				cmd,
-				filters.NoFilter,
-				"test filter",
-				nil,   // lock (auto-created)
-				false, // cleanup
-				"",    // empty schedule
-				writeStartupMessage,
-				runUpdatesWithNotifications,
-				client,
-				"",  // scope
-				nil, // no notifier
-				"v1.0.0",
-				false,            // monitorOnly
-				true,             // updateOnStart - triggers immediate update
-				false,            // skipFirstRun
-				containerNoPorts, // currentWatchtowerContainer without exposed ports
-				false,            // startupMessageSent
-				tt.ephemeralSelfUpdate,
-				false, // reviveStopped
-				false, // useComposeDependsOn
-			)
+			err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
+				Filter:                     filters.NoFilter,
+				FilterDesc:                 "test filter",
+				Lock:                       nil,
+				ScheduleSpec:               "",
+				WriteStartupMessage:        writeStartupMessage,
+				RunUpdate:                  runUpdatesWithNotifications,
+				Client:                     client,
+				Scope:                      "",
+				Notifier:                   nil,
+				MetaVersion:                "v1.0.0",
+				UpdateOnStart:              true, // triggers immediate update
+				SkipFirstRun:               false,
+				CurrentWatchtowerContainer: containerNoPorts, // without exposed ports
+				StartupMessageSent:         false,
+				BaseParams: types.UpdateParams{
+					Cleanup:             false,
+					MonitorOnly:         false,
+					EphemeralSelfUpdate: tt.ephemeralSelfUpdate,
+					ReviveStopped:       false,
+					UseComposeDependsOn: false,
+				},
+			})
 			require.NoError(t, err)
 
 			// Without exposed ports, the port-conflict guard should not trigger,
@@ -1104,7 +1072,6 @@ func TestRunUpgradesOnSchedule_ReviveStoppedPropagation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := &cobra.Command{}
 			client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
 
 			ctx := t.Context()
@@ -1117,36 +1084,34 @@ func TestRunUpgradesOnSchedule_ReviveStoppedPropagation(t *testing.T) {
 				return &metrics.Metric{Scanned: 1, Updated: 0, Failed: 0}
 			}
 
-			writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {}
-
-			cmd.PersistentFlags().Bool("update-on-start", true, "")
+			writeStartupMessage := func(logging.StartupParams) {}
 
 			timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 			defer timeoutCancel()
 
-			err := scheduling.RunUpgradesOnSchedule(
-				timeoutCtx,
-				cmd,
-				filters.NoFilter,
-				"test filter",
-				nil,   // lock (auto-created)
-				false, // cleanup
-				"",    // empty schedule
-				writeStartupMessage,
-				runUpdatesWithNotifications,
-				client,
-				"",  // scope
-				nil, // no notifier
-				"v1.0.0",
-				false,            // monitorOnly
-				true,             // updateOnStart - triggers immediate update
-				false,            // skipFirstRun
-				nil,              // currentWatchtowerContainer
-				false,            // startupMessageSent
-				false,            // ephemeralSelfUpdate
-				tt.reviveStopped, // reviveStopped
-				false,            // useComposeDependsOn
-			)
+			err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
+				Filter:                     filters.NoFilter,
+				FilterDesc:                 "test filter",
+				Lock:                       nil,
+				ScheduleSpec:               "",
+				WriteStartupMessage:        writeStartupMessage,
+				RunUpdate:                  runUpdatesWithNotifications,
+				Client:                     client,
+				Scope:                      "",
+				Notifier:                   nil,
+				MetaVersion:                "v1.0.0",
+				UpdateOnStart:              true, // triggers immediate update
+				SkipFirstRun:               false,
+				CurrentWatchtowerContainer: nil,
+				StartupMessageSent:         false,
+				BaseParams: types.UpdateParams{
+					Cleanup:             false,
+					MonitorOnly:         false,
+					EphemeralSelfUpdate: false,
+					ReviveStopped:       tt.reviveStopped,
+					UseComposeDependsOn: false,
+				},
+			})
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.expectSelected, capturedParams.ReviveStopped,
@@ -1178,7 +1143,6 @@ func TestRunUpgradesOnSchedule_UseComposeDependsOnPropagation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := &cobra.Command{}
 			client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
 
 			ctx := t.Context()
@@ -1191,36 +1155,34 @@ func TestRunUpgradesOnSchedule_UseComposeDependsOnPropagation(t *testing.T) {
 				return &metrics.Metric{Scanned: 1, Updated: 0, Failed: 0}
 			}
 
-			writeStartupMessage := func(*cobra.Command, time.Time, string, string, container.Client, types.Notifier, string, *bool) {}
-
-			cmd.PersistentFlags().Bool("update-on-start", true, "")
+			writeStartupMessage := func(logging.StartupParams) {}
 
 			timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 			defer timeoutCancel()
 
-			err := scheduling.RunUpgradesOnSchedule(
-				timeoutCtx,
-				cmd,
-				filters.NoFilter,
-				"test filter",
-				nil,   // lock (auto-created)
-				false, // cleanup
-				"",    // empty schedule
-				writeStartupMessage,
-				runUpdatesWithNotifications,
-				client,
-				"",  // scope
-				nil, // no notifier
-				"v1.0.0",
-				false,                  // monitorOnly
-				true,                   // updateOnStart - triggers immediate update
-				false,                  // skipFirstRun
-				nil,                    // currentWatchtowerContainer
-				false,                  // startupMessageSent
-				false,                  // ephemeralSelfUpdate
-				false,                  // reviveStopped
-				tt.useComposeDependsOn, // useComposeDependsOn
-			)
+			err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
+				Filter:                     filters.NoFilter,
+				FilterDesc:                 "test filter",
+				Lock:                       nil,
+				ScheduleSpec:               "",
+				WriteStartupMessage:        writeStartupMessage,
+				RunUpdate:                  runUpdatesWithNotifications,
+				Client:                     client,
+				Scope:                      "",
+				Notifier:                   nil,
+				MetaVersion:                "v1.0.0",
+				UpdateOnStart:              true, // triggers immediate update
+				SkipFirstRun:               false,
+				CurrentWatchtowerContainer: nil,
+				StartupMessageSent:         false,
+				BaseParams: types.UpdateParams{
+					Cleanup:             false,
+					MonitorOnly:         false,
+					EphemeralSelfUpdate: false,
+					ReviveStopped:       false,
+					UseComposeDependsOn: tt.useComposeDependsOn,
+				},
+			})
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.expectSelected, capturedParams.UseComposeDependsOn,

--- a/internal/scheduling/scheduling_test.go
+++ b/internal/scheduling/scheduling_test.go
@@ -73,6 +73,24 @@ func createTestContainer(chain string, opts ...testContainerOption) *container.C
 	return container.NewContainer(inspectResponse, nil)
 }
 
+// testDeps returns ScheduleDeps with common test defaults.
+// Callers override ScheduleSpec, UpdateOnStart, SkipFirstRun, containers, and BaseParams as needed.
+func testDeps(
+	client container.Client,
+	runUpdate func(context.Context, types.Filter, types.UpdateParams) *metrics.Metric,
+	writeStartup func(logging.StartupParams),
+) scheduling.ScheduleDeps {
+	return scheduling.ScheduleDeps{
+		Filter:              filters.NoFilter,
+		FilterDesc:          "test filter",
+		WriteStartupMessage: writeStartup,
+		RunUpdate:           runUpdate,
+		Client:              client,
+		MetaVersion:         "v1.0.0",
+		BaseParams:          types.UpdateParams{},
+	}
+}
+
 func TestWaitForRunningUpdate(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -120,29 +138,8 @@ func TestRunUpgradesOnSchedule_EmptySchedule(t *testing.T) {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 	defer timeoutCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
-		Filter:                     filters.NoFilter,
-		FilterDesc:                 "test filter",
-		Lock:                       nil,
-		ScheduleSpec:               "",
-		WriteStartupMessage:        writeStartupMessage,
-		RunUpdate:                  runUpdatesWithNotifications,
-		Client:                     client,
-		Scope:                      "",
-		Notifier:                   nil,
-		MetaVersion:                "v1.0.0",
-		UpdateOnStart:              false,
-		SkipFirstRun:               false,
-		CurrentWatchtowerContainer: nil,
-		StartupMessageSent:         false,
-		BaseParams: types.UpdateParams{
-			Cleanup:             false,
-			MonitorOnly:         false,
-			EphemeralSelfUpdate: false,
-			ReviveStopped:       false,
-			UseComposeDependsOn: false,
-		},
-	})
+	deps := testDeps(client, runUpdatesWithNotifications, writeStartupMessage)
+	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, deps)
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -168,29 +165,9 @@ func TestRunUpgradesOnSchedule_StartupMessageSuppressed(t *testing.T) {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 	defer timeoutCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
-		Filter:                     filters.NoFilter,
-		FilterDesc:                 "test filter",
-		Lock:                       nil,
-		ScheduleSpec:               "",
-		WriteStartupMessage:        writeStartupMessage,
-		RunUpdate:                  runUpdatesWithNotifications,
-		Client:                     client,
-		Scope:                      "",
-		Notifier:                   nil,
-		MetaVersion:                "v1.0.0",
-		UpdateOnStart:              false,
-		SkipFirstRun:               false,
-		CurrentWatchtowerContainer: nil,
-		StartupMessageSent:         true, // suppress the startup message
-		BaseParams: types.UpdateParams{
-			Cleanup:             false,
-			MonitorOnly:         false,
-			EphemeralSelfUpdate: false,
-			ReviveStopped:       false,
-			UseComposeDependsOn: false,
-		},
-	})
+	deps := testDeps(client, runUpdatesWithNotifications, writeStartupMessage)
+	deps.StartupMessageSent = true
+	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, deps)
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -220,29 +197,10 @@ func TestRunUpgradesOnSchedule_UpdateOnStart(t *testing.T) {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 	defer timeoutCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
-		Filter:                     filters.NoFilter,
-		FilterDesc:                 "test filter",
-		Lock:                       nil,
-		ScheduleSpec:               "",
-		WriteStartupMessage:        writeStartupMessage,
-		RunUpdate:                  runUpdatesWithNotifications,
-		Client:                     client,
-		Scope:                      "",
-		Notifier:                   nil,
-		MetaVersion:                "v1.0.0",
-		UpdateOnStart:              true,
-		SkipFirstRun:               false,
-		CurrentWatchtowerContainer: nil,
-		StartupMessageSent:         false,
-		BaseParams: types.UpdateParams{
-			Cleanup:             false,
-			MonitorOnly:         false,
-			EphemeralSelfUpdate: false,
-			ReviveStopped:       false,
-			UseComposeDependsOn: false,
-		},
-	})
+	deps := testDeps(client, runUpdatesWithNotifications, writeStartupMessage)
+	deps.UpdateOnStart = true
+
+	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, deps)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
@@ -280,29 +238,10 @@ func TestRunUpgradesOnSchedule_InvalidCronSpec(t *testing.T) {
 
 	writeStartupMessage := func(logging.StartupParams) {}
 
-	err := scheduling.RunUpgradesOnSchedule(ctx, scheduling.ScheduleDeps{
-		Filter:                     filters.NoFilter,
-		FilterDesc:                 "test filter",
-		Lock:                       nil,
-		ScheduleSpec:               "invalid cron spec",
-		WriteStartupMessage:        writeStartupMessage,
-		RunUpdate:                  runUpdatesWithNotifications,
-		Client:                     client,
-		Scope:                      "",
-		Notifier:                   nil,
-		MetaVersion:                "v1.0.0",
-		UpdateOnStart:              false,
-		SkipFirstRun:               false,
-		CurrentWatchtowerContainer: nil,
-		StartupMessageSent:         false,
-		BaseParams: types.UpdateParams{
-			Cleanup:             false,
-			MonitorOnly:         false,
-			EphemeralSelfUpdate: false,
-			ReviveStopped:       false,
-			UseComposeDependsOn: false,
-		},
-	})
+	deps := testDeps(client, runUpdatesWithNotifications, writeStartupMessage)
+	deps.ScheduleSpec = "invalid cron spec"
+
+	err := scheduling.RunUpgradesOnSchedule(ctx, deps)
 	if err == nil {
 		t.Error("expected error")
 	}
@@ -365,29 +304,10 @@ func TestRunUpgradesOnSchedule_QuotedScheduleSpec(t *testing.T) {
 			timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 			defer timeoutCancel()
 
-			err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
-				Filter:                     filters.NoFilter,
-				FilterDesc:                 "test filter",
-				Lock:                       nil,
-				ScheduleSpec:               tt.scheduleSpec,
-				WriteStartupMessage:        writeStartupMessage,
-				RunUpdate:                  runUpdatesWithNotifications,
-				Client:                     client,
-				Scope:                      "",
-				Notifier:                   nil,
-				MetaVersion:                "v1.0.0",
-				UpdateOnStart:              false,
-				SkipFirstRun:               true, // should skip Watchtower self-update on first run
-				CurrentWatchtowerContainer: nil,
-				StartupMessageSent:         false,
-				BaseParams: types.UpdateParams{
-					Cleanup:             false,
-					MonitorOnly:         false,
-					EphemeralSelfUpdate: false,
-					ReviveStopped:       false,
-					UseComposeDependsOn: false,
-				},
-			})
+			deps := testDeps(client, runUpdatesWithNotifications, writeStartupMessage)
+			deps.ScheduleSpec = tt.scheduleSpec
+			deps.SkipFirstRun = true
+			err := scheduling.RunUpgradesOnSchedule(timeoutCtx, deps)
 
 			if tt.expectError {
 				if err == nil {
@@ -417,29 +337,9 @@ func TestRunUpgradesOnSchedule_ContextCancellation(t *testing.T) {
 	canceledCtx, cancelFunc := context.WithCancel(ctx)
 	cancelFunc()
 
-	err := scheduling.RunUpgradesOnSchedule(canceledCtx, scheduling.ScheduleDeps{
-		Filter:                     filters.NoFilter,
-		FilterDesc:                 "test filter",
-		Lock:                       nil,
-		ScheduleSpec:               "",
-		WriteStartupMessage:        writeStartupMessage,
-		RunUpdate:                  runUpdatesWithNotifications,
-		Client:                     client,
-		Scope:                      "",
-		Notifier:                   nil,
-		MetaVersion:                "v1.0.0",
-		UpdateOnStart:              false,
-		SkipFirstRun:               false,
-		CurrentWatchtowerContainer: nil,
-		StartupMessageSent:         false,
-		BaseParams: types.UpdateParams{
-			Cleanup:             false,
-			MonitorOnly:         false,
-			EphemeralSelfUpdate: false,
-			ReviveStopped:       false,
-			UseComposeDependsOn: false,
-		},
-	})
+	deps := testDeps(client, runUpdatesWithNotifications, writeStartupMessage)
+
+	err := scheduling.RunUpgradesOnSchedule(canceledCtx, deps)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
@@ -483,29 +383,11 @@ func TestRunUpgradesOnSchedule_MonitorOnlyParameter(t *testing.T) {
 			timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 			defer timeoutCancel()
 
-			err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
-				Filter:                     filters.NoFilter,
-				FilterDesc:                 "test filter",
-				Lock:                       nil,
-				ScheduleSpec:               "",
-				WriteStartupMessage:        writeStartupMessage,
-				RunUpdate:                  runUpdatesWithNotifications,
-				Client:                     client,
-				Scope:                      "",
-				Notifier:                   nil,
-				MetaVersion:                "v1.0.0",
-				UpdateOnStart:              true, // trigger immediate update
-				SkipFirstRun:               false,
-				CurrentWatchtowerContainer: nil,
-				StartupMessageSent:         false,
-				BaseParams: types.UpdateParams{
-					Cleanup:             false,
-					MonitorOnly:         tt.monitorOnly,
-					EphemeralSelfUpdate: false,
-					ReviveStopped:       false,
-					UseComposeDependsOn: false,
-				},
-			})
+			deps := testDeps(client, runUpdatesWithNotifications, writeStartupMessage)
+			deps.UpdateOnStart = true
+			deps.BaseParams.MonitorOnly = tt.monitorOnly
+
+			err := scheduling.RunUpgradesOnSchedule(timeoutCtx, deps)
 			if err != nil {
 				t.Errorf("expected no error, got %v", err)
 			}
@@ -613,29 +495,9 @@ func TestRunUpgradesOnSchedule_CronWithSeconds(t *testing.T) {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer timeoutCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
-		Filter:                     filters.NoFilter,
-		FilterDesc:                 "test filter",
-		Lock:                       nil,
-		ScheduleSpec:               scheduleSpec,
-		WriteStartupMessage:        writeStartupMessage,
-		RunUpdate:                  runUpdatesWithNotifications,
-		Client:                     client,
-		Scope:                      "",
-		Notifier:                   nil,
-		MetaVersion:                "v1.0.0",
-		UpdateOnStart:              false,
-		SkipFirstRun:               false,
-		CurrentWatchtowerContainer: nil,
-		StartupMessageSent:         false,
-		BaseParams: types.UpdateParams{
-			Cleanup:             false,
-			MonitorOnly:         false,
-			EphemeralSelfUpdate: false,
-			ReviveStopped:       false,
-			UseComposeDependsOn: false,
-		},
-	})
+	deps := testDeps(client, runUpdatesWithNotifications, writeStartupMessage)
+	deps.ScheduleSpec = scheduleSpec
+	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, deps)
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -669,29 +531,10 @@ func TestRunUpgradesOnSchedule_SkipFirstRun_True(t *testing.T) {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 3500*time.Millisecond)
 	defer timeoutCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
-		Filter:                     filters.NoFilter,
-		FilterDesc:                 "test filter",
-		Lock:                       nil,
-		ScheduleSpec:               scheduleSpec,
-		WriteStartupMessage:        writeStartupMessage,
-		RunUpdate:                  runUpdatesWithNotifications,
-		Client:                     client,
-		Scope:                      "",
-		Notifier:                   nil,
-		MetaVersion:                "v1.0.0",
-		UpdateOnStart:              false,
-		SkipFirstRun:               true, // should skip Watchtower self-update on first run
-		CurrentWatchtowerContainer: nil,
-		StartupMessageSent:         false,
-		BaseParams: types.UpdateParams{
-			Cleanup:             false,
-			MonitorOnly:         false,
-			EphemeralSelfUpdate: false,
-			ReviveStopped:       false,
-			UseComposeDependsOn: false,
-		},
-	})
+	deps := testDeps(client, runUpdatesWithNotifications, writeStartupMessage)
+	deps.ScheduleSpec = scheduleSpec
+	deps.SkipFirstRun = true
+	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, deps)
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -737,29 +580,10 @@ func TestRunUpgradesOnSchedule_WatchtowerParent_Skipping(t *testing.T) {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 2500*time.Millisecond)
 	defer timeoutCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
-		Filter:                     filters.NoFilter,
-		FilterDesc:                 "test filter",
-		Lock:                       nil,
-		ScheduleSpec:               scheduleSpec,
-		WriteStartupMessage:        writeStartupMessage,
-		RunUpdate:                  runUpdatesWithNotifications,
-		Client:                     client,
-		Scope:                      "",
-		Notifier:                   nil,
-		MetaVersion:                "v1.0.0",
-		UpdateOnStart:              false,
-		SkipFirstRun:               false,
-		CurrentWatchtowerContainer: parentContainer, // should skip updates
-		StartupMessageSent:         false,
-		BaseParams: types.UpdateParams{
-			Cleanup:             false,
-			MonitorOnly:         false,
-			EphemeralSelfUpdate: false,
-			ReviveStopped:       false,
-			UseComposeDependsOn: false,
-		},
-	})
+	deps := testDeps(client, runUpdatesWithNotifications, writeStartupMessage)
+	deps.ScheduleSpec = scheduleSpec
+	deps.CurrentWatchtowerContainer = parentContainer
+	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, deps)
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -798,29 +622,9 @@ func TestRunUpgradesOnSchedule_ScheduledRuns_Execution(t *testing.T) {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 2500*time.Millisecond)
 	defer timeoutCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
-		Filter:                     filters.NoFilter,
-		FilterDesc:                 "test filter",
-		Lock:                       nil,
-		ScheduleSpec:               scheduleSpec,
-		WriteStartupMessage:        writeStartupMessage,
-		RunUpdate:                  runUpdatesWithNotifications,
-		Client:                     client,
-		Scope:                      "",
-		Notifier:                   nil,
-		MetaVersion:                "v1.0.0",
-		UpdateOnStart:              false,
-		SkipFirstRun:               false,
-		CurrentWatchtowerContainer: nil,
-		StartupMessageSent:         false,
-		BaseParams: types.UpdateParams{
-			Cleanup:             false,
-			MonitorOnly:         false,
-			EphemeralSelfUpdate: false,
-			ReviveStopped:       false,
-			UseComposeDependsOn: false,
-		},
-	})
+	deps := testDeps(client, runUpdatesWithNotifications, writeStartupMessage)
+	deps.ScheduleSpec = scheduleSpec
+	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, deps)
 	// Should complete without error when context times out (clean cancellation)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -877,29 +681,11 @@ func TestRunUpgradesOnSchedule_EphemeralSelfUpdateWithExposedPorts(t *testing.T)
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 	defer timeoutCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
-		Filter:                     filters.NoFilter,
-		FilterDesc:                 "test filter",
-		Lock:                       nil,
-		ScheduleSpec:               "",
-		WriteStartupMessage:        writeStartupMessage,
-		RunUpdate:                  runUpdatesWithNotifications,
-		Client:                     client,
-		Scope:                      "",
-		Notifier:                   nil,
-		MetaVersion:                "v1.0.0",
-		UpdateOnStart:              true, // triggers immediate update
-		SkipFirstRun:               false,
-		CurrentWatchtowerContainer: containerWithPorts, // with exposed ports
-		StartupMessageSent:         false,
-		BaseParams: types.UpdateParams{
-			Cleanup:             false,
-			MonitorOnly:         false,
-			EphemeralSelfUpdate: true, // bypasses port-conflict guard
-			ReviveStopped:       false,
-			UseComposeDependsOn: false,
-		},
-	})
+	deps := testDeps(client, runUpdatesWithNotifications, writeStartupMessage)
+	deps.UpdateOnStart = true
+	deps.CurrentWatchtowerContainer = containerWithPorts
+	deps.BaseParams.EphemeralSelfUpdate = true
+	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, deps)
 	require.NoError(t, err)
 
 	// With ephemeralSelfUpdate=true, the port-conflict guard should be bypassed,
@@ -939,29 +725,10 @@ func TestRunUpgradesOnSchedule_PortConflictGuard_SkipsSelfUpdate(t *testing.T) {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 	defer timeoutCancel()
 
-	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
-		Filter:                     filters.NoFilter,
-		FilterDesc:                 "test filter",
-		Lock:                       nil,
-		ScheduleSpec:               "",
-		WriteStartupMessage:        writeStartupMessage,
-		RunUpdate:                  runUpdatesWithNotifications,
-		Client:                     client,
-		Scope:                      "",
-		Notifier:                   nil,
-		MetaVersion:                "v1.0.0",
-		UpdateOnStart:              true, // triggers immediate update
-		SkipFirstRun:               false,
-		CurrentWatchtowerContainer: containerWithPorts, // with exposed ports
-		StartupMessageSent:         false,
-		BaseParams: types.UpdateParams{
-			Cleanup:             false,
-			MonitorOnly:         false,
-			EphemeralSelfUpdate: false, // port-conflict guard is active
-			ReviveStopped:       false,
-			UseComposeDependsOn: false,
-		},
-	})
+	deps := testDeps(client, runUpdatesWithNotifications, writeStartupMessage)
+	deps.UpdateOnStart = true
+	deps.CurrentWatchtowerContainer = containerWithPorts
+	err := scheduling.RunUpgradesOnSchedule(timeoutCtx, deps)
 	require.NoError(t, err)
 
 	// With ephemeralSelfUpdate=false and exposed ports, the port-conflict guard
@@ -1016,29 +783,11 @@ func TestRunUpgradesOnSchedule_NoExposedPorts_AllowsSelfUpdate(t *testing.T) {
 			timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 			defer timeoutCancel()
 
-			err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
-				Filter:                     filters.NoFilter,
-				FilterDesc:                 "test filter",
-				Lock:                       nil,
-				ScheduleSpec:               "",
-				WriteStartupMessage:        writeStartupMessage,
-				RunUpdate:                  runUpdatesWithNotifications,
-				Client:                     client,
-				Scope:                      "",
-				Notifier:                   nil,
-				MetaVersion:                "v1.0.0",
-				UpdateOnStart:              true, // triggers immediate update
-				SkipFirstRun:               false,
-				CurrentWatchtowerContainer: containerNoPorts, // without exposed ports
-				StartupMessageSent:         false,
-				BaseParams: types.UpdateParams{
-					Cleanup:             false,
-					MonitorOnly:         false,
-					EphemeralSelfUpdate: tt.ephemeralSelfUpdate,
-					ReviveStopped:       false,
-					UseComposeDependsOn: false,
-				},
-			})
+			deps := testDeps(client, runUpdatesWithNotifications, writeStartupMessage)
+			deps.UpdateOnStart = true
+			deps.CurrentWatchtowerContainer = containerNoPorts
+			deps.BaseParams.EphemeralSelfUpdate = tt.ephemeralSelfUpdate
+			err := scheduling.RunUpgradesOnSchedule(timeoutCtx, deps)
 			require.NoError(t, err)
 
 			// Without exposed ports, the port-conflict guard should not trigger,
@@ -1089,29 +838,10 @@ func TestRunUpgradesOnSchedule_ReviveStoppedPropagation(t *testing.T) {
 			timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 			defer timeoutCancel()
 
-			err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
-				Filter:                     filters.NoFilter,
-				FilterDesc:                 "test filter",
-				Lock:                       nil,
-				ScheduleSpec:               "",
-				WriteStartupMessage:        writeStartupMessage,
-				RunUpdate:                  runUpdatesWithNotifications,
-				Client:                     client,
-				Scope:                      "",
-				Notifier:                   nil,
-				MetaVersion:                "v1.0.0",
-				UpdateOnStart:              true, // triggers immediate update
-				SkipFirstRun:               false,
-				CurrentWatchtowerContainer: nil,
-				StartupMessageSent:         false,
-				BaseParams: types.UpdateParams{
-					Cleanup:             false,
-					MonitorOnly:         false,
-					EphemeralSelfUpdate: false,
-					ReviveStopped:       tt.reviveStopped,
-					UseComposeDependsOn: false,
-				},
-			})
+			deps := testDeps(client, runUpdatesWithNotifications, writeStartupMessage)
+			deps.UpdateOnStart = true
+			deps.BaseParams.ReviveStopped = tt.reviveStopped
+			err := scheduling.RunUpgradesOnSchedule(timeoutCtx, deps)
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.expectSelected, capturedParams.ReviveStopped,
@@ -1160,29 +890,10 @@ func TestRunUpgradesOnSchedule_UseComposeDependsOnPropagation(t *testing.T) {
 			timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 			defer timeoutCancel()
 
-			err := scheduling.RunUpgradesOnSchedule(timeoutCtx, scheduling.ScheduleDeps{
-				Filter:                     filters.NoFilter,
-				FilterDesc:                 "test filter",
-				Lock:                       nil,
-				ScheduleSpec:               "",
-				WriteStartupMessage:        writeStartupMessage,
-				RunUpdate:                  runUpdatesWithNotifications,
-				Client:                     client,
-				Scope:                      "",
-				Notifier:                   nil,
-				MetaVersion:                "v1.0.0",
-				UpdateOnStart:              true, // triggers immediate update
-				SkipFirstRun:               false,
-				CurrentWatchtowerContainer: nil,
-				StartupMessageSent:         false,
-				BaseParams: types.UpdateParams{
-					Cleanup:             false,
-					MonitorOnly:         false,
-					EphemeralSelfUpdate: false,
-					ReviveStopped:       false,
-					UseComposeDependsOn: tt.useComposeDependsOn,
-				},
-			})
+			deps := testDeps(client, runUpdatesWithNotifications, writeStartupMessage)
+			deps.UpdateOnStart = true
+			deps.BaseParams.UseComposeDependsOn = tt.useComposeDependsOn
+			err := scheduling.RunUpgradesOnSchedule(timeoutCtx, deps)
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.expectSelected, capturedParams.UseComposeDependsOn,

--- a/pkg/notifications/doc.go
+++ b/pkg/notifications/doc.go
@@ -1,8 +1,9 @@
-// Package notifications provides mechanisms for sending notifications via various services in Watchtower.
+// Package notifications provides the notification client for sending Watchtower update messages.
 // It integrates with Shoutrrr for service delivery, supporting custom templates, batching, and JSON marshaling.
 //
 // Key components:
-//   - Notifier Creation: Configures notifiers from flags (notifier.go).
+//   - NewNotifier: Constructs the client from internal/config/notify.Notify (notifier.go).
+//   - NewNotifierFromFlags: Test helper that reads Cobra flags then calls NewNotifier.
 //   - Shoutrrr Integration: Handles message sending and batching (shoutrrr.go).
 //   - JSON Marshaling: Formats notification data (json.go).
 //   - Preview: Renders notification previews (preview.go).
@@ -12,13 +13,12 @@
 // Use --notification-url with the appropriate shoutrrr URL scheme instead.
 // See the deprecation notices on specific types and functions for details.
 //
-// Usage example:
+// Usage example (after config.Load):
 //
-//	notifier := notifications.NewNotifier(cmd)
+//	notifier := notifications.NewNotifier(cfg.Notify)
 //	notifier.StartNotification()
 //	notifier.SendNotification(report)
 //	notifier.Close()
 //
-// The package uses Shoutrrr for service abstraction, supports custom templates, and allows configuration
-// via command-line flags or environment variables, with logging handled through logrus.
+// The package uses Shoutrrr for service abstraction and custom templates, with logging via logrus.
 package notifications

--- a/pkg/notifications/email.go
+++ b/pkg/notifications/email.go
@@ -167,11 +167,15 @@ func (e *emailTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 	}
 
 	url := conf.GetURL().String()
+
 	clog.WithFields(logrus.Fields{
-		"url":          url,
 		"tls_skip":     e.tlsSkipVerify,
 		"auth_enabled": len(e.User) > 0,
 	}).Debug("Generated SMTP URL")
+
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		clog.WithField("url", url).Trace("Generated SMTP URL")
+	}
 
 	return url, nil
 }

--- a/pkg/notifications/email.go
+++ b/pkg/notifications/email.go
@@ -174,7 +174,8 @@ func (e *emailTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 	}).Debug("Generated SMTP URL")
 
 	if logrus.IsLevelEnabled(logrus.TraceLevel) {
-		clog.WithField("url", url).Trace("Generated SMTP URL")
+		clog.WithField("url", redactServiceURL(url)).
+			Trace("Generated SMTP URL")
 	}
 
 	return url, nil

--- a/pkg/notifications/email.go
+++ b/pkg/notifications/email.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	notifyConfig "github.com/nicholas-fedor/watchtower/internal/config/notify"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
@@ -50,10 +51,10 @@ type emailTypeNotifier struct {
 	delay                  time.Duration   // Delay for batching notifications.
 }
 
-// newEmailNotifier creates an email notifier from command-line flags.
+// newEmailNotifier creates an email notifier from resolved legacy settings.
 //
 // Parameters:
-//   - c: Cobra command with flags.
+//   - legacy: Deprecated email SMTP settings (from process config or flags).
 //
 // Returns:
 //   - types.ConvertibleNotifier: New email notifier instance.
@@ -64,17 +65,15 @@ type emailTypeNotifier struct {
 // TODO: Remove newEmailNotifier for the v2 release.
 //
 //nolint:godox
-func newEmailNotifier(c *cobra.Command) types.ConvertibleNotifier {
-	flags := c.Flags()
-
-	from, _ := flags.GetString("notification-email-from")
-	to, _ := flags.GetString("notification-email-to") //nolint:varnamelen
-	server, _ := flags.GetString("notification-email-server")
-	user, _ := flags.GetString("notification-email-server-user")
-	password, _ := flags.GetString("notification-email-server-password")
-	port, _ := flags.GetInt("notification-email-server-port")
-	tlsSkipVerify, _ := flags.GetBool("notification-email-server-tls-skip-verify")
-	delay, _ := flags.GetInt("notification-email-delay")
+func newEmailNotifier(legacy notifyConfig.Legacy) types.ConvertibleNotifier {
+	from := legacy.EmailFrom
+	to := legacy.EmailTo //nolint:varnamelen
+	server := legacy.EmailServer
+	user := legacy.EmailUser
+	password := legacy.EmailPassword
+	port := legacy.EmailPort
+	tlsSkipVerify := legacy.EmailTLSSkipVerify
+	delay := legacy.EmailDelay
 
 	clog := logrus.WithFields(logrus.Fields{
 		"from":          from,

--- a/pkg/notifications/gotify.go
+++ b/pkg/notifications/gotify.go
@@ -8,8 +8,8 @@ import (
 	"github.com/nicholas-fedor/shoutrrr/pkg/services/push/gotify"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
+	notifyConfig "github.com/nicholas-fedor/watchtower/internal/config/notify"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
@@ -39,10 +39,10 @@ type gotifyTypeNotifier struct {
 	gotifyInsecureSkipVerify bool   // Skip TLS verification if true.
 }
 
-// newGotifyNotifier creates a Gotify notifier from command-line flags.
+// newGotifyNotifier creates a Gotify notifier from resolved legacy settings.
 //
 // Parameters:
-//   - c: Cobra command with flags.
+//   - legacy: Deprecated Gotify server settings (from process config or flags).
 //
 // Returns:
 //   - types.ConvertibleNotifier: New Gotify notifier instance.
@@ -53,13 +53,10 @@ type gotifyTypeNotifier struct {
 // TODO: Remove newGotifyNotifier for the v2 release.
 //
 //nolint:godox
-func newGotifyNotifier(c *cobra.Command) types.ConvertibleNotifier {
-	flags := c.Flags()
-
-	// Extract and validate configuration.
-	apiURL := getGotifyURL(flags)
-	token := getGotifyToken(flags)
-	skipVerify, _ := flags.GetBool("notification-gotify-tls-skip-verify")
+func newGotifyNotifier(legacy notifyConfig.Legacy) types.ConvertibleNotifier {
+	apiURL := requireGotifyURL(legacy.GotifyURL)
+	token := requireGotifyToken(legacy.GotifyToken)
+	skipVerify := legacy.GotifyTLSSkipVerify
 
 	clog := logrus.WithFields(logrus.Fields{
 		"url":         apiURL,
@@ -79,18 +76,17 @@ func newGotifyNotifier(c *cobra.Command) types.ConvertibleNotifier {
 	}
 }
 
-// getGotifyToken retrieves the Gotify token from flags.
+// requireGotifyToken validates a Gotify token.
 //
 // Parameters:
-//   - flags: Flag set to check.
+//   - gotifyToken: Token value from resolved configuration or flags.
 //
 // Returns:
 //   - string: Token value (fatal if empty).
 //
 // Deprecated: This function is part of the legacy gotify notifier and will be removed
 // for the v2 release. Use --notification-url with a gotify:// URL instead.
-func getGotifyToken(flags *pflag.FlagSet) string {
-	gotifyToken, _ := flags.GetString("notification-gotify-token")
+func requireGotifyToken(gotifyToken string) string {
 	clog := logrus.WithField("flag", "notification-gotify-token")
 
 	// Fatal error if token is missing.
@@ -105,18 +101,17 @@ func getGotifyToken(flags *pflag.FlagSet) string {
 	return gotifyToken
 }
 
-// getGotifyURL retrieves and validates the Gotify URL from flags.
+// requireGotifyURL validates a Gotify URL.
 //
 // Parameters:
-//   - flags: Flag set to check.
+//   - gotifyURL: URL value from resolved configuration or flags.
 //
 // Returns:
 //   - string: Validated URL (fatal if empty or malformed).
 //
 // Deprecated: This function is part of the legacy gotify notifier and will be removed
 // for the v2 release. Use --notification-url with a gotify:// URL instead.
-func getGotifyURL(flags *pflag.FlagSet) string {
-	gotifyURL, _ := flags.GetString("notification-gotify-url")
+func requireGotifyURL(gotifyURL string) string {
 	clog := logrus.WithFields(logrus.Fields{
 		"flag": "notification-gotify-url",
 		"url":  gotifyURL,

--- a/pkg/notifications/gotify.go
+++ b/pkg/notifications/gotify.go
@@ -151,8 +151,13 @@ func requireGotifyURL(gotifyURL string) string {
 // Deprecated: This method is part of the legacy gotify notifier and will be removed
 // for the v2 release. Use --notification-url with a gotify:// URL instead.
 func (n *gotifyTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
-	clog := logrus.WithField("url", n.gotifyURL)
+	clog := logrus.NewEntry(logrus.StandardLogger())
 	clog.Debug("Generating Gotify service URL")
+
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		clog.WithField("url", n.gotifyURL).
+			Trace("Gotify API URL loaded")
+	}
 
 	// Parse the API URL.
 	apiURL, err := url.Parse(n.gotifyURL)
@@ -171,10 +176,15 @@ func (n *gotifyTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 	}
 
 	urlStr := config.GetURL().String()
-	clog.WithFields(logrus.Fields{
-		"service_url": urlStr,
-		"disable_tls": apiURL.Scheme == "http",
-	}).Debug("Generated Gotify service URL")
+
+	clog.WithField("disable_tls", apiURL.Scheme == "http").
+		Debug("Generated Gotify service URL")
+
+	// Service URL embeds the app token; log only at trace.
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		clog.WithField("service_url", urlStr).
+			Trace("Generated Gotify service URL")
+	}
 
 	return urlStr, nil
 }

--- a/pkg/notifications/gotify.go
+++ b/pkg/notifications/gotify.go
@@ -59,14 +59,14 @@ func newGotifyNotifier(legacy notifyConfig.Legacy) types.ConvertibleNotifier {
 	skipVerify := legacy.GotifyTLSSkipVerify
 
 	clog := logrus.WithFields(logrus.Fields{
-		"url":         apiURL,
+		"url":         redactServiceURL(apiURL),
 		"skip_verify": skipVerify,
 	})
 	clog.Debug("Initializing Gotify notifier")
 
-	// Log token only at trace level for security.
 	if logrus.IsLevelEnabled(logrus.TraceLevel) {
-		clog.WithField("token", token).Trace("Gotify notifier token loaded")
+		clog.WithField("token_length", len(token)).
+			Trace("Gotify notifier token loaded")
 	}
 
 	return &gotifyTypeNotifier{
@@ -155,7 +155,7 @@ func (n *gotifyTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 	clog.Debug("Generating Gotify service URL")
 
 	if logrus.IsLevelEnabled(logrus.TraceLevel) {
-		clog.WithField("url", n.gotifyURL).
+		clog.WithField("url", redactServiceURL(n.gotifyURL)).
 			Trace("Gotify API URL loaded")
 	}
 
@@ -180,9 +180,8 @@ func (n *gotifyTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 	clog.WithField("disable_tls", apiURL.Scheme == "http").
 		Debug("Generated Gotify service URL")
 
-	// Service URL embeds the app token; log only at trace.
 	if logrus.IsLevelEnabled(logrus.TraceLevel) {
-		clog.WithField("service_url", urlStr).
+		clog.WithField("service_url", redactServiceURL(urlStr)).
 			Trace("Generated Gotify service URL")
 	}
 

--- a/pkg/notifications/msteams.go
+++ b/pkg/notifications/msteams.go
@@ -57,7 +57,7 @@ type msTeamsTypeNotifier struct {
 //nolint:godox
 func newMsTeamsNotifier(legacy notifyConfig.Legacy) types.ConvertibleNotifier {
 	webHookURL := legacy.MSTeamsHook
-	clog := logrus.WithField("url", webHookURL)
+	clog := logrus.WithField("url", redactServiceURL(webHookURL))
 
 	if len(webHookURL) == 0 {
 		clog.Fatal(
@@ -84,7 +84,7 @@ func (n *msTeamsTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 	clog.Debug("Generating Microsoft Teams service URL")
 
 	if logrus.IsLevelEnabled(logrus.TraceLevel) {
-		clog.WithField("url", n.webHookURL).
+		clog.WithField("url", redactServiceURL(n.webHookURL)).
 			Trace("Microsoft Teams webhook URL loaded")
 	}
 
@@ -108,7 +108,7 @@ func (n *msTeamsTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 
 	urlStr := config.GetURL().String()
 	if logrus.IsLevelEnabled(logrus.TraceLevel) {
-		clog.WithField("service_url", urlStr).
+		clog.WithField("service_url", redactServiceURL(urlStr)).
 			Trace("Generated Microsoft Teams service URL")
 	} else {
 		clog.Debug("Generated Microsoft Teams service URL")

--- a/pkg/notifications/msteams.go
+++ b/pkg/notifications/msteams.go
@@ -80,8 +80,13 @@ func newMsTeamsNotifier(legacy notifyConfig.Legacy) types.ConvertibleNotifier {
 // Deprecated: This method is part of the legacy msteams notifier and will be removed
 // for the v2 release. Use --notification-url with a teams:// URL instead.
 func (n *msTeamsTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
-	clog := logrus.WithField("url", n.webHookURL)
+	clog := logrus.NewEntry(logrus.StandardLogger())
 	clog.Debug("Generating Microsoft Teams service URL")
+
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		clog.WithField("url", n.webHookURL).
+			Trace("Microsoft Teams webhook URL loaded")
+	}
 
 	// Validate the webhook URL is parseable and absolute.
 	parsed, err := url.Parse(n.webHookURL)
@@ -102,7 +107,12 @@ func (n *msTeamsTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 	}
 
 	urlStr := config.GetURL().String()
-	clog.WithField("service_url", urlStr).Debug("Generated Microsoft Teams service URL")
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		clog.WithField("service_url", urlStr).
+			Trace("Generated Microsoft Teams service URL")
+	} else {
+		clog.Debug("Generated Microsoft Teams service URL")
+	}
 
 	return urlStr, nil
 }

--- a/pkg/notifications/msteams.go
+++ b/pkg/notifications/msteams.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	notifyConfig "github.com/nicholas-fedor/watchtower/internal/config/notify"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
@@ -40,10 +41,10 @@ type msTeamsTypeNotifier struct {
 	webHookURL string
 }
 
-// newMsTeamsNotifier creates a Teams notifier from command-line flags.
+// newMsTeamsNotifier creates a Teams notifier from resolved legacy settings.
 //
 // Parameters:
-//   - cmd: Cobra command with flags.
+//   - legacy: Deprecated MSTeams webhook settings (from process config or flags).
 //
 // Returns:
 //   - types.ConvertibleNotifier: New Teams notifier instance.
@@ -54,11 +55,8 @@ type msTeamsTypeNotifier struct {
 // TODO: Remove newMsTeamsNotifier for the v2 release.
 //
 //nolint:godox
-func newMsTeamsNotifier(cmd *cobra.Command) types.ConvertibleNotifier {
-	flags := cmd.Flags()
-
-	// Extract and validate webhook URL.
-	webHookURL, _ := flags.GetString("notification-msteams-hook")
+func newMsTeamsNotifier(legacy notifyConfig.Legacy) types.ConvertibleNotifier {
+	webHookURL := legacy.MSTeamsHook
 	clog := logrus.WithField("url", webHookURL)
 
 	if len(webHookURL) == 0 {

--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -8,102 +8,259 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	notifyConfig "github.com/nicholas-fedor/watchtower/internal/config/notify"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
-// ColorHex is the default notification color used for services that support it (formatted as a CSS hex string).
+// ColorHex is the default notification color used for services that support it
+// (formatted as a CSS hex string).
 const ColorHex = "#406170"
 
-// ColorInt is the default notification color used for services that support it (as an int value).
+// ColorInt is the default notification color used for services that support it
+// (as an int value).
 const ColorInt = 0x406170
 
-// NewNotifier creates a new Notifier from global configuration.
+// NewNotifier constructs the notification client from resolved process settings.
+//
+// It parses the notification log level, loads an optional template file, builds static
+// template data, appends legacy Shoutrrr URLs when configured, and creates the client.
 //
 // Parameters:
-//   - c: Cobra command with flags.
+//   - cfg: Notification settings from config.Load (Config.Notify).
 //
 // Returns:
 //   - types.Notifier: Configured notifier instance.
-func NewNotifier(c *cobra.Command) types.Notifier {
-	flag := c.Flags()
-
-	// Parse log level from flags.
-	level, _ := flag.GetString("notifications-level")
-	clog := logrus.WithField("level", level)
+func NewNotifier(cfg notifyConfig.Notify) types.Notifier {
+	// Parse log level from resolved configuration.
+	clog := logrus.WithField("level", cfg.Level)
 	clog.Debug("Parsing notifications log level")
 
-	logLevel, err := logrus.ParseLevel(level)
+	logLevel, err := logrus.ParseLevel(cfg.Level)
 	if err != nil {
 		clog.WithError(err).Fatal("Invalid notifications log level")
 	}
 
-	// Extract notification settings.
-	reportTemplate, _ := flag.GetBool("notification-report")
-	stdout, _ := flag.GetBool("notification-log-stdout")
+	// Prefer template file contents when set; otherwise use the inline template string.
+	tplString := cfg.Template
 
-	tplString, _ := flag.GetString("notification-template")
-	if tplFile, _ := flag.GetString("notification-template-file"); tplFile != "" {
-		content, err := os.ReadFile(tplFile)
-		if err != nil {
-			clog.WithError(err).
-				WithField("file", tplFile).
+	if cfg.TemplateFile != "" {
+		content, readErr := os.ReadFile(cfg.TemplateFile)
+		if readErr != nil {
+			clog.WithError(readErr).
+				WithField("file", cfg.TemplateFile).
 				Fatal("Failed to read notification template file")
 		}
 
 		tplString = string(content)
 
-		clog.WithField("file", tplFile).Debug("Loaded notification template from file")
+		clog.WithField("file", cfg.TemplateFile).
+			Debug("Loaded notification template from file")
 	}
 
-	urls, _ := flag.GetStringArray("notification-url")
+	data := templateData(cfg.Hostname, cfg.TitleTag, cfg.EmailSubjectTag, cfg.SkipTitle)
 
-	data := GetTemplateData(c)
-	urls, delay := AppendLegacyUrls(urls, c)
+	// Start from configured Shoutrrr URLs, then append any legacy type URLs.
+	urls := append([]string(nil), cfg.URLs...)
+	urls, delay := appendLegacyURLs(urls, cfg.LegacyTypes, cfg.Legacy)
+
+	// Prefer legacy delay when set; otherwise use the configured delay in seconds.
+	if delay == 0 && cfg.DelaySeconds > 0 {
+		delay = time.Duration(cfg.DelaySeconds) * time.Second
+	}
 
 	// Use report template when enabled, otherwise use legacy template.
-	legacy := !reportTemplate
+	legacyTemplate := !cfg.Report
 
 	clog.WithFields(logrus.Fields{
 		"urls":        urls,
 		"template":    tplString,
-		"skip_report": !reportTemplate,
-		"stdout":      stdout,
+		"skip_report": !cfg.Report,
+		"stdout":      cfg.LogStdout,
 		"delay":       delay,
 		"hostname":    data.Host,
 		"title":       data.Title,
-		"legacy":      legacy,
+		"legacy":      legacyTemplate,
 	}).Debug("Creating notifier with configuration")
 
-	return createNotifier(urls, logLevel, tplString, legacy, data, stdout, delay)
+	return createNotifier(
+		urls,
+		logLevel,
+		tplString,
+		legacyTemplate,
+		data,
+		cfg.LogStdout,
+		delay,
+	)
 }
 
-// AppendLegacyUrls adds shoutrrr URLs from legacy notification flags.
+// NewNotifierFromFlags creates a notification client from Cobra flags.
+//
+// Prefer config.Load plus NewNotifier in production. This entry point is for
+// tests that configure notifications via flags only.
+//
+// Parameters:
+//   - c: Cobra command with flags.
+//
+// Returns:
+//   - types.Notifier: Configured notification client.
+func NewNotifierFromFlags(c *cobra.Command) types.Notifier {
+	return NewNotifier(notifyFromFlags(c))
+}
+
+// notifyFromFlags reads notification-related flags into confignotify.Notify.
+//
+// This is a test and deprecated-path helper. Production code must use config.Load
+// and pass Config.Notify to NewNotifier instead of scraping Cobra flags here.
+//
+// Parameters:
+//   - c: Cobra command with flags.
+//
+// Returns:
+//   - confignotify.Notify: Values for NewNotifier.
+func notifyFromFlags(c *cobra.Command) notifyConfig.Notify {
+	flag := c.Flags()
+	persistent := c.PersistentFlags()
+
+	urls, _ := flag.GetStringArray("notification-url")
+	legacyTypes, _ := flag.GetStringSlice("notifications")
+	level, _ := flag.GetString("notifications-level")
+	template, _ := flag.GetString("notification-template")
+	templateFile, _ := flag.GetString("notification-template-file")
+	report, _ := flag.GetBool("notification-report")
+	skipTitle, _ := flag.GetBool("notification-skip-title")
+	logStdout, _ := flag.GetBool("notification-log-stdout")
+	delaySec, _ := persistent.GetInt("notifications-delay")
+	hostname, _ := persistent.GetString("notifications-hostname")
+	titleTag, _ := flag.GetString("notification-title-tag")
+	emailSubjectTag, _ := flag.GetString("notification-email-subjecttag")
+
+	emailFrom, _ := flag.GetString("notification-email-from")
+	emailTo, _ := flag.GetString("notification-email-to")
+	emailServer, _ := flag.GetString("notification-email-server")
+	emailUser, _ := flag.GetString("notification-email-server-user")
+	emailPassword, _ := flag.GetString("notification-email-server-password")
+	emailPort, _ := flag.GetInt("notification-email-server-port")
+	emailTLSSkip, _ := flag.GetBool("notification-email-server-tls-skip-verify")
+	emailDelay, _ := flag.GetInt("notification-email-delay")
+	slackHook, _ := flag.GetString("notification-slack-hook-url")
+	slackID, _ := flag.GetString("notification-slack-identifier")
+	slackChannel, _ := flag.GetString("notification-slack-channel")
+	slackEmoji, _ := flag.GetString("notification-slack-icon-emoji")
+	slackIcon, _ := flag.GetString("notification-slack-icon-url")
+	msTeamsHook, _ := flag.GetString("notification-msteams-hook")
+	gotifyURL, _ := flag.GetString("notification-gotify-url")
+	gotifyToken, _ := flag.GetString("notification-gotify-token")
+	gotifyTLSSkip, _ := flag.GetBool("notification-gotify-tls-skip-verify")
+
+	return notifyConfig.Notify{
+		URLs:            urls,
+		LegacyTypes:     legacyTypes,
+		Level:           level,
+		Template:        template,
+		TemplateFile:    templateFile,
+		Report:          report,
+		LogStdout:       logStdout,
+		SkipTitle:       skipTitle,
+		DelaySeconds:    delaySec,
+		Hostname:        hostname,
+		TitleTag:        titleTag,
+		EmailSubjectTag: emailSubjectTag,
+		Legacy: notifyConfig.Legacy{
+			EmailFrom:           emailFrom,
+			EmailTo:             emailTo,
+			EmailServer:         emailServer,
+			EmailUser:           emailUser,
+			EmailPassword:       emailPassword,
+			EmailPort:           emailPort,
+			EmailTLSSkipVerify:  emailTLSSkip,
+			EmailDelay:          emailDelay,
+			SlackHookURL:        slackHook,
+			SlackIdentifier:     slackID,
+			SlackChannel:        slackChannel,
+			SlackIconEmoji:      slackEmoji,
+			SlackIconURL:        slackIcon,
+			MSTeamsHook:         msTeamsHook,
+			GotifyURL:           gotifyURL,
+			GotifyToken:         gotifyToken,
+			GotifyTLSSkipVerify: gotifyTLSSkip,
+		},
+	}
+}
+
+// templateData builds static notification title/host data from resolved values.
+//
+// Parameters:
+//   - hostname: Hostname from configuration, or empty to use the system hostname.
+//   - titleTag: Optional title prefix tag.
+//   - emailSubjectTag: Deprecated fallback tag when titleTag is empty.
+//   - skipTitle: When true, title is left empty.
+//
+// Returns:
+//   - StaticData: Host and title for notification templates.
+func templateData(hostname, titleTag, emailSubjectTag string, skipTitle bool) StaticData {
+	clog := logrus.WithField("hostname_flag", hostname)
+	clog.Debug("Retrieving template data")
+
+	// Get hostname from configuration or system.
+	if hostname == "" {
+		hostname, _ = os.Hostname()
+		clog.WithField("hostname", hostname).Debug("Using system hostname")
+	}
+
+	title := ""
+
+	if !skipTitle {
+		tag := titleTag
+		if tag == "" {
+			tag = emailSubjectTag
+			if tag != "" {
+				clog.WithField("tag", tag).
+					Warn("Using deprecated email subject tag flag. Use the notification-title-tag configuration option instead.")
+			}
+		}
+
+		title = GetTitle(hostname, tag)
+	}
+
+	clog.WithFields(logrus.Fields{
+		"hostname": hostname,
+		"title":    title,
+	}).Debug("Populated template data")
+
+	return StaticData{
+		Host:  hostname,
+		Title: title,
+	}
+}
+
+// appendLegacyURLs adds shoutrrr URLs from legacy notification type names.
 //
 // Parameters:
 //   - urls: Initial URL list.
-//   - cmd: Cobra command with flags.
+//   - notificationTypes: Legacy type names (email, slack, msteams, gotify).
+//   - legacy: Per-type settings for deprecated notifiers.
 //
 // Returns:
-//   - []string: Updated URL list.
-//   - time.Duration: Notification delay.
+//   - []string: Updated URL list including generated Shoutrrr URLs.
+//   - time.Duration: Delay reported by a legacy DelayNotifier, or zero.
 //
 // Deprecated: Legacy notification types are deprecated.
 // Use --notification-url instead.
 //
-// TODO: Remove AppendLegacyUrls for the v2 release.
+// TODO: Remove appendLegacyURLs for the v2 release.
 //
 //nolint:godox
-func AppendLegacyUrls(urls []string, cmd *cobra.Command) ([]string, time.Duration) {
-	clog := logrus.WithField("function", "AppendLegacyUrls")
+func appendLegacyURLs(
+	urls []string,
+	notificationTypes []string,
+	legacy notifyConfig.Legacy,
+) ([]string, time.Duration) {
+	clog := logrus.WithField("function", "appendLegacyURLs")
 	clog.Debug("Appending legacy notification URLs")
 
 	// Fetch legacy notification types.
-	notificationTypes, err := cmd.Flags().GetStringSlice("notifications")
-	if err != nil {
-		clog.WithError(err).Fatal("Could not read notifications argument")
-	}
-
-	clog.WithField("types", notificationTypes).Debug("Processing legacy notification types")
+	clog.WithField("types", notificationTypes).
+		Debug("Processing legacy notification types")
 
 	legacyDelay := time.Duration(0)
 
@@ -112,23 +269,24 @@ func AppendLegacyUrls(urls []string, cmd *cobra.Command) ([]string, time.Duratio
 
 		switch notificationType {
 		case emailType:
-			legacyNotifier = newEmailNotifier(cmd)
+			legacyNotifier = newEmailNotifier(legacy)
 		case slackType:
-			legacyNotifier = newSlackNotifier(cmd)
+			legacyNotifier = newSlackNotifier(legacy)
 		case msTeamsType:
-			legacyNotifier = newMsTeamsNotifier(cmd)
+			legacyNotifier = newMsTeamsNotifier(legacy)
 		case gotifyType:
-			legacyNotifier = newGotifyNotifier(cmd)
+			legacyNotifier = newGotifyNotifier(legacy)
 		case shoutrrrType:
 			continue
 		default:
-			clog.WithField("type", notificationType).Fatal("Unknown notification type")
+			clog.WithField("type", notificationType).
+				Fatal("Unknown notification type")
 
 			continue
 		}
 
 		// Generate shoutrrr URL from legacy notifier.
-		shoutrrrURL, err := legacyNotifier.GetURL(cmd)
+		shoutrrrURL, err := legacyNotifier.GetURL(nil)
 		if err != nil {
 			clog.WithError(err).
 				WithField("type", notificationType).
@@ -152,28 +310,57 @@ func AppendLegacyUrls(urls []string, cmd *cobra.Command) ([]string, time.Duratio
 		}).Trace("Created Shoutrrr URL from legacy notifier")
 	}
 
-	delay := GetDelay(cmd, legacyDelay)
 	clog.WithFields(logrus.Fields{
 		"urls":  urls,
-		"delay": delay,
+		"delay": legacyDelay,
 	}).Debug("Completed legacy URL appending")
 
-	return urls, delay
+	return urls, legacyDelay
 }
 
-// GetDelay determines the notification delay from flags or legacy value.
+// AppendLegacyUrls adds shoutrrr URLs from legacy notification flags.
 //
 // Parameters:
-//   - c: Cobra command with flags.
-//   - legacyDelay: Delay from legacy notifier.
+//   - urls: Initial URL list.
+//   - cmd: Cobra command with flags.
 //
 // Returns:
-//   - time.Duration: Selected delay.
+//   - []string: Updated URL list.
+//   - time.Duration: Notification delay (legacy delay notifier or --notifications-delay).
 //
-// TODO: Simplify GetDelay to only use --notifications-delay when legacy types are removed.
+// Deprecated: Legacy notification types are deprecated.
+// Use --notification-url instead. Prefer NewNotifier with Config.Notify from config.Load.
+//
+// TODO: Remove AppendLegacyUrls for the v2 release.
 //
 //nolint:godox
-func GetDelay(c *cobra.Command, legacyDelay time.Duration) time.Duration {
+func AppendLegacyUrls(urls []string, cmd *cobra.Command) ([]string, time.Duration) {
+	cfg := notifyFromFlags(cmd)
+
+	urls, legacyDelay := appendLegacyURLs(urls, cfg.LegacyTypes, cfg.Legacy)
+
+	if legacyDelay == 0 && cfg.DelaySeconds > 0 {
+		return urls, time.Duration(cfg.DelaySeconds) * time.Second
+	}
+
+	return urls, legacyDelay
+}
+
+// GetDelay selects the notification delay from a legacy value or configured seconds.
+//
+// Parameters:
+//   - delaySeconds: Configured delay in seconds (from Config.Notify.DelaySeconds).
+//   - legacyDelay: Delay from a legacy notifier type, preferred when non-zero.
+//
+// Returns:
+//   - time.Duration: Selected delay (legacy delay if set, otherwise delaySeconds, otherwise zero).
+//
+// Deprecated: Prefer NewNotifier with Config.Notify from config.Load.
+//
+// TODO: Simplify GetDelay to only use configured delay seconds when legacy types are removed.
+//
+//nolint:godox
+func GetDelay(delaySeconds int, legacyDelay time.Duration) time.Duration {
 	clog := logrus.WithField("legacy_delay", legacyDelay)
 	clog.Debug("Determining notification delay")
 
@@ -184,18 +371,18 @@ func GetDelay(c *cobra.Command, legacyDelay time.Duration) time.Duration {
 		return legacyDelay
 	}
 
-	// Check configured delay from flags.
-	delay, _ := c.PersistentFlags().GetInt("notifications-delay")
-	if delay > 0 {
-		delayDuration := time.Duration(delay) * time.Second
-		clog.WithField("delay", delayDuration).Debug("Using configured delay from flags")
+	// Use configured delay when no legacy delay applies.
+	if delaySeconds > 0 {
+		delayDuration := time.Duration(delaySeconds) * time.Second
+		clog.WithField("delay", delayDuration).
+			Debug("Using configured delay")
 
 		return delayDuration
 	}
 
 	clog.Debug("No delay configured, using zero")
 
-	return time.Duration(0)
+	return 0
 }
 
 // GetTitle formats the notification title with hostname and tag.
@@ -230,57 +417,28 @@ func GetTitle(hostname, tag string) string {
 	}
 
 	title := b.String()
-	clog.WithField("title", title).Debug("Generated notification title")
+	clog.WithField("title", title).
+		Debug("Generated notification title")
 
 	return title
 }
 
-// GetTemplateData populates static notification data from flags and env.
+// GetTemplateData populates static notification data from Cobra flags.
+//
+// Prefer config.Load plus NewNotifier in production. This helper remains for tests
+// and deprecated call paths that still configure notifications via flags.
 //
 // Parameters:
 //   - c: Cobra command with flags.
 //
 // Returns:
-//   - StaticData: Populated data.
+//   - StaticData: Populated data (hostname from flag or system; title unless skip-title).
+//
+// Deprecated: Prefer NewNotifier with Config.Notify from config.Load.
 func GetTemplateData(c *cobra.Command) StaticData {
-	flag := c.PersistentFlags()
+	cfg := notifyFromFlags(c)
 
-	// Get hostname from flag or system.
-	hostname, _ := flag.GetString("notifications-hostname")
-	clog := logrus.WithField("hostname_flag", hostname)
-	clog.Debug("Retrieving template data")
-
-	if hostname == "" {
-		hostname, _ = os.Hostname()
-		clog.WithField("hostname", hostname).Debug("Using system hostname")
-	}
-
-	// Generate title unless skipped.
-	title := ""
-
-	if skip, _ := flag.GetBool("notification-skip-title"); !skip {
-		tag, _ := flag.GetString("notification-title-tag")
-		if tag == "" {
-			// Check legacy email tag.
-			tag, _ = flag.GetString("notification-email-subjecttag")
-			if tag != "" {
-				clog.WithField("tag", tag).
-					Warn("Using deprecated email subject tag flag. Use the notification-title-tag configuration option instead.")
-			}
-		}
-
-		title = GetTitle(hostname, tag)
-	}
-
-	clog.WithFields(logrus.Fields{
-		"hostname": hostname,
-		"title":    title,
-	}).Debug("Populated template data")
-
-	return StaticData{
-		Host:  hostname,
-		Title: title,
-	}
+	return templateData(cfg.Hostname, cfg.TitleTag, cfg.EmailSubjectTag, cfg.SkipTitle)
 }
 
 // LogLegacyDeprecationWarnings logs deprecation warnings for legacy notification types.

--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -72,7 +72,7 @@ func NewNotifier(cfg notifyConfig.Notify) types.Notifier {
 	legacyTemplate := !cfg.Report
 
 	clog.WithFields(logrus.Fields{
-		"urls":        urls,
+		"url_count":   len(urls),
 		"template":    tplString,
 		"skip_report": !cfg.Report,
 		"stdout":      cfg.LogStdout,
@@ -81,6 +81,11 @@ func NewNotifier(cfg notifyConfig.Notify) types.Notifier {
 		"title":       data.Title,
 		"legacy":      legacyTemplate,
 	}).Debug("Creating notifier with configuration")
+
+	// Notification URLs often embed tokens. Log them only at trace (see email.go / gotify.go).
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		clog.WithField("urls", urls).Trace("Notifier Shoutrrr URLs loaded")
+	}
 
 	return createNotifier(
 		urls,

--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	notifyConfig "github.com/nicholas-fedor/watchtower/internal/config/notify"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
@@ -139,6 +140,31 @@ func notifyFromFlags(c *cobra.Command) notifyConfig.Notify {
 	titleTag, _ := flag.GetString("notification-title-tag")
 	emailSubjectTag, _ := flag.GetString("notification-email-subjecttag")
 
+	return notifyConfig.Notify{
+		URLs:            urls,
+		LegacyTypes:     legacyTypes,
+		Level:           level,
+		Template:        template,
+		TemplateFile:    templateFile,
+		Report:          report,
+		LogStdout:       logStdout,
+		SkipTitle:       skipTitle,
+		DelaySeconds:    delaySec,
+		Hostname:        hostname,
+		TitleTag:        titleTag,
+		EmailSubjectTag: emailSubjectTag,
+		Legacy:          legacyFromFlags(flag),
+	}
+}
+
+// legacyFromFlags reads deprecated per-service notification flags into Legacy.
+//
+// Parameters:
+//   - flag: Flag set containing legacy notification options.
+//
+// Returns:
+//   - notifyConfig.Legacy: Email, Slack, MS Teams, and Gotify legacy settings.
+func legacyFromFlags(flag *pflag.FlagSet) notifyConfig.Legacy {
 	emailFrom, _ := flag.GetString("notification-email-from")
 	emailTo, _ := flag.GetString("notification-email-to")
 	emailServer, _ := flag.GetString("notification-email-server")
@@ -157,38 +183,24 @@ func notifyFromFlags(c *cobra.Command) notifyConfig.Notify {
 	gotifyToken, _ := flag.GetString("notification-gotify-token")
 	gotifyTLSSkip, _ := flag.GetBool("notification-gotify-tls-skip-verify")
 
-	return notifyConfig.Notify{
-		URLs:            urls,
-		LegacyTypes:     legacyTypes,
-		Level:           level,
-		Template:        template,
-		TemplateFile:    templateFile,
-		Report:          report,
-		LogStdout:       logStdout,
-		SkipTitle:       skipTitle,
-		DelaySeconds:    delaySec,
-		Hostname:        hostname,
-		TitleTag:        titleTag,
-		EmailSubjectTag: emailSubjectTag,
-		Legacy: notifyConfig.Legacy{
-			EmailFrom:           emailFrom,
-			EmailTo:             emailTo,
-			EmailServer:         emailServer,
-			EmailUser:           emailUser,
-			EmailPassword:       emailPassword,
-			EmailPort:           emailPort,
-			EmailTLSSkipVerify:  emailTLSSkip,
-			EmailDelay:          emailDelay,
-			SlackHookURL:        slackHook,
-			SlackIdentifier:     slackID,
-			SlackChannel:        slackChannel,
-			SlackIconEmoji:      slackEmoji,
-			SlackIconURL:        slackIcon,
-			MSTeamsHook:         msTeamsHook,
-			GotifyURL:           gotifyURL,
-			GotifyToken:         gotifyToken,
-			GotifyTLSSkipVerify: gotifyTLSSkip,
-		},
+	return notifyConfig.Legacy{
+		EmailFrom:           emailFrom,
+		EmailTo:             emailTo,
+		EmailServer:         emailServer,
+		EmailUser:           emailUser,
+		EmailPassword:       emailPassword,
+		EmailPort:           emailPort,
+		EmailTLSSkipVerify:  emailTLSSkip,
+		EmailDelay:          emailDelay,
+		SlackHookURL:        slackHook,
+		SlackIdentifier:     slackID,
+		SlackChannel:        slackChannel,
+		SlackIconEmoji:      slackEmoji,
+		SlackIconURL:        slackIcon,
+		MSTeamsHook:         msTeamsHook,
+		GotifyURL:           gotifyURL,
+		GotifyToken:         gotifyToken,
+		GotifyTLSSkipVerify: gotifyTLSSkip,
 	}
 }
 

--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -79,9 +79,9 @@ func NewNotifier(cfg notifyConfig.Notify) types.Notifier {
 		"legacy":      legacyTemplate,
 	}).Debug("Creating notifier with configuration")
 
-	// Notification URLs often embed tokens. Log them only at trace (see email.go / gotify.go).
 	if logrus.IsLevelEnabled(logrus.TraceLevel) {
-		clog.WithField("urls", urls).Trace("Notifier Shoutrrr URLs loaded")
+		clog.WithField("urls", redactServiceURLs(urls)).
+			Trace("Notifier Shoutrrr URLs loaded")
 	}
 
 	return createNotifier(
@@ -326,13 +326,13 @@ func appendLegacyURLs(
 
 		clog.WithFields(logrus.Fields{
 			"type": notificationType,
-			"url":  shoutrrrURL,
+			"url":  redactServiceURL(shoutrrrURL),
 		}).Trace("Created Shoutrrr URL from legacy notifier")
 	}
 
 	clog.WithFields(logrus.Fields{
-		"urls":  urls,
-		"delay": legacyDelay,
+		"url_count": len(urls),
+		"delay":     legacyDelay,
 	}).Debug("Completed legacy URL appending")
 
 	return urls, legacyDelay

--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -246,6 +246,20 @@ func templateData(hostname, titleTag, emailSubjectTag string, skipTitle bool) St
 	}
 }
 
+// legacyNotifierCtor builds a ConvertibleNotifier from resolved legacy settings.
+//
+//nolint:staticcheck // SA1019: legacy ConvertibleNotifier until v2.
+type legacyNotifierCtor func(notifyConfig.Legacy) types.ConvertibleNotifier
+
+// legacyNotifierCtors maps legacy notification type names to constructors.
+// shoutrrr is omitted so those entries are skipped during append.
+var legacyNotifierCtors = map[string]legacyNotifierCtor{
+	emailType:   newEmailNotifier,
+	slackType:   newSlackNotifier,
+	msTeamsType: newMsTeamsNotifier,
+	gotifyType:  newGotifyNotifier,
+}
+
 // appendLegacyURLs adds shoutrrr URLs from legacy notification type names.
 //
 // Parameters:
@@ -271,32 +285,25 @@ func appendLegacyURLs(
 	clog := logrus.WithField("function", "appendLegacyURLs")
 	clog.Debug("Appending legacy notification URLs")
 
-	// Fetch legacy notification types.
 	clog.WithField("types", notificationTypes).
 		Debug("Processing legacy notification types")
 
 	legacyDelay := time.Duration(0)
 
 	for _, notificationType := range notificationTypes {
-		var legacyNotifier types.ConvertibleNotifier
-
-		switch notificationType {
-		case emailType:
-			legacyNotifier = newEmailNotifier(legacy)
-		case slackType:
-			legacyNotifier = newSlackNotifier(legacy)
-		case msTeamsType:
-			legacyNotifier = newMsTeamsNotifier(legacy)
-		case gotifyType:
-			legacyNotifier = newGotifyNotifier(legacy)
-		case shoutrrrType:
+		if notificationType == shoutrrrType {
 			continue
-		default:
+		}
+
+		ctor, ok := legacyNotifierCtors[notificationType]
+		if !ok {
 			clog.WithField("type", notificationType).
 				Fatal("Unknown notification type")
 
 			continue
 		}
+
+		legacyNotifier := ctor(legacy)
 
 		// Generate shoutrrr URL from legacy notifier.
 		shoutrrrURL, err := legacyNotifier.GetURL(nil)

--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -62,12 +62,8 @@ func NewNotifier(cfg notifyConfig.Notify) types.Notifier {
 
 	// Start from configured Shoutrrr URLs, then append any legacy type URLs.
 	urls := append([]string(nil), cfg.URLs...)
-	urls, delay := appendLegacyURLs(urls, cfg.LegacyTypes, cfg.Legacy)
-
-	// Prefer legacy delay when set; otherwise use the configured delay in seconds.
-	if delay == 0 && cfg.DelaySeconds > 0 {
-		delay = time.Duration(cfg.DelaySeconds) * time.Second
-	}
+	urls, legacyDelay := appendLegacyURLs(urls, cfg.LegacyTypes, cfg.Legacy)
+	delay := GetDelay(cfg.DelaySeconds, legacyDelay)
 
 	// Use report template when enabled, otherwise use legacy template.
 	legacyTemplate := !cfg.Report
@@ -356,11 +352,7 @@ func AppendLegacyUrls(urls []string, cmd *cobra.Command) ([]string, time.Duratio
 
 	urls, legacyDelay := appendLegacyURLs(urls, cfg.LegacyTypes, cfg.Legacy)
 
-	if legacyDelay == 0 && cfg.DelaySeconds > 0 {
-		return urls, time.Duration(cfg.DelaySeconds) * time.Second
-	}
-
-	return urls, legacyDelay
+	return urls, GetDelay(cfg.DelaySeconds, legacyDelay)
 }
 
 // GetDelay selects the notification delay from a legacy value or configured seconds.

--- a/pkg/notifications/notifier_test.go
+++ b/pkg/notifications/notifier_test.go
@@ -123,7 +123,7 @@ var _ = ginkgo.Describe("notifications", func() {
 			ginkgo.It(
 				"should use the specified legacy delay and ignore the specified delay",
 				func() {
-					delay := notifications.GetDelay(0, 7*time.Second)
+					delay := notifications.GetDelay(5, 7*time.Second)
 					gomega.Expect(delay).To(gomega.Equal(7 * time.Second))
 				},
 			)

--- a/pkg/notifications/notifier_test.go
+++ b/pkg/notifications/notifier_test.go
@@ -28,7 +28,7 @@ var _ = ginkgo.Describe("notifications", func() {
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			notifier := notifications.NewNotifier(command)
+			notifier := notifications.NewNotifierFromFlags(command)
 
 			gomega.Expect(notifier.GetNames()).To(gomega.BeEmpty())
 		})
@@ -99,25 +99,13 @@ var _ = ginkgo.Describe("notifications", func() {
 		})
 		ginkgo.When("no delay is defined", func() {
 			ginkgo.It("should use the default delay", func() {
-				command := cmd.NewRootCommand()
-				flags.RegisterNotificationFlags(command)
-
-				delay := notifications.GetDelay(command, time.Duration(0))
+				delay := notifications.GetDelay(0, time.Duration(0))
 				gomega.Expect(delay).To(gomega.Equal(time.Duration(0)))
 			})
 		})
 		ginkgo.When("delay is defined", func() {
 			ginkgo.It("should use the specified delay", func() {
-				command := cmd.NewRootCommand()
-				flags.RegisterNotificationFlags(command)
-
-				err := command.ParseFlags([]string{
-					"--notifications-delay",
-					"5",
-				})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				delay := notifications.GetDelay(command, time.Duration(0))
+				delay := notifications.GetDelay(5, time.Duration(0))
 				gomega.Expect(delay).To(gomega.Equal(5 * time.Second))
 			})
 		})
@@ -125,9 +113,7 @@ var _ = ginkgo.Describe("notifications", func() {
 			//nolint:godox
 			// TODO: Remove legacy delay tests when legacy notification types are removed.
 			ginkgo.It("should use the specified legacy delay", func() {
-				command := cmd.NewRootCommand()
-				flags.RegisterNotificationFlags(command)
-				delay := notifications.GetDelay(command, 5*time.Second)
+				delay := notifications.GetDelay(0, 5*time.Second)
 				gomega.Expect(delay).To(gomega.Equal(5 * time.Second))
 			})
 		})
@@ -137,16 +123,7 @@ var _ = ginkgo.Describe("notifications", func() {
 			ginkgo.It(
 				"should use the specified legacy delay and ignore the specified delay",
 				func() {
-					command := cmd.NewRootCommand()
-					flags.RegisterNotificationFlags(command)
-
-					err := command.ParseFlags([]string{
-						"--notifications-delay",
-						"0",
-					})
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-					delay := notifications.GetDelay(command, 7*time.Second)
+					delay := notifications.GetDelay(0, 7*time.Second)
 					gomega.Expect(delay).To(gomega.Equal(7 * time.Second))
 				},
 			)
@@ -174,7 +151,7 @@ var _ = ginkgo.Describe("notifications", func() {
 				})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				notifier := notifications.NewNotifier(command)
+				notifier := notifications.NewNotifierFromFlags(command)
 				gomega.Expect(notifier).NotTo(gomega.BeNil())
 				gomega.Expect(notifier.GetNames()).To(gomega.ContainElement("logger"))
 			})
@@ -396,7 +373,7 @@ var _ = ginkgo.Describe("notifications", func() {
 				}
 				gomega.Expect(command.ParseFlags(args)).To(gomega.Succeed())
 
-				notifier := notifications.NewNotifier(command)
+				notifier := notifications.NewNotifierFromFlags(command)
 				names := notifier.GetNames()
 				gomega.Expect(names).To(gomega.ContainElement("gotify"))
 
@@ -424,7 +401,7 @@ var _ = ginkgo.Describe("notifications", func() {
 				logrus.SetOutput(io.Discard)
 				defer logrus.SetOutput(os.Stderr)
 
-				notifier := notifications.NewNotifier(command)
+				notifier := notifications.NewNotifierFromFlags(command)
 				names := notifier.GetNames()
 				gomega.Expect(names).To(gomega.ContainElement("gotify"))
 

--- a/pkg/notifications/redact.go
+++ b/pkg/notifications/redact.go
@@ -1,0 +1,46 @@
+package notifications
+
+import "net/url"
+
+// redactServiceURL returns a non-sensitive summary of a notification service URL.
+//
+// Scheme is preserved so operators can see the service type.
+// userinfo, host, path, and query (often tokens) are replaced.
+//
+// Parameters:
+//   - raw: Full service or webhook URL that may embed credentials.
+//
+// Returns:
+//   - string: Redacted form such as "slack://[redacted]", or "[redacted]" when empty/invalid.
+func redactServiceURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" {
+		return "[redacted]"
+	}
+
+	return parsed.Scheme + "://[redacted]"
+}
+
+// redactServiceURLs redacts each URL in urls.
+//
+// Parameters:
+//   - urls: Full service URLs that may embed credentials.
+//
+// Returns:
+//   - []string: Redacted summaries in the same order.
+func redactServiceURLs(urls []string) []string {
+	if len(urls) == 0 {
+		return nil
+	}
+
+	out := make([]string, len(urls))
+	for i, raw := range urls {
+		out[i] = redactServiceURL(raw)
+	}
+
+	return out
+}

--- a/pkg/notifications/shoutrrr.go
+++ b/pkg/notifications/shoutrrr.go
@@ -125,7 +125,7 @@ func (n *shoutrrrTypeNotifier) AddLogHook() {
 	n.hookOnce.Do(func() {
 		n.receiving.Store(true)
 		logrus.AddHook(n)
-		LocalLog.WithField("urls", n.Urls).
+		LocalLog.WithField("urls", redactServiceURLs(n.Urls)).
 			Debug("Added Shoutrrr notifier as logrus hook, starting notification goroutine")
 
 		// Send using a separate goroutine to avoid blocking the main process.

--- a/pkg/notifications/slack.go
+++ b/pkg/notifications/slack.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	notifyConfig "github.com/nicholas-fedor/watchtower/internal/config/notify"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
@@ -40,10 +41,10 @@ type slackTypeNotifier struct {
 	IconURL   string // URL icon for messages.
 }
 
-// newSlackNotifier creates a Slack notifier from command-line flags.
+// newSlackNotifier creates a Slack notifier from resolved legacy settings.
 //
 // Parameters:
-//   - c: Cobra command with flags.
+//   - legacy: Deprecated Slack/Discord webhook settings (from process config or flags).
 //
 // Returns:
 //   - types.ConvertibleNotifier: New Slack notifier instance.
@@ -54,15 +55,12 @@ type slackTypeNotifier struct {
 // TODO: Remove newSlackNotifier for the v2 release.
 //
 //nolint:godox
-func newSlackNotifier(c *cobra.Command) types.ConvertibleNotifier {
-	flags := c.Flags()
-
-	// Extract Slack configuration from flags.
-	hookURL, _ := flags.GetString("notification-slack-hook-url")
-	userName, _ := flags.GetString("notification-slack-identifier")
-	channel, _ := flags.GetString("notification-slack-channel")
-	emoji, _ := flags.GetString("notification-slack-icon-emoji")
-	iconURL, _ := flags.GetString("notification-slack-icon-url")
+func newSlackNotifier(legacy notifyConfig.Legacy) types.ConvertibleNotifier {
+	hookURL := legacy.SlackHookURL
+	userName := legacy.SlackIdentifier
+	channel := legacy.SlackChannel
+	emoji := legacy.SlackIconEmoji
+	iconURL := legacy.SlackIconURL
 
 	clog := logrus.WithFields(logrus.Fields{
 		"hook_url": hookURL,

--- a/pkg/notifications/slack.go
+++ b/pkg/notifications/slack.go
@@ -94,8 +94,13 @@ func newSlackNotifier(legacy notifyConfig.Legacy) types.ConvertibleNotifier {
 // Deprecated: This method is part of the legacy slack notifier and will be removed
 // for the v2 release. Use --notification-url with a slack:// URL instead.
 func (s *slackTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
-	clog := logrus.WithField("hook_url", s.HookURL)
+	clog := logrus.NewEntry(logrus.StandardLogger())
 	clog.Debug("Generating Slack service URL")
+
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		clog.WithField("hook_url", s.HookURL).
+			Trace("Slack hook URL loaded")
+	}
 
 	// Normalize URL and split parts.
 	trimmedURL := strings.TrimRight(s.HookURL, "/")
@@ -119,7 +124,12 @@ func (s *slackTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 		}
 
 		urlStr := conf.GetURL().String()
-		clog.WithField("service_url", urlStr).Debug("Generated Discord service URL")
+		if logrus.IsLevelEnabled(logrus.TraceLevel) {
+			clog.WithField("service_url", urlStr).
+				Trace("Generated Discord service URL")
+		} else {
+			clog.Debug("Generated Discord service URL")
+		}
 
 		return urlStr, nil
 	}
@@ -149,7 +159,12 @@ func (s *slackTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 	}
 
 	urlStr := conf.GetURL().String()
-	clog.WithField("service_url", urlStr).Debug("Generated Slack service URL")
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		clog.WithField("service_url", urlStr).
+			Trace("Generated Slack service URL")
+	} else {
+		clog.Debug("Generated Slack service URL")
+	}
 
 	return urlStr, nil
 }

--- a/pkg/notifications/slack.go
+++ b/pkg/notifications/slack.go
@@ -98,7 +98,7 @@ func (s *slackTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 	clog.Debug("Generating Slack service URL")
 
 	if logrus.IsLevelEnabled(logrus.TraceLevel) {
-		clog.WithField("hook_url", s.HookURL).
+		clog.WithField("hook_url", redactServiceURL(s.HookURL)).
 			Trace("Slack hook URL loaded")
 	}
 
@@ -125,7 +125,7 @@ func (s *slackTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 
 		urlStr := conf.GetURL().String()
 		if logrus.IsLevelEnabled(logrus.TraceLevel) {
-			clog.WithField("service_url", urlStr).
+			clog.WithField("service_url", redactServiceURL(urlStr)).
 				Trace("Generated Discord service URL")
 		} else {
 			clog.Debug("Generated Discord service URL")
@@ -160,7 +160,7 @@ func (s *slackTypeNotifier) GetURL(_ *cobra.Command) (string, error) {
 
 	urlStr := conf.GetURL().String()
 	if logrus.IsLevelEnabled(logrus.TraceLevel) {
-		clog.WithField("service_url", urlStr).
+		clog.WithField("service_url", redactServiceURL(urlStr)).
 			Trace("Generated Slack service URL")
 	} else {
 		clog.Debug("Generated Slack service URL")


### PR DESCRIPTION
This PR reworks how Watchtower loads and applies process configuration so flags, environment variables, and runtime policy resolve through one path instead of scattered Cobra/Viper reads.

## Problem

Configuration and update policy were assembled in multiple places (cmd, flags, API, schedule, notifications). That made behavior hard to reason about, allowed partial UpdateParams builders, and mixed registration-time env baking with ad hoc flag Gets.

## Solution

Introduce domain config packages and a single Config.Load resolver, split flags into FlagSpec domains with static defaults and consistent env bridging, and project one complete UpdateParams snapshot for run-once, schedule, and HTTP API. Drain orchestration assembly out of cmd and point notifications at resolved settings.

## Changes

- Add internal/config domain types, Load, and shared UpdateParams / RunConfig / startup projections
- Convert flags to FlagSpec domains with BindAll, ApplyEnvToFlags, and CLI-neutral env semantics (including NO_COLOR presence)
- Unify schedule and API BaseParams; fix filter alignment and sensitive notifier URL logging
- Slim cmd/root wiring and clean up related tests and package docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified configuration resolution across CLI flags, environment variables, and runtime behavior.
  * Structured HTTP API, scheduling, Docker, lifecycle, update-policy, and logging configuration.
  * Improved notifications configuration with consistent templates, legacy support, and robust URL parsing.
* **Bug Fixes**
  * Ensured CLI values correctly override environment defaults (including “changed” tracking).
  * Added validation for API host inputs and conflicting update modes.
  * Preserved commas inside notification URLs during parsing.
  * Interpreted numeric timeout values as seconds (legacy compatibility).
* **Documentation**
  * Updated configuration, startup-message, and notification usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->