### PR TITLE
docs(readme): remove star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,6 @@ Watchtower supports the following architectures for its Docker images:
 
 The full documentation is available at <https://watchtower.nickfedor.com/>.
 
-## Star History
-
-<a href="https://www.star-history.com/?type=timeline&logscale=&legend=top-left&repos=nicholas-fedor%2Fwatchtower">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=nicholas-fedor/watchtower&type=timeline&theme=dark&logscale&legend=top-left&sealed_token=psoQA5TipWC1du5poc_YGImqILCN0FiZccvjEEFxLhVS0YlPr7Ur79tUc-gAfaOoQuQBhG0uA4rkmJc_H2nWZPnnfs6Fq1Z9jeWvALffxz0H7YHaCRgcruDl9IAZfnk583p-dw8eADmTsMTnK6t8ANgDLXxFd3mM-R3Y_8_HYOe35IQc3FgUkdYQJG1_" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=nicholas-fedor/watchtower&type=timeline&logscale&legend=top-left&sealed_token=psoQA5TipWC1du5poc_YGImqILCN0FiZccvjEEFxLhVS0YlPr7Ur79tUc-gAfaOoQuQBhG0uA4rkmJc_H2nWZPnnfs6Fq1Z9jeWvALffxz0H7YHaCRgcruDl9IAZfnk583p-dw8eADmTsMTnK6t8ANgDLXxFd3mM-R3Y_8_HYOe35IQc3FgUkdYQJG1_" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=nicholas-fedor/watchtower&type=timeline&logscale&legend=top-left&sealed_token=psoQA5TipWC1du5poc_YGImqILCN0FiZccvjEEFxLhVS0YlPr7Ur79tUc-gAfaOoQuQBhG0uA4rkmJc_H2nWZPnnfs6Fq1Z9jeWvALffxz0H7YHaCRgcruDl9IAZfnk583p-dw8eADmTsMTnK6t8ANgDLXxFd3mM-R3Y_8_HYOe35IQc3FgUkdYQJG1_" />
- </picture>
-</a>
 <!-- markdownlint-restore -->
 
 ## Contributors


### PR DESCRIPTION
The star history chart is no longer functional due to GitHub's API changes and the prior workaround is also broken. 

Removing the star chart until things are no longer broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Star History section and chart from the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->