### PR TITLE
fix(api): respect label-enable setting for container details

### DIFF
--- a/internal/api/handlers/containers/details/details_test.go
+++ b/internal/api/handlers/containers/details/details_test.go
@@ -18,11 +18,13 @@ func TestGetContainerDetails(t *testing.T) {
 		name    string
 		client  func(t *testing.T) *mockContainer.MockClient
 		filter  types.Filter
+		params  types.UpdateParams
 		wantErr bool
 		wantLen int
+		want    func(t *testing.T, details []ContainerDetails)
 	}{
 		{
-			name: "successful list with container",
+			name: "successful list with labeled enabled container",
 			client: func(t *testing.T) *mockContainer.MockClient {
 				t.Helper()
 				c := mockContainer.NewMockClient(t)
@@ -42,9 +44,100 @@ func TestGetContainerDetails(t *testing.T) {
 
 				return c
 			},
-			filter:  nil,
+			params:  types.UpdateParams{},
 			wantErr: false,
 			wantLen: 1,
+			want: func(t *testing.T, details []ContainerDetails) {
+				t.Helper()
+				assert.True(t, details[0].Enabled)
+			},
+		},
+		{
+			name: "unlabeled container is enabled when label-enable is false",
+			client: func(t *testing.T) *mockContainer.MockClient {
+				t.Helper()
+				c := mockContainer.NewMockClient(t)
+				container := mockTypes.NewMockContainer(t)
+				container.EXPECT().Name().Return("unlabeled-container")
+				container.EXPECT().ImageName().Return("nginx:latest")
+				container.EXPECT().ImageID().Return(types.ImageID("sha256:abc123"))
+				container.EXPECT().IsRunning().Return(true)
+				container.EXPECT().IsWatchtower().Return(false)
+				container.EXPECT().IsMonitorOnly(mock.Anything).Return(false)
+				container.EXPECT().IsNoPull(mock.Anything).Return(false)
+				container.EXPECT().Enabled().Return(false, false)
+				container.EXPECT().IsStale().Return(false)
+				container.EXPECT().Scope().Return("", true)
+				container.EXPECT().ImageInfo().Return(nil)
+				c.EXPECT().ListContainers(mock.Anything).Return([]types.Container{container}, nil)
+
+				return c
+			},
+			params:  types.UpdateParams{LabelEnable: false},
+			wantErr: false,
+			wantLen: 1,
+			want: func(t *testing.T, details []ContainerDetails) {
+				t.Helper()
+				assert.True(t, details[0].Enabled)
+			},
+		},
+		{
+			name: "unlabeled container is disabled when label-enable is true",
+			client: func(t *testing.T) *mockContainer.MockClient {
+				t.Helper()
+				c := mockContainer.NewMockClient(t)
+				container := mockTypes.NewMockContainer(t)
+				container.EXPECT().Name().Return("unlabeled-container")
+				container.EXPECT().ImageName().Return("nginx:latest")
+				container.EXPECT().ImageID().Return(types.ImageID("sha256:abc123"))
+				container.EXPECT().IsRunning().Return(true)
+				container.EXPECT().IsWatchtower().Return(false)
+				container.EXPECT().IsMonitorOnly(mock.Anything).Return(false)
+				container.EXPECT().IsNoPull(mock.Anything).Return(false)
+				container.EXPECT().Enabled().Return(false, false)
+				container.EXPECT().IsStale().Return(false)
+				container.EXPECT().Scope().Return("", true)
+				container.EXPECT().ImageInfo().Return(nil)
+				c.EXPECT().ListContainers(mock.Anything).Return([]types.Container{container}, nil)
+
+				return c
+			},
+			params:  types.UpdateParams{LabelEnable: true},
+			wantErr: false,
+			wantLen: 1,
+			want: func(t *testing.T, details []ContainerDetails) {
+				t.Helper()
+				assert.False(t, details[0].Enabled)
+			},
+		},
+		{
+			name: "labeled false container is disabled when label-enable is false",
+			client: func(t *testing.T) *mockContainer.MockClient {
+				t.Helper()
+				c := mockContainer.NewMockClient(t)
+				container := mockTypes.NewMockContainer(t)
+				container.EXPECT().Name().Return("disabled-container")
+				container.EXPECT().ImageName().Return("nginx:latest")
+				container.EXPECT().ImageID().Return(types.ImageID("sha256:abc123"))
+				container.EXPECT().IsRunning().Return(true)
+				container.EXPECT().IsWatchtower().Return(false)
+				container.EXPECT().IsMonitorOnly(mock.Anything).Return(false)
+				container.EXPECT().IsNoPull(mock.Anything).Return(false)
+				container.EXPECT().Enabled().Return(false, true)
+				container.EXPECT().IsStale().Return(false)
+				container.EXPECT().Scope().Return("", true)
+				container.EXPECT().ImageInfo().Return(nil)
+				c.EXPECT().ListContainers(mock.Anything).Return([]types.Container{container}, nil)
+
+				return c
+			},
+			params:  types.UpdateParams{LabelEnable: false},
+			wantErr: false,
+			wantLen: 1,
+			want: func(t *testing.T, details []ContainerDetails) {
+				t.Helper()
+				assert.False(t, details[0].Enabled)
+			},
 		},
 		{
 			name: "client error returns wrapped error",
@@ -56,6 +149,7 @@ func TestGetContainerDetails(t *testing.T) {
 				return c
 			},
 			filter:  nil,
+			params:  types.UpdateParams{},
 			wantErr: true,
 		},
 	}
@@ -63,13 +157,17 @@ func TestGetContainerDetails(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := tt.client(t)
-			details, err := GetContainerDetails(t.Context(), client, tt.filter, "", "", types.UpdateParams{})
+			details, err := GetContainerDetails(t.Context(), client, tt.filter, "", "", tt.params)
 
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 				assert.Len(t, details, tt.wantLen)
+
+				if tt.want != nil {
+					tt.want(t, details)
+				}
 			}
 		})
 	}

