### PR TITLE
fix: recover orphaned Watchtower containers on startup

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -277,6 +277,19 @@ func preRun(cmd *cobra.Command, _ []string) {
 		)
 		defer exitCancel()
 
+		// Attempt to recover an orphaned Watchtower container that is stuck
+		// in the created state before exiting. If recovery succeeds, the
+		// old container still exits with restart policy set to "no".
+		recoveredContainer, recovered := actions.TryRecoverOrphanedContainer(
+			exitCtx,
+			client,
+			currentWatchtowerContainer,
+		)
+		if recovered {
+			logrus.WithField("container", recoveredContainer.Name()).
+				Info("Recovered orphaned Watchtower container, exiting old instance")
+		}
+
 		// Update current Watchtower container's restart policy to "no" to prevent unwanted restarts
 		client.SetNoRestartPolicy(exitCtx, currentWatchtowerContainer)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -280,8 +280,14 @@ func preRun(cmd *cobra.Command, _ []string) {
 		// Attempt to recover an orphaned Watchtower container that is stuck
 		// in the created state before exiting. If recovery succeeds, the
 		// old container still exits with restart policy set to "no".
+		recoverCtx, recoverCancel := context.WithTimeout(
+			context.Background(),
+			restartPolicyTimeout,
+		)
+		defer recoverCancel()
+
 		recoveredContainer, recovered := actions.TryRecoverOrphanedContainer(
-			exitCtx,
+			recoverCtx,
 			client,
 			currentWatchtowerContainer,
 		)

--- a/internal/actions/actions_internal_test.go
+++ b/internal/actions/actions_internal_test.go
@@ -1569,9 +1569,9 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 
 			// Wait for CreateContainer to be called, indicating the initial rename
 			// has completed. Then cancel the parent context.
-			for client.TestData.CreateContainerCount.Load() == 0 {
-				time.Sleep(1 * time.Millisecond)
-			}
+			gomega.Eventually(func() int32 {
+				return client.TestData.CreateContainerCount.Load()
+			}).Should(gomega.BeNumerically(">", 0))
 
 			parentCancel()
 			wg.Wait()
@@ -1661,9 +1661,9 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 
 			// Wait for StartContainer to be called, indicating the initial rename
 			// and create have completed. Then cancel the parent context.
-			for client.TestData.StartContainerCount.Load() == 0 {
-				time.Sleep(1 * time.Millisecond)
-			}
+			gomega.Eventually(func() int32 {
+				return client.TestData.StartContainerCount.Load()
+			}).Should(gomega.BeNumerically(">", 0))
 
 			parentCancel()
 			wg.Wait()
@@ -1761,9 +1761,9 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 			// Wait for StartContainer to be called (which means RenameContainer has completed)
 			// before canceling the parent context. This ensures we cancel at the right moment -
 			// after rename succeeds but during/after start fails.
-			for client.TestData.StartContainerCount.Load() == 0 {
-				time.Sleep(1 * time.Millisecond)
-			}
+			gomega.Eventually(func() int32 {
+				return client.TestData.StartContainerCount.Load()
+			}).Should(gomega.BeNumerically(">", 0))
 
 			// Cancel the parent context after StartContainer has been called.
 			// The detached context should allow cleanup to proceed even though

--- a/internal/actions/actions_internal_test.go
+++ b/internal/actions/actions_internal_test.go
@@ -1541,12 +1541,40 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 			}
 
 			testContainer := client.TestData.Containers[0]
-			_, renamed, err := restartStaleContainer(
-				context.Background(),
-				testContainer,
-				client,
-				params,
+
+			// Use a cancellable parent context to verify rename-back survives cancellation.
+			parentCtx, parentCancel := context.WithCancel(context.Background())
+			defer parentCancel()
+
+			// Add simulated latency to CreateContainer so the initial rename completes
+			// before we cancel the parent context.
+			client.TestData.SimulatedLatency = 5 * time.Millisecond
+
+			var (
+				renamed bool
+				err     error
 			)
+
+			// Run restartStaleContainer in a goroutine so we can cancel the parent
+			// after the initial handoff rename but before/during create failure.
+			var wg sync.WaitGroup
+			wg.Go(func() {
+				_, renamed, err = restartStaleContainer(
+					parentCtx,
+					testContainer,
+					client,
+					params,
+				)
+			})
+
+			// Wait for CreateContainer to be called, indicating the initial rename
+			// has completed. Then cancel the parent context.
+			for client.TestData.CreateContainerCount.Load() == 0 {
+				time.Sleep(1 * time.Millisecond)
+			}
+
+			parentCancel()
+			wg.Wait()
 
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to create container"))
@@ -1605,12 +1633,40 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 			}
 
 			testContainer := client.TestData.Containers[0]
