### PR TITLE
fix(cleanup): remove orphaned Watchtower containers stuck in created state

### DIFF
--- a/internal/actions/actions_internal_test.go
+++ b/internal/actions/actions_internal_test.go
@@ -1503,12 +1503,6 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 					expectedDeadline := time.Now().Add(tc.expectedTimeout)
 					gomega.Expect(createDeadline).To(gomega.BeTemporally("~", expectedDeadline, time.Second))
 					gomega.Expect(startDeadline).To(gomega.BeTemporally("~", expectedDeadline, time.Second))
-				} else {
-					_, createHasDeadline := client.TestData.CreateContainerCtx.Deadline()
-					_, startHasDeadline := client.TestData.StartContainerByIDCtx.Deadline()
-
-					gomega.Expect(createHasDeadline).To(gomega.BeFalse())
-					gomega.Expect(startHasDeadline).To(gomega.BeFalse())
 				}
 			})
 		}

--- a/internal/actions/actions_internal_test.go
+++ b/internal/actions/actions_internal_test.go
@@ -1486,6 +1486,30 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 					gomega.Expect(createHasDeadline).To(gomega.BeFalse())
 					gomega.Expect(startHasDeadline).To(gomega.BeFalse())
 				}
+
+				// Verify CreateContainer and StartContainerByID also use the detached context.
+				// These operations run after CreateContainer succeeds, so the same deadline
+				// should apply when expectDeadline is true.
+				gomega.Expect(client.TestData.CreateContainerCount.Load()).To(gomega.Equal(int32(1)))
+				gomega.Expect(client.TestData.StartContainerCount.Load()).To(gomega.Equal(int32(1)))
+
+				if tc.expectDeadline {
+					createDeadline, createHasDeadline := client.TestData.CreateContainerCtx.Deadline()
+					gomega.Expect(createHasDeadline).To(gomega.BeTrue())
+
+					startDeadline, startHasDeadline := client.TestData.StartContainerByIDCtx.Deadline()
+					gomega.Expect(startHasDeadline).To(gomega.BeTrue())
+
+					expectedDeadline := time.Now().Add(tc.expectedTimeout)
+					gomega.Expect(createDeadline).To(gomega.BeTemporally("~", expectedDeadline, time.Second))
+					gomega.Expect(startDeadline).To(gomega.BeTemporally("~", expectedDeadline, time.Second))
+				} else {
+					_, createHasDeadline := client.TestData.CreateContainerCtx.Deadline()
+					_, startHasDeadline := client.TestData.StartContainerByIDCtx.Deadline()
+
+					gomega.Expect(createHasDeadline).To(gomega.BeFalse())
+					gomega.Expect(startHasDeadline).To(gomega.BeFalse())
+				}
 			})
 		}
 	})

--- a/internal/actions/cleanup.go
+++ b/internal/actions/cleanup.go
@@ -194,16 +194,62 @@ func CleanupOldWatchtowerContainers(
 		oldContainers = append(oldContainers, c)
 	}
 
