### PR TITLE
fix(notifications): mark slice flags as changed after docker secret expansion

### DIFF
--- a/internal/config/precedence_test.go
+++ b/internal/config/precedence_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -29,6 +30,8 @@ func newLoadedCommand(t *testing.T, env map[string]string, args ...string) confi
 	flagSet := cmd.PersistentFlags()
 	require.NoError(t, flags.ApplyEnvToFlags(flagSet, flags.AllSpecs()))
 	flags.ProcessFlagAliases(flagSet)
+
+	flags.GetSecretsFromFiles(cmd)
 
 	cfg, err := config.Load(cmd, nil)
 	require.NoError(t, err)
@@ -173,4 +176,63 @@ func TestLoad_APIChangedReflectsCLIOnly(t *testing.T) {
 		assert.True(t, config.AnyHTTPAPIConfig(run),
 			"CLI host/port/rate-limit should still trip the no-endpoint warning")
 	})
+}
+
+// TestLoad_NotificationURLFromSecretFile_ResolvesContentNotPath verifies that
+// a notification-url env pointing to a file resolves to the file content,
+// not the file path, in Config.Notify.URLs.
+func TestLoad_NotificationURLFromSecretFile_ResolvesContentNotPath(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "watchtower-")
+	require.NoError(t, err)
+	_, err = file.WriteString("gotify://gotify.example.com/token123")
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	cfg := newLoadedCommand(t, map[string]string{
+		"WATCHTOWER_NOTIFICATION_URL": file.Name(),
+	})
+
+	require.Len(t, cfg.Notify.URLs, 1)
+	assert.Equal(t, "gotify://gotify.example.com/token123", cfg.Notify.URLs[0])
+	assert.NotContains(t, cfg.Notify.URLs[0], "/run/secrets/")
+}
+
+// TestLoad_KindStringSecretFromFiles_ResolveContent verifies that KindString
+// notification secrets resolve their file contents through config.Load.
+func TestLoad_KindStringSecretFromFiles_ResolveContent(t *testing.T) {
+	emailFile, err := os.CreateTemp(t.TempDir(), "watchtower-")
+	require.NoError(t, err)
+	_, err = emailFile.WriteString("supersecretstring")
+	require.NoError(t, err)
+	require.NoError(t, emailFile.Close())
+
+	slackFile, err := os.CreateTemp(t.TempDir(), "watchtower-")
+	require.NoError(t, err)
+	_, err = slackFile.WriteString("slack://token@channel")
+	require.NoError(t, err)
+	require.NoError(t, slackFile.Close())
+
+	msteamsFile, err := os.CreateTemp(t.TempDir(), "watchtower-")
+	require.NoError(t, err)
+	_, err = msteamsFile.WriteString("https://outlook.office.com/webhook/abc123")
+	require.NoError(t, err)
+	require.NoError(t, msteamsFile.Close())
+
+	gotifyFile, err := os.CreateTemp(t.TempDir(), "watchtower-")
+	require.NoError(t, err)
+	_, err = gotifyFile.WriteString("gotify_token_abc")
+	require.NoError(t, err)
+	require.NoError(t, gotifyFile.Close())
+
+	cfg := newLoadedCommand(t, map[string]string{
+		"WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD": emailFile.Name(),
+		"WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL":        slackFile.Name(),
+		"WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL":      msteamsFile.Name(),
+		"WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN":          gotifyFile.Name(),
+	})
+
+	assert.Equal(t, "supersecretstring", cfg.Notify.Legacy.EmailPassword)
+	assert.Equal(t, "slack://token@channel", cfg.Notify.Legacy.SlackHookURL)
+	assert.Equal(t, "https://outlook.office.com/webhook/abc123", cfg.Notify.Legacy.MSTeamsHook)
+	assert.Equal(t, "gotify_token_abc", cfg.Notify.Legacy.GotifyToken)
 }

