### PR TITLE
fix: resolve SSE endpoint closing immediately after retry line

### DIFF
--- a/internal/api/handlers/events/handler.go
+++ b/internal/api/handlers/events/handler.go
@@ -67,8 +67,6 @@ func (h *Handler) Handle() fiber.Handler {
 			return err
 		}
 
-		defer h.Broadcaster.Unsubscribe(subCh)
-
 		return h.serveStream(c, subCh, done)
 	}
 }
@@ -147,6 +145,9 @@ func (h *Handler) subscribe() (<-chan Event, <-chan struct{}, error) {
 func (h *Handler) serveStream(c fiber.Ctx, subCh <-chan Event, done <-chan struct{}) error {
 	return sse.New(sse.Config{
 		Retry: sseRetryInterval,
+		OnClose: func(_ fiber.Ctx, _ error) {
+			h.Broadcaster.Unsubscribe(subCh)
+		},
 		Handler: func(c fiber.Ctx, stream *sse.Stream) error {
 			return h.dispatchEvents(stream, subCh, done)
 		},

--- a/internal/api/handlers/events/handler_test.go
+++ b/internal/api/handlers/events/handler_test.go
@@ -1,9 +1,11 @@
 package events
 
 import (
+	"bufio"
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -312,6 +314,56 @@ func TestHandler_Handle_MaxSubscribersHTTP(t *testing.T) {
 	defer resp.Body.Close()
 
 	assert.Equal(t, fiber.StatusServiceUnavailable, resp.StatusCode)
+}
+
+func TestHandler_Handle_StreamStaysOpenAndDeliversEvent(t *testing.T) {
+	b := NewBroadcaster()
+	h := NewHandler(b, nil)
+
+	app := fiber.New(fiber.Config{})
+	app.Get("/v1/events", h.Handle())
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		b.Publish(Event{
+			Type:      "scan_completed",
+			Timestamp: time.Now().UTC(),
+			Data:      ScanCompletedData{Scanned: 1, Updated: 0, Failed: 0},
+		})
+	}()
+
+	resp, err := app.Test(httptest.NewRequestWithContext(
+		t.Context(),
+		http.MethodGet,
+		"/v1/events",
+		http.NoBody,
+	), fiber.TestConfig{
+		Timeout: 500 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+
+	scanner := bufio.NewScanner(resp.Body)
+	found := false
+
+	for scanner.Scan() {
+		if strings.Contains(scanner.Text(), "event: scan_completed") {
+			found = true
+
+			break
+		}
+	}
+
+	err = scanner.Err()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.True(t, found, "expected event not received in stream")
 }
 
 func TestHandler_Handle_OriginCheckPrecedence(t *testing.T) {


### PR DESCRIPTION
This PR fixes the `/v1/events` SSE endpoint, which was closing the connection ~18ms after sending the initial `retry: 5000` line instead of remaining open and streaming events.

## Problem

The SSE handler registered `defer h.Broadcaster.Unsubscribe(subCh)` in `Handle()`, but Fiber v3's `SendStreamWriter` runs the stream callback in a background goroutine and returns immediately. The outer handler's `defer` fired before the stream goroutine even began, closing the `done` channel and causing `dispatchEvents` to return immediately, which closed the pipe and ended the HTTP connection.

## Solution

Move subscriber cleanup from the outer handler's `defer` into the SSE middleware's `OnClose` callback, which runs when the stream actually ends. Add a regression test that verifies the stream stays open long enough to receive a published event.

## Changes

- Remove the premature defer Unsubscribe in Handle()
- Add the OnClose callback to the Fiber SSE config for proper cleanup
- Add test verifying stream stays open and delivers events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event stream lifecycle handling so connections remain open and receive events reliably.
  * Ensured subscriptions are cleaned up when the event stream closes.

* **Tests**
  * Added coverage verifying that completed-event notifications are delivered through the open stream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->