### PR TITLE
fix: clear engine-generated MACs on container recreation

### DIFF
--- a/pkg/container/container_source.go
+++ b/pkg/container/container_source.go
@@ -621,6 +621,44 @@ func isEngineGeneratedMAC(mac dockerNetwork.HardwareAddr, ip netip.Addr) bool {
 	return string(mac) == expected
 }
 
+// onlyGeneratedMacs reports whether every non-empty MAC in the source
+// container's original network settings matches the bridge driver's
+// engine-generated pattern for that endpoint's IP.
+//
+// It is used by validateMacAddresses to allow missing MACs in the processed
+// config when those MACs were intentionally cleared by processEndpoint because
+// they were engine-generated.
+//
+// Parameters:
+//   - sourceContainer: The container whose original network settings are inspected.
+//
+// Returns:
+//   - bool: True if the container had at least one MAC and every one of them was
+//     engine-generated. False if there were no MACs or at least one was user-configured.
+func onlyGeneratedMacs(sourceContainer types.Container) bool {
+	containerInfo := sourceContainer.ContainerInfo()
+
+	if containerInfo == nil || containerInfo.NetworkSettings == nil {
+		return false
+	}
+
+	hasMac := false
+
+	for _, endpoint := range containerInfo.NetworkSettings.Networks {
+		if endpoint == nil || len(endpoint.MacAddress) == 0 {
+			continue
+		}
+
+		hasMac = true
+
+		if !isEngineGeneratedMAC(endpoint.MacAddress, endpoint.IPAddress) {
+			return false
+		}
+	}
+
+	return hasMac
+}
+
 // validateMacAddresses verifies the presence of MAC addresses in a container's network configuration
 // and logs appropriate messages based on the container's state, network mode, and Docker API version.
 // It ensures that MAC addresses are correctly handled for modern API versions (>= 1.44) and logs
@@ -740,6 +778,15 @@ func validateMacAddresses(
 
 			return nil
 		}
+
+		// If all original MACs were engine-generated, the absence is expected because
+		// processEndpoint intentionally clears them to avoid stale MACs after IP reassignment.
+		if onlyGeneratedMacs(sourceContainer) {
+			clog.Debug("No MAC address found; all original MACs were engine-generated and intentionally cleared")
+
+			return nil
+		}
+
 		// Running containers should have MAC addresses, but absence may indicate
 		// either a lack of support or a configuration issue.
 		clog.WithField("state", containerState).

