### PR TITLE
feat(api): emit SSE events for the HTTP API check endpoint

### DIFF
--- a/docs/http-api/endpoints/check/index.md
+++ b/docs/http-api/endpoints/check/index.md
@@ -84,3 +84,15 @@ The `/v1/check` endpoint returns a JSON array of container check results:
 |     200     | Check completed successfully                   |
 |     401     | Invalid or missing authentication token        |
 |     500     | Internal server error during request processing|
+
+## SSE Events
+
+When the [`/v1/events`](../events/index.md) SSE endpoint is also enabled, execution of the `v1/check` endpoint broadcasts the following events:
+
+- `scan_started`:  Broadcasted before the check begins
+- `scan_completed`: Broadcasted after the check finishes successfully
+- `scan_failed`: Broadcasted if the check encounters an error
+
+!!! Note
+    The `scan_completed` payload always reports `updated: 0` because no updates are applied.
+    The `failed` field counts containers whose per-container check returned an error.

--- a/docs/http-api/endpoints/events/index.md
+++ b/docs/http-api/endpoints/events/index.md
@@ -48,12 +48,19 @@ The events endpoint uses a separate token from the main API token to limit blast
 
 - Started
 - Completed
+- Failed
+
+!!! Note
+    Scan events are broadcasted only for updates (HTTP API or scheduled) or checks (HTTP API).
 
 ### Update Events
 
 - Started
 - Completed
 - Failed
+
+!!! Note
+    Update events are broadcasted only for HTTP API or scheduled updates.
 
 ## Event Format
 

--- a/docs/http-api/endpoints/update/index.md
+++ b/docs/http-api/endpoints/update/index.md
@@ -307,3 +307,12 @@ services:
 
 !!! Warning
     Enabling the HTTP API with port mappings will automatically disable Watchtower's self-update functionality to prevent port conflicts during container recreation. See [Updating Watchtower](../../../getting-started/updating-watchtower/index.md#port_configuration_limitation) for more details.
+
+## SSE Events
+
+When the [`/v1/events`](../events/index.md) SSE endpoint is also enabled, the update process broadcasts the following events:
+
+- `scan_started`:  Broadcasted before the update scan begins
+- `scan_completed`:  Broadcasted after the update scan finishes
+- `scan_failed`:  Broadcasted if the update scan encounters an error
+- `image_cleanup`:  Broadcasted after image cleanup if enabled and images were removed

--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -80,20 +80,7 @@ func RunUpdatesWithNotifications(
 		params.EventBroadcaster.Publish(events.Event{
 			Type:      "scan_started",
 			Timestamp: time.Now().UTC(),
-			Data: events.ScanStartedData{
-				Cleanup:             updateConfig.Cleanup,
-				NoRestart:           updateConfig.NoRestart,
-				MonitorOnly:         updateConfig.MonitorOnly,
-				LifecycleHooks:      updateConfig.LifecycleHooks,
-				RollingRestart:      updateConfig.RollingRestart,
-				LabelPrecedence:     updateConfig.LabelPrecedence,
-				NoPull:              updateConfig.NoPull,
-				RunOnce:             updateConfig.RunOnce,
-				UseComposeDependsOn: updateConfig.UseComposeDependsOn,
-				SkipSelfUpdate:      updateConfig.SkipSelfUpdate,
-				EphemeralSelfUpdate: updateConfig.EphemeralSelfUpdate,
-				ReviveStopped:       updateConfig.ReviveStopped,
-			},
+			Data:      events.NewScanStartedData(updateConfig),
 		})
 	}
 

