### PR TITLE
fix(ephemeral): prevent repeated self-updates when host ports are published

### DIFF
--- a/internal/actions/actions_internal_test.go
+++ b/internal/actions/actions_internal_test.go
@@ -1532,7 +1532,7 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 					Staleness: map[string]bool{
 						"watchtower": true,
 					},
-					StartContainerError: errors.New("simulated start failure"),
+					StartContainerByIDError: errors.New("simulated start failure"),
 				},
 				false,
 				false,
@@ -1568,7 +1568,7 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 			parentCtx, parentCancel := context.WithCancel(context.Background())
 
 			// Create a mock client with a Watchtower container.
-			// Configure StartContainerError to trigger the cleanup path.
+			// Configure StartContainerByIDError to trigger the cleanup path.
 			// Add simulated latency to allow time for operations to complete.
 			client := mockActions.CreateMockClient(
 				&mockActions.TestData{
@@ -1589,8 +1589,8 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 					Staleness: map[string]bool{
 						"watchtower": true,
 					},
-					StartContainerError: errors.New("simulated start failure"),
-					SimulatedLatency:    5 * time.Millisecond, // Allow time for operations
+					StartContainerByIDError: errors.New("simulated start failure"),
+					SimulatedLatency:        5 * time.Millisecond, // Allow time for operations
 				},
 				false,
 				false,
@@ -1615,7 +1615,7 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 				// Call restartStaleContainer with the parent context.
 				// The test flow is:
 				// 1. RenameContainer succeeds (uses parent context)
-				// 2. StartContainer fails due to StartContainerError
+				// 2. StartContainerByID fails due to StartContainerByIDError
 				// 3. Cleanup runs using the detached context (should survive parent cancellation)
 				_, renamed, err = restartStaleContainer(
 					parentCtx,
@@ -1640,7 +1640,7 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 			// Wait for the goroutine to complete.
 			wg.Wait()
 
-			// The operation should fail due to StartContainer error, but the
+			// The operation should fail due to StartContainerByID error, but the
 			// cleanup (StopAndRemoveContainer) should have been attempted
 			// using the detached context, which survives parent cancellation.
 			gomega.Expect(err).To(gomega.HaveOccurred())

--- a/internal/actions/ephemeral.go
+++ b/internal/actions/ephemeral.go
@@ -341,9 +341,11 @@ func orchestrateSelfUpdate(
 		return err
 	}
 
-	renamed := false
 	if !oldGone {
-		renamed, err = renameOldContainerForHandoff(ctx, client, clog, oldContainer, originalName)
+		// renamed controls whether a rename was performed (skip if already
+		// watchtower-old-*). Recovery uses !oldGone so a predecessor left under
+		// that prefix from an earlier attempt is still restored and restarted.
+		_, err = renameOldContainerForHandoff(ctx, client, clog, oldContainer, originalName)
 		if err != nil {
 			return err
 		}
@@ -356,7 +358,9 @@ func orchestrateSelfUpdate(
 		oldContainer,
 	)
 	if err != nil {
-		if renamed {
+		// Recover any existing predecessor, including one already renamed to
+		// watchtower-old-* from an earlier attempt (renamed may be false).
+		if !oldGone {
 			restoreAndStartOldContainer(ctx, client, clog, oldContainer, originalName)
 		}
 
@@ -367,7 +371,7 @@ func orchestrateSelfUpdate(
 	if err != nil {
 		cleanupFailedNewContainer(ctx, client, clog, newContainerID)
 
-		if renamed {
+		if !oldGone {
 			restoreAndStartOldContainer(ctx, client, clog, oldContainer, originalName)
 		}
 
@@ -647,6 +651,12 @@ func stopOldContainer(
 			oldContainer.ID(),
 		)
 		if inspectErr != nil {
+			if cerrdefs.IsNotFound(inspectErr) {
+				clog.Debug("Old container already removed")
+
+				return true, nil
+			}
+
 			clog.WithError(inspectErr).Error("Failed to re-inspect old container after stop failure")
 			clog.WithError(err).Error("Failed to stop old container")
 

--- a/internal/actions/ephemeral.go
+++ b/internal/actions/ephemeral.go
@@ -44,7 +44,7 @@ var (
 	errOrchestratorStartFailed = errors.New("failed to start new container")
 	// errOrchestratorInspectFailed indicates a failure to inspect a container during orchestration.
 	errOrchestratorInspectFailed = errors.New("failed to inspect container during orchestration")
-	// errOrchestratorRenameFailed indicates a failure to rename the old container before handoff.
+	// errOrchestratorRenameFailed indicates a failure to rename the old container for handoff.
 	errOrchestratorRenameFailed = errors.New("failed to rename old container for handoff")
 	// errNewContainerNotRunning indicates the new container is not running after start.
 	errNewContainerNotRunning = errors.New("new container is not running after start")
@@ -181,14 +181,15 @@ func EphemeralSelfUpdate(
 // The orchestrator follows a deterministic state machine:
 //  1. VALIDATE: Read and validate environment variables
 //  2. INSPECT: Get the old container's full configuration
-//  3. RENAME OLD: Free the original name while keeping the process running
-//  4. CREATE NEW: Create a new container from the new image with the same config
-//  5. START NEW: Start the new Watchtower container
-//  6. VERIFY: Confirm the new container is running
-//  7. CLEANUP OLD: Stop and remove the renamed predecessor
+//  3. STOP OLD: Stop the old container (frees host ports)
+//  4. RENAME OLD: Move the stopped predecessor off the original name
+//  5. CREATE NEW: Create a new container from the new image with the same config
+//  6. START NEW: Start the new Watchtower container
+//  7. VERIFY: Confirm the new container is running
+//  8. REMOVE OLD: Delete the renamed predecessor
 //
-// If create/start/verify fails after rename, the original name is restored on the
-// old container so a running Watchtower remains addressable.
+// Stop before create releases published host ports. Rename keeps the stopped
+// predecessor for recovery if create or start fails (restore name and start).
 //
 // Parameters:
 //   - ctx: Context for cancellation and timeouts.
@@ -286,13 +287,15 @@ func readOrchestratorEnv() (string, string, string, string, error) {
 // Sequence:
 //  1. Inspect the old container and propagate the chain label.
 //  2. Pin Config.Image to newImage for create.
-//  3. Rename the old container off the original name (process keeps running).
-//  4. Create and start the new container under the original name.
-//  5. Verify the new container is running.
-//  6. Stop and remove the renamed old container.
+//  3. Stop the old container (frees host ports).
+//  4. Rename the stopped old container off the original name.
+//  5. Create and start the new container under the original name.
+//  6. Verify the new container is running.
+//  7. Remove the renamed predecessor.
 //
-// On create/start/verify failure after rename, the original name is restored on
-// the old container so a running Watchtower remains addressable.
+// Stop before create releases published host ports. Rename keeps the stopped
+// predecessor available for recovery. On create/start/verify failure after
+// rename, the original name is restored and the old container is started again.
 //
 // Parameters:
 //   - ctx: Context for cancellation and timeouts.
@@ -318,7 +321,6 @@ func orchestrateSelfUpdate(
 		"original_name": originalName,
 	})
 
-	// Inspect the old container and propagate the chain label.
 	oldContainer, err := inspectOldContainer(
 		ctx,
 		client,
@@ -332,9 +334,19 @@ func orchestrateSelfUpdate(
 
 	pinContainerCreateImage(oldContainer, newImage, clog)
 
-	renamed, err := renameOldContainerForHandoff(ctx, client, clog, oldContainer, originalName)
+	// Free host ports before create. Keep the container so rename can preserve
+	// it for recovery if the replacement fails.
+	oldGone, err := stopOldContainer(ctx, client, clog, oldContainer)
 	if err != nil {
 		return err
+	}
+
+	renamed := false
+	if !oldGone {
+		renamed, err = renameOldContainerForHandoff(ctx, client, clog, oldContainer, originalName)
+		if err != nil {
+			return err
+		}
 	}
 
 	newContainerID, err := createAndStartNewContainer(
@@ -345,34 +357,33 @@ func orchestrateSelfUpdate(
 	)
 	if err != nil {
 		if renamed {
-			restoreOldContainerName(ctx, client, clog, oldContainer, originalName)
+			restoreAndStartOldContainer(ctx, client, clog, oldContainer, originalName)
 		}
 
 		return err
 	}
 
-	// Verify the new container is running, starting it explicitly if needed.
 	err = ensureContainerRunning(ctx, client, clog, newContainerID)
 	if err != nil {
 		cleanupFailedNewContainer(ctx, client, clog, newContainerID)
 
 		if renamed {
-			restoreOldContainerName(ctx, client, clog, oldContainer, originalName)
+			restoreAndStartOldContainer(ctx, client, clog, oldContainer, originalName)
 		}
 
 		return err
 	}
 
-	// New instance is healthy; stop and remove the renamed predecessor.
-	_, stopErr := stopAndRemoveOldContainer(ctx, client, clog, oldContainer)
-	if stopErr != nil {
-		clog.WithError(stopErr).
-			Warn("New Watchtower is running but cleanup of the old container failed")
+	if !oldGone {
+		removeErr := removeOldContainer(ctx, client, clog, oldContainer)
+		if removeErr != nil {
+			clog.WithError(removeErr).
+				Warn("New Watchtower is running but cleanup of the old container failed")
+		}
 	}
 
 	// Emit the actual new container ID at Info level so notification templates
-	// can consume the correct "new_id" field. The orchestrator container runs
-	// after the source Watchtower process is stopped by the orchestrator.
+	// can consume the correct "new_id" field.
 	clog.WithField("new_id", newContainerID.ShortID()).
 		Info("Started new container")
 
@@ -381,6 +392,11 @@ func orchestrateSelfUpdate(
 
 // pinContainerCreateImage sets Config.Image on a concrete container.Container so
 // GetCreateConfig uses newImage for the replacement instance.
+//
+// Parameters:
+//   - oldContainer: Source container whose create config is pinned.
+//   - newImage: Image reference to use when creating the replacement.
+//   - clog: Logger with container context fields.
 func pinContainerCreateImage(oldContainer types.Container, newImage string, clog *logrus.Entry) {
 	if newImage == "" {
 		return
@@ -388,7 +404,7 @@ func pinContainerCreateImage(oldContainer types.Container, newImage string, clog
 
 	c, ok := oldContainer.(*container.Container)
 	if !ok {
-		clog.Debug("Old container is not a concrete Container; cannot pin create image")
+		clog.Debug("Old container is not a concrete Container. Cannot pin create image")
 
 		return
 	}
@@ -402,11 +418,11 @@ func pinContainerCreateImage(oldContainer types.Container, newImage string, clog
 	clog.WithField("pinned_image", newImage).Debug("Pinned create image for ephemeral self-update")
 }
 
-// renameOldContainerForHandoff renames the old container off its original name so
-// StartContainer can claim that name. The process keeps running under the new name.
+// renameOldContainerForHandoff renames the stopped old container off its original
+// name so StartContainer can claim that name. The container is kept for recovery.
 //
 // Returns:
-//   - renamed: True when a rename was performed (caller must restore on failure).
+//   - renamed: True when a rename was performed.
 //   - error: Non-nil if rename fails.
 func renameOldContainerForHandoff(
 	ctx context.Context,
@@ -416,13 +432,14 @@ func renameOldContainerForHandoff(
 	originalName string,
 ) (bool, error) {
 	if container.IsOldContainer(oldContainer.Name()) {
-		clog.Debug("Old container already has a watchtower-old name; skipping rename")
+		clog.Debug("Old container already has a watchtower-old name. Skipping rename")
 
 		return false, nil
 	}
 
 	targetName := types.WatchtowerOldPrefix + oldContainer.ID().ShortID()
-	clog.WithField("target_name", targetName).Debug("Renaming old Watchtower container to free original name")
+	clog.WithField("target_name", targetName).
+		Debug("Renaming stopped Watchtower container to free original name")
 
 	err := client.RenameContainer(ctx, oldContainer, targetName)
 	if err != nil {
@@ -434,14 +451,21 @@ func renameOldContainerForHandoff(
 	clog.WithFields(logrus.Fields{
 		"original_name": originalName,
 		"target_name":   targetName,
-	}).Debug("Renamed old Watchtower container for handoff")
+	}).Debug("Renamed stopped Watchtower container for handoff")
 
 	return true, nil
 }
 
-// restoreOldContainerName renames the old container back to originalName after a
-// failed create/start so operators keep a named running instance.
-func restoreOldContainerName(
+// restoreAndStartOldContainer renames the predecessor back to originalName and
+// starts it after a failed create/start so a Watchtower instance remains running.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeouts.
+//   - client: Container client for Docker operations.
+//   - clog: Logger with container context fields.
+//   - oldContainer: Stopped predecessor to restore.
+//   - originalName: Canonical name to restore on the predecessor.
+func restoreAndStartOldContainer(
 	ctx context.Context,
 	client container.Client,
 	clog *logrus.Entry,
@@ -453,23 +477,38 @@ func restoreOldContainerName(
 	}
 
 	clog.WithField("original_name", originalName).
-		Warn("Restoring old Watchtower container name after handoff failure")
+		Warn("Restoring old Watchtower container after handoff failure")
 
 	err := client.RenameContainer(ctx, oldContainer, originalName)
 	if err != nil {
 		clog.WithError(err).
 			WithField("original_name", originalName).
-			Error("Failed to restore old Watchtower container name; manual intervention required")
+			Error("Failed to restore old Watchtower container name. Manual intervention required")
+
+		return
+	}
+
+	err = client.StartContainerByID(ctx, oldContainer.ID())
+	if err != nil {
+		clog.WithError(err).
+			WithField("original_name", originalName).
+			Error("Failed to restart old Watchtower container after name restore. Manual intervention required")
 
 		return
 	}
 
 	clog.WithField("original_name", originalName).
-		Info("Restored old Watchtower container name after handoff failure")
+		Info("Restored and restarted old Watchtower container after handoff failure")
 }
 
 // cleanupFailedNewContainer best-effort removes a new container that failed
-// verification so the original name can be restored on the old instance.
+// verification so the original name can be restored on the predecessor.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeouts.
+//   - client: Container client for Docker operations.
+//   - clog: Logger with container context fields.
+//   - newContainerID: ID of the failed replacement container to remove.
 func cleanupFailedNewContainer(
 	ctx context.Context,
 	client container.Client,
@@ -569,28 +608,26 @@ func inspectOldContainer(
 	return oldContainer, nil
 }
 
-// stopAndRemoveOldContainer stops the old container and removes it to free its
-// name for the new one. If StopContainer returns NotFound, removal is skipped
-// because the Docker daemon already removed the container.
+// stopOldContainer stops the old container so published host ports are released
+// before the replacement is created. The container is left in place for rename
+// and optional recovery.
 //
 // Parameters:
 //   - ctx: Context for cancellation and timeouts.
 //   - client: Container client for Docker operations.
 //   - clog: Logger with container context fields.
-//   - oldContainer: The old Watchtower container to stop and remove.
+//   - oldContainer: The old Watchtower container to stop.
 //
 // Returns:
-//   - skipRemoval: True if removal was skipped (container already gone).
-//   - error: Non-nil if stopping or removing fails fatally.
-func stopAndRemoveOldContainer(
+//   - oldGone: True when the container is already absent (NotFound on stop).
+//   - error: Non-nil if stopping fails fatally while the container still runs.
+func stopOldContainer(
 	ctx context.Context,
 	client container.Client,
 	clog *logrus.Entry,
 	oldContainer types.Container,
 ) (bool, error) {
 	clog.Debug("Stopping old Watchtower container")
-
-	skipRemoval := false
 
 	err := client.StopContainer(
 		ctx,
@@ -601,64 +638,71 @@ func stopAndRemoveOldContainer(
 		if cerrdefs.IsNotFound(err) {
 			clog.Debug("Old container already removed")
 
-			// Container was already removed during the stop attempt.
-			// Skip removal and proceed to creating the new one.
-			skipRemoval = true
-		} else {
-			// StopContainer failed for a reason other than NotFound.
-			// Re-inspect the container to get its current state, since the
-			// old container object may be stale after the failed stop attempt.
-			freshContainer, inspectErr := client.GetContainer(
-				ctx,
-				oldContainer.ID(),
-			)
-			if inspectErr != nil {
-				clog.WithError(inspectErr).Error("Failed to re-inspect old container after stop failure")
-				clog.WithError(err).Error("Failed to stop old container")
-
-				return false, fmt.Errorf("%w: %w", errOrchestratorStopFailed, err)
-			}
-
-			if !freshContainer.IsRunning() {
-				// Container stopped despite the error. Proceed with removal.
-				clog.Debug("Old container is not running after stop attempt - proceeding with removal")
-			} else {
-				// Container is still running and StopContainer failed. This is fatal.
-				clog.WithError(err).Error("Failed to stop old container")
-
-				return false, fmt.Errorf("%w: %w", errOrchestratorStopFailed, err)
-			}
+			return true, nil
 		}
-	} else {
-		// StopContainer succeeded.
-		clog.Debug("Old container stopped")
+
+		// Re-inspect after a non-NotFound stop error. The cached view may be stale.
+		freshContainer, inspectErr := client.GetContainer(
+			ctx,
+			oldContainer.ID(),
+		)
+		if inspectErr != nil {
+			clog.WithError(inspectErr).Error("Failed to re-inspect old container after stop failure")
+			clog.WithError(err).Error("Failed to stop old container")
+
+			return false, fmt.Errorf("%w: %w", errOrchestratorStopFailed, err)
+		}
+
+		if !freshContainer.IsRunning() {
+			clog.Debug("Old container is not running after stop attempt")
+
+			return false, nil
+		}
+
+		clog.WithError(err).Error("Failed to stop old container")
+
+		return false, fmt.Errorf("%w: %w", errOrchestratorStopFailed, err)
 	}
 
-	// Remove the old container to free its name for the new one.
-	// StartTargetContainer renames the new container to the source
-	// container's name, which fails if a stopped container with the same
-	// name still exists.
-	//
-	// This step is skipped if skipRemoval is true, which occurs when
-	// StopContainer returns NotFound (container already removed).
-	if !skipRemoval {
-		clog.Debug("Removing old Watchtower container to free the name for the new container")
+	clog.Debug("Old container stopped")
 
-		err = client.RemoveContainer(ctx, oldContainer)
-		if err != nil {
-			if cerrdefs.IsNotFound(err) {
-				clog.Debug("Old container already removed")
-			} else {
-				clog.WithError(err).Error("Failed to remove old container")
+	return false, nil
+}
 
-				return false, fmt.Errorf("%w: %w", errOrchestratorRemoveFailed, err)
-			}
-		} else {
-			clog.Debug("Old container removed")
+// removeOldContainer removes the renamed predecessor after a successful handoff.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeouts.
+//   - client: Container client for Docker operations.
+//   - clog: Logger with container context fields.
+//   - oldContainer: The old Watchtower container to remove.
+//
+// Returns:
+//   - error: Non-nil if removal fails for a reason other than NotFound.
+func removeOldContainer(
+	ctx context.Context,
+	client container.Client,
+	clog *logrus.Entry,
+	oldContainer types.Container,
+) error {
+	clog.Debug("Removing old Watchtower container after successful handoff")
+
+	err := client.RemoveContainer(ctx, oldContainer)
+	if err != nil {
+		if cerrdefs.IsNotFound(err) {
+			clog.Debug("Old container already removed")
+
+			return nil
 		}
+
+		clog.WithError(err).Error("Failed to remove old container")
+
+		return fmt.Errorf("%w: %w", errOrchestratorRemoveFailed, err)
 	}
 
-	return skipRemoval, nil
+	clog.Debug("Old container removed")
+
+	return nil
 }
 
 // createAndStartNewContainer creates and starts a new container using the old

--- a/internal/actions/ephemeral_internal_test.go
+++ b/internal/actions/ephemeral_internal_test.go
@@ -197,7 +197,9 @@ var _ = ginkgo.Describe("orchestrateSelfUpdate handoff", func() {
 
 		client := mockActions.CreateMockClient(
 			&mockActions.TestData{
-				Containers:          []types.Container{old},
+				Containers: []types.Container{old},
+				// Fail only the replacement create/start path. Leave recovery
+				// StartContainerByID successful so restart can be asserted.
 				StartContainerError: errors.New("simulated create failure"),
 			},
 			false,
@@ -224,6 +226,8 @@ var _ = ginkgo.Describe("orchestrateSelfUpdate handoff", func() {
 		gomega.Expect(client.TestData.RenameTargets[1]).To(gomega.Equal("watchtower"))
 		// Predecessor must not be deleted when handoff fails.
 		gomega.Expect(client.TestData.RemoveContainerCount.Load()).To(gomega.Equal(int32(0)))
+		// Recovery restart succeeded (StartContainerByIDError is unset).
+		gomega.Expect(client.Stopped[string(old.ID())]).To(gomega.BeFalse())
 
 		stopIdx := firstOperationIndex(client.TestData.OperationOrder, "StopContainer")
 		renameIdx := firstOperationIndex(client.TestData.OperationOrder, "RenameContainer")
@@ -232,7 +236,6 @@ var _ = ginkgo.Describe("orchestrateSelfUpdate handoff", func() {
 
 		gomega.Expect(stopIdx).To(gomega.BeNumerically("<", renameIdx))
 		gomega.Expect(renameIdx).To(gomega.BeNumerically("<", startIdx))
-		// Recovery attempts StartContainerByID after restoring the name.
 		gomega.Expect(restartIdx).To(gomega.BeNumerically(">", startIdx))
 	})
 

--- a/internal/actions/ephemeral_internal_test.go
+++ b/internal/actions/ephemeral_internal_test.go
@@ -3,79 +3,88 @@ package actions
 import (
 	"context"
 	"errors"
+	"net/netip"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
 	dockerContainer "github.com/moby/moby/api/types/container"
+	dockerNetwork "github.com/moby/moby/api/types/network"
 
 	mockActions "github.com/nicholas-fedor/watchtower/internal/actions/mocks"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
+// firstOperationIndex returns the index of the first occurrence of name in ops,
+// or -1 when name is absent.
+//
+// Parameters:
+//   - ops: Ordered list of operation names.
+//   - name: Operation name to locate.
+//
+// Returns:
+//   - int: Zero-based index, or -1 if not found.
+func firstOperationIndex(ops []string, name string) int {
+	for i, op := range ops {
+		if op == name {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// createEphemeralHandoffContainer builds a running Watchtower mock used by
+// orchestrateSelfUpdate handoff tests.
+//
+// Parameters:
+//   - id: Container ID.
+//   - portBindings: Optional host port bindings. Nil yields empty bindings.
+//
+// Returns:
+//   - types.Container: Configured mock container.
+func createEphemeralHandoffContainer(
+	id string,
+	portBindings dockerNetwork.PortMap,
+) types.Container {
+	if portBindings == nil {
+		portBindings = dockerNetwork.PortMap{}
+	}
+
+	const (
+		name  = "/watchtower"
+		image = "watchtower:v1"
+	)
+
+	ctr := mockActions.CreateMockContainerWithConfig(
+		id,
+		name,
+		image,
+		true,
+		false,
+		time.Now(),
+		&dockerContainer.Config{
+			Image: image,
+			Labels: map[string]string{
+				"com.centurylinklabs.watchtower": "true",
+			},
+		},
+	)
+
+	info := ctr.ContainerInfo()
+	if info != nil && info.HostConfig != nil {
+		info.HostConfig.PortBindings = portBindings
+	}
+
+	return ctr
+}
+
 var _ = ginkgo.Describe("orchestrateSelfUpdate handoff", func() {
-	ginkgo.It("renames old container before create and restores name when create fails", func() {
-		old := mockActions.CreateMockContainerWithConfig(
-			"wt-old-id",
-			"/watchtower",
-			"watchtower:v1",
-			true,
-			false,
-			time.Now(),
-			&dockerContainer.Config{
-				Image: "watchtower:v1",
-				Labels: map[string]string{
-					"com.centurylinklabs.watchtower": "true",
-				},
-			},
-		)
-
-		client := mockActions.CreateMockClient(
-			&mockActions.TestData{
-				Containers: []types.Container{old},
-				// Mock StartContainer is the create+start path used by the orchestrator.
-				StartContainerError: errors.New("simulated create failure"),
-			},
-			false,
-			false,
-		)
-
-		err := orchestrateSelfUpdate(
-			context.Background(),
-			client,
-			"wt-old-id",
-			"watchtower:v2",
-			"watchtower",
-			"",
-		)
-
-		gomega.Expect(err).To(gomega.HaveOccurred())
-		gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to create new container"))
-		// Rename off original name, then rename back after create failure.
-		gomega.Expect(client.TestData.RenameContainerCount.Load()).To(gomega.Equal(int32(2)))
-		gomega.Expect(client.TestData.RenameTargets).To(gomega.HaveLen(2))
-		gomega.Expect(client.TestData.RenameTargets[0]).To(gomega.HavePrefix(types.WatchtowerOldPrefix))
-		gomega.Expect(client.TestData.RenameTargets[1]).To(gomega.Equal("watchtower"))
-		// Old instance must not have been stop/removed before create failed.
-		gomega.Expect(client.TestData.StopContainerCount.Load()).To(gomega.Equal(int32(0)))
-	})
-
-	ginkgo.It("stops and removes the renamed old container after successful handoff", func() {
-		old := mockActions.CreateMockContainerWithConfig(
-			"wt-old-id-ok",
-			"/watchtower",
-			"watchtower:v1",
-			true,
-			false,
-			time.Now(),
-			&dockerContainer.Config{
-				Image: "watchtower:v1",
-				Labels: map[string]string{
-					"com.centurylinklabs.watchtower": "true",
-				},
-			},
-		)
+	// Stop frees host ports. Rename keeps the stopped predecessor for recovery.
+	// Remove runs only after the replacement is verified running.
+	ginkgo.It("stops, renames, creates, then removes the old container on success", func() {
+		old := createEphemeralHandoffContainer("wt-old-id-ok", nil)
 
 		client := mockActions.CreateMockClient(
 			&mockActions.TestData{
@@ -95,9 +104,189 @@ var _ = ginkgo.Describe("orchestrateSelfUpdate handoff", func() {
 		)
 
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(client.TestData.RenameContainerCount.Load()).To(gomega.Equal(int32(1)))
 		gomega.Expect(client.TestData.StartContainerCount.Load()).To(gomega.BeNumerically(">=", int32(1)))
-		// Cleanup of renamed predecessor after successful handoff.
 		gomega.Expect(client.TestData.StopContainerCount.Load()).To(gomega.BeNumerically(">=", int32(1)))
+		gomega.Expect(client.TestData.RenameContainerCount.Load()).To(gomega.Equal(int32(1)))
+		gomega.Expect(client.TestData.RemoveContainerCount.Load()).To(gomega.BeNumerically(">=", int32(1)))
+		gomega.Expect(client.TestData.RenameTargets).To(gomega.HaveLen(1))
+		gomega.Expect(client.TestData.RenameTargets[0]).To(gomega.HavePrefix(types.WatchtowerOldPrefix))
+
+		stopIdx := firstOperationIndex(client.TestData.OperationOrder, "StopContainer")
+		renameIdx := firstOperationIndex(client.TestData.OperationOrder, "RenameContainer")
+		startIdx := firstOperationIndex(client.TestData.OperationOrder, "StartContainer")
+		removeIdx := firstOperationIndex(client.TestData.OperationOrder, "RemoveContainer")
+
+		gomega.Expect(stopIdx).To(gomega.BeNumerically(">=", 0))
+		gomega.Expect(renameIdx).To(gomega.BeNumerically(">=", 0))
+		gomega.Expect(startIdx).To(gomega.BeNumerically(">=", 0))
+		gomega.Expect(removeIdx).To(gomega.BeNumerically(">=", 0))
+		gomega.Expect(stopIdx).To(gomega.BeNumerically("<", renameIdx))
+		gomega.Expect(renameIdx).To(gomega.BeNumerically("<", startIdx))
+		gomega.Expect(startIdx).To(gomega.BeNumerically("<", removeIdx))
+	})
+
+	ginkgo.It("stops the old container before create when host ports are published", func() {
+		old := createEphemeralHandoffContainer(
+			"wt-old-ports",
+			dockerNetwork.PortMap{
+				dockerNetwork.MustParsePort("8080/tcp"): {
+					{HostIP: netip.MustParseAddr("0.0.0.0"), HostPort: "8080"},
+				},
+			},
+		)
+
+		gomega.Expect(old.HasExposedPorts()).To(gomega.BeTrue())
+
+		client := mockActions.CreateMockClient(
+			&mockActions.TestData{
+				Containers: []types.Container{old},
+			},
+			false,
+			false,
+		)
+
+		err := orchestrateSelfUpdate(
+			context.Background(),
+			client,
+			"wt-old-ports",
+			"watchtower:v2",
+			"watchtower",
+			"",
+		)
+
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		stopIdx := firstOperationIndex(client.TestData.OperationOrder, "StopContainer")
+		startIdx := firstOperationIndex(client.TestData.OperationOrder, "StartContainer")
+
+		gomega.Expect(stopIdx).To(gomega.BeNumerically(">=", 0))
+		gomega.Expect(startIdx).To(gomega.BeNumerically(">=", 0))
+		gomega.Expect(stopIdx).To(gomega.BeNumerically("<", startIdx))
+	})
+
+	ginkgo.It("does not create a new container when stopping the old container fails", func() {
+		old := createEphemeralHandoffContainer("wt-old-stop-fail", nil)
+
+		client := mockActions.CreateMockClient(
+			&mockActions.TestData{
+				Containers:             []types.Container{old},
+				StopContainerError:     errors.New("simulated stop failure"),
+				StopContainerFailCount: 1,
+			},
+			false,
+			false,
+		)
+
+		err := orchestrateSelfUpdate(
+			context.Background(),
+			client,
+			"wt-old-stop-fail",
+			"watchtower:v2",
+			"watchtower",
+			"",
+		)
+
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to stop old container"))
+		gomega.Expect(client.TestData.StartContainerCount.Load()).To(gomega.Equal(int32(0)))
+		gomega.Expect(client.TestData.RenameContainerCount.Load()).To(gomega.Equal(int32(0)))
+	})
+
+	ginkgo.It("restores and restarts the old container when create fails after rename", func() {
+		old := createEphemeralHandoffContainer("wt-old-create-fail", nil)
+
+		client := mockActions.CreateMockClient(
+			&mockActions.TestData{
+				Containers:          []types.Container{old},
+				StartContainerError: errors.New("simulated create failure"),
+			},
+			false,
+			false,
+		)
+
+		err := orchestrateSelfUpdate(
+			context.Background(),
+			client,
+			"wt-old-create-fail",
+			"watchtower:v2",
+			"watchtower",
+			"",
+		)
+
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to create new container"))
+
+		gomega.Expect(client.TestData.StopContainerCount.Load()).To(gomega.BeNumerically(">=", int32(1)))
+		// Rename off original name, then rename back on failure.
+		gomega.Expect(client.TestData.RenameContainerCount.Load()).To(gomega.Equal(int32(2)))
+		gomega.Expect(client.TestData.RenameTargets).To(gomega.HaveLen(2))
+		gomega.Expect(client.TestData.RenameTargets[0]).To(gomega.HavePrefix(types.WatchtowerOldPrefix))
+		gomega.Expect(client.TestData.RenameTargets[1]).To(gomega.Equal("watchtower"))
+		// Predecessor must not be deleted when handoff fails.
+		gomega.Expect(client.TestData.RemoveContainerCount.Load()).To(gomega.Equal(int32(0)))
+
+		stopIdx := firstOperationIndex(client.TestData.OperationOrder, "StopContainer")
+		renameIdx := firstOperationIndex(client.TestData.OperationOrder, "RenameContainer")
+		startIdx := firstOperationIndex(client.TestData.OperationOrder, "StartContainer")
+		restartIdx := firstOperationIndex(client.TestData.OperationOrder, "StartContainerByID")
+
+		gomega.Expect(stopIdx).To(gomega.BeNumerically("<", renameIdx))
+		gomega.Expect(renameIdx).To(gomega.BeNumerically("<", startIdx))
+		// Recovery attempts StartContainerByID after restoring the name.
+		gomega.Expect(restartIdx).To(gomega.BeNumerically(">", startIdx))
+	})
+
+	ginkgo.It("pins Config.Image to the new image reference before create", func() {
+		old := createEphemeralHandoffContainer("wt-old-pin", nil)
+
+		client := mockActions.CreateMockClient(
+			&mockActions.TestData{
+				Containers: []types.Container{old},
+			},
+			false,
+			false,
+		)
+
+		err := orchestrateSelfUpdate(
+			context.Background(),
+			client,
+			"wt-old-pin",
+			"watchtower:v2",
+			"watchtower",
+			"",
+		)
+
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(client.TestData.LastStartedContainer).NotTo(gomega.BeNil())
+		gomega.Expect(client.TestData.LastStartedContainer.ImageName()).To(gomega.Equal("watchtower:v2"))
+	})
+
+	ginkgo.It("propagates the container chain label onto the source config used for create", func() {
+		old := createEphemeralHandoffContainer("wt-old-chain", nil)
+
+		client := mockActions.CreateMockClient(
+			&mockActions.TestData{
+				Containers: []types.Container{old},
+			},
+			false,
+			false,
+		)
+
+		chain := "prev-id,wt-old-chain"
+		err := orchestrateSelfUpdate(
+			context.Background(),
+			client,
+			"wt-old-chain",
+			"watchtower:v2",
+			"watchtower",
+			chain,
+		)
+
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(client.TestData.LastStartedContainer).NotTo(gomega.BeNil())
+
+		gotChain, present := client.TestData.LastStartedContainer.GetContainerChain()
+		gomega.Expect(present).To(gomega.BeTrue())
+		gomega.Expect(gotChain).To(gomega.Equal(chain))
 	})
 })

--- a/internal/actions/ephemeral_test.go
+++ b/internal/actions/ephemeral_test.go
@@ -175,4 +175,32 @@ var _ = ginkgo.Describe("EphemeralSelfUpdate", func() {
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("ephemeral orchestrator failed"))
 		})
 	})
+
+	// EphemeralSelfUpdate only starts the orchestrator. Replacement is asynchronous.
+	ginkgo.When("the orchestrator launches successfully", func() {
+		ginkgo.It("returns without performing stop or start on the source client path", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			sourceContainer := createDefaultMockContainer("source-async", map[string]string{
+				"com.centurylinklabs.watchtower": "true",
+			})
+
+			client := createDefaultMockClient(&mockActions.TestData{})
+
+			newID, renamed, err := actions.EphemeralSelfUpdate(
+				ctx,
+				client,
+				sourceContainer,
+				types.UpdateParams{},
+			)
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(newID).To(gomega.BeEmpty())
+			gomega.Expect(renamed).To(gomega.BeFalse())
+			gomega.Expect(client.TestData.StopContainerCount.Load()).To(gomega.Equal(int32(0)))
+			gomega.Expect(client.TestData.StartContainerCount.Load()).To(gomega.Equal(int32(0)))
+			gomega.Expect(client.TestData.RenameContainerCount.Load()).To(gomega.Equal(int32(0)))
+		})
+	})
 })

--- a/internal/actions/mocks/client.go
+++ b/internal/actions/mocks/client.go
@@ -52,6 +52,7 @@ type TestData struct {
 	ListContainersFailCount      int                                   // Number of times ListContainers should fail before succeeding.
 	StopContainerError           error                                 // Error to return from StopContainer (for testing).
 	StartContainerError          error                                 // Error to return from StartContainer (for testing).
+	StartContainerByIDError      error                                 // Error to return from StartContainerByID (for testing).
 	CreateContainerError         error                                 // Error to return from CreateContainer (for testing).
 	UpdateContainerError         error                                 // Error to return from UpdateContainer (for testing).
 	StopContainerFailCount       int                                   // Number of times StopContainer should fail before succeeding.
@@ -324,7 +325,7 @@ func (client MockClient) StartContainer(ctx context.Context, c types.Container) 
 
 // StartContainerByID simulates starting a container by its ID directly.
 // It provides a minimal implementation for testing purposes.
-// Returns the configured StartContainerError if set.
+// Returns the configured StartContainerByIDError if set.
 func (client MockClient) StartContainerByID(ctx context.Context, containerID types.ContainerID) error {
 	client.TestData.StartContainerCount.Add(1)
 	client.TestData.recordOperation("StartContainerByID")
@@ -333,8 +334,8 @@ func (client MockClient) StartContainerByID(ctx context.Context, containerID typ
 		return err
 	}
 
-	if client.TestData.StartContainerError != nil {
-		return client.TestData.StartContainerError
+	if client.TestData.StartContainerByIDError != nil {
+		return client.TestData.StartContainerByIDError
 	}
 
 	// Mark the container running when present so re-inspect after start succeeds.

--- a/internal/actions/mocks/client.go
+++ b/internal/actions/mocks/client.go
@@ -60,11 +60,28 @@ type TestData struct {
 	StopOrder                    []string                              // Order in which containers were stopped.
 	CreateOrder                  []string                              // Order in which containers were created.
 	StartOrder                   []string                              // Order in which containers were started.
-	SimulatedLatency             time.Duration                         // Simulated latency for operations (default 0 for fast tests, set for context cancellation tests).
-	LastContainerChain           string                                // Last container chain passed to CreateEphemeralOrchestrator.
-	LastUpdateConfig             *dockerContainer.UpdateConfig         // Last UpdateContainer config received.
-	SetNoRestartPolicyContainer  types.Container                        // Last container passed to SetNoRestartPolicy.
-	SetNoRestartPolicyCtx        context.Context                        // Last context passed to SetNoRestartPolicy.
+	// OperationOrder records client method names in call order for handoff sequencing assertions.
+	OperationOrder              []string
+	RemoveContainerCount        atomic.Int32                  // Number of times RemoveContainer was called.
+	SimulatedLatency            time.Duration                 // Simulated latency for operations (default 0 for fast tests, set for context cancellation tests).
+	LastContainerChain          string                        // Last container chain passed to CreateEphemeralOrchestrator.
+	LastUpdateConfig            *dockerContainer.UpdateConfig // Last UpdateContainer config received.
+	LastStartedContainer        types.Container               // Last container passed to StartContainer.
+	LastStartedContainerID      types.ContainerID             // ID returned by the last successful StartContainer call.
+	SetNoRestartPolicyContainer types.Container               // Last container passed to SetNoRestartPolicy.
+	SetNoRestartPolicyCtx       context.Context               // Last context passed to SetNoRestartPolicy.
+}
+
+// recordOperation appends an operation name to OperationOrder for sequencing tests.
+//
+// Parameters:
+//   - name: Client method name to record (for example, "StopContainer").
+func (testdata *TestData) recordOperation(name string) {
+	if testdata == nil {
+		return
+	}
+
+	testdata.OperationOrder = append(testdata.OperationOrder, name)
 }
 
 // TriedToRemoveImage checks if RemoveImageByID has been invoked.
@@ -175,6 +192,7 @@ func (client MockClient) ListContainers(ctx context.Context, filter ...types.Fil
 // and returns nil for simplicity.
 func (client MockClient) StopContainer(ctx context.Context, c types.Container, _ time.Duration) error {
 	client.TestData.StopContainerCount.Add(1)
+	client.TestData.recordOperation("StopContainer")
 
 	if err := client.checkContextCancellation(ctx); err != nil {
 		return err
@@ -196,6 +214,7 @@ func (client MockClient) StopContainer(ctx context.Context, c types.Container, _
 func (client MockClient) StopAndRemoveContainer(ctx context.Context, c types.Container, timeout time.Duration) error {
 	client.TestData.StopAndRemoveContainerCount.Add(1)
 	client.TestData.LastStopAndRemoveID = c.ID()
+	client.TestData.recordOperation("StopAndRemoveContainer")
 
 	err := client.StopContainer(ctx, c, timeout)
 	if err != nil {
@@ -255,6 +274,8 @@ func (client MockClient) CreateContainer(ctx context.Context, c types.Container)
 // Returns the configured StartContainerError if set.
 func (client MockClient) StartContainer(ctx context.Context, c types.Container) (types.ContainerID, error) {
 	client.TestData.StartContainerCount.Add(1)
+	client.TestData.recordOperation("StartContainer")
+	client.TestData.LastStartedContainer = c
 
 	if err := client.checkContextCancellation(ctx); err != nil {
 		return "", err
@@ -266,7 +287,39 @@ func (client MockClient) StartContainer(ctx context.Context, c types.Container) 
 
 	client.TestData.StartOrder = append(client.TestData.StartOrder, c.Name())
 
-	return c.ID(), nil
+	// Return a distinct ID so handoff verification can distinguish the replacement
+	// instance from the source, matching real Docker create+start behavior.
+	newID := types.ContainerID(string(c.ID()) + "-started")
+	client.TestData.LastStartedContainerID = newID
+
+	if client.TestData.ContainersByID == nil {
+		client.TestData.ContainersByID = make(map[types.ContainerID]types.Container)
+	}
+
+	if _, exists := client.TestData.ContainersByID[newID]; !exists {
+		// Register as running so ensureContainerRunning accepts the handoff.
+		labels := map[string]string{}
+		if info := c.ContainerInfo(); info != nil && info.Config != nil && info.Config.Labels != nil {
+			for k, v := range info.Config.Labels {
+				labels[k] = v
+			}
+		}
+
+		client.TestData.ContainersByID[newID] = CreateMockContainerWithConfig(
+			string(newID),
+			c.Name(),
+			c.ImageName(),
+			true,
+			false,
+			time.Now(),
+			&dockerContainer.Config{
+				Image:  c.ImageName(),
+				Labels: labels,
+			},
+		)
+	}
+
+	return newID, nil
 }
 
 // StartContainerByID simulates starting a container by its ID directly.
@@ -274,6 +327,7 @@ func (client MockClient) StartContainer(ctx context.Context, c types.Container) 
 // Returns the configured StartContainerError if set.
 func (client MockClient) StartContainerByID(ctx context.Context, containerID types.ContainerID) error {
 	client.TestData.StartContainerCount.Add(1)
+	client.TestData.recordOperation("StartContainerByID")
 
 	if err := client.checkContextCancellation(ctx); err != nil {
 		return err
@@ -281,6 +335,15 @@ func (client MockClient) StartContainerByID(ctx context.Context, containerID typ
 
 	if client.TestData.StartContainerError != nil {
 		return client.TestData.StartContainerError
+	}
+
+	// Mark the container running when present so re-inspect after start succeeds.
+	delete(client.Stopped, string(containerID))
+
+	if c, ok := client.TestData.ContainersByID[containerID]; ok {
+		if info := c.ContainerInfo(); info != nil && info.State != nil {
+			info.State.Running = true
+		}
 	}
 
 	return nil
@@ -292,6 +355,7 @@ func (client MockClient) RenameContainer(ctx context.Context, _ types.Container,
 	client.TestData.RenameContainerCount.Add(1)
 	client.TestData.LastRenameTarget = newName
 	client.TestData.RenameTargets = append(client.TestData.RenameTargets, newName)
+	client.TestData.recordOperation("RenameContainer")
 
 	if err := client.checkContextCancellation(ctx); err != nil {
 		return err
@@ -455,6 +519,9 @@ func (client MockClient) WaitForContainerHealthy(ctx context.Context, _ types.Co
 // RemoveContainer simulates removing a container.
 // It returns nil to indicate success.
 func (client MockClient) RemoveContainer(ctx context.Context, _ types.Container) error {
+	client.TestData.RemoveContainerCount.Add(1)
+	client.TestData.recordOperation("RemoveContainer")
+
 	if err := client.checkContextCancellation(ctx); err != nil {
 		return err
 	}

--- a/internal/api/handlers/check/handler.go
+++ b/internal/api/handlers/check/handler.go
@@ -148,16 +148,16 @@ func (h *Handler) Handle(c fiber.Ctx) error {
 		logrus.WithError(err).WithField("notify", "no").
 			Error("Failed to check for updates")
 
-	// Notify SSE subscribers that the check scan failed.
-	if h.eventBroadcaster != nil {
-		h.eventBroadcaster.Publish(events.Event{
-			Type:      "scan_failed",
-			Timestamp: time.Now().UTC(),
-			Data: events.ScanFailedData{
-				Error: "failed to check for updates",
-			},
-		})
-	}
+		// Notify SSE subscribers that the check scan failed.
+		if h.eventBroadcaster != nil {
+			h.eventBroadcaster.Publish(events.Event{
+				Type:      "scan_failed",
+				Timestamp: time.Now().UTC(),
+				Data: events.ScanFailedData{
+					Error: "failed to check for updates",
+				},
+			})
+		}
 
 		sendErr := c.Status(fiber.StatusInternalServerError).
 			SendString("failed to check for updates")

--- a/pkg/container/image_test.go
+++ b/pkg/container/image_test.go
@@ -738,6 +738,59 @@ var _ = ginkgo.Describe("the client", func() {
 				}
 			})
 		})
+
+		// Empty RepoDigests skips the registry pull, but HasNewImage still
+		// compares the running image ID to the local tag.
+		ginkgo.When("container image has empty RepoDigests but the local tag points at a different ID", func() {
+			ginkgo.It("skips pull and still reports the container as stale", func() {
+				currentImageID := "sha256:" + util.GenerateRandomSHA256()
+				newerLocalImageID := "sha256:" + util.GenerateRandomSHA256()
+				container := MockContainer(
+					WithImageName("registry.example.com/app:latest"),
+					WithRepoDigests([]string{}),
+					func(container *dockerContainer.InspectResponse, image *dockerImage.InspectResponse) {
+						container.Image = currentImageID
+						image.ID = currentImageID
+					},
+				)
+
+				mockServer.AllowUnhandledRequests = true
+				mockServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(
+							"GET",
+							gomega.HaveSuffix("/images/registry.example.com/app:latest/json"),
+						),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, dockerImage.InspectResponse{
+							ID:          newerLocalImageID,
+							RepoDigests: []string{},
+						}),
+					),
+				)
+
+				c := &client{api: mockClient}
+
+				resetLogrus, logbuf := captureLogrus(logrus.DebugLevel)
+				defer resetLogrus()
+
+				stale, latestID, latestDigest, err := c.IsContainerStale(
+					context.Background(),
+					container,
+					types.UpdateParams{},
+				)
+				gomega.Expect(err).To(gomega.Succeed())
+				gomega.Expect(stale).To(gomega.BeTrue())
+				gomega.Expect(string(latestID)).To(gomega.Equal(newerLocalImageID))
+				gomega.Expect(latestDigest).To(gomega.BeEmpty())
+				gomega.Eventually(logbuf).Should(gbytes.Say(`empty RepoDigests`))
+				gomega.Eventually(logbuf).Should(gbytes.Say(`Digest match, skipping pull`))
+				gomega.Eventually(logbuf).Should(gbytes.Say(`Found new image`))
+
+				for _, req := range mockServer.ReceivedRequests() {
+					gomega.Expect(req.URL.Path).ToNot(gomega.ContainSubstring("/images/create"))
+				}
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
This PR fixes ephemeral Watchtower self-updates that failed when the running instance published host ports. The orchestrator now stops the old container before renaming it, keeps that predecessor available for recovery, and removes it only after the replacement is running.

## Problem

PR #2005 changed ephemeral self-update to rename the running container before creating and starting its replacement, so a failed handoff could restore the original name. Because the predecessor was still running, it kept any published host ports. The replacement could not start, the original name was restored, and the same stale instance continued to run. Each update cycle then repeated the failed self-update.

## Solution

Use a port-safe handoff that still supports rename-based recovery. Stop the old container first, rename the stopped predecessor off the original name, create and start the replacement, then remove the predecessor only after verification succeeds. If create or start fails, restore the original name and restart the predecessor.

## Changes

- Change the ephemeral orchestrator handoff order to stop, rename, create/start, verify, then remove
- Restore and restart the predecessor when replacement fails after rename
- Add unit tests for handoff ordering, published ports, stop and create failures, and related image staleness behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-update reliability by preserving the previous container during handoffs and restoring it automatically when replacement operations fail.
  * Improved cleanup handling when containers have already stopped, supporting smoother recovery from reported stop errors.
  * Improved image freshness detection when registry digest information is unavailable.
  * Check failure notifications are now sent after the error is logged, improving event ordering and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->