-			_, renamed, err := restartStaleContainer(
-				context.Background(),
-				testContainer,
-				client,
-				params,
+
+			// Use a cancellable parent context to verify cleanup survives cancellation.
+			parentCtx, parentCancel := context.WithCancel(context.Background())
+			defer parentCancel()
+
+			// Add simulated latency so the initial rename and create complete
+			// before we cancel the parent context.
+			client.TestData.SimulatedLatency = 5 * time.Millisecond
+
+			var (
+				renamed bool
+				err     error
 			)
+
+			// Run restartStaleContainer in a goroutine so we can cancel the parent
+			// after the initial handoff and create but before/during start failure.
+			var wg sync.WaitGroup
+			wg.Go(func() {
+				_, renamed, err = restartStaleContainer(
+					parentCtx,
+					testContainer,
+					client,
+					params,
+				)
+			})
+
+			// Wait for StartContainer to be called, indicating the initial rename
+			// and create have completed. Then cancel the parent context.
+			for client.TestData.StartContainerCount.Load() == 0 {
+				time.Sleep(1 * time.Millisecond)
+			}
+
+			parentCancel()
+			wg.Wait()
 
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to start container"))
@@ -1618,6 +1674,7 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 			gomega.Expect(client.TestData.CreateContainerCount.Load()).To(gomega.Equal(int32(1)))
 			gomega.Expect(client.TestData.LastCreatedContainerID).ToNot(gomega.BeEmpty())
 			gomega.Expect(client.TestData.StopAndRemoveContainerCount.Load()).To(gomega.Equal(int32(1)))
+			gomega.Expect(client.TestData.RemoveContainerCount.Load()).To(gomega.Equal(int32(1)))
 			gomega.Expect(client.TestData.LastStopAndRemoveID).To(gomega.Equal(client.TestData.LastCreatedContainerID))
 			gomega.Expect(client.TestData.LastStopAndRemoveID).ToNot(gomega.Equal(testContainer.ID()))
 
@@ -1723,10 +1780,10 @@ var _ = ginkgo.Describe("DetachedContext", func() {
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("failed to start container"))
 			gomega.Expect(renamed).To(gomega.BeTrue())
 
-			// Verify that StopContainer was called during cleanup.
+			// Verify that RemoveContainer was called during cleanup.
 			// This demonstrates that the detached context allowed the cleanup
 			// operation to proceed even though the parent context was canceled.
-			gomega.Expect(client.TestData.StopContainerCount.Load()).To(gomega.BeNumerically(">=", int32(1)))
+			gomega.Expect(client.TestData.RemoveContainerCount.Load()).To(gomega.Equal(int32(1)))
 		})
 
 		ginkgo.It("cleanup operations complete when parent context is already canceled", func() {

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -42,6 +42,96 @@ const (
 	defaultCreateStartTimeout = 5 * time.Minute
 )
 
+// TryRecoverOrphanedContainer attempts to start an orphaned Watchtower container
+// that is stuck in the Docker "created" state. This can happen when a self-update
+// creates a replacement container but fails to start it, leaving the old container
+// running and the new container never started.
+//
+// It lists all containers, filters for Watchtower containers in the created state
+// that are not the current container, and attempts to start the first match.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeouts.
+//   - client: Container client for Docker API operations.
+//   - currentContainer: The current running container to exclude from recovery.
+//
+// Returns:
+//   - types.Container: The recovered container if successful, nil otherwise.
+//   - bool: True if a container was found and started, false otherwise.
+func TryRecoverOrphanedContainer(
+	ctx context.Context,
+	client container.Client,
+	currentContainer types.Container,
+) (types.Container, bool) {
+	if currentContainer == nil {
+		return nil, false
+	}
+
+	allContainers, err := client.ListContainers(ctx, filters.NoFilter)
+	if err != nil {
+		logrus.WithError(err).
+			Debug("Failed to list containers for orphaned Watchtower recovery")
+
+		return nil, false
+	}
+
+	currentScope, currentHasScope := currentContainer.Scope()
+	if !currentHasScope || currentScope == "" {
+		currentScope = "none"
+	}
+
+	for _, c := range allContainers {
+		if !c.IsWatchtower() {
+			continue
+		}
+
+		if c.ID() == currentContainer.ID() {
+			continue
+		}
+
+		if container.IsOldContainer(c.Name()) {
+			continue
+		}
+
+		if !c.IsCreated() {
+			continue
+		}
+
+		candidateScope, candidateHasScope := c.Scope()
+		if !candidateHasScope || candidateScope == "" {
+			candidateScope = "none"
+		}
+
+		if candidateScope != currentScope {
+			continue
+		}
+
+		logrus.WithFields(logrus.Fields{
+			"container_id":   c.ID(),
+			"container_name": c.Name(),
+		}).Info("Attempting to recover orphaned Watchtower container")
+
+		err := client.StartContainerByID(ctx, c.ID())
+		if err != nil {
+			logrus.WithError(err).WithFields(logrus.Fields{
+				"container_id":   c.ID(),
+				"container_name": c.Name(),
+			}).Debug("Failed to start orphaned Watchtower container")
+
+			continue
+		}
+
+		logrus.WithFields(logrus.Fields{
+			"container_id":   c.ID(),
+			"container_name": c.Name(),
+		}).Info("Successfully recovered orphaned Watchtower container")
+
+		return c, true
+	}
+
+	return nil, false
+}
+
 // Update scans and updates containers based on parameters.
 //
 // It checks container staleness, sorts by dependencies, and updates or restarts
@@ -103,7 +193,23 @@ func Update(
 					)
 					defer setNoRestartCancel()
 
-					//nolint:contextcheck // Using bounded context to survive caller cancellation
+					//nolint:contextcheck // setNoRestartCtx is intentionally used for recovery and restart policy updates
+					recoveredContainer, recovered := TryRecoverOrphanedContainer(
+						setNoRestartCtx,
+						client,
+						c,
+					)
+					if recovered {
+						logrus.WithField("container", recoveredContainer.Name()).
+							Info("Recovered orphaned Watchtower container, exiting old instance")
+
+						//nolint:contextcheck // setNoRestartCtx is intentionally used for restart policy update
+						client.SetNoRestartPolicy(setNoRestartCtx, c)
+
+						return nil, nil, errOldSelfDetected
+					}
+
+					//nolint:contextcheck // setNoRestartCtx is intentionally used for restart policy update
 					client.SetNoRestartPolicy(setNoRestartCtx, c)
 
 					return nil, nil, errOldSelfDetected

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -42,6 +42,51 @@ const (
 	defaultCreateStartTimeout = 5 * time.Minute
 )
 
+// isRecoverableOrphan determines whether a container is a recoverable orphaned
+// Watchtower instance. It excludes the current container, old-container names,
+// non-Watchtower containers, containers that are not in the created state, and
+// containers from a different scope.
+//
+// Parameters:
+//   - c: Candidate container to evaluate.
+//   - currentContainer: The current running container to exclude.
+//   - currentScope: Normalized scope of the current container ("none" when unset).
+//
+// Returns:
+//   - bool: True if the candidate is a recoverable orphan, false otherwise.
+func isRecoverableOrphan(
+	c types.Container,
+	currentContainer types.Container,
+	currentScope string,
+) bool {
+	if !c.IsWatchtower() {
+		return false
+	}
+
+	if c.ID() == currentContainer.ID() {
+		return false
+	}
+
+	if container.IsOldContainer(c.Name()) {
+		return false
+	}
+
+	if !c.IsCreated() {
+		return false
+	}
+
+	candidateScope, candidateHasScope := c.Scope()
+	if !candidateHasScope || candidateScope == "" {
+		candidateScope = "none"
+	}
+
+	if candidateScope != currentScope {
+		return false
+	}
+
+	return true
+}
+
 // TryRecoverOrphanedContainer attempts to start an orphaned Watchtower container
 // that is stuck in the Docker "created" state. This can happen when a self-update
 // creates a replacement container but fails to start it, leaving the old container
@@ -81,28 +126,7 @@ func TryRecoverOrphanedContainer(
 	}
 
 	for _, c := range allContainers {
-		if !c.IsWatchtower() {
-			continue
-		}
-
-		if c.ID() == currentContainer.ID() {
-			continue
-		}
-
-		if container.IsOldContainer(c.Name()) {
-			continue
-		}
-
-		if !c.IsCreated() {
-			continue
-		}
-
-		candidateScope, candidateHasScope := c.Scope()
-		if !candidateHasScope || candidateScope == "" {
-			candidateScope = "none"
-		}
-
-		if candidateScope != currentScope {
+		if !isRecoverableOrphan(c, currentContainer, currentScope) {
 			continue
 		}
 
@@ -187,27 +211,28 @@ func Update(
 					logrus.WithField("container", c.Name()).
 						Debug("Current container is an old Watchtower container, stopping self")
 
-					setNoRestartCtx, setNoRestartCancel := context.WithTimeout(
+					recoverCtx, recoverCancel := context.WithTimeout(
 						context.Background(),
 						restartPolicyTimeout(config.Timeout),
 					)
-					defer setNoRestartCancel()
+					defer recoverCancel()
 
-					//nolint:contextcheck // setNoRestartCtx is intentionally used for recovery and restart policy updates
+					//nolint:contextcheck // recoverCtx is intentionally created with timeout and passed to recovery
 					recoveredContainer, recovered := TryRecoverOrphanedContainer(
-						setNoRestartCtx,
+						recoverCtx,
 						client,
 						c,
 					)
 					if recovered {
 						logrus.WithField("container", recoveredContainer.Name()).
 							Info("Recovered orphaned Watchtower container, exiting old instance")
-
-						//nolint:contextcheck // setNoRestartCtx is intentionally used for restart policy update
-						client.SetNoRestartPolicy(setNoRestartCtx, c)
-
-						return nil, nil, errOldSelfDetected
 					}
+
+					setNoRestartCtx, setNoRestartCancel := context.WithTimeout(
+						context.Background(),
+						restartPolicyTimeout(config.Timeout),
+					)
+					defer setNoRestartCancel()
 
 					//nolint:contextcheck // setNoRestartCtx is intentionally used for restart policy update
 					client.SetNoRestartPolicy(setNoRestartCtx, c)

--- a/internal/actions/update_recovery_test.go
+++ b/internal/actions/update_recovery_test.go
@@ -236,4 +236,54 @@ var _ = ginkgo.Describe("TryRecoverOrphanedContainer", func() {
 			gomega.Expect(client.TestData.StartContainerCount.Load()).To(gomega.Equal(int32(0)))
 		})
 	})
+
+	ginkgo.When("the current container has no scope and the orphaned container has an explicit scope", func() {
+		ginkgo.It("should not start it", func() {
+			orphaned := mockActions.CreateMockContainerWithConfig(
+				"orphaned-id",
+				"watchtower-xyz",
+				"watchtower:latest",
+				false,
+				false,
+				time.Now(),
+				&dockerContainer.Config{
+					Image: "watchtower:latest",
+					Labels: map[string]string{
+						"com.centurylinklabs.watchtower":       "true",
+						"com.centurylinklabs.watchtower.scope": "scope-b",
+					},
+				},
+			)
+			orphaned.ContainerInfo().State.Status = dockerContainer.StateCreated
+
+			current := mockActions.CreateMockContainerWithConfig(
+				"current-id",
+				"watchtower-old-abc123",
+				"watchtower:latest",
+				true,
+				false,
+				time.Now(),
+				&dockerContainer.Config{
+					Image: "watchtower:latest",
+					Labels: map[string]string{
+						"com.centurylinklabs.watchtower": "true",
+					},
+				},
+			)
+
+			client := mockActions.CreateMockClient(&mockActions.TestData{
+				Containers: []types.Container{orphaned, current},
+			}, false, false)
+
+			recovered, ok := actions.TryRecoverOrphanedContainer(
+				context.Background(),
+				client,
+				current,
+			)
+
+			gomega.Expect(ok).To(gomega.BeFalse())
+			gomega.Expect(recovered).To(gomega.BeNil())
+			gomega.Expect(client.TestData.StartContainerCount.Load()).To(gomega.Equal(int32(0)))
+		})
+	})
 })

--- a/internal/actions/update_recovery_test.go
+++ b/internal/actions/update_recovery_test.go
@@ -1,0 +1,239 @@
+package actions_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	dockerContainer "github.com/moby/moby/api/types/container"
+
+	"github.com/nicholas-fedor/watchtower/internal/actions"
+	mockActions "github.com/nicholas-fedor/watchtower/internal/actions/mocks"
+	"github.com/nicholas-fedor/watchtower/pkg/types"
+)
+
+var _ = ginkgo.Describe("TryRecoverOrphanedContainer", func() {
+	ginkgo.When("listing containers fails", func() {
+		ginkgo.It("should return false without error", func() {
+			client := mockActions.CreateMockClient(&mockActions.TestData{
+				ListContainersError: context.DeadlineExceeded,
+			}, false, false)
+
+			current := mockActions.CreateMockContainer(
+				"current-id",
+				"watchtower",
+				"watchtower:latest",
+				time.Now(),
+			)
+
+			recovered, ok := actions.TryRecoverOrphanedContainer(
+				context.Background(),
+				client,
+				current,
+			)
+
+			gomega.Expect(ok).To(gomega.BeFalse())
+			gomega.Expect(recovered).To(gomega.BeNil())
+		})
+	})
+
+	ginkgo.When("no orphaned container exists", func() {
+		ginkgo.It("should return false", func() {
+			oldContainer := mockActions.CreateMockContainerWithConfig(
+				"old-id",
+				"watchtower-old-abc123",
+				"watchtower:latest",
+				true,
+				false,
+				time.Now(),
+				&dockerContainer.Config{
+					Image:  "watchtower:latest",
+					Labels: map[string]string{"com.centurylinklabs.watchtower": "true"},
+				},
+			)
+			current := mockActions.CreateMockContainer(
+				"current-id",
+				"watchtower",
+				"watchtower:latest",
+				time.Now(),
+			)
+
+			client := mockActions.CreateMockClient(&mockActions.TestData{
+				Containers: []types.Container{oldContainer, current},
+			}, false, false)
+
+			recovered, ok := actions.TryRecoverOrphanedContainer(
+				context.Background(),
+				client,
+				current,
+			)
+
+			gomega.Expect(ok).To(gomega.BeFalse())
+			gomega.Expect(recovered).To(gomega.BeNil())
+		})
+	})
+
+	ginkgo.When("an orphaned created-state Watchtower container exists", func() {
+		ginkgo.It("should start it and return the recovered container", func() {
+			config := &dockerContainer.Config{
+				Image:  "watchtower:latest",
+				Labels: map[string]string{"com.centurylinklabs.watchtower": "true"},
+			}
+			orphaned := mockActions.CreateMockContainerWithConfig(
+				"orphaned-id",
+				"watchtower-xyz",
+				"watchtower:latest",
+				false,
+				false,
+				time.Now(),
+				config,
+			)
+			orphaned.ContainerInfo().State.Status = dockerContainer.StateCreated
+
+			current := mockActions.CreateMockContainerWithConfig(
+				"current-id",
+				"watchtower-old-abc123",
+				"watchtower:latest",
+				true,
+				false,
+				time.Now(),
+				config,
+			)
+
+			client := mockActions.CreateMockClient(&mockActions.TestData{
+				Containers: []types.Container{orphaned, current},
+			}, false, false)
+
+			recovered, ok := actions.TryRecoverOrphanedContainer(
+				context.Background(),
+				client,
+				current,
+			)
+
+			gomega.Expect(ok).To(gomega.BeTrue())
+			gomega.Expect(recovered).NotTo(gomega.BeNil())
+			gomega.Expect(recovered.ID()).To(gomega.Equal(types.ContainerID("orphaned-id")))
+			gomega.Expect(client.TestData.StartContainerCount.Load()).To(gomega.Equal(int32(1)))
+		})
+	})
+
+	ginkgo.When("start fails for the orphaned container", func() {
+		ginkgo.It("should continue searching and return false", func() {
+			config := &dockerContainer.Config{
+				Image:  "watchtower:latest",
+				Labels: map[string]string{"com.centurylinklabs.watchtower": "true"},
+			}
+			orphaned := mockActions.CreateMockContainerWithConfig(
+				"orphaned-id",
+				"watchtower-xyz",
+				"watchtower:latest",
+				false,
+				false,
+				time.Now(),
+				config,
+			)
+			orphaned.ContainerInfo().State.Status = dockerContainer.StateCreated
+
+			current := mockActions.CreateMockContainerWithConfig(
+				"current-id",
+				"watchtower-old-abc123",
+				"watchtower:latest",
+				true,
+				false,
+				time.Now(),
+				config,
+			)
+
+			client := mockActions.CreateMockClient(&mockActions.TestData{
+				Containers:              []types.Container{orphaned, current},
+				StartContainerByIDError: context.DeadlineExceeded,
+			}, false, false)
+
+			recovered, ok := actions.TryRecoverOrphanedContainer(
+				context.Background(),
+				client,
+				current,
+			)
+
+			gomega.Expect(ok).To(gomega.BeFalse())
+			gomega.Expect(recovered).To(gomega.BeNil())
+			gomega.Expect(client.TestData.StartContainerCount.Load()).To(gomega.Equal(int32(1)))
+		})
+	})
+
+	ginkgo.When("the current container is nil", func() {
+		ginkgo.It("should not panic and return false", func() {
+			client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
+
+			gomega.Expect(func() {
+				actions.TryRecoverOrphanedContainer(
+					context.Background(),
+					client,
+					nil,
+				)
+			}).NotTo(gomega.Panic())
+
+			recovered, ok := actions.TryRecoverOrphanedContainer(
+				context.Background(),
+				client,
+				nil,
+			)
+
+			gomega.Expect(ok).To(gomega.BeFalse())
+			gomega.Expect(recovered).To(gomega.BeNil())
+		})
+	})
+
+	ginkgo.When("the orphaned container is in a different scope", func() {
+		ginkgo.It("should not start it", func() {
+			orphaned := mockActions.CreateMockContainerWithConfig(
+				"orphaned-id",
+				"watchtower-xyz",
+				"watchtower:latest",
+				false,
+				false,
+				time.Now(),
+				&dockerContainer.Config{
+					Image: "watchtower:latest",
+					Labels: map[string]string{
+						"com.centurylinklabs.watchtower":       "true",
+						"com.centurylinklabs.watchtower.scope": "scope-b",
+					},
+				},
+			)
+			orphaned.ContainerInfo().State.Status = dockerContainer.StateCreated
+
+			current := mockActions.CreateMockContainerWithConfig(
+				"current-id",
+				"watchtower-old-abc123",
+				"watchtower:latest",
+				true,
+				false,
+				time.Now(),
+				&dockerContainer.Config{
+					Image: "watchtower:latest",
+					Labels: map[string]string{
+						"com.centurylinklabs.watchtower":       "true",
+						"com.centurylinklabs.watchtower.scope": "scope-a",
+					},
+				},
+			)
+
+			client := mockActions.CreateMockClient(&mockActions.TestData{
+				Containers: []types.Container{orphaned, current},
+			}, false, false)
+
+			recovered, ok := actions.TryRecoverOrphanedContainer(
+				context.Background(),
+				client,
+				current,
+			)
+
+			gomega.Expect(ok).To(gomega.BeFalse())
+			gomega.Expect(recovered).To(gomega.BeNil())
+			gomega.Expect(client.TestData.StartContainerCount.Load()).To(gomega.Equal(int32(0)))
+		})
+	})
+})


### PR DESCRIPTION
This PR adds startup recovery for the broken self-update state described in #2093. When Watchtower detects it is running as an old container, it now attempts to recover an orphaned replacement container stuck in the Docker created state before exiting. If recovery succeeds, the old instance still exits with its restart policy set to no, allowing the recovered container to take over without manual cleanup.

## Problem

On slow hosts, the self-update create/start sequence can exceed the timeout, leaving the replacement container in the created state and never started. On the next startup, Watchtower detects it is running as the old container, sets its restart policy to no, and exits—permanently leaving the orphaned container behind and breaking the instance until manual cleanup.

## Solution

This PR introduces TryRecoverOrphanedContainer, which scans for Watchtower containers in the created state that belong to the same scope and attempts to start them before the old instance exits. Scope matching prevents cross-scope interference, and the existing restart-policy safeguard remains in place regardless of whether recovery succeeds.

## Changes

- Add TryRecoverOrphanedContainer to recover containers from failed self-updates
- Invoke recovery during pre-run and update flows before setting no-restart policy
- Add dedicated test suite for recovery scenarios and context cancellation behavior

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery when Watchtower encounters an orphaned container during restart or update operations.
  - Automatically attempts to start eligible orphaned containers before disabling the current container’s restart policy.
  - Safely handles missing, outdated, mismatched, or failed container recovery scenarios.
  - Ensures failed recovery attempts clean up newly created containers and preserve existing restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->