### PR TITLE
fix(update): increase create/start timeout and use fresh contexts for recovery

### DIFF
--- a/internal/actions/actions_internal_test.go
+++ b/internal/actions/actions_internal_test.go
@@ -1370,25 +1370,32 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 	ginkgo.Describe("restartStaleContainer detached context deadline", func() {
 		testCases := []TestDetachedContextDeadlineCase{
 			{
-				name:            "positive timeout creates context with deadline",
+				name:            "positive timeout above minimum uses configured timeout",
+				timeout:         10 * time.Minute,
+				expectDeadline:  true,
+				expectedTimeout: 10 * time.Minute,
+				description:     "When Timeout exceeds defaultCreateStartTimeout, the detached context uses the configured timeout",
+			},
+			{
+				name:            "positive timeout below minimum creates context with minimum deadline",
 				timeout:         30 * time.Second,
 				expectDeadline:  true,
-				expectedTimeout: 30 * time.Second,
-				description:     "When Timeout > 0, the detached context should have a deadline set",
+				expectedTimeout: defaultCreateStartTimeout,
+				description:     "When Timeout is below defaultCreateStartTimeout, the detached context uses the minimum",
 			},
 			{
-				name:            "zero timeout creates context with fallback deadline",
+				name:            "zero timeout creates context with minimum deadline",
 				timeout:         0,
 				expectDeadline:  true,
-				expectedTimeout: defaultRestartPolicyTimeout,
-				description:     "When Timeout is zero, the detached context should use the fallback deadline",
+				expectedTimeout: defaultCreateStartTimeout,
+				description:     "When Timeout is zero, the detached context uses the minimum create/start deadline",
 			},
 			{
-				name:            "negative timeout creates context with fallback deadline",
+				name:            "negative timeout creates context with minimum deadline",
 				timeout:         -1 * time.Second,
 				expectDeadline:  true,
-				expectedTimeout: defaultRestartPolicyTimeout,
-				description:     "When Timeout is negative, the detached context should use the fallback deadline",
+				expectedTimeout: defaultCreateStartTimeout,
+				description:     "When Timeout is negative, the detached context uses the minimum create/start deadline",
 			},
 		}
 
@@ -1508,6 +1515,20 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 			gomega.Expect(client.TestData.RenameTargets).To(gomega.HaveLen(2))
 			gomega.Expect(client.TestData.RenameTargets[1]).To(gomega.Equal("watchtower"))
 			gomega.Expect(client.TestData.StartContainerCount.Load()).To(gomega.Equal(int32(0)))
+
+			// Assert that CreateContainer and RenameContainer received distinct contexts.
+			// The first rename (initial handoff) uses the caller context, the second
+			// rename (recovery after create failure) uses a fresh bounded context.
+			createCtx := client.TestData.CreateContainerCtx
+			renameBackCtx := client.TestData.RenameContainerCtx
+
+			gomega.Expect(createCtx).NotTo(gomega.BeNil(), "CreateContainer should receive a context")
+			gomega.Expect(renameBackCtx).NotTo(gomega.BeNil(), "RenameContainer should receive a context for rename-back")
+			gomega.Expect(createCtx).NotTo(gomega.Equal(renameBackCtx), "CreateContainer and rename-back should use distinct contexts")
+
+			// Assert that the rename-back context has an active deadline (is a bounded timeout context).
+			_, hasDeadline := renameBackCtx.Deadline()
+			gomega.Expect(hasDeadline).To(gomega.BeTrue(), "rename-back context should have a deadline for bounded recovery")
 		})
 	})
 
@@ -1559,6 +1580,21 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 			gomega.Expect(client.TestData.StopAndRemoveContainerCount.Load()).To(gomega.Equal(int32(1)))
 			gomega.Expect(client.TestData.LastStopAndRemoveID).To(gomega.Equal(client.TestData.LastCreatedContainerID))
 			gomega.Expect(client.TestData.LastStopAndRemoveID).ToNot(gomega.Equal(testContainer.ID()))