--- a/internal/config/viper_get_test.go
+++ b/internal/config/viper_get_test.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nicholas-fedor/watchtower/internal/flags/spec"
+)
+
+// TestStringSliceValue_ChangedFlagWinsOverEnv verifies that stringSliceValue
+// reads the flag when Changed=true instead of falling back to os.Getenv.
+func TestStringSliceValue_ChangedFlagWinsOverEnv(t *testing.T) {
+	vip := viper.New()
+	flagSet := pflag.NewFlagSet(t.Name(), pflag.ContinueOnError)
+
+	flagSet.StringArray("test-flag", []string{}, "")
+	require.NoError(t, flagSet.Set("test-flag", "gotify://host/token"))
+	flag := flagSet.Lookup("test-flag")
+	require.NotNil(t, flag)
+	flag.Changed = true
+
+	// Env points to a different file path - if stringSliceValue re-reads env instead
+	// of the flag, it will return the file path instead of the URL.
+	t.Setenv("TEST_NOTIFICATION_URL", "/run/secrets/WATCHTOWER_NOTIFICATION_URL")
+
+	result := stringSliceValue(
+		vip,
+		flagSet,
+		"test-flag",
+		[]string{"TEST_NOTIFICATION_URL"},
+		spec.ListNotificationURLs,
+	)
+
+	assert.Equal(t, []string{"gotify://host/token"}, result,
+		"stringSliceValue must prefer the Changed=true flag over raw env")
+}
+
+// TestStringSliceValue_UnchangedFlagFallsBackToEnv verifies that stringSliceValue
+// falls back to os.Getenv when the flag value is unchanged.
+func TestStringSliceValue_UnchangedFlagFallsBackToEnv(t *testing.T) {
+	vip := viper.New()
+	flagSet := pflag.NewFlagSet(t.Name(), pflag.ContinueOnError)
+
+	flagSet.StringArray("test-flag", []string{}, "")
+	require.NoError(t, flagSet.Set("test-flag", "/run/secrets/WATCHTOWER_NOTIFICATION_URL"))
+	flag := flagSet.Lookup("test-flag")
+	require.NotNil(t, flag)
+	flag.Changed = false
+
+	t.Setenv("TEST_NOTIFICATION_URL", "/run/secrets/WATCHTOWER_NOTIFICATION_URL")
+
+	result := stringSliceValue(
+		vip,
+		flagSet,
+		"test-flag",
+		[]string{"TEST_NOTIFICATION_URL"},
+		spec.ListNotificationURLs,
+	)
+
+	assert.Equal(t, []string{"/run/secrets/WATCHTOWER_NOTIFICATION_URL"}, result,
+		"stringSliceValue must fall back to env when Changed=false")
+}
+
+// TestStringSliceValue_ViperGetStringSliceIsFinalFallback verifies that stringSliceValue
+// falls back to Viper when neither the flag nor env provide a value.
+func TestStringSliceValue_ViperGetStringSliceIsFinalFallback(t *testing.T) {
+	vip := viper.New()
+	flagSet := pflag.NewFlagSet(t.Name(), pflag.ContinueOnError)
+
+	flagSet.StringArray("test-flag", []string{}, "")
+	require.NoError(t, flagSet.Set("test-flag", ""))
+	flag := flagSet.Lookup("test-flag")
+	require.NotNil(t, flag)
+	flag.Changed = false
+
+	// Ensure env key is unset.
+	t.Setenv("TEST_NOTIFICATION_URL", "")
+
+	// Set value via viper (simulating a config file).
+	vip.Set("test-flag", []string{"smtp://user:pass@host:25"})
+
+	result := stringSliceValue(
+		vip,
+		flagSet,
+		"test-flag",
+		[]string{"TEST_NOTIFICATION_URL"},
+		spec.ListNotificationURLs,
+	)
+
+	assert.Equal(t, []string{"smtp://user:pass@host:25"}, result,
+		"stringSliceValue must fall back to viper when flag and env are unset")
+}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -346,6 +346,10 @@ func getSecretFromFile(flags *pflag.FlagSet, secret string) error {
 			return fmt.Errorf("%w: %w", errReplaceSliceFailed, err)
 		}
 
+		// Mark the flag as explicitly set so downstream consumers read the expanded
+		// value from the flag rather than re-deriving from raw os.Getenv.
+		flag.Changed = true
+
 		return nil
 	}
 

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -991,27 +991,183 @@ func TestGetSecretFromFile_CloseError(t *testing.T) {
 	// Full coverage requires mocking os.File.Close to fail
 }
 
