### PR TITLE
fix(container): only warn about missing image info for monitored containers

### DIFF
--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -614,9 +614,6 @@ func (c *client) GetContainer(ctx context.Context, containerID types.ContainerID
 		return nil, err
 	}
 
-	// Containers reaching this path have already passed filtering, so missing image
-	// metadata is worth a warning here even though GetSourceContainer logs it at
-	// debug level. See the comment there for why that call site cannot warn.
 	if !container.HasImageInfo() {
 		c.logger().Warn().
 			Str("container", container.Name()).

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -614,6 +614,17 @@ func (c *client) GetContainer(ctx context.Context, containerID types.ContainerID
 		return nil, err
 	}
 
+	// Containers reaching this path have already passed filtering, so missing image
+	// metadata is worth a warning here even though GetSourceContainer logs it at
+	// debug level. See the comment there for why that call site cannot warn.
+	if !container.HasImageInfo() {
+		c.logger().Warn().
+			Str("container", container.Name()).
+			Str("container_id", string(containerID)).
+			Str("image", container.ImageName()).
+			Msg("Failed to retrieve image info")
+	}
+
 	c.logger().Debug().
 		Str("container_id", string(containerID)).
 		Msg("Retrieved container details")

--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -516,6 +516,34 @@ var _ = ginkgo.Describe("the client", func() {
 			})
 		})
 