+
+			// Assert that GetContainer and StopAndRemoveContainer receive a fresh
+			// context distinct from the create/start detached context.
+			getCtx := client.TestData.GetContainerCtx
+			cleanupCtx := client.TestData.StopAndRemoveContainerCtx
+			createCtx := client.TestData.CreateContainerCtx
+
+			gomega.Expect(getCtx).NotTo(gomega.BeNil(), "GetContainer should receive a context")
+			gomega.Expect(cleanupCtx).NotTo(gomega.BeNil(), "StopAndRemoveContainer should receive a context")
+			gomega.Expect(getCtx).To(gomega.Equal(cleanupCtx), "GetContainer and StopAndRemoveContainer should share the same cleanup context")
+			gomega.Expect(getCtx).NotTo(gomega.Equal(createCtx), "cleanup context should be distinct from the create/start detached context")
+
+			// Assert that the cleanup context has an active deadline (is a bounded timeout context).
+			_, hasDeadline := getCtx.Deadline()
+			gomega.Expect(hasDeadline).To(gomega.BeTrue(), "cleanup context should have a deadline for bounded recovery")
 		})
 	})
 

--- a/internal/actions/actions_internal_test.go
+++ b/internal/actions/actions_internal_test.go
@@ -1454,15 +1454,37 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 				// renamed Watchtower container.
 				gomega.Expect(client.TestData.SetNoRestartPolicyCount.Load()).To(gomega.Equal(int32(1)))
 
+				// Verify CreateContainer and StartContainerByID also use the detached context.
+				// These operations run after the initial rename, so they should share the same
+				// deadline when expectDeadline is true.
+				createCtx := client.TestData.CreateContainerCtx
+				startCtx := client.TestData.StartContainerByIDCtx
+				noRestartCtx := client.TestData.SetNoRestartPolicyCtx
+
+				gomega.Expect(createCtx).NotTo(gomega.BeNil(), "CreateContainer should receive a context")
+				gomega.Expect(startCtx).NotTo(gomega.BeNil(), "StartContainerByID should receive a context")
+				gomega.Expect(createCtx).To(gomega.Equal(startCtx), "CreateContainer and StartContainerByID should share the same detached context")
+				gomega.Expect(createCtx).To(gomega.Equal(noRestartCtx), "CreateContainer should use the same detached context as SetNoRestartPolicy")
+
 				if tc.expectDeadline {
-					deadline, hasDeadline := client.TestData.SetNoRestartPolicyCtx.Deadline()
-					gomega.Expect(hasDeadline).To(gomega.BeTrue())
+					_, createHasDeadline := createCtx.Deadline()
+					_, startHasDeadline := startCtx.Deadline()
+
+					gomega.Expect(createHasDeadline).To(gomega.BeTrue())
+					gomega.Expect(startHasDeadline).To(gomega.BeTrue())
 
 					expectedDeadline := time.Now().Add(tc.expectedTimeout)
-					gomega.Expect(deadline).To(gomega.BeTemporally("~", expectedDeadline, time.Second))
+					createDeadline, _ := createCtx.Deadline()
+					startDeadline, _ := startCtx.Deadline()
+
+					gomega.Expect(createDeadline).To(gomega.BeTemporally("~", expectedDeadline, time.Second))
+					gomega.Expect(startDeadline).To(gomega.BeTemporally("~", expectedDeadline, time.Second))
 				} else {
-					_, hasDeadline := client.TestData.SetNoRestartPolicyCtx.Deadline()
-					gomega.Expect(hasDeadline).To(gomega.BeFalse())
+					_, createHasDeadline := createCtx.Deadline()
+					_, startHasDeadline := startCtx.Deadline()
+
+					gomega.Expect(createHasDeadline).To(gomega.BeFalse())
+					gomega.Expect(startHasDeadline).To(gomega.BeFalse())
 				}
 			})
 		}

--- a/internal/actions/mocks/client.go
+++ b/internal/actions/mocks/client.go
@@ -71,6 +71,11 @@ type TestData struct {
 	LastStartedContainerID      types.ContainerID             // ID returned by the last successful StartContainer call.
 	SetNoRestartPolicyContainer types.Container               // Last container passed to SetNoRestartPolicy.
 	SetNoRestartPolicyCtx       context.Context               // Last context passed to SetNoRestartPolicy.
+	CreateContainerCtx          context.Context               // Last context passed to CreateContainer.
+	RenameContainerCtx          context.Context               // Last context passed to RenameContainer.
+	StartContainerByIDCtx       context.Context               // Last context passed to StartContainerByID.
+	GetContainerCtx             context.Context               // Last context passed to GetContainer.
+	StopAndRemoveContainerCtx   context.Context               // Last context passed to StopAndRemoveContainer.
 }
 
 // recordOperation appends an operation name to OperationOrder for sequencing tests.