--- a/pkg/container/container_source.go
+++ b/pkg/container/container_source.go
@@ -623,39 +623,72 @@ func isEngineGeneratedMAC(mac dockerNetwork.HardwareAddr, ip netip.Addr) bool {
 
 // onlyGeneratedMacs reports whether every non-empty MAC in the source
 // container's original network settings matches the bridge driver's
-// engine-generated pattern for that endpoint's IP.
+// engine-generated pattern for that endpoint's IP, and whether every non-nil
+// original endpoint is present in the processed configuration.
 //
 // It is used by validateMacAddresses to allow missing MACs in the processed
-// config when those MACs were intentionally cleared by processEndpoint because
-// they were engine-generated.
+// config only when those MACs were intentionally cleared by processEndpoint and
+// no endpoints were lost during processing.
 //
 // Parameters:
 //   - sourceContainer: The container whose original network settings are inspected.
+//   - processedConfig: The processed network configuration whose endpoint coverage is checked.
 //
 // Returns:
 //   - bool: True if the container had at least one MAC and every one of them was
-//     engine-generated. False if there were no MACs or at least one was user-configured.
-func onlyGeneratedMacs(sourceContainer types.Container) bool {
+//     engine-generated, and all non-nil original endpoints appear in the processed
+//     config. False otherwise.
+func onlyGeneratedMacs(sourceContainer types.Container, processedConfig *dockerNetwork.NetworkingConfig) bool {
+	if sourceContainer == nil {
+		return false
+	}
+
 	containerInfo := sourceContainer.ContainerInfo()
 
 	if containerInfo == nil || containerInfo.NetworkSettings == nil {
 		return false
 	}
 
+	// Build a set of network names present in the processed config so we can
+	// verify that every non-nil original endpoint survived processing.
+	processedNetworks := make(map[string]bool, len(processedConfig.EndpointsConfig))
+
+	for name := range processedConfig.EndpointsConfig {
+		processedNetworks[name] = true
+	}
+
 	hasMac := false
 
-	for _, endpoint := range containerInfo.NetworkSettings.Networks {
-		if endpoint == nil || len(endpoint.MacAddress) == 0 {
+	for networkName, endpoint := range containerInfo.NetworkSettings.Networks {
+		// Nil endpoints carry no MAC and do not participate in coverage checks.
+		if endpoint == nil {
+			continue
+		}
+
+		// A non-nil original endpoint that was dropped during processing means
+		// the missing-MAC result may not be fully explained by intentional
+		// clearing, so do not grant the waiver.
+		if !processedNetworks[networkName] {
+			return false
+		}
+
+		// Endpoints without a MAC cannot be engine-generated, but they also do
+		// not disprove the hypothesis that every original MAC was generated.
+		if len(endpoint.MacAddress) == 0 {
 			continue
 		}
 
 		hasMac = true
 
+		// Any user-configured MAC disproves the all-generated hypothesis and
+		// preserves normal missing-MAC validation behavior.
 		if !isEngineGeneratedMAC(endpoint.MacAddress, endpoint.IPAddress) {
 			return false
 		}
 	}
 
+	// Require at least one original MAC so that containers with no MACs at all
+	// do not incorrectly bypass validation.
 	return hasMac
 }
 
@@ -779,9 +812,11 @@ func validateMacAddresses(
 			return nil
 		}
 
-		// If all original MACs were engine-generated, the absence is expected because
-		// processEndpoint intentionally clears them to avoid stale MACs after IP reassignment.
-		if onlyGeneratedMacs(sourceContainer) {
+		// If all original MACs were engine-generated and every non-nil original
+		// endpoint is present in the processed config, the absence is expected
+		// because processEndpoint intentionally clears them to avoid stale MACs
+		// after IP reassignment.
+		if onlyGeneratedMacs(sourceContainer, config) {
 			clog.Debug("No MAC address found; all original MACs were engine-generated and intentionally cleared")
 
 			return nil

--- a/pkg/container/container_source.go
+++ b/pkg/container/container_source.go
@@ -587,6 +587,10 @@ func processEndpoint(
 			clog.Debug("Cleared MAC address, IP address, and DNS names for legacy API")
 		}
 	} else if isEngineGeneratedMAC(targetEndpoint.MacAddress, sourceEndpoint.IPAddress) {
+		// Clear MACs derived from the endpoint's IPv4 address. Docker 29.x+ bridge
+		// networks assign random MACs and will not match the engine-generated
+		// pattern, but older Docker versions and overlay networks still produce
+		// IP-derived MACs that become stale after IP reassignment.
 		targetEndpoint.MacAddress = dockerNetwork.HardwareAddr{}
 
 		clog.Debug("Cleared engine-generated MAC address; Docker will regenerate for new IP")
@@ -598,11 +602,13 @@ func processEndpoint(
 // isEngineGeneratedMAC reports whether mac matches the bridge driver's engine-generated
 // pattern derived from the endpoint's current IPv4 address.
 //
-// Docker's bridge driver stores MACs as ASCII strings of the form "02:42:aa:bb:cc:dd",
-// where the last four bytes are the IPv4 octets. A MAC matching that pattern for the
-// given IP is not a user-configured value and should not be preserved across container
-// recreation. If ip is not a valid IPv4 address, the MAC is assumed to be user-configured
-// and false is returned.
+// Docker ≤ 25.x bridge networks assigned MACs of the form "02:42:aa:bb:cc:dd",
+// where the last four bytes are the IPv4 octets. Docker 29.x+ switched the bridge
+// driver to fully random MACs, but overlay networks still use IP-derived MACs, so
+// this check remains relevant for those drivers and for older Docker versions.
+// A MAC matching that pattern for the given IP is not a user-configured value and
+// should not be preserved across container recreation. If ip is not a valid IPv4
+// address, the MAC is assumed to be user-configured and false is returned.
 //
 // Parameters:
 //   - mac: MAC address to check.

--- a/pkg/container/container_source.go
+++ b/pkg/container/container_source.go
@@ -586,9 +586,39 @@ func processEndpoint(
 		} else {
 			clog.Debug("Cleared MAC address, IP address, and DNS names for legacy API")
 		}
+	} else if isEngineGeneratedMAC(targetEndpoint.MacAddress, sourceEndpoint.IPAddress) {
+		targetEndpoint.MacAddress = dockerNetwork.HardwareAddr{}
+
+		clog.Debug("Cleared engine-generated MAC address; Docker will regenerate for new IP")
 	}
 
 	return targetEndpoint, nil
+}
+
+// isEngineGeneratedMAC reports whether mac matches the bridge driver's engine-generated
+// pattern derived from the endpoint's current IPv4 address.
+//
+// Docker's bridge driver stores MACs as ASCII strings of the form "02:42:aa:bb:cc:dd",
+// where the last four bytes are the IPv4 octets. A MAC matching that pattern for the
+// given IP is not a user-configured value and should not be preserved across container
+// recreation. If ip is not a valid IPv4 address, the MAC is assumed to be user-configured
+// and false is returned.
+//
+// Parameters:
+//   - mac: MAC address to check.
+//   - ip: Endpoint's current IPv4 address.
+//
+// Returns:
+//   - bool: True if the MAC was engine-generated from ip, false otherwise.
+func isEngineGeneratedMAC(mac dockerNetwork.HardwareAddr, ip netip.Addr) bool {
+	if len(mac) != 17 || !ip.Is4() {
+		return false
+	}
+
+	ipv4 := ip.As4()
+	expected := fmt.Sprintf("02:42:%02x:%02x:%02x:%02x", ipv4[0], ipv4[1], ipv4[2], ipv4[3])
+
+	return string(mac) == expected
 }
 
 // validateMacAddresses verifies the presence of MAC addresses in a container's network configuration

--- a/pkg/container/container_source_test.go
+++ b/pkg/container/container_source_test.go
@@ -1721,7 +1721,7 @@ var _ = ginkgo.Describe("onlyGeneratedMacs", func() {
 				},
 				"custom": {
 					NetworkID:  "custom_network_id",
-					MacAddress: dockerNetwork.HardwareAddr("aa:bb:cc:dd:ee:ff"),
+					MacAddress: dockerNetwork.HardwareAddr("02:42:0a:00:00:05"),
 					IPAddress:  netip.MustParseAddr("10.0.0.5"),
 				},
 			}),

--- a/pkg/container/container_source_test.go
+++ b/pkg/container/container_source_test.go
@@ -973,7 +973,7 @@ var _ = ginkgo.Describe("getNetworkConfig", func() {
 				WithNetworkSettings(map[string]*dockerNetwork.EndpointSettings{
 					"bridge": {
 						NetworkID:  "bridge_network_id",
-						MacAddress: dockerNetwork.HardwareAddr("02:42:ac:11:00:02"),
+						MacAddress: dockerNetwork.HardwareAddr("aa:bb:cc:dd:ee:ff"),
 						IPAddress:  netip.MustParseAddr("172.17.0.2"),
 						Aliases:    []string{"container_id", "test-alias"},
 						DNSNames:   []string{"test.example.com"},
@@ -991,7 +991,7 @@ var _ = ginkgo.Describe("getNetworkConfig", func() {
 			endpoint := config.EndpointsConfig["bridge"]
 			gomega.Expect(endpoint.NetworkID).To(gomega.Equal("bridge_network_id"))
 			gomega.Expect(endpoint.MacAddress).To(gomega.Equal(
-				dockerNetwork.HardwareAddr("02:42:ac:11:00:02"),
+				dockerNetwork.HardwareAddr("aa:bb:cc:dd:ee:ff"),
 			))
 			gomega.Expect(endpoint.IPAddress).To(gomega.Equal(
 				netip.MustParseAddr("172.17.0.2"),
@@ -1210,7 +1210,7 @@ var _ = ginkgo.Describe("processEndpoint", func() {
 			ginkgo.It("should preserve MAC address, IP address, and DNS names", func() {
 				sourceEndpoint := &dockerNetwork.EndpointSettings{
 					NetworkID:  "bridge_network_id",
-					MacAddress: dockerNetwork.HardwareAddr("02:42:ac:11:00:02"),
+					MacAddress: dockerNetwork.HardwareAddr("aa:bb:cc:dd:ee:ff"),
 					IPAddress:  netip.MustParseAddr("172.17.0.2"),
 					DNSNames:   []string{"test.example.com"},
 					Aliases:    []string{"container_id", "test-alias"},
@@ -1230,7 +1230,7 @@ var _ = ginkgo.Describe("processEndpoint", func() {
 
 				gomega.Expect(result.NetworkID).To(gomega.Equal("bridge_network_id"))
 				gomega.Expect(result.MacAddress).To(gomega.Equal(
-					dockerNetwork.HardwareAddr("02:42:ac:11:00:02"),
+					dockerNetwork.HardwareAddr("aa:bb:cc:dd:ee:ff"),
 				))
 				gomega.Expect(result.IPAddress).To(gomega.Equal(
 					netip.MustParseAddr("172.17.0.2"),
@@ -1242,6 +1242,130 @@ var _ = ginkgo.Describe("processEndpoint", func() {
 				))
 				// Aliases should be filtered to remove container short ID
 				gomega.Expect(result.Aliases).To(gomega.ConsistOf("test-alias"))
+			})
+
+			ginkgo.It("should clear engine-generated MAC when it matches the endpoint IP", func() {
+				sourceEndpoint := &dockerNetwork.EndpointSettings{
+					NetworkID:  "bridge_network_id",
+					MacAddress: dockerNetwork.HardwareAddr("02:42:ac:11:00:02"),
+					IPAddress:  netip.MustParseAddr("172.17.0.2"),
+				}
+				containerID := types.ContainerID("container_id")
+
+				result, err := processEndpoint(
+					sourceEndpoint,
+					containerID,
+					clientVersion,
+					isHostNetwork,
+				)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				gomega.Expect(result.MacAddress).To(gomega.Equal(dockerNetwork.HardwareAddr{}))
+			})
+
+			ginkgo.It("should preserve user-configured MAC that does not match the endpoint IP", func() {
+				sourceEndpoint := &dockerNetwork.EndpointSettings{
+					NetworkID:  "bridge_network_id",
+					MacAddress: dockerNetwork.HardwareAddr("aa:bb:cc:dd:ee:ff"),
+					IPAddress:  netip.MustParseAddr("172.17.0.2"),
+				}
+				containerID := types.ContainerID("container_id")
+
+				result, err := processEndpoint(
+					sourceEndpoint,
+					containerID,
+					clientVersion,
+					isHostNetwork,
+				)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				gomega.Expect(result.MacAddress).To(gomega.Equal(
+					dockerNetwork.HardwareAddr("aa:bb:cc:dd:ee:ff"),
+				))
+			})
+
+			ginkgo.It("should preserve engine-generated MAC when endpoint IP is empty", func() {
+				sourceEndpoint := &dockerNetwork.EndpointSettings{
+					NetworkID:  "bridge_network_id",
+					MacAddress: dockerNetwork.HardwareAddr("02:42:ac:11:00:02"),
+					IPAddress:  netip.Addr{},
+				}
+				containerID := types.ContainerID("container_id")
+
+				result, err := processEndpoint(
+					sourceEndpoint,
+					containerID,
+					clientVersion,
+					isHostNetwork,
+				)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				gomega.Expect(result.MacAddress).To(gomega.Equal(
+					dockerNetwork.HardwareAddr("02:42:ac:11:00:02"),
+				))
+			})
+
+			ginkgo.It("should preserve engine-generated MAC when endpoint IP is IPv6", func() {
+				sourceEndpoint := &dockerNetwork.EndpointSettings{
+					NetworkID:  "bridge_network_id",
+					MacAddress: dockerNetwork.HardwareAddr("02:42:ac:11:00:02"),
+					IPAddress:  netip.MustParseAddr("::1"),
+				}
+				containerID := types.ContainerID("container_id")
+
+				result, err := processEndpoint(
+					sourceEndpoint,
+					containerID,
+					clientVersion,
+					isHostNetwork,
+				)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				gomega.Expect(result.MacAddress).To(gomega.Equal(
+					dockerNetwork.HardwareAddr("02:42:ac:11:00:02"),
+				))
+			})
+
+			ginkgo.It("should clear empty MAC without error", func() {
+				sourceEndpoint := &dockerNetwork.EndpointSettings{
+					NetworkID:  "bridge_network_id",
+					MacAddress: dockerNetwork.HardwareAddr{},
+					IPAddress:  netip.MustParseAddr("172.17.0.2"),
+				}
+				containerID := types.ContainerID("container_id")
+
+				result, err := processEndpoint(
+					sourceEndpoint,
+					containerID,
+					clientVersion,
+					isHostNetwork,
+				)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				gomega.Expect(result.MacAddress).To(gomega.Equal(dockerNetwork.HardwareAddr{}))
+			})
+
+			ginkgo.It("should preserve user-configured MAC matching engine-generated prefix with different IP", func() {
+				// A user-configured MAC that happens to start with 02:42 but whose last
+				// four bytes do not match the endpoint's IP must not be cleared.
+				sourceEndpoint := &dockerNetwork.EndpointSettings{
+					NetworkID:  "bridge_network_id",
+					MacAddress: dockerNetwork.HardwareAddr("02:42:de:ad:be:ef"),
+					IPAddress:  netip.MustParseAddr("172.17.0.2"),
+				}
+				containerID := types.ContainerID("container_id")
+
+				result, err := processEndpoint(
+					sourceEndpoint,
+					containerID,
+					clientVersion,
+					isHostNetwork,
+				)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				gomega.Expect(result.MacAddress).To(gomega.Equal(
+					dockerNetwork.HardwareAddr("02:42:de:ad:be:ef"),
+				))
 			})
 
 			ginkgo.It("should handle multiple aliases correctly", func() {
@@ -1490,6 +1614,57 @@ var _ = ginkgo.Describe("processEndpoint", func() {
 				gomega.Expect(result).To(gomega.BeNil())
 			})
 		})
+	})
+})
+
+var _ = ginkgo.Describe("isEngineGeneratedMAC", func() {
+	ginkgo.It("should return true for MAC derived from the endpoint IPv4 address", func() {
+		mac := dockerNetwork.HardwareAddr("02:42:ac:11:00:02")
+		ip := netip.MustParseAddr("172.17.0.2")
+
+		gomega.Expect(isEngineGeneratedMAC(mac, ip)).To(gomega.BeTrue())
+	})
+
+	ginkgo.It("should return false for user-configured MAC with matching prefix but different IP", func() {
+		mac := dockerNetwork.HardwareAddr("02:42:de:ad:be:ef")
+		ip := netip.MustParseAddr("172.17.0.2")
+
+		gomega.Expect(isEngineGeneratedMAC(mac, ip)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should return false when MAC is empty", func() {
+		mac := dockerNetwork.HardwareAddr{}
+		ip := netip.MustParseAddr("172.17.0.2")
+
+		gomega.Expect(isEngineGeneratedMAC(mac, ip)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should return false when IP is empty", func() {
+		mac := dockerNetwork.HardwareAddr("02:42:ac:11:00:02")
+		ip := netip.Addr{}
+
+		gomega.Expect(isEngineGeneratedMAC(mac, ip)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should return false when IP is IPv6", func() {
+		mac := dockerNetwork.HardwareAddr("02:42:ac:11:00:02")
+		ip := netip.MustParseAddr("::1")
+
+		gomega.Expect(isEngineGeneratedMAC(mac, ip)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should return false when MAC length is not 6", func() {
+		mac := dockerNetwork.HardwareAddr("02:42:ac:11")
+		ip := netip.MustParseAddr("172.17.0.2")
+
+		gomega.Expect(isEngineGeneratedMAC(mac, ip)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should return true for the reproduction case from issue #2104", func() {
+		mac := dockerNetwork.HardwareAddr("02:42:0a:63:00:02")
+		ip := netip.MustParseAddr("10.99.0.2")
+
+		gomega.Expect(isEngineGeneratedMAC(mac, ip)).To(gomega.BeTrue())
 	})
 })
 

--- a/pkg/container/container_source_test.go
+++ b/pkg/container/container_source_test.go
@@ -1689,6 +1689,102 @@ var _ = ginkgo.Describe("isEngineGeneratedMAC", func() {
 	})
 })
 
+var _ = ginkgo.Describe("onlyGeneratedMacs", func() {
+	ginkgo.It("should return true when all original MACs are engine-generated and all endpoints are covered", func() {
+		container := MockContainer(
+			WithNetworkSettings(map[string]*dockerNetwork.EndpointSettings{
+				"bridge": {
+					NetworkID:  "bridge_network_id",
+					MacAddress: dockerNetwork.HardwareAddr("02:42:ac:11:00:02"),
+					IPAddress:  netip.MustParseAddr("172.17.0.2"),
+				},
+			}),
+		)
+		processedConfig := &dockerNetwork.NetworkingConfig{
+			EndpointsConfig: map[string]*dockerNetwork.EndpointSettings{
+				"bridge": {
+					NetworkID: "bridge_network_id",
+				},
+			},
+		}
+
+		gomega.Expect(onlyGeneratedMacs(container, processedConfig)).To(gomega.BeTrue())
+	})
+
+	ginkgo.It("should return false when a non-nil original endpoint is missing from the processed config", func() {
+		container := MockContainer(
+			WithNetworkSettings(map[string]*dockerNetwork.EndpointSettings{
+				"bridge": {
+					NetworkID:  "bridge_network_id",
+					MacAddress: dockerNetwork.HardwareAddr("02:42:ac:11:00:02"),
+					IPAddress:  netip.MustParseAddr("172.17.0.2"),
+				},
+				"custom": {
+					NetworkID:  "custom_network_id",
+					MacAddress: dockerNetwork.HardwareAddr("aa:bb:cc:dd:ee:ff"),
+					IPAddress:  netip.MustParseAddr("10.0.0.5"),
+				},
+			}),
+		)
+		processedConfig := &dockerNetwork.NetworkingConfig{
+			EndpointsConfig: map[string]*dockerNetwork.EndpointSettings{
+				"bridge": {
+					NetworkID: "bridge_network_id",
+				},
+			},
+		}
+
+		gomega.Expect(onlyGeneratedMacs(container, processedConfig)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should return false when there is a user-configured MAC", func() {
+		container := MockContainer(
+			WithNetworkSettings(map[string]*dockerNetwork.EndpointSettings{
+				"bridge": {
+					NetworkID:  "bridge_network_id",
+					MacAddress: dockerNetwork.HardwareAddr("aa:bb:cc:dd:ee:ff"),
+					IPAddress:  netip.MustParseAddr("172.17.0.2"),
+				},
+			}),
+		)
+		processedConfig := &dockerNetwork.NetworkingConfig{
+			EndpointsConfig: map[string]*dockerNetwork.EndpointSettings{
+				"bridge": {
+					NetworkID: "bridge_network_id",
+				},
+			},
+		}
+
+		gomega.Expect(onlyGeneratedMacs(container, processedConfig)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should return false when there are no MACs at all", func() {
+		container := MockContainer(
+			WithNetworkSettings(map[string]*dockerNetwork.EndpointSettings{
+				"bridge": {
+					NetworkID: "bridge_network_id",
+					IPAddress: netip.MustParseAddr("172.17.0.2"),
+				},
+			}),
+		)
+		processedConfig := &dockerNetwork.NetworkingConfig{
+			EndpointsConfig: map[string]*dockerNetwork.EndpointSettings{
+				"bridge": {
+					NetworkID: "bridge_network_id",
+				},
+			},
+		}
+
+		gomega.Expect(onlyGeneratedMacs(container, processedConfig)).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("should return false when container info is nil", func() {
+		processedConfig := &dockerNetwork.NetworkingConfig{}
+
+		gomega.Expect(onlyGeneratedMacs(nil, processedConfig)).To(gomega.BeFalse())
+	})
+})
+
 var _ = ginkgo.Describe("validateMacAddresses", func() {
 	ginkgo.Context("with legacy API version (< 1.44)", func() {
 		clientVersion := "1.40"

--- a/pkg/container/container_source_test.go
+++ b/pkg/container/container_source_test.go
@@ -1016,6 +1016,27 @@ var _ = ginkgo.Describe("getNetworkConfig", func() {
 			gomega.Expect(config.EndpointsConfig).To(gomega.HaveKey("bridge"))
 			gomega.Expect(config.EndpointsConfig).To(gomega.HaveKey("custom_network"))
 		})
+
+		ginkgo.It("should clear engine-generated MAC for running container without validation error", func() {
+			container := MockContainer(
+				WithNetworkMode("bridge"),
+				WithContainerState(dockerContainer.State{Running: true, Status: "running"}),
+				WithNetworkSettings(map[string]*dockerNetwork.EndpointSettings{
+					"bridge": {
+						NetworkID:  "bridge_network_id",
+						MacAddress: dockerNetwork.HardwareAddr("02:42:ac:11:00:02"),
+						IPAddress:  netip.MustParseAddr("172.17.0.2"),
+					},
+				}),
+			)
+
+			config := getNetworkConfig(container, "1.50")
+
+			gomega.Expect(config).ToNot(gomega.BeNil())
+			gomega.Expect(config.EndpointsConfig).To(gomega.HaveKey("bridge"))
+			endpoint := config.EndpointsConfig["bridge"]
+			gomega.Expect(endpoint.MacAddress).To(gomega.Equal(dockerNetwork.HardwareAddr{}))
+		})
 	})
 
 	ginkgo.Context("with host network mode", func() {

--- a/pkg/container/container_target_test.go
+++ b/pkg/container/container_target_test.go
@@ -148,7 +148,7 @@ var _ = ginkgo.Describe("Target Container Operations", func() {
 					"bridge": {
 						NetworkID:  "network_bridge_id",
 						IPAddress:  netip.MustParseAddr("172.17.0.2"),
-						MacAddress: dockerNetwork.HardwareAddr("02:42:ac:11:00:02"),
+						MacAddress: dockerNetwork.HardwareAddr("aa:bb:cc:dd:ee:ff"),
 						Aliases:    []string{"test-watchtower"},
 					},
 				}),


### PR DESCRIPTION
This PR resolves an issue where Watchtower preserves across container recreation MAC addresses that are generated by the Docker bridge driver.

## Problem

Watchtower preserves endpoint settings when recreating containers, but the Docker API does not distinguish user-configured MACs from engine-generated ones. As a result, engine-generated `02:42:` MACs are copied to the replacement container and become stale after IP reassignment. Under certain conditions, this can lead to containers sharing MAC addresses, which results subsequent downstream issues.

Note: Docker 29.x+ switched the bridge driver from IP-derived MACs to fully random MACs, so this symptom is primarily observable on Docker ≤ 25.x and on overlay networks, which still use IP-derived MACs.

## Solution

Added a targeted check in `processEndpoint` that clears only MACs matching the bridge driver's deterministic `02:42:<ipv4>` pattern for API >= 1.44 non-host networks. User-configured MACs and all other network fields remain untouched. The heuristic is safe because the bridge driver derives MACs exclusively from IPv4 octets and a user-configured MAC will essentially never coincide with that pattern.

Because clearing these MACs leaves the processed configuration without a MAC where one previously existed, `validateMacAddresses` was adjusted to permit missing MACs when the source container had only engine-generated MACs and all non-nil original endpoints are accounted for in the processed configuration.

## Changes

- Detect Docker bridge driver generated MACs derived from IPv4 address
- Clear engine-generated MACs during endpoint processing
- Preserve user-configured MAC addresses that do not match the IP pattern
- Allow intentionally cleared engine-generated MACs to pass `validateMacAddresses`
- Add tests for engine-generated MAC detection, clearing logic, and validation waiver behavior
- Update existing test fixtures to use user-configured MACs where preservation is the expected behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container networking by clearing automatically generated MAC addresses when appropriate.
  * Preserved user-configured MAC addresses and safely handled IPv4, IPv6, empty, and malformed address scenarios.
* **Tests**
  * Added comprehensive coverage for MAC address detection and container network behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->