+		ginkgo.When(`the image of a container cannot be inspected`, func() {
+			ginkgo.It("should warn, naming the container and its image", func() {
+				// GetContainer is only reached for containers already being acted
+				// upon, so missing image metadata is worth a warning here even
+				// though GetSourceContainer logs it at debug level.
+				mockServer.AppendHandlers(missingImageHandlers(testContainerID)...)
+
+				log, logBuf := captureLog(zerolog.WarnLevel)
+				client := &client{
+					api:           docker,
+					log:           log,
+					ClientOptions: ClientOptions{},
+				}
+
+				container, err := client.GetContainer(
+					context.Background(),
+					types.ContainerID(testContainerID),
+				)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(container.HasImageInfo()).To(gomega.BeFalse())
+
+				logged := string(logBuf.Contents())
+				gomega.Expect(logged).To(gomega.ContainSubstring("Failed to retrieve image info"))
+				gomega.Expect(logged).To(gomega.ContainSubstring("test-container"))
+				gomega.Expect(logged).To(gomega.ContainSubstring("test-image:latest"))
+			})
+		})
+
 		ginkgo.When(`a container uses container network mode`, func() {
 			ginkgo.When(`the network container can be resolved`, func() {
 				ginkgo.It("should return the container name instead of the ID", func() {

--- a/pkg/container/container_source.go
+++ b/pkg/container/container_source.go
@@ -130,6 +130,18 @@ func ListSourceContainers(log *zerolog.Logger,
 		}
 
 		if filter == nil || filter(container) {
+			// Warn about missing image metadata only for containers that survive the
+			// filter. GetSourceContainer logs this at debug level because it runs
+			// before filtering, and warning there would produce notifications for
+			// containers the user has explicitly excluded from monitoring.
+			if !container.HasImageInfo() {
+				log.Warn().
+					Str("container", container.Name()).
+					Str("container_id", runningContainer.ID).
+					Str("image", container.ImageName()).
+					Msg("Failed to retrieve image info")
+			}
+
 			hostContainers = append(hostContainers, container)
 		}
 	}
@@ -211,8 +223,15 @@ func GetSourceContainer(log *zerolog.Logger,
 	// Fetch image info, falling back if it fails.
 	imageResult, err := api.ImageInspect(ctx, containerInfo.Image)
 	if err != nil {
-		clog.Warn().
+		// Logged at debug level because this runs before container filtering.
+		// Warning here would notify about containers the user has excluded via
+		// --disable-containers and friends. Callers that know the container is
+		// actually monitored re-log this at warning level; see
+		// ListSourceContainers and client.GetContainer.
+		clog.Debug().
 			Err(err).
+			Str("container", util.NormalizeContainerName(containerInfo.Name)).
+			Str("image", containerInfo.Image).
 			Msg("Failed to retrieve image info")
 
 		return NewContainer(log, containerInfo, nil), nil

--- a/pkg/container/container_source.go
+++ b/pkg/container/container_source.go
@@ -130,10 +130,6 @@ func ListSourceContainers(log *zerolog.Logger,
 		}
 
 		if filter == nil || filter(container) {
-			// Warn about missing image metadata only for containers that survive the
-			// filter. GetSourceContainer logs this at debug level because it runs
-			// before filtering, and warning there would produce notifications for
-			// containers the user has explicitly excluded from monitoring.
 			if !container.HasImageInfo() {
 				log.Warn().
 					Str("container", container.Name()).
@@ -223,11 +219,6 @@ func GetSourceContainer(log *zerolog.Logger,
 	// Fetch image info, falling back if it fails.
 	imageResult, err := api.ImageInspect(ctx, containerInfo.Image)
 	if err != nil {
-		// Logged at debug level because this runs before container filtering.
-		// Warning here would notify about containers the user has excluded via
-		// --disable-containers and friends. Callers that know the container is
-		// actually monitored re-log this at warning level; see
-		// ListSourceContainers and client.GetContainer.
 		clog.Debug().
 			Err(err).
 			Str("container", util.NormalizeContainerName(containerInfo.Name)).

--- a/pkg/container/container_source_test.go
+++ b/pkg/container/container_source_test.go
@@ -216,6 +216,85 @@ var _ = ginkgo.Describe("ListSourceContainers", func() {
 			gomega.Expect(containers).To(gomega.BeEmpty())
 		})
 	})
+
+	ginkgo.When("image inspection fails", func() {
+		// Mocks a container whose image can no longer be inspected, which happens
+		// when the image is removed out from under a running container.
+		mockMissingImage := func(containerID string) []http.HandlerFunc {
+			return []http.HandlerFunc{
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(
+						"GET",
+						gomega.MatchRegexp(
+							fmt.Sprintf("^/v[0-9.]+/containers/%s/json$", containerID),
+						),
+					),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, dockerContainer.InspectResponse{
+						ID:    containerID,
+						Name:  "/test-container",
+						Image: "test-image:latest",
+						State: &dockerContainer.State{
+							Status:  "running",
+							Running: true,
+						},
+						HostConfig: &dockerContainer.HostConfig{},
+						Config: &dockerContainer.Config{
+							Image: "test-image:latest",
+						},
+					}),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(
+						"GET",
+						gomega.MatchRegexp("^/v[0-9.]+/images/test-image:latest/json$"),
+					),
+					ghttp.RespondWith(http.StatusNotFound, `{"message":"No such image"}`),
+				),
+			}
+		}
+
+		ginkgo.It("should not warn for containers excluded by the filter", func() {
+			mockServer.AppendHandlers(verifyFilters([]string{"running"}))
+			mockServer.AppendHandlers(mockMissingImage(testContainerID)...)
+
+			log, logBuf := captureLog(zerolog.WarnLevel)
+			excludeAll := filters.FilterByDisableNames(
+				log,
+				[]string{"test-container"},
+				filters.NoFilter,
+			)
+
+			containers, err := ListSourceContainers(log, context.Background(),
+				docker,
+				ClientOptions{},
+				excludeAll,
+			)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(containers).To(gomega.BeEmpty())
+			gomega.Expect(string(logBuf.Contents())).
+				ToNot(gomega.ContainSubstring("Failed to retrieve image info"))
+		})
+
+		ginkgo.It("should warn for containers that pass the filter", func() {
+			mockServer.AppendHandlers(verifyFilters([]string{"running"}))
+			mockServer.AppendHandlers(mockMissingImage(testContainerID)...)
+
+			log, logBuf := captureLog(zerolog.WarnLevel)
+
+			containers, err := ListSourceContainers(log, context.Background(),
+				docker,
+				ClientOptions{},
+				nil,
+			)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(containers).To(gomega.HaveLen(1))
+
+			logged := string(logBuf.Contents())
+			gomega.Expect(logged).To(gomega.ContainSubstring("Failed to retrieve image info"))
+			// The warning must identify the container by name, not just by ID.
+			gomega.Expect(logged).To(gomega.ContainSubstring("test-container"))
+		})
+	})
 })
 
 var _ = ginkgo.Describe("buildListFilterArgs", func() {

--- a/pkg/container/container_source_test.go
+++ b/pkg/container/container_source_test.go
@@ -218,44 +218,9 @@ var _ = ginkgo.Describe("ListSourceContainers", func() {
 	})
 
 	ginkgo.When("image inspection fails", func() {
-		// Mocks a container whose image can no longer be inspected, which happens
-		// when the image is removed out from under a running container.
-		mockMissingImage := func(containerID string) []http.HandlerFunc {
-			return []http.HandlerFunc{
-				ghttp.CombineHandlers(
-					ghttp.VerifyRequest(
-						"GET",
-						gomega.MatchRegexp(
-							fmt.Sprintf("^/v[0-9.]+/containers/%s/json$", containerID),
-						),
-					),
-					ghttp.RespondWithJSONEncoded(http.StatusOK, dockerContainer.InspectResponse{
-						ID:    containerID,
-						Name:  "/test-container",
-						Image: "test-image:latest",
-						State: &dockerContainer.State{
-							Status:  "running",
-							Running: true,
-						},
-						HostConfig: &dockerContainer.HostConfig{},
-						Config: &dockerContainer.Config{
-							Image: "test-image:latest",
-						},
-					}),
-				),
-				ghttp.CombineHandlers(
-					ghttp.VerifyRequest(
-						"GET",
-						gomega.MatchRegexp("^/v[0-9.]+/images/test-image:latest/json$"),
-					),
-					ghttp.RespondWith(http.StatusNotFound, `{"message":"No such image"}`),
-				),
-			}
-		}
-
 		ginkgo.It("should not warn for containers excluded by the filter", func() {
 			mockServer.AppendHandlers(verifyFilters([]string{"running"}))
-			mockServer.AppendHandlers(mockMissingImage(testContainerID)...)
+			mockServer.AppendHandlers(missingImageHandlers(testContainerID)...)
 
 			log, logBuf := captureLog(zerolog.WarnLevel)
 			excludeAll := filters.FilterByDisableNames(
@@ -277,7 +242,7 @@ var _ = ginkgo.Describe("ListSourceContainers", func() {
 
 		ginkgo.It("should warn for containers that pass the filter", func() {
 			mockServer.AppendHandlers(verifyFilters([]string{"running"}))
-			mockServer.AppendHandlers(mockMissingImage(testContainerID)...)
+			mockServer.AppendHandlers(missingImageHandlers(testContainerID)...)
 
 			log, logBuf := captureLog(zerolog.WarnLevel)
 
@@ -291,8 +256,9 @@ var _ = ginkgo.Describe("ListSourceContainers", func() {
 
 			logged := string(logBuf.Contents())
 			gomega.Expect(logged).To(gomega.ContainSubstring("Failed to retrieve image info"))
-			// The warning must identify the container by name, not just by ID.
+			// The warning must identify the container by name and image, not just by ID.
 			gomega.Expect(logged).To(gomega.ContainSubstring("test-container"))
+			gomega.Expect(logged).To(gomega.ContainSubstring("test-image:latest"))
 		})
 	})
 })

--- a/pkg/container/test_helpers_test.go
+++ b/pkg/container/test_helpers_test.go
@@ -1,10 +1,16 @@
 package container
 
 import (
+	"fmt"
+	"net/http"
 	"time"
 
+	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/ghttp"
 	"github.com/rs/zerolog"
+
+	dockerContainer "github.com/moby/moby/api/types/container"
 
 	"github.com/nicholas-fedor/watchtower/internal/logging"
 )
@@ -23,4 +29,42 @@ func captureLog(level zerolog.Level) (*zerolog.Logger, *gbytes.Buffer) {
 	l := zerolog.New(w).Level(level).With().Timestamp().Logger()
 
 	return &l, buf
+}
+
+// missingImageHandlers mocks a running container whose image can no longer be
+// inspected, which happens when the image is removed out from under it.
+//
+// The container inspect succeeds and the image inspect returns 404, so callers
+// end up with a container whose HasImageInfo reports false.
+func missingImageHandlers(containerID string) []http.HandlerFunc {
+	return []http.HandlerFunc{
+		ghttp.CombineHandlers(
+			ghttp.VerifyRequest(
+				"GET",
+				gomega.MatchRegexp(
+					fmt.Sprintf("^/v[0-9.]+/containers/%s/json$", containerID),
+				),
+			),
+			ghttp.RespondWithJSONEncoded(http.StatusOK, dockerContainer.InspectResponse{
+				ID:    containerID,
+				Name:  "/test-container",
+				Image: "test-image:latest",
+				State: &dockerContainer.State{
+					Status:  "running",
+					Running: true,
+				},
+				HostConfig: &dockerContainer.HostConfig{},
+				Config: &dockerContainer.Config{
+					Image: "test-image:latest",
+				},
+			}),
+		),
+		ghttp.CombineHandlers(
+			ghttp.VerifyRequest(
+				"GET",
+				gomega.MatchRegexp("^/v[0-9.]+/images/test-image:latest/json$"),
+			),
+			ghttp.RespondWith(http.StatusNotFound, `{"message":"No such image"}`),
+		),
+	}
 }


### PR DESCRIPTION
The `Failed to retrieve image info` warning is emitted by `GetSourceContainer`, which runs while the container list is being built — before any filter is applied. Containers excluded via `--disable-containers`, `--scope`, label filters and friends therefore still produce warning-level output on every cycle. With `--notifications-level warn`, that becomes a notification per cycle about containers the user has explicitly opted out of monitoring.

## Problem

This is easy to hit when a container references an image that no longer resolves — for example after the image is rebuilt, or removed out from under a running container. Adding the container to `--disable-containers` does not silence it, because exclusion happens after the warning has already been logged.

Observed on 1.20.3 with two excluded containers, `--notifications-level warn`, and nothing else wrong:

```
level=warning msg="Failed to retrieve image info" container_id=1e2b9e0462... error="Error response from daemon: No such image: sha256:68691186b81b..."
level=warning msg="Failed to retrieve image info" container_id=370762c298... error="Error response from daemon: No such image: sha256:34672fac7017..."
```

Note the message carries only `container_id` — no container name and no image — so the notification gives the operator nothing actionable to grep for.

## Solution

Log the failure at debug level in `GetSourceContainer`, and re-emit it at warning level from the two call sites that know the container is actually monitored:

- `ListSourceContainers`, after the filter has accepted the container.
- `client.GetContainer`, which is only reached for containers already being acted upon (lifecycle hooks, post-update lookups, ephemeral handling).

The warning now also carries the container name and image name.

## Changes

- `pkg/container/container_source.go` — demote the warning in `GetSourceContainer` to debug; emit it post-filter in `ListSourceContainers`.
- `pkg/container/client.go` — emit it in `GetContainer`, preserving current behavior for direct lookups.
- `pkg/container/container_source_test.go` — two specs: an excluded container with an uninspectable image produces no warning, and a monitored one still does, carrying its name.

## Behavior

Unchanged for monitored containers: same message, same level, plus two extra fields. Only containers the user has already excluded go quiet.

## Verification

- `go build ./...`, `go vet ./pkg/container/...`
- `golangci-lint run --config build/golangci-lint/golangci-lint.yaml ./pkg/container/...` — 0 issues
- `go test ./...` — `pkg/container` 520 specs pass, 0 skipped
- Reverting the source change makes the new test fail, confirming it covers the reported behavior

Unrelated: `TestContainerLookupWithTimeoutContext` in `cmd` fails on a pristine checkout of `main` at 9f67809 as well, so it is not affected by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warnings when container image metadata is unavailable, including relevant container details.
  * Prevented misleading image warnings for containers excluded by configured filters.
  * Reduced unnecessary log noise when image inspection fails while retaining fallback container behavior.
* **Tests**
  * Added coverage for filtered containers and image inspection failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->