-// TestGetSecretFromFile_SliceReplaceError tests slice replacement errors (simplified).
-func TestGetSecretFromFile_SliceReplaceError(t *testing.T) {
-	cmd := new(cobra.Command)
-
-	SetDefaults()
-	RegisterNotificationFlags(cmd)
-	// Use a real file to ensure slice processing
+// TestGetSecretFromFile_StringPathStillMarksChanged verifies that KindString
+// secret expansion still marks Changed=true via flags.Set.
+func TestGetSecretFromFile_StringPathStillMarksChanged(t *testing.T) {
+	cmd := newTestCommand()
 	file, err := os.CreateTemp(t.TempDir(), "watchtower-")
 	require.NoError(t, err)
-	_, err = file.WriteString("discord://entry1\ntelegram://entry2")
+	_, err = file.WriteString("supersecretstring")
 	require.NoError(t, err)
-
-	fileName := file.Name()
 	require.NoError(t, file.Close())
 
-	err = cmd.ParseFlags([]string{"--notification-url", fileName})
+	err = cmd.ParseFlags([]string{"--notification-email-server-password", file.Name()})
 	require.NoError(t, err)
-	// Note: Without mocking SliceValue.Replace, this won't fail as intended
+
+	err = getSecretFromFile(cmd.PersistentFlags(), "notification-email-server-password")
+	require.NoError(t, err)
+
+	flag := cmd.PersistentFlags().Lookup("notification-email-server-password")
+	require.NotNil(t, flag)
+	assert.True(t, flag.Changed, "KindString secret expansion must mark Changed=true")
+	assert.Equal(t, "supersecretstring", flag.Value.String())
+}
+
+// TestGetSecretFromFile_SlicePath_MarksChangedAfterReplace verifies that
+// getSecretFromFile marks Changed=true after expanding a file path so the
+// pflag value is preferred over raw os.Getenv.
+func TestGetSecretFromFile_SlicePath_MarksChangedAfterReplace(t *testing.T) {
+	cmd := newTestCommand()
+	file, err := os.CreateTemp(t.TempDir(), "watchtower-")
+	require.NoError(t, err)
+	_, err = file.WriteString("gotify://gotify.example.com/token123")
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	err = cmd.ParseFlags([]string{"--notification-url", file.Name()})
+	require.NoError(t, err)
+	parseWithEnv(t, cmd)
+
+	flag := cmd.PersistentFlags().Lookup("notification-url")
+	require.NotNil(t, flag)
+
 	err = getSecretFromFile(cmd.PersistentFlags(), "notification-url")
-	require.NoError(t, err) // Adjust expectation since Replace doesn't fail without mock
-	// Full coverage of line 663 requires mocking pflag.SliceValue.Replace to fail
+	require.NoError(t, err)
+
+	urls, err := cmd.PersistentFlags().GetStringArray("notification-url")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"gotify://gotify.example.com/token123"}, urls)
+	assert.True(t, flag.Changed, "slice secret expansion must mark Changed=true")
+}
+
+// TestGetSecretFromFile_SlicePath_MultiLineFile verifies that a multi-line
+// docker secret file expands into multiple slice values with Changed=true.
+func TestGetSecretFromFile_SlicePath_MultiLineFile(t *testing.T) {
+	cmd := newTestCommand()
+	file, err := os.CreateTemp(t.TempDir(), "watchtower-")
+	require.NoError(t, err)
+	_, err = file.WriteString("gotify://host1/token1\ndiscord://host2/token2")
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	err = cmd.ParseFlags([]string{"--notification-url", file.Name()})
+	require.NoError(t, err)
+	parseWithEnv(t, cmd)
+
+	err = getSecretFromFile(cmd.PersistentFlags(), "notification-url")
+	require.NoError(t, err)
+
+	urls, err := cmd.PersistentFlags().GetStringArray("notification-url")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"gotify://host1/token1", "discord://host2/token2"}, urls)
+
+	flag := cmd.PersistentFlags().Lookup("notification-url")
+	assert.True(t, flag.Changed)
+}
+
+// TestGetSecretFromFile_SlicePath_LiteralURLsUnchanged verifies that literal
+// notification URLs survive getSecretFromFile without modification and that
+// Changed=true is set on the processed flag.
+func TestGetSecretFromFile_SlicePath_LiteralURLsUnchanged(t *testing.T) {
+    cmd := newTestCommand()
+
+    err := cmd.ParseFlags([]string{
+        "--notification-url", "gotify://gotify.example.com/token123",
+        "--notification-url", "discord://token@channel",
+    })
+    require.NoError(t, err)
+    parseWithEnv(t, cmd)
+
+    flag := cmd.PersistentFlags().Lookup("notification-url")
+    require.NotNil(t, flag)
+
+    err = getSecretFromFile(cmd.PersistentFlags(), "notification-url")
+    require.NoError(t, err)
+
+    urls, err := cmd.PersistentFlags().GetStringArray("notification-url")
+    require.NoError(t, err)
+    assert.Equal(t, []string{"gotify://gotify.example.com/token123", "discord://token@channel"}, urls)
+
+    // Changed is true after Replace regardless of whether expansion occurred; the
+    // processed value is explicit user config and downstream consumers must read it.
+    assert.True(t, flag.Changed)
+}
+
+// TestGetSecretsFromFile_PorcelainAppendPreservedWithSecret verifies that
+// porcelain mode appends logger:// before secret expansion and the merged
+// slice retains both values with Changed=true.
+func TestGetSecretsFromFile_PorcelainAppendPreservedWithSecret(t *testing.T) {
+	t.Setenv("WATCHTOWER_NOTIFICATION_URL", "/file/that/does/not/exist") // placeholder; real file used via flag
+
+	cmd := newTestCommand()
+	file, err := os.CreateTemp(t.TempDir(), "watchtower-")
+	require.NoError(t, err)
+	_, err = file.WriteString("gotify://host/token")
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	err = cmd.ParseFlags([]string{
+		"--notification-url", file.Name(),
+		"--porcelain", "v1",
+	})
+	require.NoError(t, err)
+	ProcessFlagAliases(cmd.PersistentFlags())
+
+	urls, err := cmd.PersistentFlags().GetStringArray("notification-url")
+	require.NoError(t, err)
+	assert.Contains(t, urls, "logger://", "porcelain value must survive secret expansion")
+
+	err = getSecretFromFile(cmd.PersistentFlags(), "notification-url")
+	require.NoError(t, err)
+
+	urls, err = cmd.PersistentFlags().GetStringArray("notification-url")
+	require.NoError(t, err)
+	assert.Contains(t, urls, "logger://")
+	assert.Contains(t, urls, "gotify://host/token")
+
+	flag := cmd.PersistentFlags().Lookup("notification-url")
+	assert.True(t, flag.Changed)
+}
+
+// TestApplyEnvToFlags_DoesNotReBrideExpandedSecret verifies that re-running
+// ApplyEnvToFlags does not overwrite an expanded secret with the raw file path.
+func TestApplyEnvToFlags_DoesNotReBrideExpandedSecret(t *testing.T) {
+	cmd := newTestCommand()
+	file, err := os.CreateTemp(t.TempDir(), "watchtower-")
+	require.NoError(t, err)
+	_, err = file.WriteString("gotify://host/token")
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	// Step 1: env bridge sets pflag to the file path
+	t.Setenv("WATCHTOWER_NOTIFICATION_URL", file.Name())
+
+	err = cmd.ParseFlags([]string{})
+	require.NoError(t, err)
+	err = ApplyEnvToFlags(cmd.PersistentFlags(), AllSpecs())
+	require.NoError(t, err)
+
+	flag := cmd.PersistentFlags().Lookup("notification-url")
+	require.NotNil(t, flag)
+	assert.False(t, flag.Changed, "env bridge must leave Changed=false")
+
+	// Step 2: secret expansion replaces content and marks Changed=true
+	err = getSecretFromFile(cmd.PersistentFlags(), "notification-url")
+	require.NoError(t, err)
+
+	urls, err := cmd.PersistentFlags().GetStringArray("notification-url")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"gotify://host/token"}, urls)
+	assert.True(t, flag.Changed)
+
+	// Step 3: re-running ApplyEnvToFlags must not overwrite the expanded value
+	err = ApplyEnvToFlags(cmd.PersistentFlags(), AllSpecs())
+	require.NoError(t, err)
+
+	urls, err = cmd.PersistentFlags().GetStringArray("notification-url")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"gotify://host/token"}, urls, "re-applying env must not clobber expanded secret")
+	assert.True(t, flag.Changed)
 }
 
 // TestProcessFlagAliases_InvalidPorcelain tests invalid porcelain version handling.