--- a/internal/api/handlers/containers/details/handler.go
+++ b/internal/api/handlers/containers/details/handler.go
@@ -129,13 +129,19 @@ func (h *Handler) Handle(c fiber.Ctx) error {
 //   - filter: Container filter function.
 //   - nameFilter: Exact container name to filter by, or empty for no filter.
 //   - imageFilter: Exact image name to filter by, or empty for no filter.
-//   - params: Update parameters supplying MonitorOnly, NoPull and LabelPrecedence
-//     globals for computing per-container effective flags.
+//   - params: Update parameters for computing per-container effective flags.
 //
 // Returns:
 //   - []ContainerDetails: Detailed information for each matching container.
 //   - error: Non-nil if listing containers fails.
-func GetContainerDetails(ctx context.Context, client container.Client, filter types.Filter, nameFilter, imageFilter string, params types.UpdateParams) ([]ContainerDetails, error) {
+func GetContainerDetails(
+	ctx context.Context,
+	client container.Client,
+	filter types.Filter,
+	nameFilter,
+	imageFilter string,
+	params types.UpdateParams,
+) ([]ContainerDetails, error) {
 	var list []types.Container
 
 	var err error
@@ -161,7 +167,15 @@ func GetContainerDetails(ctx context.Context, client container.Client, filter ty
 			continue
 		}
 
-		enabled, _ := c.Enabled()
+		rawEnabled, hasLabel := c.Enabled()
+
+		var enabled bool
+		if !hasLabel {
+			enabled = !params.LabelEnable
+		} else {
+			enabled = rawEnabled
+		}
+
 		scope, _ := c.Scope()
 
 		containerDetails := ContainerDetails{
@@ -177,7 +191,8 @@ func GetContainerDetails(ctx context.Context, client container.Client, filter ty
 			Scope:       scope,
 		}
 
-		if info := c.ImageInfo(); info != nil && len(info.RepoDigests) > 0 {
+		info := c.ImageInfo()
+		if info != nil && len(info.RepoDigests) > 0 {
 			_, digest, found := strings.Cut(info.RepoDigests[0], "@")
 			if found {
 				containerDetails.Digest = digest

--- a/internal/config/update_params.go
+++ b/internal/config/update_params.go
@@ -46,5 +46,6 @@ func (c Config) UpdateParams(overrides RunOverrides) types.UpdateParams {
 		SkipSelfUpdate:      overrides.SkipSelfUpdate,
 		EphemeralSelfUpdate: c.Update.EphemeralSelfUpdate,
 		CooldownDelay:       c.Update.CooldownDelay,
+		LabelEnable:         c.Filter.LabelEnable,
 	}
 }

--- a/internal/config/update_params_test.go
+++ b/internal/config/update_params_test.go
@@ -54,8 +54,9 @@ func TestUpdateParamsAssignsEveryField(t *testing.T) {
 			GID:     1000,
 		},
 		Filter: filter.Filter{
-			Predicate: filters.NoFilter,
-			Desc:      "all",
+			Predicate:   filters.NoFilter,
+			Desc:        "all",
+			LabelEnable: true,
 		},
 	}
 

--- a/pkg/types/update_params.go
+++ b/pkg/types/update_params.go
@@ -26,4 +26,5 @@ type UpdateParams struct {
 	SkipSelfUpdate      bool          `json:"skip_self_update"`       // Skip Watchtower self-update if true.
 	EphemeralSelfUpdate bool          `json:"ephemeral_self_update"`  // Use ephemeral container for self-update if true.
 	CooldownDelay       time.Duration `json:"cooldown_delay"`         // Minimum time since image creation before allowing updates.
+	LabelEnable         bool          `json:"label_enable"`           // Require enable label for monitoring.
 }


### PR DESCRIPTION
This PR fixes the /v1/containers/details endpoint so the enabled field reflects effective monitoring status instead of only the raw container label.

## Problem

The enabled field is computed by reading only the raw container label via Container.Enabled(). The global `label-enable` configuration option is consumed exclusively by FilterByEnableLabel and is never surfaced in the API response, so unlabeled containers appear disabled even when they are actively monitored.

## Solution

Added LabelEnable to types.UpdateParams as the single source of truth for the configuration option, populated it from config.Filter.LabelEnable in Config.UpdateParams(), and changed the handler to compute the effective status.

## Changes

- Add LabelEnable field to types.UpdateParams
- Populate LabelEnable from config.Filter.LabelEnable in Config.UpdateParams()
- Compute effective enabled in the details handler
- Add handler tests covering labeled and unlabeled containers with label-enable true and false
- Update UpdateParams exhaustiveness test fixture for the new field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for controlling container monitoring through labels.
  * Container details now accurately report enabled status based on container labels or the configured default behavior.
  * Added the `label_enable` option to update parameters for configuring label-based monitoring.

* **Tests**
  * Expanded coverage for labeled and unlabeled containers across different monitoring settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->