+	// Find orphaned Watchtower containers that are stuck in the created state.
+	// These can be left behind when a self-update creates a replacement but
+	// fails to start it. The new container never runs and the old instance
+	// may already be running under its original name.
+	var orphanedCreatedContainers []types.Container
+
+	for _, c := range allContainers {
+		if !c.IsWatchtower() {
+			continue
+		}
+
+		if c.ID() == currentContainerID {
+			continue
+		}
+
+		if container.IsOldContainer(c.Name()) {
+			continue
+		}
+
+		if !c.IsCreated() {
+			continue
+		}
+
+		// Scope check: only clean up orphaned containers in the same scope.
+		containerScope, containerHasScope := c.Scope()
+		if !containerHasScope || containerScope == "" {
+			containerScope = "none"
+		}
+
+		if containerScope != scope {
+			logrus.WithFields(logrus.Fields{
+				"container":       c.Name(),
+				"container_scope": containerScope,
+				"current_scope":   scope,
+			}).Debug("Skipping orphaned Watchtower container in different scope")
+
+			continue
+		}
+
+		orphanedCreatedContainers = append(orphanedCreatedContainers, c)
+	}
+
+	oldContainers = append(oldContainers, orphanedCreatedContainers...)
+
 	if len(oldContainers) == 0 {
-		logrus.Debug("No old Watchtower containers found")
+		logrus.Debug("No old or orphaned Watchtower containers found")
 
 		return 0, nil
 	}
 
 	logrus.WithFields(logrus.Fields{
-		"count":      len(oldContainers),
-		"containers": containerNames(oldContainers),
-	}).Info("Found old Watchtower containers, cleaning up")
+		"count":                  len(oldContainers),
+		"old_count":              len(oldContainers) - len(orphanedCreatedContainers),
+		"orphaned_created_count": len(orphanedCreatedContainers),
+		"containers":             containerNames(oldContainers),
+	}).Info("Found old or orphaned Watchtower containers, cleaning up")
 
 	// Find the current container in the list so image collection works
 	var currentContainerObj types.Container

--- a/internal/actions/cleanup_test.go
+++ b/internal/actions/cleanup_test.go
@@ -1957,6 +1957,23 @@ func createMockContainer(
 	return container.NewContainer(&content, imageInfo)
 }
 