--- a/pkg/notifications/shoutrrr_test.go
+++ b/pkg/notifications/shoutrrr_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/onsi/gomega/gbytes"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	mockActions "github.com/nicholas-fedor/watchtower/internal/actions/mocks"
 	"github.com/nicholas-fedor/watchtower/internal/flags"
@@ -1437,4 +1439,42 @@ func TestCloseWithNoGoroutine(t *testing.T) {
 	case <-time.After(1 * time.Second):
 		t.Fatalf("Close() took too long without goroutine (timeout exceeded)")
 	}
+}
+
+// TestCreateNotifier_FatalsOnBadURL verifies that createNotifier calls Fatal
+// when given a docker-secret file path instead of a valid URL.
+func TestCreateNotifier_FatalsOnBadURL(t *testing.T) {
+	originalExit := logrus.StandardLogger().ExitFunc
+
+	defer func() { logrus.StandardLogger().ExitFunc = originalExit }()
+
+	logrus.StandardLogger().ExitFunc = func(_ int) { panic("FATAL") }
+
+	assert.PanicsWithValue(t, "FATAL", func() {
+		createNotifier(
+			[]string{"/run/secrets/WATCHTOWER_NOTIFICATION_URL"},
+			logrus.InfoLevel,
+			"",
+			true,
+			StaticData{},
+			false,
+			0,
+		)
+	})
+}
+
+// TestCreateNotifier_AcceptsGotifyURLFromFileExpansion verifies that createNotifier
+// succeeds when given a valid Gotify URL matching expanded secret content.
+func TestCreateNotifier_AcceptsGotifyURLFromFileExpansion(t *testing.T) {
+	notifier := createNotifier(
+		[]string{"gotify://gotify.example.com/token123"},
+		logrus.InfoLevel,
+		"",
+		true,
+		StaticData{},
+		false,
+		0,
+	)
+
+	require.NotNil(t, notifier)
 }


