### PR TITLE
fix(notifications): remove redundant type field from deprecation warnings

### DIFF
--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -556,7 +556,6 @@ func LogLegacyDeprecationWarnings(log *zerolog.Logger, notificationTypes []strin
 		switch notificationType {
 		case emailType, slackType, msTeamsType, gotifyType:
 			log.Warn().
-				Str("type", notificationType).
 				Msgf("Using deprecated legacy %s notification configuration. "+
 					"Use the notification-url configuration option instead.",
 					notificationType)


### PR DESCRIPTION
This PR removes a redundant field from the deprecation warning.

## Problem

When Watchtower sends a deprecated legacy notification warning, it includes the structured type in the notification.

## Solution

Removed the redundant type from the structured logging, as the notification type is already included in the message.

## Changes

- Removed the structured notification type from the warning log entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified deprecation warning log output by removing an unnecessary structured field.
  * Preserved the existing warning message and notification-type details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->