+// createMockCreatedContainer creates a Watchtower container in the "created" state,
+// simulating a container that was created but never started during a failed self-update.
+func createMockCreatedContainer(
+	id, name, image string,
+	created time.Time,
+	labels map[string]string,
+) types.Container {
+	c := createMockContainer(id, name, image, false, false, created, labels)
+
+	info := c.ContainerInfo()
+	if info != nil && info.State != nil {
+		info.State.Status = dockerContainer.StateCreated
+	}
+
+	return c
+}
+
 var _ = ginkgo.Describe("CleanupOldWatchtowerContainers", func() {
 	ginkgo.When("no old containers exist", func() {
 		ginkgo.It("should return nil when no containers exist", func() {
@@ -2454,6 +2471,177 @@ var _ = ginkgo.Describe("CleanupOldWatchtowerContainers", func() {
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(removed).To(gomega.Equal(1))
+		})
+	})
+
+	ginkgo.When("orphaned created-state containers exist", func() {
+		ginkgo.It("should remove Watchtower containers stuck in created state", func() {
+			mockClient := mockContainer.NewMockClient(ginkgo.GinkgoT())
+
+			orphaned := createMockCreatedContainer(
+				"orphaned-id",
+				"watchtower-abc123",
+				"watchtower:latest",
+				time.Now(),
+				map[string]string{
+					"com.centurylinklabs.watchtower": "true",
+				},
+			)
+
+			mockClient.EXPECT().
+				ListContainers(mock.Anything, mock.Anything).
+				Return([]types.Container{orphaned}, nil)
+			mockClient.EXPECT().
+				StopAndRemoveContainer(mock.Anything, orphaned, 10*time.Minute).
+				Return(nil)
+
+			removed, err := CleanupOldWatchtowerContainers(
+				context.Background(),
+				mockClient,
+				false,
+				"none",
+				"current-id",
+				nil,
+			)
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(removed).To(gomega.Equal(1))
+		})
+
+		ginkgo.It("should skip created-state containers that are not Watchtower", func() {
+			mockClient := mockContainer.NewMockClient(ginkgo.GinkgoT())
+
+			nonWT := createMockCreatedContainer(
+				"non-wt-id",
+				"other-app",
+				"other:latest",
+				time.Now(),
+				map[string]string{},
+			)
+
+			mockClient.EXPECT().
+				ListContainers(mock.Anything, mock.Anything).
+				Return([]types.Container{nonWT}, nil)
+
+			removed, err := CleanupOldWatchtowerContainers(
+				context.Background(),
+				mockClient,
+				false,
+				"none",
+				"current-id",
+				nil,
+			)
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(removed).To(gomega.Equal(0))
+		})
+
+		ginkgo.It("should skip the current container even if it is in created state", func() {
+			mockClient := mockContainer.NewMockClient(ginkgo.GinkgoT())
+
+			current := createMockCreatedContainer(
+				"current-id",
+				"watchtower",
+				"watchtower:latest",
+				time.Now(),
+				map[string]string{
+					"com.centurylinklabs.watchtower": "true",
+				},
+			)
+
+			mockClient.EXPECT().
+				ListContainers(mock.Anything, mock.Anything).
+				Return([]types.Container{current}, nil)
+
+			removed, err := CleanupOldWatchtowerContainers(
+				context.Background(),
+				mockClient,
+				false,
+				"none",
+				"current-id",
+				nil,
+			)
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(removed).To(gomega.Equal(0))
+		})
+
+		ginkgo.It("should remove both old and orphaned created-state containers together", func() {
+			mockClient := mockContainer.NewMockClient(ginkgo.GinkgoT())
+
+			oldContainer := createMockContainer(
+				"old-id",
+				"watchtower-old-abc123",
+				"watchtower:old",
+				true,
+				false,
+				time.Now(),
+				map[string]string{
+					"com.centurylinklabs.watchtower": "true",
+				},
+			)
+			orphaned := createMockCreatedContainer(
+				"orphaned-id",
+				"watchtower-xyz789",
+				"watchtower:latest",
+				time.Now(),
+				map[string]string{
+					"com.centurylinklabs.watchtower": "true",
+				},
+			)
+
+			mockClient.EXPECT().
+				ListContainers(mock.Anything, mock.Anything).
+				Return([]types.Container{oldContainer, orphaned}, nil)
+			mockClient.EXPECT().
+				StopAndRemoveContainer(mock.Anything, oldContainer, 10*time.Minute).
+				Return(nil)
+			mockClient.EXPECT().
+				StopAndRemoveContainer(mock.Anything, orphaned, 10*time.Minute).
+				Return(nil)
+
+			removed, err := CleanupOldWatchtowerContainers(
+				context.Background(),
+				mockClient,
+				false,
+				"none",
+				"current-id",
+				nil,
+			)
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(removed).To(gomega.Equal(2))
+		})
+
+		ginkgo.It("should skip created-state containers from a different scope", func() {
+			mockClient := mockContainer.NewMockClient(ginkgo.GinkgoT())
+
+			differentScopeOrphaned := createMockCreatedContainer(
+				"orphaned-scoped-id",
+				"watchtower-scoped",
+				"watchtower:latest",
+				time.Now(),
+				map[string]string{
+					"com.centurylinklabs.watchtower":       "true",
+					"com.centurylinklabs.watchtower.scope": "prod",
+				},
+			)
+
+			mockClient.EXPECT().
+				ListContainers(mock.Anything, mock.Anything).
+				Return([]types.Container{differentScopeOrphaned}, nil)
+
+			removed, err := CleanupOldWatchtowerContainers(
+				context.Background(),
+				mockClient,
+				false,
+				"none",
+				"current-id",
+				nil,
+			)
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(removed).To(gomega.Equal(0))
 		})
 	})
 })

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -219,6 +219,19 @@ func (c *Container) IsRestarting() bool {
 	return c.containerInfo.State.Restarting
 }
 
+// IsCreated checks if the container is in the Docker "created" state,
+// meaning it was successfully created but never started.
+//
+// Returns:
+//   - bool: True if the container is in created state, false otherwise.
+func (c *Container) IsCreated() bool {
+	if c.containerInfo == nil || c.containerInfo.State == nil {
+		return false
+	}
+
+	return c.containerInfo.State.Status == dockerContainer.StateCreated
+}
+
 // Name returns the normalized name of the container.
 //
 // Returns:

--- a/pkg/sorter/mocks/container.go
+++ b/pkg/sorter/mocks/container.go
@@ -140,6 +140,7 @@ func (c *SimpleContainer) PostUpdateTimeout() int {
 	return 30
 }
 func (c *SimpleContainer) IsRestarting() bool                               { return false }
+func (c *SimpleContainer) IsCreated() bool                                  { return false }
 func (c *SimpleContainer) GetCreateConfig() *dockerContainer.Config         { return nil }
 func (c *SimpleContainer) GetCreateHostConfig() *dockerContainer.HostConfig { return nil }
 func (c *SimpleContainer) HasExposedPorts() bool                            { return false }

--- a/pkg/types/container.go
+++ b/pkg/types/container.go
@@ -48,6 +48,7 @@ type Container interface {
 	PreUpdateTimeout() int                            // Pre-update timeout.
 	PostUpdateTimeout() int                           // Post-update timeout.
 	IsRestarting() bool                               // Restarting status check.
+	IsCreated() bool                                  // Created-state check.
 	GetCreateConfig() *dockerContainer.Config         // Creation config.
 	GetCreateHostConfig() *dockerContainer.HostConfig // Host creation config.
 	GetContainerChain() (string, bool)                // Container chain label value and presence.

--- a/pkg/types/mocks/Container.go
+++ b/pkg/types/mocks/Container.go
@@ -943,6 +943,50 @@ func (_c *MockContainer_ImageName_Call) RunAndReturn(run func() string) *MockCon
 	return _c
 }
 
+// IsCreated provides a mock function for the type MockContainer
+func (_mock *MockContainer) IsCreated() bool {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsCreated")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func() bool); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// MockContainer_IsCreated_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsCreated'
+type MockContainer_IsCreated_Call struct {
+	*mock.Call
+}
+
+// IsCreated is a helper method to define mock.On call
+func (_e *MockContainer_Expecter) IsCreated() *MockContainer_IsCreated_Call {
+	return &MockContainer_IsCreated_Call{Call: _e.mock.On("IsCreated")}
+}
+
+func (_c *MockContainer_IsCreated_Call) Run(run func()) *MockContainer_IsCreated_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockContainer_IsCreated_Call) Return(b bool) *MockContainer_IsCreated_Call {
+	_c.Call.Return(b)
+	return _c
+}
+
+func (_c *MockContainer_IsCreated_Call) RunAndReturn(run func() bool) *MockContainer_IsCreated_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsLinkedToRestarting provides a mock function for the type MockContainer
 func (_mock *MockContainer) IsLinkedToRestarting() bool {
 	ret := _mock.Called()


### PR DESCRIPTION
This PR extends Watchtower's self-update cleanup process to detect and remove orphaned Watchtower containers left in a Docker `created` state after a failed self-update to prevent them from accumulating across restarts.

## Problem

When a self-update creates a replacement container but fails to start it, the new container can be left in the created state indefinitely. The existing cleanup logic only targets containers with the watchtower-old-* prefix, so these orphaned containers are never removed. Over time they accumulate, and on subsequent runs they can interfere with scope resolution or container selection.

## Solution

CleanupOldWatchtowerContainers now scans for Watchtower containers in the created state that are not the current container and not already marked as old, then removes them alongside the existing old-container cleanup. The new path respects scope boundaries by normalizing absent scope labels to "none" and skipping containers from different scopes, matching existing scoped behavior. A new IsCreated state check was added to the container interface and implemented to support this filtering.

## Changes

- Add IsCreated() to the container interface and implementation
- Extend CleanupOldWatchtowerContainers to collect and remove orphaned created-state containers within the same scope
- Add cleanup regression tests covering Watchtower filtering, current-container exclusion, old-container exclusion, scope mismatch, and mixed old-plus-orphaned removal
- Regenerate affected mocks for the new interface method



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup to remove orphaned Watchtower containers stuck in the created state.
  * Cleanup now respects the current scope and preserves the active container.
  * Cleanup reporting now includes counts and names for old and orphaned containers.
  * Improved handling of container state information when metadata is unavailable.

* **Tests**
  * Added coverage for identifying and removing orphaned containers while excluding unrelated or active containers.
  * Expanded deadline handling tests for container creation and startup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->