### PR DESCRIPTION
This PR fixes a regression where notification URLs configured via Docker Secrets were passed to Shoutrrr as file paths instead of their contents.

## Problem

When `WATCHTOWER_NOTIFICATION_URL` points to a Docker Secret file, such as `/var/secrets/WATCHTOWER_NOTIFICATION_URL`, Watchtower reads the file successfully but then creates the Shoutrrr sender with the file path instead of the URL inside it. This results in the notifications process failing to initialize with the following error: `Failed to initialize Shoutrrr notifications" error="creating sender with options for URLs [/run/secrets/WATCHTOWER_NOTIFICATION_URL]: error initializing router services: unknown service: \"\"`

## Solution

Set `flag.Changed = true` immediately after a successful `sliceValue.Replace` in `getSecretFromFile`. This signals that the flag value is authoritative, so `stringSliceValue` reads the expanded pflag value instead of falling back to `os.Getenv`.

## Changes

- Set `flag.Changed = true` in `getSecretFromFile` after slice replacement
- Add regression tests at the flag expansion, config-load, and notifier layers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed secret values loaded from files being treated as file paths instead of their contents.
  * Ensured secret-backed notification settings resolve correctly, including email, Slack, Microsoft Teams, Gotify, and notification URLs.
  * Preserved expanded secret values when environment configuration is reapplied.
  * Improved handling of slice-based secret settings and porcelain-mode values.
  * Ensured invalid notification URLs fail clearly while valid Gotify URLs are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->