### PR TITLE
fix(notify-upgrade): address command execution bugs and update migration docs

### DIFF
--- a/cmd/notify-upgrade.go
+++ b/cmd/notify-upgrade.go
@@ -12,9 +12,11 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	appconfig "github.com/nicholas-fedor/watchtower/internal/config"
+	appConfig "github.com/nicholas-fedor/watchtower/internal/config"
 	"github.com/nicholas-fedor/watchtower/internal/flags"
+	"github.com/nicholas-fedor/watchtower/pkg/container"
 	"github.com/nicholas-fedor/watchtower/pkg/notifications"
+	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
 // cleanupTimeout defines the duration after which the temporary notification file is removed.
@@ -69,8 +71,8 @@ func runNotifyUpgrade(cmd *cobra.Command, args []string) {
 //     Non-critical failures (e.g., file removal after timeout) are logged but do not result in an error return.
 func runNotifyUpgradeE(cmd *cobra.Command, _ []string) error {
 	// Process flag aliases and expand secrets before resolving configuration.
-	// Use PersistentFlags so env/alias bridging matches config.Load's bind source.
-	flagSet := cmd.PersistentFlags()
+	// Use Root().PersistentFlags so env/alias bridging matches config.Load's bind source across subcommands.
+	flagSet := cmd.Root().PersistentFlags()
 
 	err := flags.ApplyEnvToFlags(flagSet, flags.AllSpecs())
 	if err != nil {
@@ -78,23 +80,31 @@ func runNotifyUpgradeE(cmd *cobra.Command, _ []string) error {
 	}
 
 	flags.ProcessFlagAliases(flagSet)
-	flags.GetSecretsFromFiles(cmd)
 
-	cfg, loadErr := appconfig.Load(cmd, nil)
+	err = flags.SetupLogging(flagSet)
+	if err != nil {
+		return fmt.Errorf("setup logging: %w", err)
+	}
+
+	flags.GetSecretsFromFiles(cmd.Root())
+
+	cfg, loadErr := appConfig.Load(cmd.Root(), nil)
 	if loadErr != nil {
 		return fmt.Errorf("load configuration: %w", loadErr)
 	}
 
-	notifier := notifications.NewNotifier(cfg.Notify)
-	urls := notifier.GetURLs()
+	urls, buildErr := notifications.BuildURLs(cfg.Notify)
+	if buildErr != nil {
+		return fmt.Errorf("build notification URLs: %w", buildErr)
+	}
 
 	// Log the identified notification types (e.g., "email, slack") to inform the user of what configurations are being upgraded.
-	logrus.WithField("notifiers", strings.Join(notifier.GetNames(), ", ")).
+	logrus.WithField("notifiers", strings.Join(cfg.Notify.LegacyTypes, ", ")).
 		Info("Found notification config(s)")
 
-	// Create a temporary file in the root directory with a pattern that ensures uniqueness (e.g., "watchtower-notif-urls-123").
+	// Create a temporary file in the working directory with a pattern that ensures uniqueness (e.g., "watchtower-notif-urls-123").
 	// This file will store the generated URLs for user retrieval.
-	outFile, err := os.CreateTemp("/", "watchtower-notif-urls-*")
+	outFile, err := os.CreateTemp(".", "watchtower-notif-urls-*")
 	if err != nil {
 		// Log the failure with the specific error and return a wrapped error to halt execution, as file creation is critical.
 		logrus.WithError(err).Debug("Temporary file creation failed")
@@ -121,7 +131,7 @@ func runNotifyUpgradeE(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Write the constructed string to the temporary file. This is a critical step, as the file's purpose is to store this data.
-	_, err = fmt.Fprint(outFile, urlBuilder.String())
+	_, err = fmt.Fprintln(outFile, urlBuilder.String())
 	if err != nil {
 		logrus.WithError(err).
 			WithField("file", outFile.Name()).
@@ -144,8 +154,16 @@ func runNotifyUpgradeE(cmd *cobra.Command, _ []string) error {
 	// Use a placeholder ("<CONTAINER>") if this fails, ensuring the user still gets actionable guidance.
 	containerID := "<CONTAINER>"
 
-	if currentWatchtowerContainerID != "" {
-		containerID = currentWatchtowerContainerID.ShortID() // Use the short ID (e.g., "abc123") for brevity in user instructions.
+	var cid types.ContainerID
+
+	cid, err = container.GetContainerIDFromMountinfo()
+	if err == nil && cid != "" {
+		containerID = cid.ShortID()
+	} else {
+		cid, err = container.GetContainerIDFromCgroupFile()
+		if err == nil && cid != "" {
+			containerID = cid.ShortID()
+		}
 	}
 
 	// Provide user instructions for retrieving the file, split into two log lines for clarity: a prompt and the exact command.

--- a/cmd/notify-upgrade.go
+++ b/cmd/notify-upgrade.go
@@ -169,7 +169,7 @@ func runNotifyUpgradeE(cmd *cobra.Command, _ []string) error {
 	// Provide user instructions for retrieving the file, split into two log lines for clarity: a prompt and the exact command.
 	logrus.Info(
 		fmt.Sprintf(
-			"To get the environment file, use: cp %s:%s ./watchtower-notifications.env",
+			"To get the environment file, use: docker cp %s:%s ./watchtower-notifications.env",
 			containerID,
 			outFile.Name(),
 		),

--- a/docs/notifications/deprecations/migration-tool/index.md
+++ b/docs/notifications/deprecations/migration-tool/index.md
@@ -4,104 +4,620 @@
 
 Watchtower includes a `notify-upgrade` command to help convert legacy notification configurations to Shoutrrr URLs for use with the [`NOTIFICATION URL`](../../../configuration/notifications/index.md#notification_url).
 
-The output is written to a temporary file, which you can copy using:
+It parses legacy Watchtower notification configurations and outputs Shoutrrr URLs to a temporary file inside the Watchtower container.
+
+## Usage
+
+The `notify-upgrade` command converts legacy Watchtower notification configurations into Shoutrrr URLs and writes them to a temporary file inside the container.
+
+### Running the Command
+
+The `notify-upgrade` can be run either against a Watchtower container that is already running or as a single-run instance that allows you to convert a Docker Compose configuration or Docker CLI flag / environment variable configuration.
+
+#### Existing Deployment
+
+If Watchtower is already deployed and running with your legacy notification configuration, you can execute `notify-upgrade` directly inside the container:
+
+```bash
+docker exec watchtower /watchtower notify-upgrade
+```
+
+This works because the Watchtower binary is installed at `/watchtower` and `notify-upgrade` is a built-in subcommand.
+The common mistake is running `docker exec watchtower notify-upgrade`, which fails because `notify-upgrade` is not a standalone executable in `$PATH`.
+
+!!! Note
+    Running `notify-upgrade` inside an existing container does **not** stop or restart the main Watchtower process.
+    `docker exec` runs a separate, short-lived process.
+    The only side effect is that the `notify-upgrade` process will stay alive for up to 5 minutes while waiting for you to retrieve the temporary file, after which it cleans up and exits.
+
+#### Single-Use Run
+
+If you have not yet deployed Watchtower or if you want to run `notify-upgrade` as a one-off command without starting the persistent Watchtower update loop, then run a temporary container configured with `notify-upgrade` as the command.
+
+=== "Email (SMTP)"
+
+    === "Docker Compose"
+        ```yaml
+        services:
+          watchtower:
+            image: nickfedor/watchtower:latest
+            command: notify-upgrade
+            environment:
+              WATCHTOWER_NOTIFICATIONS: email
+              WATCHTOWER_NOTIFICATION_EMAIL_SERVER: smtp.example.com
+              WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT: 587
+              WATCHTOWER_NOTIFICATION_EMAIL_SERVER_USER: user@example.com
+              WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD: secret
+              WATCHTOWER_NOTIFICATION_EMAIL_FROM: sender@example.com
+              WATCHTOWER_NOTIFICATION_EMAIL_TO: recipient@example.com
+            volumes:
+              - /var/run/docker.sock:/var/run/docker.sock
+        ```
+    === "Docker CLI (Env Vars)"
+        ```bash
+        docker run --rm \
+          --name watchtower-notify-upgrade \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          -e WATCHTOWER_NOTIFICATIONS=email \
+          -e WATCHTOWER_NOTIFICATION_EMAIL_SERVER=smtp.example.com \
+          -e WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT=587 \
+          -e WATCHTOWER_NOTIFICATION_EMAIL_SERVER_USER=user@example.com \
+          -e WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD=secret \
+          -e WATCHTOWER_NOTIFICATION_EMAIL_FROM=sender@example.com \
+          -e WATCHTOWER_NOTIFICATION_EMAIL_TO=recipient@example.com \
+          nickfedor/watchtower \
+          notify-upgrade
+        ```
+    === "Docker CLI (Flags)"
+        ```bash
+        docker run --rm \
+          --name watchtower-notify-upgrade \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          nickfedor/watchtower \
+          notify-upgrade \
+          --notifications email \
+          --notification-email-server smtp.example.com \
+          --notification-email-server-port 587 \
+          --notification-email-server-user user@example.com \
+          --notification-email-server-password secret \
+          --notification-email-from sender@example.com \
+          --notification-email-to recipient@example.com
+        ```
+
+=== "Gotify"
+
+    === "Docker Compose"
+        ```yaml
+        services:
+          watchtower:
+            image: nickfedor/watchtower:latest
+            command: notify-upgrade
+            environment:
+              WATCHTOWER_NOTIFICATIONS: gotify
+              WATCHTOWER_NOTIFICATION_GOTIFY_URL: "https://my.gotify.tld/"
+              WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN: "SuperSecretToken"
+              WATCHTOWER_NOTIFICATION_GOTIFY_TLS_SKIP_VERIFY: true
+            volumes:
+              - /var/run/docker.sock:/var/run/docker.sock
+        ```
+    === "Docker CLI (Env Vars)"
+        ```bash
+        docker run --rm \
+          --name watchtower-notify-upgrade \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          -e WATCHTOWER_NOTIFICATIONS=gotify \
+          -e WATCHTOWER_NOTIFICATION_GOTIFY_URL="https://my.gotify.tld/" \
+          -e WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN="SuperSecretToken" \
+          -e WATCHTOWER_NOTIFICATION_GOTIFY_TLS_SKIP_VERIFY=true \
+          nickfedor/watchtower \
+          notify-upgrade
+        ```
+    === "Docker CLI (Flags)"
+        ```bash
+        docker run --rm \
+          --name watchtower-notify-upgrade \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          nickfedor/watchtower \
+          notify-upgrade \
+          --notifications gotify \
+          --notification-gotify-url "https://my.gotify.tld/" \
+          --notification-gotify-token "SuperSecretToken" \
+          --notification-gotify-tls-skip-verify
+        ```
+
+=== "Slack"
+
+    === "Docker Compose"
+        ```yaml
+        services:
+          watchtower:
+            image: nickfedor/watchtower:latest
+            command: notify-upgrade
+            environment:
+              WATCHTOWER_NOTIFICATIONS: slack
+              WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL: "https://hooks.slack.com/services/AAA/BBB/CCC"
+              WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER: watchtower-server-1
+              WATCHTOWER_NOTIFICATION_SLACK_CHANNEL: "#my-custom-channel"
+            volumes:
+              - /var/run/docker.sock:/var/run/docker.sock
+        ```
+    === "Docker CLI (Env Vars)"
+        ```bash
+        docker run --rm \
+          --name watchtower-notify-upgrade \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          -e WATCHTOWER_NOTIFICATIONS=slack \
+          -e WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL="https://hooks.slack.com/services/AAA/BBB/CCC" \
+          -e WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER=watchtower-server-1 \
+          -e WATCHTOWER_NOTIFICATION_SLACK_CHANNEL="#my-custom-channel" \
+          nickfedor/watchtower \
+          notify-upgrade
+        ```
+    === "Docker CLI (Flags)"
+        ```bash
+        docker run --rm \
+          --name watchtower-notify-upgrade \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          nickfedor/watchtower \
+          notify-upgrade \
+          --notifications slack \
+          --notification-slack-hook-url "https://hooks.slack.com/services/AAA/BBB/CCC" \
+          --notification-slack-identifier watchtower-server-1 \
+          --notification-slack-channel "#my-custom-channel"
+        ```
+
+=== "Microsoft Teams"
+
+    === "Docker Compose"
+        ```yaml
+        services:
+          watchtower:
+            image: nickfedor/watchtower:latest
+            command: notify-upgrade
+            environment:
+              WATCHTOWER_NOTIFICATIONS: msteams
+              WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL: "https://prod-00.westus.logic.azure.com:443/workflows/abc123/triggers/manual/paths/invoke?api-version=2016-06-00&sp=/triggers/manual/run&sv=1.0&sig=XXXXXXXX"
+            volumes:
+              - /var/run/docker.sock:/var/run/docker.sock
+        ```
+    === "Docker CLI (Env Vars)"
+        ```bash
+        docker run --rm \
+          --name watchtower-notify-upgrade \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          -e WATCHTOWER_NOTIFICATIONS=msteams \
+          -e WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL="https://prod-00.westus.logic.azure.com:443/workflows/abc123/triggers/manual/paths/invoke?api-version=2016-06-00&sp=/triggers/manual/run&sv=1.0&sig=XXXXXXXX" \
+          nickfedor/watchtower \
+          notify-upgrade
+        ```
+    === "Docker CLI (Flags)"
+        ```bash
+        docker run --rm \
+          --name watchtower-notify-upgrade \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          nickfedor/watchtower \
+          notify-upgrade \
+          --notifications msteams \
+          --notification-msteams-hook "https://prod-00.westus.logic.azure.com:443/workflows/abc123/triggers/manual/paths/invoke?api-version=2016-06-00&sp=/triggers/manual/run&sv=1.0&sig=XXXXXXXX"
+        ```
+
+!!! Important
+    Replace the example environment variables with your own legacy notification configuration.
+    The `notify-upgrade` command inspects the container's current configuration, so it must be started with your legacy notification settings.
+
+### Retrieving the Generated File
+
+After running `notify-upgrade`, the converted Shoutrrr URL is written to a temporary file in the container's working directory, with a filename like `watchtower-notif-urls-XXXXXX`.
+
+The command logs the exact container path and prints a copy command, for example:
+
+```text
+INFO To get the environment file, use: cp abc123:watchtower-notif-urls-123456789 ./watchtower-notifications.env
+```
+
+Copy it to your local machine with:
 
 ```bash
 docker cp <CONTAINER>:<FILE_PATH> ./watchtower-notifications.env
 ```
 
-## SMTP Migration Walkthrough
+The temporary file is automatically removed after **5 minutes** or when the container stops, so copy it promptly after generation.
+If you are running `notify-upgrade` as a one-off command (`docker run --rm ...`), the process will wait up to 5 minutes before exiting.
 
-Example Legacy Configuration:
+## Migration Walkthrough
 
-1. Run the following Docker Compose configuration / Docker CLI command:
+Select the tab that matches your legacy notification service.
 
-    === "Docker Compose"
-        ```yaml
-        services:
-            watchtower:
-                image: nickfedor/watchtower:latest
-                environment:
-                    WATCHTOWER_NOTIFICATIONS: email
-                    WATCHTOWER_NOTIFICATION_EMAIL_SERVER: smtp.example.com
-                    WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT: 587
-                    WATCHTOWER_NOTIFICATION_EMAIL_SERVER_USER: user@example.com
-                    WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD: secret
-                    WATCHTOWER_NOTIFICATION_EMAIL_FROM: sender@example.com
-                    WATCHTOWER_NOTIFICATION_EMAIL_TO: recipient@example.com
-                volumes:
-                   - /var/run/docker.sock:/var/run/docker.sock
-        ```
-    === "Docker CLI (Env Vars)"
+=== "Email (SMTP)"
+
+    1. Run the following Docker Compose configuration / Docker CLI command:
+
+        === "Docker Compose"
+            ```yaml
+            services:
+                watchtower:
+                    image: nickfedor/watchtower:latest
+                    environment:
+                        WATCHTOWER_NOTIFICATIONS: email
+                        WATCHTOWER_NOTIFICATION_EMAIL_SERVER: smtp.example.com
+                        WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT: 587
+                        WATCHTOWER_NOTIFICATION_EMAIL_SERVER_USER: user@example.com
+                        WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD: secret
+                        WATCHTOWER_NOTIFICATION_EMAIL_FROM: sender@example.com
+                        WATCHTOWER_NOTIFICATION_EMAIL_TO: recipient@example.com
+                    volumes:
+                    - /var/run/docker.sock:/var/run/docker.sock
+            ```
+        === "Docker CLI (Env Vars)"
+            ```bash
+            docker run -d \
+            --name watchtower \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              -e WATCHTOWER_NOTIFICATIONS=email \
+              -e WATCHTOWER_NOTIFICATION_EMAIL_SERVER=smtp.example.com \
+              -e WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT=587 \
+              -e WATCHTOWER_NOTIFICATION_EMAIL_SERVER_USER=user@example.com \
+              -e WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD=secret \
+              -e WATCHTOWER_NOTIFICATION_EMAIL_FROM=sender@example.com \
+              -e WATCHTOWER_NOTIFICATION_EMAIL_TO=recipient@example.com \
+              nickfedor/watchtower
+            ```
+        === "Docker CLI (Flags)"
+            ```bash
+            docker run -d \
+              --name watchtower \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              nickfedor/watchtower \
+              --notifications email \
+              --notification-email-server smtp.example.com \
+              --notification-email-server-port 587 \
+              --notification-email-server-user user@example.com \
+              --notification-email-server-password secret \
+              --notification-email-from sender@example.com \
+              --notification-email-to recipient@example.com
+            ```
+
+    2. With the container running, execute the `notify-upgrade` command:
+
         ```bash
-        docker run -d \
-        --name watchtower \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        -e WATCHTOWER_NOTIFICATIONS=email \
-        -e WATCHTOWER_NOTIFICATION_EMAIL_SERVER=smtp.example.com \
-        -e WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT=587 \
-        -e WATCHTOWER_NOTIFICATION_EMAIL_SERVER_USER=user@example.com \
-        -e WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD=secret \
-        -e WATCHTOWER_NOTIFICATION_EMAIL_FROM=sender@example.com \
-        -e WATCHTOWER_NOTIFICATION_EMAIL_TO=recipient@example.com \
-        nickfedor/watchtower
+        docker exec watchtower /watchtower notify-upgrade
         ```
-    === "Docker CLI (Flags)"
+
+        Then copy the resulting file out of the container:
+
         ```bash
-        docker run -d \
-        --name watchtower \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        nickfedor/watchtower \
-        --notifications email \
-        --notification-email-server smtp.example.com \
-        --notification-email-server-port 587 \
-        --notification-email-server-user user@example.com \
-        --notification-email-server-password secret \
-        --notification-email-from sender@example.com \
-        --notification-email-to recipient@example.com
+        docker cp watchtower:<CONTAINER>:<FILE_PATH> ./watchtower-notifications.env
         ```
 
-2. The following converted Shoutrrr URL should be produced:
+    3. The following converted Shoutrrr URL should be produced:
 
-    ```text
-    smtp://user@example.com:secret@smtp.example.com:587/?fromaddress=sender@example.com&toaddresses=recipient@example.com&encryption=ExplicitTLS&usestarttls=yes
-    ```
-
-3. Replace the deprecated configuration with the coverted Shoutrrr URL:
-
-    === "Docker Compose"
-        ```yaml
-        services:
-            watchtower:
-                image: nickfedor/watchtower:latest
-                environment:
-                    WATCHTOWER_NOTIFICATION_URL: smtp://user@example.com:secret@smtp.example.com:587/?fromaddress=sender@example.com&toaddresses=recipient@example.com&encryption=ExplicitTLS&usestarttls=yes
-                    WATCHTOWER_NOTIFICATIONS_DELAY: "10"
-                    WATCHTOWER_NOTIFICATION_TITLE_TAG: Watchtower
-                volumes:
-                   - /var/run/docker.sock:/var/run/docker.sock
+        ```text
+        smtp://user@example.com:secret@smtp.example.com:587/?fromaddress=sender@example.com&toaddresses=recipient@example.com&encryption=ExplicitTLS&usestarttls=yes
         ```
-    === "Docker CLI (Env Vars)"
+
+    4. Replace the deprecated configuration with the coverted Shoutrrr URL:
+
+        === "Docker Compose"
+            ```yaml
+            services:
+                watchtower:
+                    image: nickfedor/watchtower:latest
+                    environment:
+                        WATCHTOWER_NOTIFICATION_URL: smtp://user@example.com:secret@smtp.example.com:587/?fromaddress=sender@example.com&toaddresses=recipient@example.com&encryption=ExplicitTLS&usestarttls=yes
+                        WATCHTOWER_NOTIFICATIONS_DELAY: "10"
+                        WATCHTOWER_NOTIFICATION_TITLE_TAG: Watchtower
+                    volumes:
+                    - /var/run/docker.sock:/var/run/docker.sock
+            ```
+        === "Docker CLI (Env Vars)"
+            ```bash
+            docker run -d \
+              --name watchtower \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              -e WATCHTOWER_NOTIFICATION_URL=smtp://user@example.com:secret@smtp.example.com:587/?fromaddress=sender@example.com&toaddresses=recipient@example.com&encryption=ExplicitTLS&usestarttls=yes \
+              -e WATCHTOWER_NOTIFICATIONS_DELAY=10 \
+              -e WATCHTOWER_NOTIFICATION_TITLE_TAG=Watchtower \
+              nickfedor/watchtower
+            ```
+        === "Docker CLI (Flags)"
+            ```bash
+            docker run -d \
+              --name watchtower \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              nickfedor/watchtower \
+              --notification-url "smtp://user@example.com:secret@smtp.example.com:587/?fromaddress=sender@example.com&toaddresses=recipient@example.com&encryption=ExplicitTLS&usestarttls=yes" \
+              --notifications-delay 10 \
+              --notification-title-tag Watchtower
+            ```
+
+    !!! Note
+        - Avoid using unrecognized flags like `WATCHTOWER_NOTIFICATION_EMAIL_SERVER_SSL`, as they are ignored and may cause confusion.
+        - Use the `encryption` and `usestarttls` URL parameters in the `smtp://` URL to control TLS behavior rather than deprecated flags.
+
+=== "Gotify"
+
+    1. Run the following Docker Compose configuration / Docker CLI command:
+
+        === "Docker Compose"
+            ```yaml
+            services:
+                watchtower:
+                    image: nickfedor/watchtower:latest
+                    environment:
+                        WATCHTOWER_NOTIFICATIONS: gotify
+                        WATCHTOWER_NOTIFICATION_GOTIFY_URL: "https://my.gotify.tld/"
+                        WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN: "SuperSecretToken"
+                        WATCHTOWER_NOTIFICATION_GOTIFY_TLS_SKIP_VERIFY: true
+                    volumes:
+                    - /var/run/docker.sock:/var/run/docker.sock
+            ```
+        === "Docker CLI (Env Vars)"
+            ```bash
+            docker run -d \
+              --name watchtower \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              -e WATCHTOWER_NOTIFICATIONS=gotify \
+              -e WATCHTOWER_NOTIFICATION_GOTIFY_URL="https://my.gotify.tld/" \
+              -e WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN="SuperSecretToken" \
+              -e WATCHTOWER_NOTIFICATION_GOTIFY_TLS_SKIP_VERIFY=true \
+              nickfedor/watchtower
+            ```
+        === "Docker CLI (Flags)"
+            ```bash
+            docker run -d \
+              --name watchtower \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              nickfedor/watchtower \
+              --notifications gotify \
+              --notification-gotify-url "https://my.gotify.tld/" \
+              --notification-gotify-token "SuperSecretToken" \
+              --notification-gotify-tls-skip-verify
+            ```
+
+    2. With the container running, execute the `notify-upgrade` command:
+
         ```bash
-        docker run -d \
-        --name watchtower \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        -e WATCHTOWER_NOTIFICATION_URL=smtp://user@example.com:secret@smtp.example.com:587/?fromaddress=sender@example.com&toaddresses=recipient@example.com&encryption=ExplicitTLS&usestarttls=yes \
-        -e WATCHTOWER_NOTIFICATIONS_DELAY=10 \
-        -e WATCHTOWER_NOTIFICATION_TITLE_TAG=Watchtower \
-        nickfedor/watchtower
-        ```
-    === "Docker CLI (Flags)"
-        ```bash
-        docker run -d \
-        --name watchtower \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        nickfedor/watchtower \
-        --notification-url "smtp://user@example.com:secret@smtp.example.com:587/?fromaddress=sender@example.com&toaddresses=recipient@example.com&encryption=ExplicitTLS&usestarttls=yes" \
-        --notifications-delay 10 \
-        --notification-title-tag Watchtower
+        docker exec watchtower /watchtower notify-upgrade
         ```
 
-!!! Note
-    - Avoid using unrecognized flags like `WATCHTOWER_NOTIFICATION_EMAIL_SERVER_SSL`, as they are ignored and may cause confusion.
-    - Use the `encryption` and `usestarttls` URL parameters in the `smtp://` URL to control TLS behavior rather than deprecated flags.
+        Then copy the resulting file out of the container:
+
+        ```bash
+        docker cp watchtower:<CONTAINER>:<FILE_PATH> ./watchtower-notifications.env
+        ```
+
+    3. The following converted Shoutrrr URL should be produced:
+
+        ```text
+        gotify://my.gotify.tld/SuperSecretToken?title=
+        ```
+
+    4. Replace the deprecated configuration with the coverted Shoutrrr URL:
+
+        === "Docker Compose"
+            ```yaml
+            services:
+                watchtower:
+                    image: nickfedor/watchtower:latest
+                    environment:
+                        WATCHTOWER_NOTIFICATION_URL: "gotify://my.gotify.tld/SuperSecretToken?title="
+                    volumes:
+                    - /var/run/docker.sock:/var/run/docker.sock
+            ```
+        === "Docker CLI (Env Vars)"
+            ```bash
+            docker run -d \
+              --name watchtower \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              -e WATCHTOWER_NOTIFICATION_URL="gotify://my.gotify.tld/SuperSecretToken?title=" \
+              nickfedor/watchtower
+            ```
+        === "Docker CLI (Flags)"
+            ```bash
+            docker run -d \
+              --name watchtower \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              nickfedor/watchtower \
+              --notification-url "gotify://my.gotify.tld/SuperSecretToken?title="
+            ```
+
+=== "Slack"
+
+    1. Run the following Docker Compose configuration / Docker CLI command:
+
+        === "Docker Compose"
+            ```yaml
+            services:
+                watchtower:
+                    image: nickfedor/watchtower:latest
+                    environment:
+                        WATCHTOWER_NOTIFICATIONS: slack
+                        WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL: "https://hooks.slack.com/services/AAA/BBB/CCC"
+                        WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER: watchtower-server-1
+                        WATCHTOWER_NOTIFICATION_SLACK_CHANNEL: "#my-custom-channel"
+                    volumes:
+                    - /var/run/docker.sock:/var/run/docker.sock
+            ```
+        === "Docker CLI (Env Vars)"
+            ```bash
+            docker run -d \
+              --name watchtower \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              -e WATCHTOWER_NOTIFICATIONS=slack \
+              -e WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL="https://hooks.slack.com/services/AAA/BBB/CCC" \
+              -e WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER=watchtower-server-1 \
+              -e WATCHTOWER_NOTIFICATION_SLACK_CHANNEL="#my-custom-channel" \
+              nickfedor/watchtower
+            ```
+        === "Docker CLI (Flags)"
+            ```bash
+            docker run -d \
+              --name watchtower \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              nickfedor/watchtower \
+              --notifications slack \
+              --notification-slack-hook-url "https://hooks.slack.com/services/AAA/BBB/CCC" \
+              --notification-slack-identifier watchtower-server-1 \
+              --notification-slack-channel "#my-custom-channel"
+            ```
+
+    2. With the container running, execute the `notify-upgrade` command:
+
+        ```bash
+        docker exec watchtower /watchtower notify-upgrade
+        ```
+
+        Then copy the resulting file out of the container:
+
+        ```bash
+        docker cp watchtower:<CONTAINER>:<FILE_PATH> ./watchtower-notifications.env
+        ```
+
+    3. The following converted Shoutrrr URL should be produced:
+
+        ```text
+        slack://hook:AAA-BBB-CCC@webhook?botname=watchtower&color=%23406170&channel=webhook
+        ```
+
+    4. Replace the deprecated configuration with the coverted Shoutrrr URL:
+
+        === "Docker Compose"
+            ```yaml
+            services:
+                watchtower:
+                    image: nickfedor/watchtower:latest
+                    environment:
+                        WATCHTOWER_NOTIFICATION_URL: "slack://hook:AAA-BBB-CCC@webhook?botname=watchtower&color=%23406170&channel=webhook"
+                    volumes:
+                    - /var/run/docker.sock:/var/run/docker.sock
+            ```
+        === "Docker CLI (Env Vars)"
+            ```bash
+            docker run -d \
+              --name watchtower \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              -e WATCHTOWER_NOTIFICATION_URL="slack://hook:AAA-BBB-CCC@webhook?botname=watchtower&color=%23406170&channel=webhook" \
+              nickfedor/watchtower
+            ```
+        === "Docker CLI (Flags)"
+            ```bash
+            docker run -d \
+              --name watchtower \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              nickfedor/watchtower \
+              --notification-url "slack://hook:AAA-BBB-CCC@webhook?botname=watchtower&color=%23406170&channel=webhook"
+            ```
+
+=== "Microsoft Teams"
+
+    1. Run the following Docker Compose configuration / Docker CLI command:
+
+        === "Docker Compose"
+            ```yaml
+            services:
+                watchtower:
+                    image: nickfedor/watchtower:latest
+                    environment:
+                        WATCHTOWER_NOTIFICATIONS: msteams
+                        WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL: "https://prod-00.westus.logic.azure.com:443/workflows/abc123/triggers/manual/paths/invoke?api-version=2016-06-00&sp=/triggers/manual/run&sv=1.0&sig=XXXXXXXX"
+                    volumes:
+                    - /var/run/docker.sock:/var/run/docker.sock
+            ```
+        === "Docker CLI (Env Vars)"
+            ```bash
+            docker run -d \
+              --name watchtower \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              -e WATCHTOWER_NOTIFICATIONS=msteams \
+              -e WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL="https://prod-00.westus.logic.azure.com:443/workflows/abc123/triggers/manual/paths/invoke?api-version=2016-06-00&sp=/triggers/manual/run&sv=1.0&sig=XXXXXXXX" \
+              nickfedor/watchtower
+            ```
+        === "Docker CLI (Flags)"
+            ```bash
+            docker run -d \
+              --name watchtower \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              nickfedor/watchtower \
+              --notifications msteams \
+              --notification-msteams-hook "https://prod-00.westus.logic.azure.com:443/workflows/abc123/triggers/manual/paths/invoke?api-version=2016-06-00&sp=/triggers/manual/run&sv=1.0&sig=XXXXXXXX"
+            ```
+
+    2. With the container running, execute the `notify-upgrade` command:
+
+        ```bash
+        docker exec watchtower /watchtower notify-upgrade
+        ```
+
+        Then copy the resulting file out of the container:
+
+        ```bash
+        docker cp watchtower:<CONTAINER>:<FILE_PATH> ./watchtower-notifications.env
+        ```
+
+    3. The following converted Shoutrrr URL should be produced:
+
+        ```text
+        teams://?host=https%3A%2F%2Fprod-00.westus.logic.azure.com%3A443%2Fworkflows%2Fabc123%2Ftriggers%2Fmanual%2Fpaths%2Finvoke%3Fapi-version%3D2016-06-00%26sp%3D%2Ftriggers%2Fmanual%2Frun%26sv%3D1.0%26sig%3DXXXXXXXX&color=%23406170
+        ```
+
+    4. Replace the deprecated configuration with the coverted Shoutrrr URL:
+
+        === "Docker Compose"
+            ```yaml
+            services:
+                watchtower:
+                    image: nickfedor/watchtower:latest
+                    environment:
+                        WATCHTOWER_NOTIFICATION_URL: "teams://?host=https%3A%2F%2Fprod-00.westus.logic.azure.com%3A443%2Fworkflows%2Fabc123%2Ftriggers%2Fmanual%2Fpaths%2Finvoke%3Fapi-version%3D2016-06-00%26sp%3D%2Ftriggers%2Fmanual%2Frun%26sv%3D1.0%26sig%3DXXXXXXXX&color=%23406170"
+                    volumes:
+                    - /var/run/docker.sock:/var/run/docker.sock
+            ```
+        === "Docker CLI (Env Vars)"
+            ```bash
+            docker run -d \
+              --name watchtower \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              -e WATCHTOWER_NOTIFICATION_URL="teams://?host=https%3A%2F%2Fprod-00.westus.logic.azure.com%3A443%2Fworkflows%2Fabc123%2Ftriggers%2Fmanual%2Fpaths%2Finvoke%3Fapi-version%3D2016-06-00%26sp%3D%2Ftriggers%2Fmanual%2Frun%26sv%3D1.0%26sig%3DXXXXXXXX&color=%23406170" \
+              nickfedor/watchtower
+            ```
+        === "Docker CLI (Flags)"
+            ```bash
+            docker run -d \
+              --name watchtower \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              nickfedor/watchtower \
+              --notification-url "teams://?host=https%3A%2F%2Fprod-00.westus.logic.azure.com%3A443%2Fworkflows%2Fabc123%2Ftriggers%2Fmanual%2Fpaths%2Finvoke%3Fapi-version%3D2016-06-00%26sp%3D%2Ftriggers%2Fmanual%2Frun%26sv%3D1.0%26sig%3DXXXXXXXX&color=%23406170"
+            ```
+
+## Automated Migration Script
+
+If you have a `docker-compose.yaml` with a `watchtower` service configured for legacy notifications, you can use the script below to run the entire migration process end-to-end. It starts the container, executes `notify-upgrade`, extracts the generated file, prints its contents, and cleans up.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE="${1:-watchtower}"
+OUTPUT="${2:-./watchtower-notifications.env}"
+
+CONTAINER=$(docker compose run -d "${SERVICE}" notify-upgrade)
+
+trap 'docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true' EXIT
+
+FILE=$(docker logs "${CONTAINER}" 2>&1 | grep -oP 'watchtower-notif-urls-[^ ]+' | tail -1 || true)
+
+if [[ -z "${FILE}" ]]; then
+echo "Failed to locate temporary file path in container logs." >&2
+
+exit 1
+fi
+
+docker cp "${CONTAINER}:${FILE}" "${OUTPUT}"
+
+echo "=== Generated Shoutrrr URL ==="
+cat "${OUTPUT}"
+```
+
+!!! Important
+    - The service must already be defined in `docker-compose.yaml` with your legacy notification environment variables. The script assumes the service name defaults to `watchtower`.
+    - The command will self-cleanup after 5 minutes or when the script exits.

--- a/docs/notifications/deprecations/migration-tool/index.md
+++ b/docs/notifications/deprecations/migration-tool/index.md
@@ -137,7 +137,6 @@ If you have not yet deployed Watchtower or if you want to run `notify-upgrade` a
               WATCHTOWER_NOTIFICATIONS: slack
               WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL: "https://hooks.slack.com/services/AAA/BBB/CCC"
               WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER: watchtower-server-1
-              WATCHTOWER_NOTIFICATION_SLACK_CHANNEL: "#my-custom-channel"
             volumes:
               - /var/run/docker.sock:/var/run/docker.sock
         ```
@@ -149,7 +148,6 @@ If you have not yet deployed Watchtower or if you want to run `notify-upgrade` a
           -e WATCHTOWER_NOTIFICATIONS=slack \
           -e WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL="https://hooks.slack.com/services/AAA/BBB/CCC" \
           -e WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER=watchtower-server-1 \
-          -e WATCHTOWER_NOTIFICATION_SLACK_CHANNEL="#my-custom-channel" \
           nickfedor/watchtower \
           notify-upgrade
         ```
@@ -163,7 +161,6 @@ If you have not yet deployed Watchtower or if you want to run `notify-upgrade` a
           --notifications slack \
           --notification-slack-hook-url "https://hooks.slack.com/services/AAA/BBB/CCC" \
           --notification-slack-identifier watchtower-server-1 \
-          --notification-slack-channel "#my-custom-channel"
         ```
 
 === "Microsoft Teams"
@@ -212,7 +209,7 @@ After running `notify-upgrade`, the converted Shoutrrr URL is written to a tempo
 The command logs the exact container path and prints a copy command, for example:
 
 ```text
-INFO To get the environment file, use: cp abc123:watchtower-notif-urls-123456789 ./watchtower-notifications.env
+INFO To get the environment file, use: docker cp abc123:watchtower-notif-urls-123456789 ./watchtower-notifications.env
 ```
 
 Copy it to your local machine with:
@@ -286,7 +283,7 @@ Select the tab that matches your legacy notification service.
         Then copy the resulting file out of the container:
 
         ```bash
-        docker cp watchtower:<CONTAINER>:<FILE_PATH> ./watchtower-notifications.env
+        docker cp <CONTAINER>:<FILE_PATH> ./watchtower-notifications.env
         ```
 
     3. The following converted Shoutrrr URL should be produced:
@@ -314,7 +311,7 @@ Select the tab that matches your legacy notification service.
             docker run -d \
               --name watchtower \
               -v /var/run/docker.sock:/var/run/docker.sock \
-              -e WATCHTOWER_NOTIFICATION_URL=smtp://user@example.com:secret@smtp.example.com:587/?fromaddress=sender@example.com&toaddresses=recipient@example.com&encryption=ExplicitTLS&usestarttls=yes \
+              -e "WATCHTOWER_NOTIFICATION_URL=smtp://user@example.com:secret@smtp.example.com:587/?fromaddress=sender@example.com&toaddresses=recipient@example.com&encryption=ExplicitTLS&usestarttls=yes" \
               -e WATCHTOWER_NOTIFICATIONS_DELAY=10 \
               -e WATCHTOWER_NOTIFICATION_TITLE_TAG=Watchtower \
               nickfedor/watchtower
@@ -383,7 +380,7 @@ Select the tab that matches your legacy notification service.
         Then copy the resulting file out of the container:
 
         ```bash
-        docker cp watchtower:<CONTAINER>:<FILE_PATH> ./watchtower-notifications.env
+        docker cp <CONTAINER>:<FILE_PATH> ./watchtower-notifications.env
         ```
 
     3. The following converted Shoutrrr URL should be produced:
@@ -434,7 +431,6 @@ Select the tab that matches your legacy notification service.
                         WATCHTOWER_NOTIFICATIONS: slack
                         WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL: "https://hooks.slack.com/services/AAA/BBB/CCC"
                         WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER: watchtower-server-1
-                        WATCHTOWER_NOTIFICATION_SLACK_CHANNEL: "#my-custom-channel"
                     volumes:
                     - /var/run/docker.sock:/var/run/docker.sock
             ```
@@ -444,9 +440,8 @@ Select the tab that matches your legacy notification service.
               --name watchtower \
               -v /var/run/docker.sock:/var/run/docker.sock \
               -e WATCHTOWER_NOTIFICATIONS=slack \
-              -e WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL="https://hooks.slack.com/services/AAA/BBB/CCC" \
-              -e WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER=watchtower-server-1 \
-              -e WATCHTOWER_NOTIFICATION_SLACK_CHANNEL="#my-custom-channel" \
+          -e WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL="https://hooks.slack.com/services/AAA/BBB/CCC" \
+          -e WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER=watchtower-server-1 \
               nickfedor/watchtower
             ```
         === "Docker CLI (Flags)"
@@ -457,8 +452,7 @@ Select the tab that matches your legacy notification service.
               nickfedor/watchtower \
               --notifications slack \
               --notification-slack-hook-url "https://hooks.slack.com/services/AAA/BBB/CCC" \
-              --notification-slack-identifier watchtower-server-1 \
-              --notification-slack-channel "#my-custom-channel"
+          --notification-slack-identifier watchtower-server-1 \
             ```
 
     2. With the container running, execute the `notify-upgrade` command:
@@ -470,13 +464,13 @@ Select the tab that matches your legacy notification service.
         Then copy the resulting file out of the container:
 
         ```bash
-        docker cp watchtower:<CONTAINER>:<FILE_PATH> ./watchtower-notifications.env
+        docker cp <CONTAINER>:<FILE_PATH> ./watchtower-notifications.env
         ```
 
     3. The following converted Shoutrrr URL should be produced:
 
         ```text
-        slack://hook:AAA-BBB-CCC@webhook?botname=watchtower&color=%23406170&channel=webhook
+        slack://hook:AAA-BBB-CCC@webhook?botname=watchtower&color=%23406170
         ```
 
     4. Replace the deprecated configuration with the coverted Shoutrrr URL:
@@ -487,7 +481,7 @@ Select the tab that matches your legacy notification service.
                 watchtower:
                     image: nickfedor/watchtower:latest
                     environment:
-                        WATCHTOWER_NOTIFICATION_URL: "slack://hook:AAA-BBB-CCC@webhook?botname=watchtower&color=%23406170&channel=webhook"
+                        WATCHTOWER_NOTIFICATION_URL: "slack://hook:AAA-BBB-CCC@webhook?botname=watchtower&color=%23406170"
                     volumes:
                     - /var/run/docker.sock:/var/run/docker.sock
             ```
@@ -496,7 +490,7 @@ Select the tab that matches your legacy notification service.
             docker run -d \
               --name watchtower \
               -v /var/run/docker.sock:/var/run/docker.sock \
-              -e WATCHTOWER_NOTIFICATION_URL="slack://hook:AAA-BBB-CCC@webhook?botname=watchtower&color=%23406170&channel=webhook" \
+              -e WATCHTOWER_NOTIFICATION_URL="slack://hook:AAA-BBB-CCC@webhook?botname=watchtower&color=%23406170" \
               nickfedor/watchtower
             ```
         === "Docker CLI (Flags)"
@@ -505,7 +499,7 @@ Select the tab that matches your legacy notification service.
               --name watchtower \
               -v /var/run/docker.sock:/var/run/docker.sock \
               nickfedor/watchtower \
-              --notification-url "slack://hook:AAA-BBB-CCC@webhook?botname=watchtower&color=%23406170&channel=webhook"
+              --notification-url "slack://hook:AAA-BBB-CCC@webhook?botname=watchtower&color=%23406170"
             ```
 
 === "Microsoft Teams"
@@ -551,7 +545,7 @@ Select the tab that matches your legacy notification service.
         Then copy the resulting file out of the container:
 
         ```bash
-        docker cp watchtower:<CONTAINER>:<FILE_PATH> ./watchtower-notifications.env
+        docker cp <CONTAINER>:<FILE_PATH> ./watchtower-notifications.env
         ```
 
     3. The following converted Shoutrrr URL should be produced:
@@ -604,12 +598,35 @@ CONTAINER=$(docker compose run -d "${SERVICE}" notify-upgrade)
 
 trap 'docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true' EXIT
 
-FILE=$(docker logs "${CONTAINER}" 2>&1 | grep -oP 'watchtower-notif-urls-[^ ]+' | tail -1 || true)
+if ! docker ps -q --filter "id=${CONTAINER}" | grep -q .; then
+    echo "notify-upgrade container exited before producing output. Logs:" >&2
+    docker logs "${CONTAINER}" >&2 || true
+
+    exit 1
+fi
+
+FILE=""
+TIMEOUT=300
+INTERVAL=2
+ELAPSED=0
+
+while [[ ${ELAPSED} -lt ${TIMEOUT} ]]; do
+    FILE=$(docker logs "${CONTAINER}" 2>&1 | grep -oE 'watchtower-notif-urls-[^ ]+' | tail -1 || true)
+
+    if [[ -n "${FILE}" ]]; then
+        break
+    fi
+
+    sleep "${INTERVAL}"
+
+    ELAPSED=$((ELAPSED + INTERVAL))
+done
 
 if [[ -z "${FILE}" ]]; then
-echo "Failed to locate temporary file path in container logs." >&2
+    echo "Timed out waiting for notify-upgrade output. Logs:" >&2
+    docker logs "${CONTAINER}" >/dev/null 2>&1 || true
 
-exit 1
+    exit 1
 fi
 
 docker cp "${CONTAINER}:${FILE}" "${OUTPUT}"
@@ -621,3 +638,4 @@ cat "${OUTPUT}"
 !!! Important
     - The service must already be defined in `docker-compose.yaml` with your legacy notification environment variables. The script assumes the service name defaults to `watchtower`.
     - The command will self-cleanup after 5 minutes or when the script exits.
+    - Slack channel customization is not preserved by `notify-upgrade`. The generated URL always uses the default `webhook` channel. If you need a custom channel, then manually edit the resulting Shoutrrr URL after migration.

--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -1,6 +1,8 @@
 package notifications
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -20,6 +22,9 @@ const ColorHex = "#406170"
 // ColorInt is the default notification color used for services that support it
 // (as an int value).
 const ColorInt = 0x406170
+
+// errUnknownNotificationType indicates an unsupported legacy notification type name.
+var errUnknownNotificationType = errors.New("unknown notification type")
 
 // NewNotifier constructs the notification client from resolved process settings.
 //
@@ -107,6 +112,49 @@ func NewNotifier(cfg notifyConfig.Notify) types.Notifier {
 //   - types.Notifier: Configured notification client.
 func NewNotifierFromFlags(c *cobra.Command) types.Notifier {
 	return NewNotifier(notifyFromFlags(c))
+}
+
+// BuildURLs builds Shoutrrr notification URLs from resolved notification settings
+// without initializing a notifier.
+//
+// It returns configured URLs plus any legacy Shoutrrr URLs generated from deprecated
+// notification types. Errors are returned instead of causing a fatal exit.
+//
+// Parameters:
+//   - cfg: Notification settings from config.Load (Config.Notify).
+//
+// Returns:
+//   - []string: Shoutrrr URLs ready for output or notification use.
+//   - error: Non-nil if an unknown legacy notification type is specified or if
+//     a legacy notifier fails to generate its URL.
+//
+// TODO: Remove BuildURLs after the v2 release.
+//
+//nolint:godox
+func BuildURLs(cfg notifyConfig.Notify) ([]string, error) {
+	urls := append([]string(nil), cfg.URLs...)
+
+	for _, notificationType := range cfg.LegacyTypes {
+		if notificationType == shoutrrrType {
+			continue
+		}
+
+		ctor, ok := legacyNotifierCtors[notificationType]
+		if !ok {
+			return nil, fmt.Errorf("%w: %q", errUnknownNotificationType, notificationType)
+		}
+
+		legacyNotifier := ctor(cfg.Legacy)
+
+		shoutrrrURL, err := legacyNotifier.GetURL(nil)
+		if err != nil {
+			return nil, fmt.Errorf("create %q notification config: %w", notificationType, err)
+		}
+
+		urls = append(urls, shoutrrrURL)
+	}
+
+	return urls, nil
 }
 
 // notifyFromFlags reads notification-related flags into confignotify.Notify.


### PR DESCRIPTION
The PR fixes the `notify-upgrade` subcommand so it works correctly without relying on the root command's skipped `PreRun`, and expands the migration tool documentation with complete usage instructions.

## Problem

`notify-upgrade` is a Cobra subcommand and does not inherit `PreRun` from the root command. As a result, the command was missing critical setup: logging configuration was never applied, the current container ID was never resolved for copy instructions, and invalid legacy notification config caused a fatal exit instead of returning a clean error.

## Solution

`runNotifyUpgradeE` now explicitly performs the setup steps it needs, using `cmd.Root()` for flag/env/config binding. Temp-file creation targets the working directory, container ID detection falls back to filesystem-based methods that do not require a Docker client, and a new `BuildURLs` helper returns errors for unknown legacy notification types instead of exiting the process.

## Changes

- Restored flag/env/config loading for `notify-upgrade` via `cmd.Root().PersistentFlags()` and `appConfig.Load(cmd.Root(), nil)`
- Added `flags.SetupLogging` so `--log-format`, `--log-level`, and `--no-color` are honored
- Replaced `notifications.NewNotifier` with the new `notifications.BuildURLs` to avoid `logrus.Fatal` on invalid legacy notification config
- Replaced the never-populated `currentWatchtowerContainerID` check with local filesystem-based detection using `container.GetContainerIDFromMountinfo` and `container.GetContainerIDFromCgroupFile`
- Changed temp-file creation to `os.CreateTemp(".", ...)`
- Appended a trailing newline to the generated output file
- Expanded `docs/notifications/deprecations/migration-tool/index.md` with usage guidance, per-service walkthroughs, file retrieval steps, and an automated migration script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `notify-upgrade` migration to convert legacy notification settings into Shoutrrr URLs.
  * Generated URL output is now written to a temporary file in the working directory for easier retrieval.

* **Bug Fixes**
  * Improved copy/instructions reliability by using a more robust container ID fallback.
  * Output formatting for the generated environment file is now more consistent.

* **Documentation**
  * Expanded migration walkthroughs with single-use run examples for Email/SMTP, Gotify, Slack, and Microsoft Teams.
  * Added an automated migration script with clear retrieval, timing, and manual post-edit notes (e.g., Slack channel changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->