--- a/internal/api/handlers/check/handler.go
+++ b/internal/api/handlers/check/handler.go
@@ -8,16 +8,26 @@ import (
 	"github.com/gofiber/fiber/v3"
 	"github.com/sirupsen/logrus"
 
+	"github.com/nicholas-fedor/watchtower/internal/api/handlers/events"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
 // Handler serves the /v1/check endpoint.
 type Handler struct {
-	check            CheckFunc
-	Path             string
-	maxTimeout       time.Duration
-	notifier         types.Notifier
+	// check is the function that checks container update availability.
+	check CheckFunc
+	// Path is the HTTP route path for the check endpoint.
+	Path string
+	// maxTimeout bounds the optional per-request ?timeout= query parameter.
+	maxTimeout time.Duration
+	// notifier batches log entries during the check to suppress immediate notifications.
+	notifier types.Notifier
+	// splitByContainer sends per-container notifications when true.
 	splitByContainer bool
+	// eventBroadcaster publishes SSE events for check runs.
+	eventBroadcaster *events.Broadcaster
+	// scanStartedData carries redacted policy flags reused for every scan_started event.
+	scanStartedData events.ScanStartedData
 }
 
 // New creates a new check handler backed by the given check function.
@@ -28,13 +38,25 @@ type Handler struct {
 //   - notifier: Optional notification system instance. When provided, notification batching is enabled
 //     during the check to prevent log entries from triggering immediate notifications.
 //   - splitByContainer: When true, notifications are split by container instead of being grouped.
-func New(check CheckFunc, maxTimeout time.Duration, notifier types.Notifier, splitByContainer bool) *Handler {
+//   - eventBroadcaster: Optional SSE broadcaster. When provided, scan_started, scan_completed,
+//     and scan_failed events are emitted during check runs.
+//   - scanStartedData: Pre-built redacted policy flags for the scan_started event.
+func New(
+	check CheckFunc,
+	maxTimeout time.Duration,
+	notifier types.Notifier,
+	splitByContainer bool,
+	eventBroadcaster *events.Broadcaster,
+	scanStartedData events.ScanStartedData,
+) *Handler {
 	return &Handler{
 		check:            check,
 		Path:             "/v1/check",
 		maxTimeout:       maxTimeout,
 		notifier:         notifier,
 		splitByContainer: splitByContainer,
+		eventBroadcaster: eventBroadcaster,
+		scanStartedData:  scanStartedData,
 	}
 }
 
@@ -112,10 +134,30 @@ func (h *Handler) Handle(c fiber.Ctx) error {
 		}()
 	}
 
+	// Notify SSE subscribers that the check scan is starting.
+	if h.eventBroadcaster != nil {
+		h.eventBroadcaster.Publish(events.Event{
+			Type:      "scan_started",
+			Timestamp: time.Now().UTC(),
+			Data:      h.scanStartedData,
+		})
+	}
+
 	results, err := h.check(ctx, images, containers)
 	if err != nil {
 		logrus.WithError(err).WithField("notify", "no").
 			Error("Failed to check for updates")
+
+		// Notify SSE subscribers that the check scan failed.
+		if h.eventBroadcaster != nil {
+			h.eventBroadcaster.Publish(events.Event{
+				Type:      "scan_failed",
+				Timestamp: time.Now().UTC(),
+				Data: events.ScanFailedData{
+					Error: err.Error(),
+				},
+			})
+		}
 
 		sendErr := c.Status(fiber.StatusInternalServerError).
 			SendString("failed to check for updates")
@@ -124,6 +166,28 @@ func (h *Handler) Handle(c fiber.Ctx) error {
 		}
 
 		return nil
+	}
+
+	// Count containers whose per-container check returned an error.
+	failedCount := 0
+
+	for _, r := range results {
+		if r.Error != "" {
+			failedCount++
+		}
+	}
+
+	// Notify SSE subscribers that the check scan completed successfully.
+	if h.eventBroadcaster != nil {
+		h.eventBroadcaster.Publish(events.Event{
+			Type:      "scan_completed",
+			Timestamp: time.Now().UTC(),
+			Data: events.ScanCompletedData{
+				Scanned: len(results),
+				Updated: 0,
+				Failed:  failedCount,
+			},
+		})
 	}
 
 	err = c.Status(fiber.StatusOK).JSON(fiber.Map{

--- a/internal/api/handlers/check/handler.go
+++ b/internal/api/handlers/check/handler.go
@@ -148,16 +148,16 @@ func (h *Handler) Handle(c fiber.Ctx) error {
 		logrus.WithError(err).WithField("notify", "no").
 			Error("Failed to check for updates")
 
-		// Notify SSE subscribers that the check scan failed.
-		if h.eventBroadcaster != nil {
-			h.eventBroadcaster.Publish(events.Event{
-				Type:      "scan_failed",
-				Timestamp: time.Now().UTC(),
-				Data: events.ScanFailedData{
-					Error: err.Error(),
-				},
-			})
-		}
+	// Notify SSE subscribers that the check scan failed.
+	if h.eventBroadcaster != nil {
+		h.eventBroadcaster.Publish(events.Event{
+			Type:      "scan_failed",
+			Timestamp: time.Now().UTC(),
+			Data: events.ScanFailedData{
+				Error: "failed to check for updates",
+			},
+		})
+	}
 
 		sendErr := c.Status(fiber.StatusInternalServerError).
 			SendString("failed to check for updates")

--- a/internal/api/handlers/check/handler_test.go
+++ b/internal/api/handlers/check/handler_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/gofiber/fiber/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/nicholas-fedor/watchtower/internal/api/handlers/events"
 )
 
 func TestNew(t *testing.T) {
@@ -30,7 +32,7 @@ func TestNew(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := New(tt.check, 5*time.Minute, nil, false)
+			h := New(tt.check, 5*time.Minute, nil, false, nil, events.ScanStartedData{})
 			require.NotNil(t, h)
 			assert.Equal(t, "/v1/check", h.Path)
 		})
@@ -70,7 +72,7 @@ func TestHandler_Handle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := New(tt.checkFunc, 5*time.Minute, nil, false)
+			h := New(tt.checkFunc, 5*time.Minute, nil, false, nil, events.ScanStartedData{})
 			app := fiber.New(fiber.Config{})
 			app.Post("/v1/check", h.Handle)
 
@@ -135,7 +137,7 @@ func TestHandler_Handle_WithFilters(t *testing.T) {
 				capturedNames = names
 
 				return []ContainerCheck{}, nil
-			}, 5*time.Minute, nil, false)
+			}, 5*time.Minute, nil, false, nil, events.ScanStartedData{})
 			app := fiber.New(fiber.Config{})
 			app.Post("/v1/check", h.Handle)
 
@@ -162,7 +164,7 @@ func TestHandler_Handle_TimeoutOverride(t *testing.T) {
 	t.Run("valid timeout is applied", func(t *testing.T) {
 		h := New(func(ctx context.Context, _, _ []string) ([]ContainerCheck, error) {
 			return []ContainerCheck{}, nil
-		}, 5*time.Minute, nil, false)
+		}, 5*time.Minute, nil, false, nil, events.ScanStartedData{})
 		app := fiber.New(fiber.Config{})
 		app.Post("/v1/check", h.Handle)
 
@@ -178,7 +180,7 @@ func TestHandler_Handle_TimeoutOverride(t *testing.T) {
 	t.Run("timeout exceeding max is clamped", func(t *testing.T) {
 		h := New(func(ctx context.Context, _, _ []string) ([]ContainerCheck, error) {
 			return []ContainerCheck{}, nil
-		}, 2*time.Minute, nil, false)
+		}, 2*time.Minute, nil, false, nil, events.ScanStartedData{})
 		app := fiber.New(fiber.Config{})
 		app.Post("/v1/check", h.Handle)
 
@@ -194,11 +196,143 @@ func TestHandler_Handle_TimeoutOverride(t *testing.T) {
 	t.Run("invalid timeout is ignored", func(t *testing.T) {
 		h := New(func(ctx context.Context, _, _ []string) ([]ContainerCheck, error) {
 			return []ContainerCheck{}, nil
-		}, 5*time.Minute, nil, false)
+		}, 5*time.Minute, nil, false, nil, events.ScanStartedData{})
 		app := fiber.New(fiber.Config{})
 		app.Post("/v1/check", h.Handle)
 
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/check?timeout=bogus", nil)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}
+
+func TestHandler_Handle_EmitsEvents(t *testing.T) {
+	scanStartedData := events.ScanStartedData{
+		Cleanup:             true,
+		NoRestart:           false,
+		MonitorOnly:         false,
+		LifecycleHooks:      true,
+		RollingRestart:      false,
+		LabelPrecedence:     false,
+		NoPull:              false,
+		RunOnce:             false,
+		UseComposeDependsOn: false,
+		SkipSelfUpdate:      false,
+		EphemeralSelfUpdate: false,
+		ReviveStopped:       false,
+	}
+
+	t.Run("success emits scan_started and scan_completed", func(t *testing.T) {
+		b := events.NewBroadcaster()
+		ch := b.Subscribe()
+		require.NotNil(t, ch)
+
+		h := New(
+			func(_ context.Context, _, _ []string) ([]ContainerCheck, error) {
+				return []ContainerCheck{
+					{Name: "c1", Image: "nginx:latest", ImageID: "sha256:abc", UpdateAvailable: true},
+					{Name: "c2", Image: "redis:latest", ImageID: "sha256:def", UpdateAvailable: false, Error: "registry error"},
+				}, nil
+			},
+			5*time.Minute, nil, false, b, scanStartedData,
+		)
+		app := fiber.New(fiber.Config{})
+		app.Post("/v1/check", h.Handle)
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/check", nil)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var started, completed bool
+
+		for started == false || completed == false {
+			select {
+			case evt := <-ch:
+				switch evt.Type {
+				case "scan_started":
+					started = true
+					data, ok := evt.Data.(events.ScanStartedData)
+					require.True(t, ok)
+					assert.True(t, data.Cleanup)
+				case "scan_completed":
+					completed = true
+					data, ok := evt.Data.(events.ScanCompletedData)
+					require.True(t, ok)
+					assert.Equal(t, 2, data.Scanned)
+					assert.Equal(t, 0, data.Updated)
+					assert.Equal(t, 1, data.Failed)
+				case "scan_failed":
+					t.Fatal("unexpected scan_failed event on success")
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("timeout waiting for events: started=%v completed=%v", started, completed)
+			}
+		}
+	})
+
+	t.Run("check error emits scan_started and scan_failed", func(t *testing.T) {
+		b := events.NewBroadcaster()
+		ch := b.Subscribe()
+		require.NotNil(t, ch)
+
+		h := New(
+			func(_ context.Context, _, _ []string) ([]ContainerCheck, error) {
+				return nil, errors.New("docker api error")
+			},
+			5*time.Minute, nil, false, b, scanStartedData,
+		)
+		app := fiber.New(fiber.Config{})
+		app.Post("/v1/check", h.Handle)
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/check", nil)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+		var started, failed bool
+
+		for started == false || failed == false {
+			select {
+			case evt := <-ch:
+				switch evt.Type {
+				case "scan_started":
+					started = true
+				case "scan_failed":
+					failed = true
+					data, ok := evt.Data.(events.ScanFailedData)
+					require.True(t, ok)
+					assert.Equal(t, "docker api error", data.Error)
+				case "scan_completed":
+					t.Fatal("unexpected scan_completed event on error")
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("timeout waiting for events: started=%v failed=%v", started, failed)
+			}
+		}
+	})
+
+	t.Run("nil broadcaster emits no events", func(t *testing.T) {
+		h := New(
+			func(_ context.Context, _, _ []string) ([]ContainerCheck, error) {
+				return []ContainerCheck{{Name: "c1"}}, nil
+			},
+			5*time.Minute, nil, false, nil, events.ScanStartedData{},
+		)
+		app := fiber.New(fiber.Config{})
+		app.Post("/v1/check", h.Handle)
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/check", nil)
 		resp, err := app.Test(req)
 		require.NoError(t, err)
 

--- a/internal/api/handlers/check/handler_test.go
+++ b/internal/api/handlers/check/handler_test.go
@@ -312,7 +312,7 @@ func TestHandler_Handle_EmitsEvents(t *testing.T) {
 					failed = true
 					data, ok := evt.Data.(events.ScanFailedData)
 					require.True(t, ok)
-					assert.Equal(t, "docker api error", data.Error)
+					assert.Equal(t, "failed to check for updates", data.Error)
 				case "scan_completed":
 					t.Fatal("unexpected scan_completed event on error")
 				}

--- a/internal/api/handlers/events/events.go
+++ b/internal/api/handlers/events/events.go
@@ -3,6 +3,8 @@ package events
 import (
 	"sync"
 	"time"
+
+	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
 const (
@@ -35,6 +37,26 @@ type ScanStartedData struct {
 	SkipSelfUpdate      bool `json:"skip_self_update"`
 	EphemeralSelfUpdate bool `json:"ephemeral_self_update"`
 	ReviveStopped       bool `json:"revive_stopped"`
+}
+
+// NewScanStartedData creates a redacted scan_started event payload from the
+// full update configuration. It intentionally omits filter functions, container
+// IDs, durations, and other internal fields from types.UpdateParams.
+func NewScanStartedData(updateParams types.UpdateParams) ScanStartedData {
+	return ScanStartedData{
+		Cleanup:             updateParams.Cleanup,
+		NoRestart:           updateParams.NoRestart,
+		MonitorOnly:         updateParams.MonitorOnly,
+		LifecycleHooks:      updateParams.LifecycleHooks,
+		RollingRestart:      updateParams.RollingRestart,
+		LabelPrecedence:     updateParams.LabelPrecedence,
+		NoPull:              updateParams.NoPull,
+		RunOnce:             updateParams.RunOnce,
+		UseComposeDependsOn: updateParams.UseComposeDependsOn,
+		SkipSelfUpdate:      updateParams.SkipSelfUpdate,
+		EphemeralSelfUpdate: updateParams.EphemeralSelfUpdate,
+		ReviveStopped:       updateParams.ReviveStopped,
+	}
 }
 
 // ScanCompletedData carries details about a scan that has finished.

--- a/internal/api/routes/check.go
+++ b/internal/api/routes/check.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nicholas-fedor/watchtower/internal/api/config"
 	"github.com/nicholas-fedor/watchtower/internal/api/handlers/check"
+	"github.com/nicholas-fedor/watchtower/internal/api/handlers/events"
 	"github.com/nicholas-fedor/watchtower/internal/api/handlers/update"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
@@ -22,10 +23,11 @@ func registerCheckRoute(app *fiber.App, auth fiber.Handler, opts config.Options)
 		checkTimeout = config.DefaultCheckTimeout
 	}
 
+	params := config.BuildUpdateParams(opts)
+	scanStartedData := events.NewScanStartedData(params)
+
 	handler := check.New(
 		func(ctx context.Context, images, names []string) ([]check.ContainerCheck, error) {
-			params := config.BuildUpdateParams(opts)
-
 			imageFilter := opts.FilterByImage(images, opts.Filter)
 			containerFilter := update.ContainerFilter(names)
 			combinedFilter := func(c types.FilterableContainer) bool {
@@ -42,6 +44,8 @@ func registerCheckRoute(app *fiber.App, auth fiber.Handler, opts config.Options)
 		checkTimeout,
 		opts.Notifier,
 		opts.NotificationSplitByContainer,
+		opts.EventBroadcaster,
+		scanStartedData,
 	)
 
 	app.Post(

--- a/internal/api/routes/check_test.go
+++ b/internal/api/routes/check_test.go
@@ -41,9 +41,10 @@ func TestRegisterCheckRoute(t *testing.T) {
 		mockClient := mockContainer.NewMockClient(t)
 
 		opts := config.Options{
-			EnableCheckAPI: true,
-			Client:         mockClient,
-			FilterByImage:  func(_ []string, f types.Filter) types.Filter { return f },
+			EnableCheckAPI:   true,
+			Client:           mockClient,
+			FilterByImage:    func(_ []string, f types.Filter) types.Filter { return f },
+			EventBroadcaster: events.NewBroadcaster(),
 		}
 
 		registerCheckRoute(app, auth, opts)

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -1069,28 +1069,28 @@ func TestGetSecretFromFile_SlicePath_MultiLineFile(t *testing.T) {
 // notification URLs survive getSecretFromFile without modification and that
 // Changed=true is set on the processed flag.
 func TestGetSecretFromFile_SlicePath_LiteralURLsUnchanged(t *testing.T) {
-    cmd := newTestCommand()
+	cmd := newTestCommand()
 
-    err := cmd.ParseFlags([]string{
-        "--notification-url", "gotify://gotify.example.com/token123",
-        "--notification-url", "discord://token@channel",
-    })
-    require.NoError(t, err)
-    parseWithEnv(t, cmd)
+	err := cmd.ParseFlags([]string{
+		"--notification-url", "gotify://gotify.example.com/token123",
+		"--notification-url", "discord://token@channel",
+	})
+	require.NoError(t, err)
+	parseWithEnv(t, cmd)
 
-    flag := cmd.PersistentFlags().Lookup("notification-url")
-    require.NotNil(t, flag)
+	flag := cmd.PersistentFlags().Lookup("notification-url")
+	require.NotNil(t, flag)
 
-    err = getSecretFromFile(cmd.PersistentFlags(), "notification-url")
-    require.NoError(t, err)
+	err = getSecretFromFile(cmd.PersistentFlags(), "notification-url")
+	require.NoError(t, err)
 
-    urls, err := cmd.PersistentFlags().GetStringArray("notification-url")
-    require.NoError(t, err)
-    assert.Equal(t, []string{"gotify://gotify.example.com/token123", "discord://token@channel"}, urls)
+	urls, err := cmd.PersistentFlags().GetStringArray("notification-url")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"gotify://gotify.example.com/token123", "discord://token@channel"}, urls)
 
-    // Changed is true after Replace regardless of whether expansion occurred; the
-    // processed value is explicit user config and downstream consumers must read it.
-    assert.True(t, flag.Changed)
+	// Changed is true after Replace regardless of whether expansion occurred; the
+	// processed value is explicit user config and downstream consumers must read it.
+	assert.True(t, flag.Changed)
 }
 
 // TestGetSecretsFromFile_PorcelainAppendPreservedWithSecret verifies that


### PR DESCRIPTION
This PR adds SSE event emission for POST /v1/check, so SSE subscribers are notified when a check-only run completes.

## Problem

The `/v1/events` SSE endpoint only emits events for updates. A registry check triggered via POST `/v1/check` produces no SSE event and leaves API consumers with limited options for determining when the check is completed.

## Solution

Added `scan_started`, `scan_completed`, and `scan_failed` event types for check runs.
The construction of the redacted configuration information that is provided by the `scan_started` event was also refactored to centralize the mapping and reduce repetition for future additions of SSE events. 

## Changes

- Add `scan_started`, `scan_completed`, and `scan_failed` SSE events to the `POST /v1/check` handler.
- Extract `ScanStartedData` construction into a shared helper used by both the update and check routes.
- Update the check handler constructor to accept an optional broadcaster and pre-built scan-started payload.
- Add handler tests verifying event emission on success, on check failure, and when no broadcaster is configured.
- Update route-registration tests to provide an `EventBroadcaster`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added SSE scan lifecycle notifications for check runs on `/v1/check`: `scan_started`, `scan_completed`, and `scan_failed`.

- **Bug Fixes**
  - `scan_started` payload is now constructed from redacted update parameters.
  - On check errors, `scan_failed` now returns the fixed message: `"failed to check for updates"`.

- **Documentation**
  - Updated HTTP API docs with new **SSE Events** sections for the check and update endpoints, clarifying outcomes and counters.

- **Tests**
  - Expanded SSE emission tests for success, failure, and when notifications are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->