### PR TITLE
fix(notifications): validate required fields and standardize error messages

### DIFF
--- a/pkg/notifications/email.go
+++ b/pkg/notifications/email.go
@@ -66,6 +66,24 @@ type emailTypeNotifier struct {
 //
 //nolint:godox
 func newEmailNotifier(legacy notifyConfig.Legacy) types.ConvertibleNotifier {
+	if legacy.EmailFrom == "" {
+		logrus.Fatal(
+			"Email from address is empty.",
+		)
+	}
+
+	if legacy.EmailTo == "" {
+		logrus.Fatal(
+			"Email to address is empty.",
+		)
+	}
+
+	if legacy.EmailServer == "" {
+		logrus.Fatal(
+			"Email server is empty.",
+		)
+	}
+
 	from := legacy.EmailFrom
 	to := legacy.EmailTo //nolint:varnamelen
 	server := legacy.EmailServer

--- a/pkg/notifications/gotify.go
+++ b/pkg/notifications/gotify.go
@@ -92,7 +92,7 @@ func requireGotifyToken(gotifyToken string) string {
 	// Fatal error if token is missing.
 	if len(gotifyToken) < 1 {
 		clog.Fatal(
-			"Gotify token is empty; required argument --notification-gotify-token(cli) or WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN(env) is empty",
+			"Gotify token is empty.",
 		)
 	}
 
@@ -120,7 +120,7 @@ func requireGotifyURL(gotifyURL string) string {
 	// Fatal error if URL is missing.
 	if len(gotifyURL) < 1 {
 		clog.Fatal(
-			"Gotify URL is empty; required argument --notification-gotify-url(cli) or WATCHTOWER_NOTIFICATION_GOTIFY_URL(env) is empty",
+			"Gotify URL is empty",
 		)
 	}
 

--- a/pkg/notifications/msteams.go
+++ b/pkg/notifications/msteams.go
@@ -61,7 +61,7 @@ func newMsTeamsNotifier(legacy notifyConfig.Legacy) types.ConvertibleNotifier {
 
 	if len(webHookURL) == 0 {
 		clog.Fatal(
-			"Microsoft Teams webhook URL is empty; required argument --notification-msteams-hook(cli) or WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL(env) missing",
+			"Microsoft Teams webhook URL is empty",
 		)
 	}
 

--- a/pkg/notifications/notifier_test.go
+++ b/pkg/notifications/notifier_test.go
@@ -324,6 +324,28 @@ var _ = ginkgo.Describe("notifications", func() {
 				})
 			})
 		})
+		ginkgo.When("the hook URL is empty", func() {
+			ginkgo.It("should fatal with a clear missing argument message", func() {
+				originalExit := logrus.StandardLogger().ExitFunc
+				defer func() { logrus.StandardLogger().ExitFunc = originalExit }()
+
+				logrus.StandardLogger().ExitFunc = func(_ int) { panic("FATAL") }
+
+				gomega.Expect(func() {
+					command := cmd.NewRootCommand()
+					flags.RegisterNotificationFlags(command)
+
+					args := []string{
+						"--notifications",
+						"slack",
+					}
+
+					command.ParseFlags(args)
+
+					notifications.NewNotifierFromFlags(command)
+				}).To(gomega.Panic())
+			})
+		})
 	})
 
 	//nolint:godox
@@ -513,6 +535,82 @@ var _ = ginkgo.Describe("notifications", func() {
 				}
 
 				testURL(args, expectedOutput, expectedDelay)
+			})
+		})
+		ginkgo.When("a required field is empty", func() {
+			ginkgo.It("should fatal when the from address is empty", func() {
+				originalExit := logrus.StandardLogger().ExitFunc
+				defer func() { logrus.StandardLogger().ExitFunc = originalExit }()
+
+				logrus.StandardLogger().ExitFunc = func(_ int) { panic("FATAL") }
+
+				gomega.Expect(func() {
+					command := cmd.NewRootCommand()
+					flags.RegisterNotificationFlags(command)
+
+					args := []string{
+						"--notifications",
+						"email",
+						"--notification-email-to",
+						"recipient@example.com",
+						"--notification-email-server",
+						"smtp.example.com",
+					}
+
+					command.ParseFlags(args)
+
+					notifications.NewNotifierFromFlags(command)
+				}).To(gomega.Panic())
+			})
+
+			ginkgo.It("should fatal when the to address is empty", func() {
+				originalExit := logrus.StandardLogger().ExitFunc
+				defer func() { logrus.StandardLogger().ExitFunc = originalExit }()
+
+				logrus.StandardLogger().ExitFunc = func(_ int) { panic("FATAL") }
+
+				gomega.Expect(func() {
+					command := cmd.NewRootCommand()
+					flags.RegisterNotificationFlags(command)
+
+					args := []string{
+						"--notifications",
+						"email",
+						"--notification-email-from",
+						"sender@example.com",
+						"--notification-email-server",
+						"smtp.example.com",
+					}
+
+					command.ParseFlags(args)
+
+					notifications.NewNotifierFromFlags(command)
+				}).To(gomega.Panic())
+			})
+
+			ginkgo.It("should fatal when the server is empty", func() {
+				originalExit := logrus.StandardLogger().ExitFunc
+				defer func() { logrus.StandardLogger().ExitFunc = originalExit }()
+
+				logrus.StandardLogger().ExitFunc = func(_ int) { panic("FATAL") }
+
+				gomega.Expect(func() {
+					command := cmd.NewRootCommand()
+					flags.RegisterNotificationFlags(command)
+
+					args := []string{
+						"--notifications",
+						"email",
+						"--notification-email-from",
+						"sender@example.com",
+						"--notification-email-to",
+						"recipient@example.com",
+					}
+
+					command.ParseFlags(args)
+
+					notifications.NewNotifierFromFlags(command)
+				}).To(gomega.Panic())
 			})
 		})
 	})

--- a/pkg/notifications/slack.go
+++ b/pkg/notifications/slack.go
@@ -62,6 +62,12 @@ func newSlackNotifier(legacy notifyConfig.Legacy) types.ConvertibleNotifier {
 	emoji := legacy.SlackIconEmoji
 	iconURL := legacy.SlackIconURL
 
+	if hookURL == "" {
+		logrus.Fatal(
+			"Slack hook URL is empty.",
+		)
+	}
+
 	clog := logrus.WithFields(logrus.Fields{
 		"hook_url": hookURL,
 		"username": userName,


### PR DESCRIPTION
This PR adds validation for empty legacy email or Slack notifications.

## Problem

Users migrating from legacy notifications have been retaining the notification type configuration, which then triggers Watchtower to attempt to build the Shoutrrr notification URL. In the case of SMTP and Slack notifications, this surfaces as a Shoutrrr error, rather than being caught early by Watchtower.

## Solution

Validation for empty/unset configuration options was added by mirroring the pre-existing pattern from Gotify and Teams. In addition, error messages were simplified to help keep the messages concise. 

## Changes

- Add fatal validation for empty email from, to, and server fields
- Add fatal validation for empty Slack hook URL
- Simplify Gotify token and URL error messages
- Simplify Microsoft Teams webhook URL error message
- Add tests for empty required field validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent notification services from starting with missing Slack, email, Gotify, or Microsoft Teams configuration.
  * Improved error messages for incomplete notification settings.

* **Tests**
  * Added coverage for invalid Slack and email notification configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->