@@ -215,6 +220,7 @@ func (client MockClient) StopContainer(ctx context.Context, c types.Container, _
 func (client MockClient) StopAndRemoveContainer(ctx context.Context, c types.Container, timeout time.Duration) error {
 	client.TestData.StopAndRemoveContainerCount.Add(1)
 	client.TestData.LastStopAndRemoveID = c.ID()
+	client.TestData.StopAndRemoveContainerCtx = ctx
 	client.TestData.recordOperation("StopAndRemoveContainer")
 
 	err := client.StopContainer(ctx, c, timeout)
@@ -239,6 +245,7 @@ func (client MockClient) IsContainerRunning(c types.Container) bool {
 // new instance from the source (required for self-update failure cleanup tests).
 func (client MockClient) CreateContainer(ctx context.Context, c types.Container) (types.ContainerID, error) {
 	client.TestData.CreateContainerCount.Add(1)
+	client.TestData.CreateContainerCtx = ctx
 
 	if err := client.checkContextCancellation(ctx); err != nil {
 		return "", err
@@ -329,6 +336,7 @@ func (client MockClient) StartContainer(ctx context.Context, c types.Container) 
 func (client MockClient) StartContainerByID(ctx context.Context, containerID types.ContainerID) error {
 	client.TestData.StartContainerCount.Add(1)
 	client.TestData.recordOperation("StartContainerByID")
+	client.TestData.StartContainerByIDCtx = ctx
 
 	if err := client.checkContextCancellation(ctx); err != nil {
 		return err
@@ -357,6 +365,7 @@ func (client MockClient) RenameContainer(ctx context.Context, _ types.Container,
 	client.TestData.LastRenameTarget = newName
 	client.TestData.RenameTargets = append(client.TestData.RenameTargets, newName)
 	client.TestData.recordOperation("RenameContainer")
+	client.TestData.RenameContainerCtx = ctx
 
 	if err := client.checkContextCancellation(ctx); err != nil {
 		return err
@@ -384,6 +393,7 @@ func (client MockClient) SetNoRestartPolicy(ctx context.Context, container types
 	client.TestData.SetNoRestartPolicyCount.Add(1)
 	client.TestData.SetNoRestartPolicyContainer = container
 	client.TestData.SetNoRestartPolicyCtx = ctx
+	client.TestData.recordOperation("SetNoRestartPolicy")
 }
 
 // RemoveImageByID increments the count of image removal attempts in TestData.
@@ -404,10 +414,14 @@ func (client MockClient) RemoveImageByID(ctx context.Context, imageID types.Imag
 
 // GetContainer returns the container with the specified ID from TestData.
 // It provides a mock response for testing container retrieval.
-func (client MockClient) GetContainer(_ context.Context, containerID types.ContainerID) (types.Container, error) {
+func (client MockClient) GetContainer(ctx context.Context, containerID types.ContainerID) (types.Container, error) {
+	client.TestData.GetContainerCtx = ctx
+	client.TestData.recordOperation("GetContainer")
+
 	if c, ok := client.TestData.ContainersByID[containerID]; ok {
 		return c, nil
 	}
+
 	return nil, fmt.Errorf("container not found: %s", containerID)
 }
 

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -35,6 +35,11 @@ const (
 	// defaultRestartPolicyTimeout defines the fallback timeout for restart policy
 	// updates when config.Timeout is non-positive.
 	defaultRestartPolicyTimeout = 30 * time.Second
+
+	// defaultCreateStartTimeout defines the minimum timeout for container create
+	// and start operations during restart. It guards against slow hosts where
+	// Docker API calls can exceed the default 30s restart policy timeout.
+	defaultCreateStartTimeout = 5 * time.Minute
 )
 
 // Update scans and updates containers based on parameters.
@@ -1820,10 +1825,14 @@ func restartStaleContainer(
 	// Create a detached context to survive parent context cancellation.
 	// This ensures container cleanup and update operations complete even if the
 	// parent context is canceled during the restart process.
-	// A finite fallback is applied when config.Timeout is non-positive.
+	// A finite fallback is applied when config.Timeout is non-positive, and the
+	// create/start phase uses at least defaultCreateStartTimeout to accommodate
+	// slow hosts.
+	detachedTimeout := max(restartPolicyTimeout(config.Timeout), defaultCreateStartTimeout)
+
 	detachedCtx, cancelDetached := context.WithTimeout(
 		context.Background(),
-		restartPolicyTimeout(config.Timeout),
+		detachedTimeout,
 	)
 
 	defer cancelDetached()
@@ -1952,10 +1961,19 @@ func restartStaleContainer(
 
 		// Restore the original name so the running instance is not left only as
 		// watchtower-old-* with the canonical name free and unused.
+		// Use a fresh context here: detachedCtx may already be expired if the
+		// create call hit the timeout, and we do not want recovery to fail for
+		// the same reason.
 		if renamed && originalWatchtowerName != "" && sourceContainer.IsWatchtower() {
-			//nolint:contextcheck // Using detached context intentionally to survive parent cancellation
+			renameBackCtx, renameBackCancel := context.WithTimeout(
+				context.Background(),
+				restartPolicyTimeout(config.Timeout),
+			)
+			defer renameBackCancel()
+
+			//nolint:contextcheck // fresh context is intentional for recovery after timeout
 			renameBackErr := client.RenameContainer(
-				detachedCtx,
+				renameBackCtx,
 				sourceContainer,
 				originalWatchtowerName,
 			)
@@ -1996,25 +2014,33 @@ func restartStaleContainer(
 				WithError(err).
 				Debug("Failed to start container")
 
-				// On start failure after a Watchtower rename, remove only the newly
-			// created container. The renamed source still holds the running process
-			// and must remain so the host keeps a Watchtower instance.
+				// On start failure after a Watchtower rename, remove the failed replacement
+			// container only. The renamed source still holds the running process and must
+			// remain so the host keeps a Watchtower instance.
+			// Use a fresh context because detachedCtx may already be expired if the start
+			// call hit the timeout and we do not want cleanup to fail for the same reason.
 			if renamed && sourceContainer.IsWatchtower() {
 				logrus.WithFields(fields).
 					WithField("new_id", newContainerID.ShortID()).
 					Debug("Cleaning up failed Watchtower container")
 
-				//nolint:contextcheck // Using detached context intentionally to survive parent cancellation
-				failedNew, getErr := client.GetContainer(detachedCtx, newContainerID)
+				cleanupCtx, cleanupCancel := context.WithTimeout(
+					context.Background(),
+					restartPolicyTimeout(config.Timeout),
+				)
+				defer cleanupCancel()
+
+				//nolint:contextcheck // fresh context is intentional for cleanup after timeout
+				failedNew, getErr := client.GetContainer(cleanupCtx, newContainerID)
 				if getErr != nil {
 					logrus.WithError(getErr).
 						WithFields(fields).
 						WithField("new_id", newContainerID.ShortID()).
 						Debug("Failed to inspect failed Watchtower container for cleanup")
 				} else {
-					//nolint:contextcheck // Using detached context intentionally to survive parent cancellation
+					//nolint:contextcheck // fresh context is intentional for cleanup after timeout
 					cleanupErr := client.StopAndRemoveContainer(
-						detachedCtx,
+						cleanupCtx,
 						failedNew,
 						config.Timeout,
 					)


### PR DESCRIPTION
This PR increases the timeout for container create and start operations during self-update, and uses fresh bounded contexts for recovery steps instead of reusing a potentially expired detached context.

## Problem

The detached context used for the create/start/cleanup sequence during restart was bounded by the restart policy timeout, which defaults to 30 seconds. On slow hosts, container create can exceed this limit, causing the operation to fail. When create or start fails, the recovery steps—renaming the source container back to its original name and cleaning up the failed replacement—also used the same expired context, so recovery itself would fail and leave the instance in a broken state.

## Solution

The detached context now uses at least a 5-minute timeout for the create and start phase, matching the proven default used by the ephemeral orchestrator. When create fails, the rename-back recovery uses a fresh bounded context instead of the potentially expired detached context. When start fails, the cleanup path also uses a fresh bounded context for inspecting and removing the failed replacement. This ensures recovery can complete even if the initial create or start hit the timeout.

## Changes

- Raise the minimum create/start timeout to 5 minutes via `defaultCreateStartTimeout`
- Use a fresh `renameBackCtx` for rename-back recovery after create failure
- Use a fresh `cleanupCtx` for cleanup after start failure
- Record and assert distinct contexts for create, rename, start, get, and cleanup operations in tests
- Update deadline assertions to reflect the new minimum timeout

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container restart reliability by ensuring creation and startup operations have sufficient time to complete.
  * Recovery after failed container creation now uses an independent timeout, reducing interruptions caused by expired operation contexts.
  * Cleanup after failed restarts is more resilient and can complete even when the original restart operation times out.
  * Improved handling of very short, zero, or negative timeout settings by applying a safe default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->