### PR TITLE
perf: reduce scan-cycle memory allocations

### DIFF
--- a/internal/actions/ephemeral.go
+++ b/internal/actions/ephemeral.go
@@ -414,6 +414,8 @@ func orchestrateSelfUpdate(log *zerolog.Logger, ctx context.Context,
 // pinContainerCreateImage sets Config.Image on a concrete container.Container so
 // GetCreateConfig uses newImage for the replacement instance.
 //
+// SetImageName also updates the cached ImageName used after the pin.
+//
 // Parameters:
 //   - oldContainer: Source container whose create config is pinned.
 //   - newImage: Image reference to use when creating the replacement.
@@ -435,7 +437,7 @@ func pinContainerCreateImage(oldContainer types.Container, newImage string, clog
 		return
 	}
 
-	info.Config.Image = newImage
+	c.SetImageName(newImage)
 	clog.Debug().
 		Str("pinned_image", newImage).
 		Msg("Pinned create image for ephemeral self-update")

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -295,7 +295,7 @@ func Update(log *zerolog.Logger, ctx context.Context,
 	// Run pre-check lifecycle hooks if enabled to validate the environment before updates.
 	if config.LifecycleHooks {
 		log.Debug().Msg("Executing pre-check lifecycle hooks")
-		lifecycle.ExecutePreChecks(log, ctx, client, config)
+		lifecycle.ExecutePreChecks(log, ctx, client, config, allContainers)
 	}
 
 	// Filter containers based on the provided filter (e.g., all, specific names).
@@ -778,7 +778,7 @@ func Update(log *zerolog.Logger, ctx context.Context,
 	// Run post-check lifecycle hooks if enabled to finalize the update process.
 	if config.LifecycleHooks {
 		log.Debug().Msg("Executing post-check lifecycle hooks")
-		lifecycle.ExecutePostChecks(log, ctx, client, config)
+		lifecycle.ExecutePostChecks(log, ctx, client, config, allContainers)
 	}
 
 	// Add safeguard delay if Watchtower self-update pull failed

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -292,19 +292,21 @@ func Update(log *zerolog.Logger, ctx context.Context,
 	// Track if Watchtower self-update pull failed to add safeguard delay.
 	var watchtowerPullFailed bool
 
-	// Run pre-check lifecycle hooks if enabled to validate the environment before updates.
-	if config.LifecycleHooks {
-		log.Debug().Msg("Executing pre-check lifecycle hooks")
-		lifecycle.ExecutePreChecks(log, ctx, client, config, allContainers)
-	}
-
 	// Filter containers based on the provided filter (e.g., all, specific names).
-	var filteredContainers []types.Container
+	// Use a non-nil empty slice so lifecycle hooks can distinguish a valid empty
+	// snapshot from an uninitialized list.
+	filteredContainers := make([]types.Container, 0, len(allContainers))
 
 	for _, c := range allContainers {
 		if config.Filter == nil || config.Filter(c) {
 			filteredContainers = append(filteredContainers, c)
 		}
+	}
+
+	// Run pre-check lifecycle hooks if enabled to validate the environment before updates.
+	if config.LifecycleHooks {
+		log.Debug().Msg("Executing pre-check lifecycle hooks")
+		lifecycle.ExecutePreChecks(log, ctx, client, config, filteredContainers)
 	}
 
 	// Prepare a list of container names and images for detailed debugging output.
@@ -778,7 +780,7 @@ func Update(log *zerolog.Logger, ctx context.Context,
 	// Run post-check lifecycle hooks if enabled to finalize the update process.
 	if config.LifecycleHooks {
 		log.Debug().Msg("Executing post-check lifecycle hooks")
-		lifecycle.ExecutePostChecks(log, ctx, client, config, allContainers)
+		lifecycle.ExecutePostChecks(log, ctx, client, config, filteredContainers)
 	}
 
 	// Add safeguard delay if Watchtower self-update pull failed

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -41,6 +41,9 @@ const (
 	// maxListRetries is the maximum number of retry attempts for transient Docker
 	// connection failures when listing containers.
 	maxListRetries = 3
+
+	// maxExecOutputSize is the maximum captured exec stdout/stderr size (1 MiB).
+	maxExecOutputSize = 1 << 20
 )
 
 // baseListRetryDelay is the base delay for exponential backoff between retries.
@@ -1777,13 +1780,18 @@ func (c *client) captureExecOutput(ctx context.Context, execID string) (string, 
 
 	defer response.Close()
 
-	// Read output into a buffer with timeout.
+	// Read output into a buffer with timeout and a size cap.
 	var writer bytes.Buffer
 
 	done := make(chan error, 1)
 
 	go func() {
-		_, err := io.Copy(&writer, response.Reader)
+		_, err := io.Copy(
+			&writer,
+			io.LimitReader(
+				response.Reader,
+				maxExecOutputSize,
+			))
 		done <- err
 	}()
 

--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -1327,7 +1327,7 @@ var _ = ginkgo.Describe("the client", func() {
 			client := &client{log: testLog(), api: hijackClient}
 			out, err := client.captureExecOutput(context.Background(), "exec-id")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(len(out)).To(gomega.BeNumerically("<=", maxExecOutputSize))
+			gomega.Expect(out).To(gomega.HaveLen(maxExecOutputSize))
 		})
 	})
 

--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -1284,6 +1286,48 @@ var _ = ginkgo.Describe("the client", func() {
 
 			_, err := client.captureExecOutput(ctx, "exec-id")
 			gomega.Expect(err).To(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should truncate output that exceeds the size cap", func() {
+			mockServer.AppendHandlers(ghttp.CombineHandlers(
+				ghttp.VerifyRequest("POST", gomega.MatchRegexp(`^/v[0-9.]+/exec/exec-id/start$`)),
+				func(writer http.ResponseWriter, req *http.Request) {
+					_, _ = io.Copy(io.Discard, req.Body)
+
+					hijacker, ok := writer.(http.Hijacker)
+					gomega.Expect(ok).To(gomega.BeTrue())
+
+					conn, bufWriter, err := hijacker.Hijack()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					defer conn.Close()
+
+					_, _ = bufWriter.WriteString("HTTP/1.1 101 UPGRADED\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n\r\n")
+					_, _ = bufWriter.WriteString(strings.Repeat("x", maxExecOutputSize+4096))
+					_ = bufWriter.Flush()
+
+					if tcpConn, ok := conn.(*net.TCPConn); ok {
+						_ = tcpConn.CloseWrite()
+					}
+				},
+			))
+
+			// ExecAttach hijacks the TCP connection. The suite client uses an http://
+			// host, which the Docker dialer cannot hijack. Use tcp:// against the same
+			// ghttp server.
+			serverURL, err := url.Parse(mockServer.URL())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			hijackClient, err := dockerClient.New(
+				dockerClient.WithHost("tcp://"+serverURL.Host),
+				dockerClient.WithHTTPClient(mockServer.HTTPTestServer.Client()),
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			client := &client{log: testLog(), api: hijackClient}
+			out, err := client.captureExecOutput(context.Background(), "exec-id")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(len(out)).To(gomega.BeNumerically("<=", maxExecOutputSize))
 		})
 	})
 

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -76,6 +76,7 @@ type Container struct {
 	Stale              bool                             // Marks the container as having an outdated image
 	OldImageID         types.ImageID                    // Stores the image ID before update for cleanup tracking
 	normalizedName     string                           // Cached normalized container name
+	imageName          string                           // Cached resolved image name with tag
 	containerInfo      *dockerContainer.InspectResponse // Docker container metadata
 	imageInfo          *dockerImage.InspectResponse     // Docker image metadata
 	// log is the process logger for operational Warn/Error/Debug on this instance.
@@ -86,7 +87,10 @@ type Container struct {
 
 // NewContainer creates a new Container instance with the specified metadata.
 //
+// The resolved image name is cached so later ImageName calls do not recompute it.
+//
 // Parameters:
+//   - log: Process logger. A nop logger is used when nil.
 //   - containerInfo: Docker container metadata.
 //   - imageInfo: Docker image metadata.
 //
@@ -115,6 +119,8 @@ func NewContainer(
 		imageInfo:          imageInfo,
 		log:                log,
 	}
+	// Cache the resolved image name at construct time.
+	c.imageName = c.resolveImageName()
 	c.logger().Debug().
 		Str("container", c.Name()).
 		Str("id", c.ID().ShortID()).
@@ -270,45 +276,48 @@ func (c *Container) ImageID() types.ImageID {
 	return types.ImageID(c.imageInfo.ID)
 }
 
-// ImageName returns the name of the container's image.
+// ImageName returns the cached name of the container's image.
 //
-// It uses the Zodiac label if present, otherwise Config.Image, appending ":latest" if untagged.
+// The value is resolved once in NewContainer from the Zodiac label or Config.Image.
+// When containerInfo is later cleared, the name is resolved again.
 //
 // Returns:
 //   - string: Image name (e.g., "alpine:latest").
 func (c *Container) ImageName() string {
-	clogVal := c.logger().With().
-		Str("container", c.Name()).
-		Logger()
-	clog := &clogVal
-
-	// Prefer Zodiac label for image name.
-	imageName, ok := c.getLabelValue(zodiacLabel)
-	if !ok {
-		if c.containerInfo == nil || c.containerInfo.Config == nil {
-			clog.Warn().Msg("No container config available, using default image name")
-
-			return "unknown:latest"
-		}
-
-		imageName = c.containerInfo.Config.Image
-
-		clog.Debug().Msg("Using Config.Image for image name")
-	} else {
-		clog.Debug().
-			Str("label", zodiacLabel).
-			Msg("Using Zodiac label for image name")
+	if c == nil {
+		return "unknown:latest"
 	}
 
-	// Append default tag if none specified.
-	if !strings.Contains(imageName, ":") {
-		imageName += ":latest"
-		clog.Debug().
-			Str("image", imageName).
-			Msg("Appended :latest to image name")
+	// Re-resolve when inspect data was cleared after construction.
+	if c.containerInfo == nil {
+		return c.resolveImageName()
 	}
 
-	return imageName
+	return c.imageName
+}
+
+// SetImageName updates Config.Image and the cached image name used by ImageName.
+//
+// An untagged name receives a ":latest" suffix so ImageName stays consistent
+// with resolveImageName.
+//
+// Parameters:
+//   - name: Image reference to store.
+func (c *Container) SetImageName(name string) {
+	if c == nil {
+		return
+	}
+
+	// Keep Config.Image in sync so GetCreateConfig uses the pinned reference.
+	if c.containerInfo != nil && c.containerInfo.Config != nil {
+		c.containerInfo.Config.Image = name
+	}
+
+	c.imageName = name
+	// Append the default tag if none was specified.
+	if !strings.Contains(c.imageName, ":") {
+		c.imageName += ":latest"
+	}
 }
 
 // HasImageInfo indicates whether image metadata is available.
@@ -690,6 +699,35 @@ func (c *Container) Links(useComposeDependsOn bool) []string {
 	links := getLinksFromHostConfig(c, clog)
 
 	return filterSelfReferences(links, c.Name())
+}
+
+// resolveImageName computes the image name from the Zodiac label or Config.Image.
+//
+// An untagged name receives a ":latest" suffix. Missing config yields "unknown:latest".
+//
+// Returns:
+//   - string: Image name with a tag (e.g., "alpine:latest").
+func (c *Container) resolveImageName() string {
+	// Prefer the Zodiac label for the image name.
+	imageName, ok := c.getLabelValue(zodiacLabel)
+	if !ok {
+		if c.containerInfo == nil || c.containerInfo.Config == nil {
+			c.logger().Warn().
+				Str("container", c.Name()).
+				Msg("No container config available, using default image name")
+
+			return "unknown:latest"
+		}
+
+		imageName = c.containerInfo.Config.Image
+	}
+
+	// Append the default tag if none was specified.
+	if !strings.Contains(imageName, ":") {
+		imageName += ":latest"
+	}
+
+	return imageName
 }
 
 // logger returns the container's process logger, or a discarded nop if unset.

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -280,6 +280,7 @@ func (c *Container) ImageID() types.ImageID {
 //
 // The value is resolved once in NewContainer from the Zodiac label or Config.Image.
 // When containerInfo is later cleared, the name is resolved again.
+// Callers that already hold c.mu must use imageNameLocked.
 //
 // Returns:
 //   - string: Image name (e.g., "alpine:latest").
@@ -288,12 +289,10 @@ func (c *Container) ImageName() string {
 		return "unknown:latest"
 	}
 
-	// Re-resolve when inspect data was cleared after construction.
-	if c.containerInfo == nil {
-		return c.resolveImageName()
-	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
-	return c.imageName
+	return c.imageNameLocked()
 }
 
 // SetImageName updates Config.Image and the cached image name used by ImageName.
@@ -307,6 +306,9 @@ func (c *Container) SetImageName(name string) {
 	if c == nil {
 		return
 	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	normalized := ensureImageTag(name)
 
@@ -352,7 +354,7 @@ func (c *Container) GetCreateConfig() *dockerContainer.Config {
 	if c.containerInfo == nil {
 		clog.Warn().Msg("No container info available, returning minimal config")
 
-		return &dockerContainer.Config{Image: c.ImageName()}
+		return &dockerContainer.Config{Image: c.imageNameLocked()}
 	}
 
 	config := *c.containerInfo.Config
@@ -362,7 +364,7 @@ func (c *Container) GetCreateConfig() *dockerContainer.Config {
 	if c.imageInfo == nil {
 		clog.Warn().Msg("No image info available, using container config as-is")
 
-		config.Image = c.ImageName()
+		config.Image = c.imageNameLocked()
 
 		return &config
 	}
@@ -448,7 +450,7 @@ func (c *Container) GetCreateConfig() *dockerContainer.Config {
 		config.ExposedPorts[p] = struct{}{} // Add ports from bindings.
 	}
 
-	config.Image = c.ImageName()
+	config.Image = c.imageNameLocked()
 	clog.Debug().
 		Str("image", config.Image).
 		Msg("Generated create config")
@@ -697,6 +699,16 @@ func (c *Container) Links(useComposeDependsOn bool) []string {
 	links := getLinksFromHostConfig(c, clog)
 
 	return filterSelfReferences(links, c.Name())
+}
+
+// imageNameLocked returns the cached image name. The caller must hold c.mu.
+func (c *Container) imageNameLocked() string {
+	// Re-resolve when inspect data was cleared after construction.
+	if c.containerInfo == nil {
+		return c.resolveImageName()
+	}
+
+	return c.imageName
 }
 
 // resolveImageName computes the image name from the Zodiac label or Config.Image.

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -299,7 +299,7 @@ func (c *Container) ImageName() string {
 // SetImageName updates Config.Image and the cached image name used by ImageName.
 //
 // An untagged name receives a ":latest" suffix so ImageName stays consistent
-// with resolveImageName.
+// with resolveImageName. Registry host ports are not treated as tags.
 //
 // Parameters:
 //   - name: Image reference to store.
@@ -308,16 +308,14 @@ func (c *Container) SetImageName(name string) {
 		return
 	}
 
+	normalized := ensureImageTag(name)
+
 	// Keep Config.Image in sync so GetCreateConfig uses the pinned reference.
 	if c.containerInfo != nil && c.containerInfo.Config != nil {
-		c.containerInfo.Config.Image = name
+		c.containerInfo.Config.Image = normalized
 	}
 
-	c.imageName = name
-	// Append the default tag if none was specified.
-	if !strings.Contains(c.imageName, ":") {
-		c.imageName += ":latest"
-	}
+	c.imageName = normalized
 }
 
 // HasImageInfo indicates whether image metadata is available.
@@ -722,12 +720,30 @@ func (c *Container) resolveImageName() string {
 		imageName = c.containerInfo.Config.Image
 	}
 
-	// Append the default tag if none was specified.
-	if !strings.Contains(imageName, ":") {
-		imageName += ":latest"
+	return ensureImageTag(imageName)
+}
+
+// ensureImageTag appends ":latest" when the reference has no tag.
+//
+// A colon in the registry host (for example "registry.example:5000/app") is
+// not treated as a tag.
+//
+// Parameters:
+//   - name: Image reference to normalize.
+//
+// Returns:
+//   - string: Image name with a tag.
+func ensureImageTag(name string) string {
+	if name == "" {
+		return "unknown:latest"
 	}
 
-	return imageName
+	slash := strings.LastIndex(name, "/")
+	if strings.Contains(name[slash+1:], ":") {
+		return name
+	}
+
+	return name + ":latest"
 }
 
 // logger returns the container's process logger, or a discarded nop if unset.

--- a/pkg/container/container_source.go
+++ b/pkg/container/container_source.go
@@ -12,6 +12,7 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	dockerContainer "github.com/moby/moby/api/types/container"
+	dockerImage "github.com/moby/moby/api/types/image"
 	dockerNetwork "github.com/moby/moby/api/types/network"
 	dockerClient "github.com/moby/moby/client"
 	dockerAPIVersion "github.com/moby/moby/client/pkg/versions"
@@ -103,10 +104,12 @@ func ListSourceContainers(log *zerolog.Logger,
 	}
 
 	// Convert and filter containers.
-	hostContainers := []types.Container{}
+	hostContainers := make([]types.Container, 0, len(containers.Items))
+	// Reuse ImageInspect results when multiple containers share an image ID.
+	imageCache := make(map[string]*dockerImage.InspectResponse, len(containers.Items))
 
 	for _, runningContainer := range containers.Items {
-		container, err := GetSourceContainer(log, ctx, api, types.ContainerID(runningContainer.ID))
+		container, err := getSourceContainer(log, ctx, api, types.ContainerID(runningContainer.ID), imageCache)
 		if err != nil {
 			// Log detailed error information for debugging container inspect failures
 			log.Debug().
@@ -154,6 +157,7 @@ func ListSourceContainers(log *zerolog.Logger,
 // It resolves network mode if it references another container.
 //
 // Parameters:
+//   - log: Logger for debug output.
 //   - ctx: Context for cancellation and timeout control.
 //   - api: Docker API client.
 //   - containerID: ID of the container to inspect.
@@ -166,6 +170,28 @@ func GetSourceContainer(log *zerolog.Logger,
 	api dockerClient.APIClient,
 	containerID types.ContainerID,
 ) (types.Container, error) {
+	// No per-list cache for standalone inspects.
+	return getSourceContainer(log, ctx, api, containerID, nil)
+}
+
+// getSourceContainer inspects a container and optionally reuses ImageInspect results.
+//
+// Parameters:
+//   - log: Logger for debug output.
+//   - ctx: Context for cancellation and timeout control.
+//   - api: Docker API client.
+//   - containerID: ID of the container to inspect.
+//   - imageCache: Optional per-list cache of ImageInspect results keyed by image ID.
+//
+// Returns:
+//   - types.Container: Container object if successful.
+//   - error: Non-nil if inspection fails, nil on success.
+func getSourceContainer(log *zerolog.Logger,
+	ctx context.Context,
+	api dockerClient.APIClient,
+	containerID types.ContainerID,
+	imageCache map[string]*dockerImage.InspectResponse,
+) (types.Container, error) {
 	clogVal := log.With().
 		Str("container_id", string(containerID)).
 		Logger()
@@ -174,7 +200,11 @@ func GetSourceContainer(log *zerolog.Logger,
 	clog.Debug().Msg("Inspecting container")
 
 	// Inspect the container to get its details.
-	containerResult, err := api.ContainerInspect(ctx, string(containerID), dockerClient.ContainerInspectOptions{})
+	containerResult, err := api.ContainerInspect(
+		ctx,
+		string(containerID),
+		dockerClient.ContainerInspectOptions{},
+	)
 	if err != nil {
 		// Log detailed error information for debugging
 		clog.Debug().
@@ -197,7 +227,10 @@ func GetSourceContainer(log *zerolog.Logger,
 	if containerInfo.HostConfig != nil {
 		netType, netContainerID, found := strings.Cut(string(containerInfo.HostConfig.NetworkMode), ":")
 		if found && netType == "container" {
-			parentResult, err := api.ContainerInspect(ctx, netContainerID, dockerClient.ContainerInspectOptions{})
+			parentResult, err := api.ContainerInspect(ctx,
+				netContainerID,
+				dockerClient.ContainerInspectOptions{},
+			)
 			if err != nil {
 				clog.Warn().
 					Err(err).
@@ -216,6 +249,15 @@ func GetSourceContainer(log *zerolog.Logger,
 		}
 	}
 
+	cached, ok := imageCache[containerInfo.Image]
+	if ok {
+		clog.Debug().
+			Str("image", containerInfo.Image).
+			Msg("Retrieved container and image info")
+
+		return NewContainer(log, containerInfo, cached), nil
+	}
+
 	// Fetch image info, falling back if it fails.
 	imageResult, err := api.ImageInspect(ctx, containerInfo.Image)
 	if err != nil {
@@ -228,11 +270,17 @@ func GetSourceContainer(log *zerolog.Logger,
 		return NewContainer(log, containerInfo, nil), nil
 	}
 
+	imageInfo := &imageResult.InspectResponse
+	if imageCache != nil {
+		// Store successful inspects so later containers with the same image skip the API.
+		imageCache[containerInfo.Image] = imageInfo
+	}
+
 	clog.Debug().
 		Str("image", containerInfo.Image).
 		Msg("Retrieved container and image info")
 
-	return NewContainer(log, containerInfo, &imageResult.InspectResponse), nil
+	return NewContainer(log, containerInfo, imageInfo), nil
 }
 
 // StopSourceContainer stops the specified container using the Docker API's StopContainer method.
@@ -410,10 +458,13 @@ func StopAndRemoveSourceContainer(log *zerolog.Logger,
 
 	// Call the Docker API's ContainerRemove to delete the container, forcing termination of any
 	// lingering processes (via SIGKILL if needed) and removing volumes if specified.
-	_, err = api.ContainerRemove(ctx, string(sourceContainer.ID()), dockerClient.ContainerRemoveOptions{
-		Force:         true,          // Ensure any lingering processes are terminated before removal.
-		RemoveVolumes: removeVolumes, // Remove associated volumes if the parameter is true.
-	})
+	_, err = api.ContainerRemove(
+		ctx,
+		string(sourceContainer.ID()),
+		dockerClient.ContainerRemoveOptions{
+			Force:         true,          // Ensure any lingering processes are terminated before removal.
+			RemoveVolumes: removeVolumes, // Remove associated volumes if the parameter is true.
+		})
 	if err != nil && !cerrdefs.IsNotFound(err) {
 		// Log removal failure with elapsed time and error details, excluding cases where the container
 		// was already removed by another process.
@@ -576,7 +627,8 @@ func newEmptyNetworkConfig() *dockerNetwork.NetworkingConfig {
 
 // processEndpoint sanitizes a single network endpoint for the target container.
 //
-// It filters aliases, copies IPAM config, and handles MAC addresses based on API version and network mode. Returns an error if sourceEndpoint is nil.
+// It filters aliases, copies IPAM config, and handles MAC addresses based on API
+// version and network mode. Returns an error if sourceEndpoint is nil.
 //
 // Parameters:
 //   - sourceEndpoint: Source endpoint to process.

--- a/pkg/container/container_source.go
+++ b/pkg/container/container_source.go
@@ -3,6 +3,7 @@ package container
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/netip"
 	"os"
 	"slices"
@@ -250,18 +251,7 @@ func getSourceContainer(log *zerolog.Logger,
 		}
 	}
 
-	cached, ok := imageCache[containerInfo.Image]
-	if ok {
-		clog.Debug().
-			Str("image", containerInfo.Image).
-			Msg("Retrieved container and image info")
-
-		// Clone so later mutations cannot affect other containers sharing the cache.
-		return NewContainer(log, containerInfo, cloneImageInspect(cached)), nil
-	}
-
-	// Fetch image info, falling back if it fails.
-	imageResult, err := api.ImageInspect(ctx, containerInfo.Image)
+	imageInfo, err := resolveImageInspect(ctx, api, containerInfo.Image, imageCache)
 	if err != nil {
 		clog.Debug().
 			Err(err).
@@ -272,18 +262,47 @@ func getSourceContainer(log *zerolog.Logger,
 		return NewContainer(log, containerInfo, nil), nil
 	}
 
-	imageInfo := &imageResult.InspectResponse
-	if imageCache != nil {
-		// Store successful inspects so later containers with the same image skip the API.
-		imageCache[containerInfo.Image] = imageInfo
-		imageInfo = cloneImageInspect(imageInfo)
-	}
-
 	clog.Debug().
 		Str("image", containerInfo.Image).
 		Msg("Retrieved container and image info")
 
 	return NewContainer(log, containerInfo, imageInfo), nil
+}
+
+// resolveImageInspect returns image inspect metadata, using imageCache when set.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeout control.
+//   - api: Docker API client.
+//   - imageID: Image ID or name to inspect.
+//   - imageCache: Optional per-list cache of ImageInspect results.
+//
+// Returns:
+//   - *dockerImage.InspectResponse: Isolated inspect metadata, or nil on inspect failure.
+//   - error: Non-nil if ImageInspect fails.
+func resolveImageInspect(
+	ctx context.Context,
+	api dockerClient.APIClient,
+	imageID string,
+	imageCache map[string]*dockerImage.InspectResponse,
+) (*dockerImage.InspectResponse, error) {
+	if cached, ok := imageCache[imageID]; ok {
+		return cloneImageInspect(cached), nil
+	}
+
+	imageResult, err := api.ImageInspect(ctx, imageID)
+	if err != nil {
+		return nil, fmt.Errorf("inspect image: %w", err)
+	}
+
+	imageInfo := &imageResult.InspectResponse
+	if imageCache != nil {
+		imageCache[imageID] = imageInfo
+
+		return cloneImageInspect(imageInfo), nil
+	}
+
+	return imageInfo, nil
 }
 
 // cloneImageInspect returns an independent copy of image inspect metadata.
@@ -309,11 +328,27 @@ func cloneImageInspect(src *dockerImage.InspectResponse) *dockerImage.InspectRes
 
 	if src.Config != nil {
 		cfg := *src.Config
+		cfg.Env = slices.Clone(src.Config.Env)
+		cfg.Cmd = slices.Clone(src.Config.Cmd)
+		cfg.Entrypoint = slices.Clone(src.Config.Entrypoint)
+		cfg.OnBuild = slices.Clone(src.Config.OnBuild)
+		cfg.Shell = slices.Clone(src.Config.Shell)
+		cfg.Labels = maps.Clone(src.Config.Labels)
+		cfg.Volumes = maps.Clone(src.Config.Volumes)
+		cfg.ExposedPorts = maps.Clone(src.Config.ExposedPorts)
+
+		if src.Config.Healthcheck != nil {
+			health := *src.Config.Healthcheck
+			health.Test = slices.Clone(src.Config.Healthcheck.Test)
+			cfg.Healthcheck = &health
+		}
+
 		dst.Config = &cfg
 	}
 
 	if src.GraphDriver != nil {
 		driver := *src.GraphDriver
+		driver.Data = maps.Clone(src.GraphDriver.Data)
 		dst.GraphDriver = &driver
 	}
 

--- a/pkg/container/container_source.go
+++ b/pkg/container/container_source.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/netip"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -255,7 +256,8 @@ func getSourceContainer(log *zerolog.Logger,
 			Str("image", containerInfo.Image).
 			Msg("Retrieved container and image info")
 
-		return NewContainer(log, containerInfo, cached), nil
+		// Clone so later mutations cannot affect other containers sharing the cache.
+		return NewContainer(log, containerInfo, cloneImageInspect(cached)), nil
 	}
 
 	// Fetch image info, falling back if it fails.
@@ -274,6 +276,7 @@ func getSourceContainer(log *zerolog.Logger,
 	if imageCache != nil {
 		// Store successful inspects so later containers with the same image skip the API.
 		imageCache[containerInfo.Image] = imageInfo
+		imageInfo = cloneImageInspect(imageInfo)
 	}
 
 	clog.Debug().
@@ -281,6 +284,50 @@ func getSourceContainer(log *zerolog.Logger,
 		Msg("Retrieved container and image info")
 
 	return NewContainer(log, containerInfo, imageInfo), nil
+}
+
+// cloneImageInspect returns an independent copy of image inspect metadata.
+//
+// Slice and nested pointer fields are duplicated so the cached original stays
+// read-only for other containers.
+//
+// Parameters:
+//   - src: Cached inspect response, or nil.
+//
+// Returns:
+//   - *dockerImage.InspectResponse: Isolated copy, or nil when src is nil.
+func cloneImageInspect(src *dockerImage.InspectResponse) *dockerImage.InspectResponse {
+	if src == nil {
+		return nil
+	}
+
+	dst := *src
+	dst.RepoTags = slices.Clone(src.RepoTags)
+	dst.RepoDigests = slices.Clone(src.RepoDigests)
+	dst.RootFS.Layers = slices.Clone(src.RootFS.Layers)
+	dst.Manifests = slices.Clone(src.Manifests)
+
+	if src.Config != nil {
+		cfg := *src.Config
+		dst.Config = &cfg
+	}
+
+	if src.GraphDriver != nil {
+		driver := *src.GraphDriver
+		dst.GraphDriver = &driver
+	}
+
+	if src.Descriptor != nil {
+		desc := *src.Descriptor
+		dst.Descriptor = &desc
+	}
+
+	if src.Identity != nil {
+		identity := *src.Identity
+		dst.Identity = &identity
+	}
+
+	return &dst
 }
 
 // StopSourceContainer stops the specified container using the Docker API's StopContainer method.

--- a/pkg/container/container_source_test.go
+++ b/pkg/container/container_source_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/netip"
+	"testing"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -2833,4 +2834,25 @@ func getStatusFilterKeys(f dockerClient.Filters) []string {
 	}
 
 	return keys
+}
+
+func TestCloneImageInspect_IsolatesMutations(t *testing.T) {
+	t.Parallel()
+
+	src := &dockerImage.InspectResponse{
+		ID:          "sha256:abc",
+		RepoDigests: []string{"app@sha256:abc"},
+		RepoTags:    []string{"app:latest"},
+	}
+
+	cloned := cloneImageInspect(src)
+	require.NotNil(t, cloned)
+	require.NotSame(t, src, cloned)
+
+	cloned.RepoDigests[0] = "app@sha256:mutated"
+	cloned.RepoTags = append(cloned.RepoTags, "app:dev")
+
+	require.Equal(t, []string{"app@sha256:abc"}, src.RepoDigests)
+	require.Equal(t, []string{"app:latest"}, src.RepoTags)
+	require.Nil(t, cloneImageInspect(nil))
 }

--- a/pkg/container/container_source_test.go
+++ b/pkg/container/container_source_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/moby/moby/api/types/storage"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -16,10 +17,12 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	dockerContainer "github.com/moby/moby/api/types/container"
 	dockerImage "github.com/moby/moby/api/types/image"
 	dockerNetwork "github.com/moby/moby/api/types/network"
 	dockerClient "github.com/moby/moby/client"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/nicholas-fedor/watchtower/pkg/filters"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
@@ -2843,6 +2846,25 @@ func TestCloneImageInspect_IsolatesMutations(t *testing.T) {
 		ID:          "sha256:abc",
 		RepoDigests: []string{"app@sha256:abc"},
 		RepoTags:    []string{"app:latest"},
+		Config: &dockerspec.DockerOCIImageConfig{
+			ImageConfig: ocispec.ImageConfig{
+				Env:        []string{"PATH=/usr/bin"},
+				Cmd:        []string{"app"},
+				Entrypoint: []string{"/bin/sh"},
+				Labels:     map[string]string{"app": "web"},
+				Volumes:    map[string]struct{}{"/data": {}},
+				ExposedPorts: map[string]struct{}{
+					"80/tcp": {},
+				},
+			},
+			DockerOCIImageConfigExt: dockerspec.DockerOCIImageConfigExt{
+				Healthcheck: &dockerspec.HealthcheckConfig{Test: []string{"CMD", "true"}},
+			},
+		},
+		GraphDriver: &storage.DriverData{
+			Name: "overlay2",
+			Data: map[string]string{"MergedDir": "/var/lib/docker/overlay2/abc"},
+		},
 	}
 
 	cloned := cloneImageInspect(src)
@@ -2851,8 +2873,24 @@ func TestCloneImageInspect_IsolatesMutations(t *testing.T) {
 
 	cloned.RepoDigests[0] = "app@sha256:mutated"
 	cloned.RepoTags = append(cloned.RepoTags, "app:dev")
+	cloned.Config.Env[0] = "PATH=/mutated"
+	cloned.Config.Cmd[0] = "mutated"
+	cloned.Config.Entrypoint[0] = "/bin/mutated"
+	cloned.Config.Labels["app"] = "mutated"
+	cloned.Config.Volumes["/tmp"] = struct{}{}
+	delete(cloned.Config.ExposedPorts, "80/tcp")
+	cloned.Config.Healthcheck.Test[0] = "NONE"
+	cloned.GraphDriver.Data["MergedDir"] = "/mutated"
 
 	require.Equal(t, []string{"app@sha256:abc"}, src.RepoDigests)
 	require.Equal(t, []string{"app:latest"}, src.RepoTags)
+	require.Equal(t, []string{"PATH=/usr/bin"}, src.Config.Env)
+	require.Equal(t, []string{"app"}, src.Config.Cmd)
+	require.Equal(t, []string{"/bin/sh"}, src.Config.Entrypoint)
+	require.Equal(t, map[string]string{"app": "web"}, src.Config.Labels)
+	require.Equal(t, map[string]struct{}{"/data": {}}, src.Config.Volumes)
+	require.Equal(t, map[string]struct{}{"80/tcp": {}}, src.Config.ExposedPorts)
+	require.Equal(t, []string{"CMD", "true"}, src.Config.Healthcheck.Test)
+	require.Equal(t, "/var/lib/docker/overlay2/abc", src.GraphDriver.Data["MergedDir"])
 	require.Nil(t, cloneImageInspect(nil))
 }

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -396,8 +396,22 @@ var _ = ginkgo.Describe("Container", func() {
 
 				container.SetImageName("app")
 
-				gomega.Expect(container.ContainerInfo().Config.Image).To(gomega.Equal("app"))
+				gomega.Expect(container.ContainerInfo().Config.Image).To(gomega.Equal("app:latest"))
 				gomega.Expect(container.ImageName()).To(gomega.Equal("app:latest"))
+			})
+
+			ginkgo.It("appends latest without treating a registry port as a tag", func() {
+				container = NewContainer(testLog(), &dockerContainer.InspectResponse{
+					Name: "/app",
+					Config: &dockerContainer.Config{
+						Image: "app:v1",
+					},
+				}, nil)
+
+				container.SetImageName("registry.example:5000/app")
+
+				gomega.Expect(container.ContainerInfo().Config.Image).To(gomega.Equal("registry.example:5000/app:latest"))
+				gomega.Expect(container.ImageName()).To(gomega.Equal("registry.example:5000/app:latest"))
 			})
 		})
 

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -354,6 +354,51 @@ var _ = ginkgo.Describe("Container", func() {
 				container = MockContainer(WithImageName(name))
 				gomega.Expect(container.ImageName()).To(gomega.Equal(name + ":latest"))
 			})
+
+			ginkgo.It("returns unknown:latest for a nil receiver", func() {
+				var nilContainer *Container
+
+				gomega.Expect(nilContainer.ImageName()).To(gomega.Equal("unknown:latest"))
+			})
+		})
+
+		ginkgo.Context("setting image name", func() {
+			ginkgo.It("is a no-op on a nil receiver", func() {
+				var nilContainer *Container
+
+				gomega.Expect(func() {
+					nilContainer.SetImageName("app:v2")
+				}).NotTo(gomega.Panic())
+			})
+
+			ginkgo.It("pins a tagged name on config and cache", func() {
+				container = NewContainer(testLog(), &dockerContainer.InspectResponse{
+					Name: "/app",
+					Config: &dockerContainer.Config{
+						Image: "app:v1",
+					},
+				}, nil)
+
+				container.SetImageName("app:v2")
+
+				gomega.Expect(container.ContainerInfo()).NotTo(gomega.BeNil())
+				gomega.Expect(container.ContainerInfo().Config.Image).To(gomega.Equal("app:v2"))
+				gomega.Expect(container.ImageName()).To(gomega.Equal("app:v2"))
+			})
+
+			ginkgo.It("appends latest when the pinned name is untagged", func() {
+				container = NewContainer(testLog(), &dockerContainer.InspectResponse{
+					Name: "/app",
+					Config: &dockerContainer.Config{
+						Image: "app:v1",
+					},
+				}, nil)
+
+				container.SetImageName("app")
+
+				gomega.Expect(container.ContainerInfo().Config.Image).To(gomega.Equal("app"))
+				gomega.Expect(container.ImageName()).To(gomega.Equal("app:latest"))
+			})
 		})
 
 		ginkgo.Context("fetching image ID", func() {

--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -76,9 +76,12 @@ type WarningStrategy string
 // imageClient manages image-related operations for Watchtower.
 //
 // It uses a Docker API client for image tasks.
+// imageClient performs image inspect, pull, and stale checks.
 type imageClient struct {
 	api dockerClient.APIClient
 	log *zerolog.Logger
+	// daemonInfo shares Docker Info and mirrors across check and pull paths.
+	daemonInfo *daemonInfoCache
 }
 
 // IsContainerStale determines if a container's image is outdated.
@@ -545,14 +548,7 @@ func logImageRemovalDetails(log *zerolog.Logger, items []dockerImage.DeleteRespo
 		Msg("Image removal details")
 }
 
-// newImageClient creates a new imageClient instance.
-//
-// Parameters:
-//   - api: Docker API client.
-//
-// Returns:
-//   - imageClient: Initialized client for image operations.
-
+// logger returns the image client's logger, or a discarded nop if unset.
 func (c imageClient) logger() *zerolog.Logger {
 	if c.log != nil {
 		return c.log
@@ -561,8 +557,18 @@ func (c imageClient) logger() *zerolog.Logger {
 	return nopLog()
 }
 
+// newImageClient creates a new imageClient instance.
+//
+// The client shares the process-wide Docker Info cache used for registry mirrors.
+//
+// Parameters:
+//   - api: Docker API client.
+//   - log: Logger for debug output.
+//
+// Returns:
+//   - imageClient: Initialized client for image operations.
 func newImageClient(api dockerClient.APIClient, log *zerolog.Logger) imageClient {
-	return imageClient{api: api, log: log}
+	return imageClient{api: api, log: log, daemonInfo: sharedDaemonInfoCache}
 }
 
 // shouldSkipPull determines if an image pull can be skipped.
@@ -692,8 +698,8 @@ func (c imageClient) performImagePull(
 	}
 	defer response.Close()
 
-	// Read response to complete the pull.
-	_, err = io.ReadAll(response)
+	// Drain the progress stream so the daemon finishes the pull without buffering it.
+	_, err = io.Copy(io.Discard, response)
 	if err != nil {
 		clog.Debug().
 			Err(err).

--- a/pkg/container/image_test.go
+++ b/pkg/container/image_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -188,6 +189,29 @@ var _ = ginkgo.Describe("the client", func() {
 			gomega.Expect(errors.Is(err, ErrPullImageUnauthorized)).To(gomega.BeFalse())
 			gomega.Expect(errors.Is(err, ErrPullImageNotFound)).To(gomega.BeFalse())
 			gomega.Eventually(logbuf).Should(gbytes.Say(`Failed to initiate image pull`))
+		})
+	})
+
+	ginkgo.When("draining an image pull progress stream", func() {
+		ginkgo.It("consumes the full stream without retaining the body", func() {
+			const streamSize = 2 << 20
+
+			mockServer.AllowUnhandledRequests = true
+			mockServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", gomega.MatchRegexp("/images/create")),
+					ghttp.RespondWith(http.StatusOK, strings.Repeat("x", streamSize)),
+				),
+			)
+
+			i := newImageClient(mockClient, testLog())
+			err := i.performImagePull(
+				context.Background(),
+				"registry.example.com/app:latest",
+				dockerClient.ImagePullOptions{},
+				nil,
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 	})
 

--- a/pkg/container/mirror.go
+++ b/pkg/container/mirror.go
@@ -19,10 +19,17 @@ var sharedDaemonInfoCache = &daemonInfoCache{}
 
 // daemonInfoCache holds one Docker Info snapshot for concurrent check/pull paths.
 type daemonInfoCache struct {
-	mu      sync.Mutex
-	info    *dockerSystem.Info
-	expires time.Time
-	fetched bool
+	mu       sync.Mutex
+	info     *dockerSystem.Info
+	expires  time.Time
+	fetched  bool
+	inflight chan struct{}
+}
+
+// daemonInfoResult is the outcome of one Docker Info fetch.
+type daemonInfoResult struct {
+	info *dockerSystem.Info
+	ok   bool
 }
 
 // resetDaemonInfoCache clears the process-wide Docker Info cache.
@@ -35,6 +42,7 @@ func resetDaemonInfoCache() {
 	sharedDaemonInfoCache.info = nil
 	sharedDaemonInfoCache.expires = time.Time{}
 	sharedDaemonInfoCache.fetched = false
+	sharedDaemonInfoCache.inflight = nil
 }
 
 // resolveRegistryMirrorConfig fetches the registry mirror configuration from the Docker daemon.
@@ -53,7 +61,6 @@ func (c imageClient) resolveRegistryMirrorConfig(ctx context.Context) *dockerSys
 		cache = sharedDaemonInfoCache
 	}
 
-	// Return a still-valid snapshot without calling Info().
 	cache.mu.Lock()
 	if cache.fetched && time.Now().Before(cache.expires) {
 		info := cache.info
@@ -61,10 +68,65 @@ func (c imageClient) resolveRegistryMirrorConfig(ctx context.Context) *dockerSys
 
 		return info
 	}
+
+	if cache.inflight != nil {
+		wait := cache.inflight
+		cache.mu.Unlock()
+
+		select {
+		case <-wait:
+			cache.mu.Lock()
+			fetched := cache.fetched && time.Now().Before(cache.expires)
+			info := cache.info
+			cache.mu.Unlock()
+
+			if fetched {
+				return info
+			}
+
+			// The in-flight fetch failed. Do not stampede another Info() call.
+			return nil
+		case <-ctx.Done():
+			return nil
+		}
+	}
+
+	// This caller performs the fetch. Others wait on inflight.
+	done := make(chan struct{})
+	cache.inflight = done
 	cache.mu.Unlock()
 
-	// Cache miss or expired snapshot. Fetch a fresh Info() result.
+	resolved := c.fetchDaemonInfo(ctx)
 
+	cache.mu.Lock()
+	if resolved.ok {
+		cache.info = resolved.info
+		cache.fetched = true
+		cache.expires = time.Now().Add(daemonInfoTTL)
+	}
+
+	cache.inflight = nil
+
+	close(done)
+	cache.mu.Unlock()
+
+	if !resolved.ok {
+		return nil
+	}
+
+	return resolved.info
+}
+
+// fetchDaemonInfo loads Docker Info for registry mirror resolution.
+//
+// Failures are not cached. An empty mirror list is a successful empty snapshot.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeout control.
+//
+// Returns:
+//   - daemonInfoResult: Snapshot and whether the fetch succeeded.
+func (c imageClient) fetchDaemonInfo(ctx context.Context) daemonInfoResult {
 	info, err := c.api.Info(
 		ctx,
 		dockerClient.InfoOptions{},
@@ -74,20 +136,13 @@ func (c imageClient) resolveRegistryMirrorConfig(ctx context.Context) *dockerSys
 			Err(err).
 			Msg("Failed to get system info for registry mirror resolution")
 
-		return nil
+		return daemonInfoResult{}
 	}
 
 	if info.Info.RegistryConfig == nil || len(info.Info.RegistryConfig.Mirrors) == 0 {
 		c.logger().Debug().Msg("No registry mirror configuration in Docker daemon")
 
-		// Cache the empty result so concurrent callers do not repeat Info().
-		cache.mu.Lock()
-		cache.info = nil
-		cache.fetched = true
-		cache.expires = time.Now().Add(daemonInfoTTL)
-		cache.mu.Unlock()
-
-		return nil
+		return daemonInfoResult{ok: true}
 	}
 
 	sanitized := make([]string, 0, len(info.Info.RegistryConfig.Mirrors))
@@ -104,16 +159,7 @@ func (c imageClient) resolveRegistryMirrorConfig(ctx context.Context) *dockerSys
 		Strs("global_mirrors", sanitized).
 		Msg("Resolved registry mirror configuration from Docker daemon")
 
-	resolved := &info.Info
-
-	// Store the snapshot for daemonInfoTTL.
-	cache.mu.Lock()
-	cache.info = resolved
-	cache.fetched = true
-	cache.expires = time.Now().Add(daemonInfoTTL)
-	cache.mu.Unlock()
-
-	return resolved
+	return daemonInfoResult{info: &info.Info, ok: true}
 }
 
 // buildMirrorEndpoints returns the list of registry endpoints to try for digest comparison.

--- a/pkg/container/mirror.go
+++ b/pkg/container/mirror.go
@@ -61,40 +61,43 @@ func (c imageClient) resolveRegistryMirrorConfig(ctx context.Context) *dockerSys
 		cache = sharedDaemonInfoCache
 	}
 
-	cache.mu.Lock()
-	if cache.fetched && time.Now().Before(cache.expires) {
-		info := cache.info
-		cache.mu.Unlock()
-
-		return info
-	}
-
-	if cache.inflight != nil {
-		wait := cache.inflight
-		cache.mu.Unlock()
-
-		select {
-		case <-wait:
-			cache.mu.Lock()
-			fetched := cache.fetched && time.Now().Before(cache.expires)
+	for {
+		cache.mu.Lock()
+		if cache.fetched && time.Now().Before(cache.expires) {
 			info := cache.info
 			cache.mu.Unlock()
 
-			if fetched {
-				return info
-			}
-
-			// The in-flight fetch failed. Do not stampede another Info() call.
-			return nil
-		case <-ctx.Done():
-			return nil
+			return info
 		}
+
+		if cache.inflight != nil {
+			wait := cache.inflight
+			cache.mu.Unlock()
+
+			select {
+			case <-wait:
+				// Retry so a failed or panicked leader does not strand later callers.
+				continue
+			case <-ctx.Done():
+				return nil
+			}
+		}
+
+		break
 	}
 
 	// This caller performs the fetch. Others wait on inflight.
 	done := make(chan struct{})
 	cache.inflight = done
 	cache.mu.Unlock()
+
+	defer func() {
+		cache.mu.Lock()
+		cache.inflight = nil
+
+		close(done)
+		cache.mu.Unlock()
+	}()
 
 	resolved := c.fetchDaemonInfo(ctx)
 
@@ -104,10 +107,6 @@ func (c imageClient) resolveRegistryMirrorConfig(ctx context.Context) *dockerSys
 		cache.fetched = true
 		cache.expires = time.Now().Add(daemonInfoTTL)
 	}
-
-	cache.inflight = nil
-
-	close(done)
 	cache.mu.Unlock()
 
 	if !resolved.ok {

--- a/pkg/container/mirror.go
+++ b/pkg/container/mirror.go
@@ -4,15 +4,43 @@ import (
 	"context"
 	"net/url"
 	"strings"
+	"sync"
+	"time"
 
 	dockerSystem "github.com/moby/moby/api/types/system"
 	dockerClient "github.com/moby/moby/client"
 )
 
+// daemonInfoTTL is how long a Docker Info and mirrors snapshot is reused.
+const daemonInfoTTL = 5 * time.Minute
+
+// sharedDaemonInfoCache is reused across imageClient instances in one process.
+var sharedDaemonInfoCache = &daemonInfoCache{}
+
+// daemonInfoCache holds one Docker Info snapshot for concurrent check/pull paths.
+type daemonInfoCache struct {
+	mu      sync.Mutex
+	info    *dockerSystem.Info
+	expires time.Time
+	fetched bool
+}
+
+// resetDaemonInfoCache clears the process-wide Docker Info cache.
+//
+// Tests use this to isolate Info() call counts between cases.
+func resetDaemonInfoCache() {
+	sharedDaemonInfoCache.mu.Lock()
+	defer sharedDaemonInfoCache.mu.Unlock()
+
+	sharedDaemonInfoCache.info = nil
+	sharedDaemonInfoCache.expires = time.Time{}
+	sharedDaemonInfoCache.fetched = false
+}
+
 // resolveRegistryMirrorConfig fetches the registry mirror configuration from the Docker daemon.
 //
-// It calls Info() and returns the system.Info containing global mirrors (RegistryConfig.Mirrors).
-// Returns nil if the call fails or no mirrors are configured.
+// Successful Info() results are reused for daemonInfoTTL so concurrent check and
+// pull paths share one daemon call. Failures are not cached.
 //
 // Parameters:
 //   - ctx: Context for cancellation and timeout control.
@@ -20,6 +48,23 @@ import (
 // Returns:
 //   - *dockerSystem.Info: System info with mirror configuration, or nil if unavailable.
 func (c imageClient) resolveRegistryMirrorConfig(ctx context.Context) *dockerSystem.Info {
+	cache := c.daemonInfo
+	if cache == nil {
+		cache = sharedDaemonInfoCache
+	}
+
+	// Return a still-valid snapshot without calling Info().
+	cache.mu.Lock()
+	if cache.fetched && time.Now().Before(cache.expires) {
+		info := cache.info
+		cache.mu.Unlock()
+
+		return info
+	}
+	cache.mu.Unlock()
+
+	// Cache miss or expired snapshot. Fetch a fresh Info() result.
+
 	info, err := c.api.Info(
 		ctx,
 		dockerClient.InfoOptions{},
@@ -32,14 +77,15 @@ func (c imageClient) resolveRegistryMirrorConfig(ctx context.Context) *dockerSys
 		return nil
 	}
 
-	if info.Info.RegistryConfig == nil {
+	if info.Info.RegistryConfig == nil || len(info.Info.RegistryConfig.Mirrors) == 0 {
 		c.logger().Debug().Msg("No registry mirror configuration in Docker daemon")
 
-		return nil
-	}
-
-	if len(info.Info.RegistryConfig.Mirrors) == 0 {
-		c.logger().Debug().Msg("No registry mirrors configured in Docker daemon")
+		// Cache the empty result so concurrent callers do not repeat Info().
+		cache.mu.Lock()
+		cache.info = nil
+		cache.fetched = true
+		cache.expires = time.Now().Add(daemonInfoTTL)
+		cache.mu.Unlock()
 
 		return nil
 	}
@@ -58,7 +104,16 @@ func (c imageClient) resolveRegistryMirrorConfig(ctx context.Context) *dockerSys
 		Strs("global_mirrors", sanitized).
 		Msg("Resolved registry mirror configuration from Docker daemon")
 
-	return &info.Info
+	resolved := &info.Info
+
+	// Store the snapshot for daemonInfoTTL.
+	cache.mu.Lock()
+	cache.info = resolved
+	cache.fetched = true
+	cache.expires = time.Now().Add(daemonInfoTTL)
+	cache.mu.Unlock()
+
+	return resolved
 }
 
 // buildMirrorEndpoints returns the list of registry endpoints to try for digest comparison.

--- a/pkg/container/mirror_test.go
+++ b/pkg/container/mirror_test.go
@@ -133,6 +133,9 @@ func Test_imageClient_buildMirrorEndpoints(t *testing.T) {
 // Test_newImageClient_nilLogger_noMirrors verifies resolveRegistryMirrorConfig does not
 // panic when the image client logger is nil and Docker reports no registry mirrors.
 func Test_newImageClient_nilLogger_noMirrors(t *testing.T) {
+	resetDaemonInfoCache()
+	t.Cleanup(resetDaemonInfoCache)
+
 	server := ghttp.NewServer()
 	t.Cleanup(server.Close)
 
@@ -163,4 +166,100 @@ func Test_newImageClient_nilLogger_noMirrors(t *testing.T) {
 	})
 
 	assert.Regexp(t, `^/v\d+(\.\d+)*/info$`, infoPath, "resolveRegistryMirrorConfig must call the versioned /info endpoint")
+}
+
+func TestResolveRegistryMirrorConfig_CachesInfo(t *testing.T) {
+	resetDaemonInfoCache()
+	t.Cleanup(resetDaemonInfoCache)
+
+	server := ghttp.NewServer()
+	t.Cleanup(server.Close)
+
+	var infoCalls int
+
+	server.AppendHandlers(APIVersionPingHandler())
+	server.RouteToHandler("GET", regexp.MustCompile(`^/v\d+(\.\d+)*/info$`), func(w http.ResponseWriter, _ *http.Request) {
+		infoCalls++
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"RegistryConfig":{"Mirrors":["https://mirror.example.com"]}}`))
+	})
+
+	api, err := dockerClient.New(
+		dockerClient.WithHost(server.URL()),
+		dockerClient.WithHTTPClient(server.HTTPTestServer.Client()),
+	)
+	require.NoError(t, err)
+
+	first := newImageClient(api, testLog())
+	second := newImageClient(api, testLog())
+
+	gotFirst := first.resolveRegistryMirrorConfig(context.Background())
+	gotSecond := second.resolveRegistryMirrorConfig(context.Background())
+
+	require.NotNil(t, gotFirst)
+	require.NotNil(t, gotSecond)
+	assert.Equal(t, 1, infoCalls)
+	assert.Equal(t, gotFirst.RegistryConfig.Mirrors, gotSecond.RegistryConfig.Mirrors)
+}
+
+func TestResolveRegistryMirrorConfig_InfoErrorNotCached(t *testing.T) {
+	resetDaemonInfoCache()
+	t.Cleanup(resetDaemonInfoCache)
+
+	server := ghttp.NewServer()
+	t.Cleanup(server.Close)
+
+	var infoCalls int
+
+	server.AppendHandlers(APIVersionPingHandler())
+	server.RouteToHandler("GET", regexp.MustCompile(`^/v\d+(\.\d+)*/info$`), func(w http.ResponseWriter, _ *http.Request) {
+		infoCalls++
+
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	api, err := dockerClient.New(
+		dockerClient.WithHost(server.URL()),
+		dockerClient.WithHTTPClient(server.HTTPTestServer.Client()),
+	)
+	require.NoError(t, err)
+
+	client := newImageClient(api, testLog())
+
+	assert.Nil(t, client.resolveRegistryMirrorConfig(context.Background()))
+	assert.Nil(t, client.resolveRegistryMirrorConfig(context.Background()))
+	assert.Equal(t, 2, infoCalls)
+}
+
+func TestResolveRegistryMirrorConfig_NilDaemonInfoUsesShared(t *testing.T) {
+	resetDaemonInfoCache()
+	t.Cleanup(resetDaemonInfoCache)
+
+	server := ghttp.NewServer()
+	t.Cleanup(server.Close)
+
+	var infoCalls int
+
+	server.AppendHandlers(APIVersionPingHandler())
+	server.RouteToHandler("GET", regexp.MustCompile(`^/v\d+(\.\d+)*/info$`), func(w http.ResponseWriter, _ *http.Request) {
+		infoCalls++
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"RegistryConfig":{"Mirrors":["https://mirror.example.com"]}}`))
+	})
+
+	api, err := dockerClient.New(
+		dockerClient.WithHost(server.URL()),
+		dockerClient.WithHTTPClient(server.HTTPTestServer.Client()),
+	)
+	require.NoError(t, err)
+
+	client := imageClient{api: api, log: testLog()}
+
+	got := client.resolveRegistryMirrorConfig(context.Background())
+	require.NotNil(t, got)
+	assert.Equal(t, 1, infoCalls)
 }

--- a/pkg/container/mirror_test.go
+++ b/pkg/container/mirror_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"net/http"
 	"regexp"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/onsi/gomega/ghttp"
 	"github.com/stretchr/testify/assert"
@@ -262,4 +265,67 @@ func TestResolveRegistryMirrorConfig_NilDaemonInfoUsesShared(t *testing.T) {
 	got := client.resolveRegistryMirrorConfig(context.Background())
 	require.NotNil(t, got)
 	assert.Equal(t, 1, infoCalls)
+}
+
+func TestResolveRegistryMirrorConfig_CoalescesConcurrentFetches(t *testing.T) {
+	resetDaemonInfoCache()
+	t.Cleanup(resetDaemonInfoCache)
+
+	server := ghttp.NewServer()
+	t.Cleanup(server.Close)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	var infoCalls atomic.Int32
+
+	server.AppendHandlers(APIVersionPingHandler())
+	server.RouteToHandler("GET", regexp.MustCompile(`^/v\d+(\.\d+)*/info$`), func(w http.ResponseWriter, _ *http.Request) {
+		if infoCalls.Add(1) == 1 {
+			close(started)
+			<-release
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"RegistryConfig":{"Mirrors":["https://mirror.example.com"]}}`))
+	})
+
+	api, err := dockerClient.New(
+		dockerClient.WithHost(server.URL()),
+		dockerClient.WithHTTPClient(server.HTTPTestServer.Client()),
+	)
+	require.NoError(t, err)
+
+	firstClient := newImageClient(api, testLog())
+	secondClient := newImageClient(api, testLog())
+
+	var (
+		wg          sync.WaitGroup
+		first, next *dockerSystem.Info
+	)
+
+	wg.Go(func() {
+		first = firstClient.resolveRegistryMirrorConfig(context.Background())
+	})
+	wg.Go(func() {
+		next = secondClient.resolveRegistryMirrorConfig(context.Background())
+	})
+
+	<-started
+	require.Eventually(t, func() bool {
+		sharedDaemonInfoCache.mu.Lock()
+		defer sharedDaemonInfoCache.mu.Unlock()
+
+		return sharedDaemonInfoCache.inflight != nil
+	}, time.Second, 5*time.Millisecond)
+	// Let the second caller park on the in-flight fetch before unblocking Info().
+	time.Sleep(20 * time.Millisecond)
+
+	close(release)
+	wg.Wait()
+
+	require.NotNil(t, first)
+	require.NotNil(t, next)
+	assert.Equal(t, int32(1), infoCalls.Load())
 }

--- a/pkg/container/mocks/ApiServer.go
+++ b/pkg/container/mocks/ApiServer.go
@@ -69,13 +69,20 @@ func respondWithJSONFile(
 // GetContainerHandlers includes handlers for the given containers, their references, and associated images.
 func GetContainerHandlers(containerRefs ...*ContainerRef) []http.HandlerFunc {
 	handlers := make([]http.HandlerFunc, 0, len(containerRefs)*handlersPerContainer)
+	seenImages := make(map[types.ImageID]struct{}, len(containerRefs))
+
 	for _, containerRef := range containerRefs {
 		handlers = append(handlers, getContainerFileHandler(containerRef))
 		// Append handlers for referenced containers
 		for _, ref := range containerRef.references {
 			handlers = append(handlers, getContainerFileHandler(ref))
 		}
-		// Append image handler for each container's image
+
+		if _, seen := seenImages[containerRef.image.id]; seen {
+			continue
+		}
+
+		seenImages[containerRef.image.id] = struct{}{}
 		handlers = append(handlers, getImageHandler(containerRef.image.id,
 			RespondWithJSONFile(containerRef.image.getFileName(), http.StatusOK),
 		))

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -583,7 +583,8 @@ type compiledPatterns struct {
 
 // compileNamePatterns compiles name or image filter patterns once.
 //
-// Invalid regex patterns are kept as exact literals.
+// Patterns without regex metacharacters are stored as exact literals.
+// Invalid regex patterns are also kept as exact literals.
 //
 // Parameters:
 //   - patterns: Name or image patterns.
@@ -601,6 +602,13 @@ func compileNamePatterns(patterns []string, trimSlash bool) compiledPatterns {
 		// Container names are stored without a leading slash.
 		if trimSlash {
 			pattern = strings.TrimPrefix(pattern, "/")
+		}
+
+		// Literal names skip compilation. Only patterns with metacharacters become regexes.
+		if regexp.QuoteMeta(pattern) == pattern {
+			compiled.exact = append(compiled.exact, pattern)
+
+			continue
 		}
 
 		// Invalid regex stays an exact literal, matching matchesName behavior.

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/distribution/reference"
@@ -138,7 +139,10 @@ func NoFilter(c types.FilterableContainer) bool {
 
 // FilterByNames selects containers matching specified names.
 //
+// Name patterns are compiled once when the filter is built.
+//
 // Parameters:
+//   - log: Logger for debug output.
 //   - normalizedNames: List of normalized names or regex patterns to match.
 //   - baseFilter: Base filter to chain.
 //
@@ -149,23 +153,29 @@ func FilterByNames(log *zerolog.Logger, normalizedNames []string, baseFilter typ
 		return baseFilter
 	}
 
+	// Compile once. The returned closure only evaluates the compiled matchers.
+	compiled := compileNamePatterns(normalizedNames, true)
+
 	return func(c types.FilterableContainer) bool {
-		containerName := c.Name() // Normalized name
-		clogVal := log.With().
-			Str("container", c.Name()).
-			Strs("names", normalizedNames).
-			Logger()
-		clog := &clogVal
+		containerName := c.Name()
 
-		for _, pattern := range normalizedNames {
-			if matchesName(containerName, pattern) {
-				clog.Debug().Msg("Matched container by name/pattern")
-
-				return baseFilter(c)
+		if compiled.match(containerName) {
+			if debugEnabled(log) {
+				log.Debug().
+					Str("container", containerName).
+					Strs("names", normalizedNames).
+					Msg("Matched container by name/pattern")
 			}
+
+			return baseFilter(c)
 		}
 
-		clog.Debug().Msg("Container name did not match any filter")
+		if debugEnabled(log) {
+			log.Debug().
+				Str("container", containerName).
+				Strs("names", normalizedNames).
+				Msg("Container name did not match any filter")
+		}
 
 		return false
 	}
@@ -173,7 +183,10 @@ func FilterByNames(log *zerolog.Logger, normalizedNames []string, baseFilter typ
 
 // FilterByDisableNames excludes containers matching specified names.
 //
+// Name patterns are compiled once when the filter is built.
+//
 // Parameters:
+//   - log: Logger for debug output.
 //   - normalizedDisableNames: Names or regex patterns to exclude.
 //   - baseFilter: Base filter to chain.
 //
@@ -184,23 +197,29 @@ func FilterByDisableNames(log *zerolog.Logger, normalizedDisableNames []string, 
 		return baseFilter
 	}
 
+	// Compile once. The returned closure only evaluates the compiled matchers.
+	compiled := compileNamePatterns(normalizedDisableNames, true)
+
 	return func(c types.FilterableContainer) bool {
-		containerName := c.Name() // Normalized name
-		clogVal := log.With().
-			Str("container", c.Name()).
-			Strs("disableNames", normalizedDisableNames).
-			Logger()
-		clog := &clogVal
+		containerName := c.Name()
 
-		for _, pattern := range normalizedDisableNames {
-			if matchesName(containerName, pattern) {
-				clog.Debug().Msg("Container excluded by disable name/pattern")
-
-				return false
+		if compiled.match(containerName) {
+			if debugEnabled(log) {
+				log.Debug().
+					Str("container", containerName).
+					Strs("disableNames", normalizedDisableNames).
+					Msg("Container excluded by disable name/pattern")
 			}
+
+			return false
 		}
 
-		clog.Debug().Msg("Container not excluded by disable names")
+		if debugEnabled(log) {
+			log.Debug().
+				Str("container", containerName).
+				Strs("disableNames", normalizedDisableNames).
+				Msg("Container not excluded by disable names")
+		}
 
 		return baseFilter(c)
 	}
@@ -209,7 +228,10 @@ func FilterByDisableNames(log *zerolog.Logger, normalizedDisableNames []string, 
 // FilterByMonitoredImageNamePatterns restricts monitoring to containers whose image name
 // matches specified patterns. When set, only matching containers are monitored.
 //
+// Image patterns are compiled once when the filter is built.
+//
 // Parameters:
+//   - log: Logger for debug output.
 //   - namePatterns: Image name regex patterns.
 //   - baseFilter: Base filter to chain.
 //
@@ -221,24 +243,31 @@ func FilterByMonitoredImageNamePatterns(log *zerolog.Logger, namePatterns []stri
 		return baseFilter
 	}
 
+	// Compile once. The returned closure only evaluates the compiled matchers.
+	compiled := compileNamePatterns(namePatterns, false)
+
 	return func(c types.FilterableContainer) bool {
 		imageName := c.ImageName()
-		clogVal := log.With().
-			Str("container", c.Name()).
-			Str("image", imageName).
-			Strs("namePatterns", namePatterns).
-			Logger()
-		clog := &clogVal
 
-		for _, pattern := range namePatterns {
-			if matchesImageName(imageName, pattern) {
-				clog.Debug().Msg("Container image matched pattern")
-
-				return baseFilter(c)
+		if compiled.match(imageName) {
+			if debugEnabled(log) {
+				log.Debug().
+					Str("container", c.Name()).
+					Str("image", imageName).
+					Strs("namePatterns", namePatterns).
+					Msg("Container image matched pattern")
 			}
+
+			return baseFilter(c)
 		}
 
-		clog.Debug().Msg("Container image did not match any pattern")
+		if debugEnabled(log) {
+			log.Debug().
+				Str("container", c.Name()).
+				Str("image", imageName).
+				Strs("namePatterns", namePatterns).
+				Msg("Container image did not match any pattern")
+		}
 
 		return false
 	}
@@ -247,7 +276,10 @@ func FilterByMonitoredImageNamePatterns(log *zerolog.Logger, namePatterns []stri
 // FilterBySkippedImageNamePatterns prevents monitoring of containers whose image name
 // matches specified patterns. Matching containers are excluded from monitoring.
 //
+// Image patterns are compiled once when the filter is built.
+//
 // Parameters:
+//   - log: Logger for debug output.
 //   - namePatterns: Image name regex patterns.
 //   - baseFilter: Base filter to chain.
 //
@@ -259,24 +291,31 @@ func FilterBySkippedImageNamePatterns(log *zerolog.Logger, namePatterns []string
 		return baseFilter
 	}
 
+	// Compile once. The returned closure only evaluates the compiled matchers.
+	compiled := compileNamePatterns(namePatterns, false)
+
 	return func(c types.FilterableContainer) bool {
 		imageName := c.ImageName()
-		clogVal := log.With().
-			Str("container", c.Name()).
-			Str("image", imageName).
-			Strs("namePatterns", namePatterns).
-			Logger()
-		clog := &clogVal
 
-		for _, pattern := range namePatterns {
-			if matchesImageName(imageName, pattern) {
-				clog.Debug().Msg("Container image matched skip pattern")
-
-				return false
+		if compiled.match(imageName) {
+			if debugEnabled(log) {
+				log.Debug().
+					Str("container", c.Name()).
+					Str("image", imageName).
+					Strs("namePatterns", namePatterns).
+					Msg("Container image matched skip pattern")
 			}
+
+			return false
 		}
 
-		clog.Debug().Msg("Container not skipped by image name patterns")
+		if debugEnabled(log) {
+			log.Debug().
+				Str("container", c.Name()).
+				Str("image", imageName).
+				Strs("namePatterns", namePatterns).
+				Msg("Container not skipped by image name patterns")
+		}
 
 		return baseFilter(c)
 	}
@@ -534,6 +573,80 @@ func FilterByImage(log *zerolog.Logger, images []string, baseFilter types.Filter
 
 		return false // No matching image found.
 	}
+}
+
+// compiledPatterns holds precompiled name or image matchers.
+type compiledPatterns struct {
+	exact   []string
+	regexes []*regexp.Regexp
+}
+
+// compileNamePatterns compiles name or image filter patterns once.
+//
+// Invalid regex patterns are kept as exact literals.
+//
+// Parameters:
+//   - patterns: Name or image patterns.
+//   - trimSlash: Strip a leading slash from each pattern for container names.
+//
+// Returns:
+//   - compiledPatterns: Exact literals and compiled regexes.
+func compileNamePatterns(patterns []string, trimSlash bool) compiledPatterns {
+	compiled := compiledPatterns{
+		exact:   make([]string, 0, len(patterns)),
+		regexes: make([]*regexp.Regexp, 0, len(patterns)),
+	}
+
+	for _, pattern := range patterns {
+		// Container names are stored without a leading slash.
+		if trimSlash {
+			pattern = strings.TrimPrefix(pattern, "/")
+		}
+
+		// Invalid regex stays an exact literal, matching matchesName behavior.
+		patternRe, err := regexp.Compile("^" + pattern + "$")
+		if err != nil {
+			compiled.exact = append(compiled.exact, pattern)
+
+			continue
+		}
+
+		compiled.regexes = append(compiled.regexes, patternRe)
+	}
+
+	return compiled
+}
+
+// match reports whether value matches an exact literal or compiled regex.
+//
+// Parameters:
+//   - value: Container name or image name to test.
+//
+// Returns:
+//   - bool: True when value matches a literal or regex.
+func (p compiledPatterns) match(value string) bool {
+	if slices.Contains(p.exact, value) {
+		return true
+	}
+
+	for _, re := range p.regexes {
+		if re.MatchString(value) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// debugEnabled reports whether debug logging is active on log.
+//
+// Parameters:
+//   - log: Logger to inspect. Nil is treated as disabled.
+//
+// Returns:
+//   - bool: True when debug-level logging is enabled.
+func debugEnabled(log *zerolog.Logger) bool {
+	return log != nil && log.GetLevel() <= zerolog.DebugLevel
 }
 
 // matchesImageName checks if a container's image name matches a given pattern (exact or regex).

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -1,8 +1,8 @@
 package filters
 
 import (
+	"bytes"
 	"fmt"
-	"io"
 	"strings"
 	"testing"
 
@@ -1399,6 +1399,19 @@ func TestParseLabelPairs_Malformed(t *testing.T) {
 	}
 }
 
+func TestCompileNamePatterns_ClassifiesLiteralsAndRegex(t *testing.T) {
+	t.Parallel()
+
+	compiled := compileNamePatterns([]string{"web", "nginx:.*", "["}, false)
+
+	require.Equal(t, []string{"web", "["}, compiled.exact)
+	require.Len(t, compiled.regexes, 1)
+	assert.True(t, compiled.match("web"))
+	assert.True(t, compiled.match("nginx:1.25"))
+	assert.True(t, compiled.match("["))
+	assert.False(t, compiled.match("db"))
+}
+
 func TestFilterByDisableNames_InvalidRegexIsExactMatch(t *testing.T) {
 	t.Parallel()
 
@@ -1434,47 +1447,79 @@ func TestFilterByNames_InvalidRegexIsExactMatch(t *testing.T) {
 func TestFilters_DebugLogging(t *testing.T) {
 	t.Parallel()
 
-	debug := zerolog.New(io.Discard).Level(zerolog.DebugLevel)
+	var logBuf bytes.Buffer
+
+	debug := zerolog.New(&logBuf).Level(zerolog.DebugLevel)
 
 	nameFilter := FilterByNames(&debug, []string{"web"}, NoFilter)
 	named := new(mockContainer.FilterableContainer)
 	named.On("Name").Return("web")
 	assert.True(t, nameFilter(named))
+	named.AssertExpectations(t)
+	assert.Contains(t, logBuf.String(), "Matched container by name/pattern")
+
+	logBuf.Reset()
 
 	missed := new(mockContainer.FilterableContainer)
 	missed.On("Name").Return("db")
 	assert.False(t, nameFilter(missed))
+	missed.AssertExpectations(t)
+	assert.Contains(t, logBuf.String(), "Container name did not match any filter")
+
+	logBuf.Reset()
 
 	disableFilter := FilterByDisableNames(&debug, []string{"skip"}, NoFilter)
 	skipped := new(mockContainer.FilterableContainer)
 	skipped.On("Name").Return("skip")
 	assert.False(t, disableFilter(skipped))
+	skipped.AssertExpectations(t)
+	assert.Contains(t, logBuf.String(), "Container excluded by disable name/pattern")
+
+	logBuf.Reset()
 
 	kept := new(mockContainer.FilterableContainer)
 	kept.On("Name").Return("web")
 	assert.True(t, disableFilter(kept))
+	kept.AssertExpectations(t)
+	assert.Contains(t, logBuf.String(), "Container not excluded by disable names")
+
+	logBuf.Reset()
 
 	imageFilter := FilterByMonitoredImageNamePatterns(&debug, []string{"nginx:.*"}, NoFilter)
 	matchedImage := new(mockContainer.FilterableContainer)
-	matchedImage.On("Name").Return("web").Maybe()
+	matchedImage.On("Name").Return("web")
 	matchedImage.On("ImageName").Return("nginx:1.25")
 	assert.True(t, imageFilter(matchedImage))
+	matchedImage.AssertExpectations(t)
+	assert.Contains(t, logBuf.String(), "Container image matched pattern")
+
+	logBuf.Reset()
 
 	otherImage := new(mockContainer.FilterableContainer)
-	otherImage.On("Name").Return("cache").Maybe()
+	otherImage.On("Name").Return("cache")
 	otherImage.On("ImageName").Return("redis:latest")
 	assert.False(t, imageFilter(otherImage))
+	otherImage.AssertExpectations(t)
+	assert.Contains(t, logBuf.String(), "Container image did not match any pattern")
+
+	logBuf.Reset()
 
 	skipImageFilter := FilterBySkippedImageNamePatterns(&debug, []string{"redis:.*"}, NoFilter)
 	skippedImage := new(mockContainer.FilterableContainer)
-	skippedImage.On("Name").Return("cache").Maybe()
+	skippedImage.On("Name").Return("cache")
 	skippedImage.On("ImageName").Return("redis:latest")
 	assert.False(t, skipImageFilter(skippedImage))
+	skippedImage.AssertExpectations(t)
+	assert.Contains(t, logBuf.String(), "Container image matched skip pattern")
+
+	logBuf.Reset()
 
 	keptImage := new(mockContainer.FilterableContainer)
-	keptImage.On("Name").Return("web").Maybe()
+	keptImage.On("Name").Return("web")
 	keptImage.On("ImageName").Return("nginx:latest")
 	assert.True(t, skipImageFilter(keptImage))
+	keptImage.AssertExpectations(t)
+	assert.Contains(t, logBuf.String(), "Container not skipped by image name patterns")
 }
 
 func TestMatchesImageName(t *testing.T) {

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -2,6 +2,7 @@ package filters
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -956,14 +957,14 @@ func TestFilterByImageNames(t *testing.T) {
 
 	// Image matches -> kept.
 	container := new(mockContainer.FilterableContainer)
-	container.On("Name").Return("web")
+	container.On("Name").Return("web").Maybe()
 	container.On("ImageName").Return("nginx:latest")
 	assert.True(t, filter(container))
 	container.AssertExpectations(t)
 
 	// Image does not match -> excluded.
 	container = new(mockContainer.FilterableContainer)
-	container.On("Name").Return("cache")
+	container.On("Name").Return("cache").Maybe()
 	container.On("ImageName").Return("redis:latest")
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
@@ -977,14 +978,14 @@ func TestFilterByImageNamesRegex(t *testing.T) {
 
 	// Anchored regex matches any nginx tag.
 	container := new(mockContainer.FilterableContainer)
-	container.On("Name").Return("web")
+	container.On("Name").Return("web").Maybe()
 	container.On("ImageName").Return("nginx:1.25")
 	assert.True(t, filter(container))
 	container.AssertExpectations(t)
 
 	// Anchored regex does not match a different image name.
 	container = new(mockContainer.FilterableContainer)
-	container.On("Name").Return("web")
+	container.On("Name").Return("web").Maybe()
 	container.On("ImageName").Return("nginxx:1.25")
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
@@ -998,14 +999,14 @@ func TestFilterByImageNamesRegistryPath(t *testing.T) {
 
 	// Registry path with slashes matches.
 	container := new(mockContainer.FilterableContainer)
-	container.On("Name").Return("web")
+	container.On("Name").Return("web").Maybe()
 	container.On("ImageName").Return("docker.io/library/nginx:1.25")
 	assert.True(t, filter(container))
 	container.AssertExpectations(t)
 
 	// Different registry does not match.
 	container = new(mockContainer.FilterableContainer)
-	container.On("Name").Return("web")
+	container.On("Name").Return("web").Maybe()
 	container.On("ImageName").Return("ghcr.io/org/nginx:1.25")
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
@@ -1025,14 +1026,14 @@ func TestFilterBySkippedImageNames(t *testing.T) {
 
 	// Skipped image.
 	container := new(mockContainer.FilterableContainer)
-	container.On("Name").Return("web")
+	container.On("Name").Return("web").Maybe()
 	container.On("ImageName").Return("nginx:latest")
 	assert.False(t, filter(container))
 	container.AssertExpectations(t)
 
 	// Non-skipped image passes through baseFilter.
 	container = new(mockContainer.FilterableContainer)
-	container.On("Name").Return("cache")
+	container.On("Name").Return("cache").Maybe()
 	container.On("ImageName").Return("redis:latest")
 	assert.True(t, filter(container))
 	container.AssertExpectations(t)
@@ -1396,4 +1397,91 @@ func TestParseLabelPairs_Malformed(t *testing.T) {
 			assert.ErrorIs(t, err, tc.errPrefix)
 		})
 	}
+}
+
+func TestFilterByDisableNames_InvalidRegexIsExactMatch(t *testing.T) {
+	t.Parallel()
+
+	filter := FilterByDisableNames(testLog(), []string{"["}, NoFilter)
+
+	excluded := new(mockContainer.FilterableContainer)
+	excluded.On("Name").Return("[")
+	assert.False(t, filter(excluded))
+	excluded.AssertExpectations(t)
+
+	kept := new(mockContainer.FilterableContainer)
+	kept.On("Name").Return("app")
+	assert.True(t, filter(kept))
+	kept.AssertExpectations(t)
+}
+
+func TestFilterByNames_InvalidRegexIsExactMatch(t *testing.T) {
+	t.Parallel()
+
+	filter := FilterByNames(testLog(), []string{"["}, NoFilter)
+
+	matched := new(mockContainer.FilterableContainer)
+	matched.On("Name").Return("[")
+	assert.True(t, filter(matched))
+	matched.AssertExpectations(t)
+
+	other := new(mockContainer.FilterableContainer)
+	other.On("Name").Return("app")
+	assert.False(t, filter(other))
+	other.AssertExpectations(t)
+}
+
+func TestFilters_DebugLogging(t *testing.T) {
+	t.Parallel()
+
+	debug := zerolog.New(io.Discard).Level(zerolog.DebugLevel)
+
+	nameFilter := FilterByNames(&debug, []string{"web"}, NoFilter)
+	named := new(mockContainer.FilterableContainer)
+	named.On("Name").Return("web")
+	assert.True(t, nameFilter(named))
+
+	missed := new(mockContainer.FilterableContainer)
+	missed.On("Name").Return("db")
+	assert.False(t, nameFilter(missed))
+
+	disableFilter := FilterByDisableNames(&debug, []string{"skip"}, NoFilter)
+	skipped := new(mockContainer.FilterableContainer)
+	skipped.On("Name").Return("skip")
+	assert.False(t, disableFilter(skipped))
+
+	kept := new(mockContainer.FilterableContainer)
+	kept.On("Name").Return("web")
+	assert.True(t, disableFilter(kept))
+
+	imageFilter := FilterByMonitoredImageNamePatterns(&debug, []string{"nginx:.*"}, NoFilter)
+	matchedImage := new(mockContainer.FilterableContainer)
+	matchedImage.On("Name").Return("web").Maybe()
+	matchedImage.On("ImageName").Return("nginx:1.25")
+	assert.True(t, imageFilter(matchedImage))
+
+	otherImage := new(mockContainer.FilterableContainer)
+	otherImage.On("Name").Return("cache").Maybe()
+	otherImage.On("ImageName").Return("redis:latest")
+	assert.False(t, imageFilter(otherImage))
+
+	skipImageFilter := FilterBySkippedImageNamePatterns(&debug, []string{"redis:.*"}, NoFilter)
+	skippedImage := new(mockContainer.FilterableContainer)
+	skippedImage.On("Name").Return("cache").Maybe()
+	skippedImage.On("ImageName").Return("redis:latest")
+	assert.False(t, skipImageFilter(skippedImage))
+
+	keptImage := new(mockContainer.FilterableContainer)
+	keptImage.On("Name").Return("web").Maybe()
+	keptImage.On("ImageName").Return("nginx:latest")
+	assert.True(t, skipImageFilter(keptImage))
+}
+
+func TestMatchesImageName(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, matchesImageName("nginx:latest", "nginx:latest"))
+	assert.True(t, matchesImageName("nginx:1.25", "nginx:.*"))
+	assert.False(t, matchesImageName("redis:latest", "nginx:.*"))
+	assert.False(t, matchesImageName("app", "["))
 }

--- a/pkg/lifecycle/doc.go
+++ b/pkg/lifecycle/doc.go
@@ -8,7 +8,7 @@
 // Usage example:
 //
 //	// log is the process *zerolog.Logger. ctx is the request/operation context.
-//	lifecycle.ExecutePreChecks(log, ctx, client, params)
+//	lifecycle.ExecutePreChecks(log, ctx, client, params, listed)
 //	success, err := lifecycle.ExecutePreUpdateCommand(log, ctx, client, container, uid, gid)
 //	if err != nil {
 //	    log.Error().Err(err).Msg("Pre-update failed")

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -22,70 +22,102 @@ var (
 
 // ExecutePreChecks runs pre-check lifecycle hooks for filtered containers.
 //
+// When listed is non-empty, those containers are used and ListContainers is skipped.
+// An empty or nil listed slice falls back to listing with params.Filter.
+//
 // Parameters:
+//   - log: Logger for debug output.
 //   - ctx: Context for cancellation and timeout.
 //   - client: Container client for execution.
 //   - params: Update parameters with filter.
-func ExecutePreChecks(log *zerolog.Logger, ctx context.Context, client container.Client, params types.UpdateParams) {
-	uid := params.LifecycleUID
-	gid := params.LifecycleGID
-	clogVal := log.With().
-		Str("filter", fmt.Sprintf("%v", params.Filter)).
-		Logger()
-	clog := &clogVal // Simplified filter logging
-	clog.Debug().Msg("Listing containers for pre-checks")
-
-	// Fetch containers using the provided filter.
-	containers, err := client.ListContainers(ctx, params.Filter)
-	if err != nil {
-		clog.Debug().
-			Err(err).
-			Msg("Failed to list containers for pre-checks")
-
+//   - listed: Already-listed containers from the current scan, or nil.
+func ExecutePreChecks(log *zerolog.Logger, ctx context.Context, client container.Client, params types.UpdateParams, listed []types.Container) {
+	containers, ok := resolveCheckContainers(log, ctx, client, params, listed, "pre-checks")
+	if !ok {
+		// Listing failed. Hooks are skipped for this phase.
 		return
 	}
 
-	clog.Debug().
-		Int("count", len(containers)).
-		Msg("Found containers for pre-checks")
-
 	for _, currentContainer := range containers {
-		ExecutePreCheckCommand(log, ctx, client, currentContainer, uid, gid)
+		ExecutePreCheckCommand(log, ctx, client, currentContainer, params.LifecycleUID, params.LifecycleGID)
 	}
 }
 
 // ExecutePostChecks runs post-check lifecycle hooks for filtered containers.
 //
+// When listed is non-empty, those containers are used and ListContainers is skipped.
+// An empty or nil listed slice falls back to listing with params.Filter.
+//
 // Parameters:
+//   - log: Logger for debug output.
 //   - ctx: Context for cancellation and timeout.
 //   - client: Container client for execution.
 //   - params: Update parameters with filter.
-func ExecutePostChecks(log *zerolog.Logger, ctx context.Context, client container.Client, params types.UpdateParams) {
-	uid := params.LifecycleUID
-	gid := params.LifecycleGID
+//   - listed: Already-listed containers from the current scan, or nil.
+func ExecutePostChecks(log *zerolog.Logger, ctx context.Context, client container.Client, params types.UpdateParams, listed []types.Container) {
+	containers, ok := resolveCheckContainers(log, ctx, client, params, listed, "post-checks")
+	if !ok {
+		// Listing failed. Hooks are skipped for this phase.
+		return
+	}
+
+	for _, currentContainer := range containers {
+		ExecutePostCheckCommand(log, ctx, client, currentContainer, params.LifecycleUID, params.LifecycleGID)
+	}
+}
+
+// resolveCheckContainers returns listed containers, or lists them when listed is empty.
+//
+// Parameters:
+//   - log: Logger for debug output.
+//   - ctx: Context for cancellation and timeout.
+//   - client: Container client for listing when listed is empty.
+//   - params: Update parameters whose filter is applied to a fresh list.
+//   - listed: Already-listed containers from the current scan, or nil.
+//   - phase: Log label for the pre-check or post-check phase.
+//
+// Returns:
+//   - []types.Container: Containers to run hooks against.
+//   - bool: False when listing fails.
+func resolveCheckContainers(
+	log *zerolog.Logger,
+	ctx context.Context,
+	client container.Client,
+	params types.UpdateParams,
+	listed []types.Container,
+	phase string,
+) ([]types.Container, bool) {
 	clogVal := log.With().
 		Str("filter", fmt.Sprintf("%v", params.Filter)).
 		Logger()
 	clog := &clogVal
-	clog.Debug().Msg("Listing containers for post-checks")
+
+	if len(listed) > 0 {
+		// Use the scan snapshot instead of listing again.
+		clog.Debug().
+			Int("count", len(listed)).
+			Msg("Found containers for " + phase)
+
+		return listed, true
+	}
 
 	// Fetch containers using the provided filter.
+	clog.Debug().Msg("Listing containers for " + phase)
+
 	containers, err := client.ListContainers(ctx, params.Filter)
 	if err != nil {
 		clog.Debug().
 			Err(err).
-			Msg("Failed to list containers for post-checks")
+			Msg("Failed to list containers for " + phase)
 
-		return
+		return nil, false
 	}
 
 	clog.Debug().
 		Int("count", len(containers)).
-		Msg("Found containers for post-checks")
+		Msg("Found containers for " + phase)
 
-	for _, currentContainer := range containers {
-		ExecutePostCheckCommand(log, ctx, client, currentContainer, uid, gid)
-	}
+	return containers, true
 }
 
 // ExecutePreCheckCommand executes the pre-check hook for a container.

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -22,8 +22,8 @@ var (
 
 // ExecutePreChecks runs pre-check lifecycle hooks for filtered containers.
 //
-// When listed is non-empty, those containers are used and ListContainers is skipped.
-// An empty or nil listed slice falls back to listing with params.Filter.
+// When listed is non-nil, those containers are used and ListContainers is skipped.
+// A non-nil empty slice is a valid filtered snapshot. Nil falls back to listing.
 //
 // Parameters:
 //   - log: Logger for debug output.
@@ -45,8 +45,8 @@ func ExecutePreChecks(log *zerolog.Logger, ctx context.Context, client container
 
 // ExecutePostChecks runs post-check lifecycle hooks for filtered containers.
 //
-// When listed is non-empty, those containers are used and ListContainers is skipped.
-// An empty or nil listed slice falls back to listing with params.Filter.
+// When listed is non-nil, those containers are used and ListContainers is skipped.
+// A non-nil empty slice is a valid filtered snapshot. Nil falls back to listing.
 //
 // Parameters:
 //   - log: Logger for debug output.
@@ -66,7 +66,7 @@ func ExecutePostChecks(log *zerolog.Logger, ctx context.Context, client containe
 	}
 }
 
-// resolveCheckContainers returns listed containers, or lists them when listed is empty.
+// resolveCheckContainers returns listed containers, or lists them when listed is nil.
 //
 // Parameters:
 //   - log: Logger for debug output.
@@ -92,7 +92,7 @@ func resolveCheckContainers(
 		Logger()
 	clog := &clogVal
 
-	if len(listed) > 0 {
+	if listed != nil {
 		// Use the scan snapshot instead of listing again.
 		clog.Debug().
 			Int("count", len(listed)).

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -99,7 +99,7 @@ func TestExecutePreChecks(t *testing.T) {
 				LifecycleHooks: true,
 				LifecycleUID:   0,
 				LifecycleGID:   0,
-			})
+			}, nil)
 
 			output := logBuf.String()
 			assert.NotEmpty(t, output, "expected log output")
@@ -149,13 +149,55 @@ func TestExecutePostChecks(t *testing.T) {
 				LifecycleHooks: true,
 				LifecycleUID:   0,
 				LifecycleGID:   0,
-			})
+			}, nil)
 
 			output := logBuf.String()
 			assert.NotEmpty(t, output, "expected log output")
 			assert.Contains(t, output, tt.expectedLogMsg)
 		})
 	}
+}
+
+func TestExecutePreChecks_UsesListedContainers(t *testing.T) {
+	log, logBuf := logging.NewTestLogger(logging.DebugLevel)
+	client := mockContainer.NewMockClient(t)
+	listed := []types.Container{
+		mockedContainer(withLabels(map[string]string{
+			"com.centurylinklabs.watchtower.lifecycle.pre-check": "pre-check",
+		})),
+	}
+
+	client.On("ExecuteCommand", mock.Anything, mock.Anything, "pre-check", 1, 0, 0).
+		Return(true, nil)
+
+	ExecutePreChecks(log, context.Background(), client, types.UpdateParams{
+		Filter:         func(types.FilterableContainer) bool { return true },
+		LifecycleHooks: true,
+	}, listed)
+
+	client.AssertNotCalled(t, "ListContainers", mock.Anything, mock.Anything)
+	assert.Contains(t, logBuf.String(), "Found containers for pre-checks")
+}
+
+func TestExecutePostChecks_UsesListedContainers(t *testing.T) {
+	log, logBuf := logging.NewTestLogger(logging.DebugLevel)
+	client := mockContainer.NewMockClient(t)
+	listed := []types.Container{
+		mockedContainer(withLabels(map[string]string{
+			"com.centurylinklabs.watchtower.lifecycle.post-check": "post-check",
+		})),
+	}
+
+	client.On("ExecuteCommand", mock.Anything, mock.Anything, "post-check", 1, 0, 0).
+		Return(true, nil)
+
+	ExecutePostChecks(log, context.Background(), client, types.UpdateParams{
+		Filter:         func(types.FilterableContainer) bool { return true },
+		LifecycleHooks: true,
+	}, listed)
+
+	client.AssertNotCalled(t, "ListContainers", mock.Anything, mock.Anything)
+	assert.Contains(t, logBuf.String(), "Found containers for post-checks")
 }
 
 // TestExecutePreCheckCommand tests the ExecutePreCheckCommand function.

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -200,6 +200,34 @@ func TestExecutePostChecks_UsesListedContainers(t *testing.T) {
 	assert.Contains(t, logBuf.String(), "Found containers for post-checks")
 }
 
+func TestExecutePreChecks_EmptyListedDoesNotRelist(t *testing.T) {
+	log, _ := logging.NewTestLogger(logging.DebugLevel)
+	client := mockContainer.NewMockClient(t)
+	listed := []types.Container{}
+
+	ExecutePreChecks(log, context.Background(), client, types.UpdateParams{
+		Filter:         func(types.FilterableContainer) bool { return true },
+		LifecycleHooks: true,
+	}, listed)
+
+	client.AssertNotCalled(t, "ListContainers", mock.Anything, mock.Anything)
+	client.AssertNotCalled(t, "ExecuteCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestExecutePostChecks_EmptyListedDoesNotRelist(t *testing.T) {
+	log, _ := logging.NewTestLogger(logging.DebugLevel)
+	client := mockContainer.NewMockClient(t)
+	listed := []types.Container{}
+
+	ExecutePostChecks(log, context.Background(), client, types.UpdateParams{
+		Filter:         func(types.FilterableContainer) bool { return true },
+		LifecycleHooks: true,
+	}, listed)
+
+	client.AssertNotCalled(t, "ListContainers", mock.Anything, mock.Anything)
+	client.AssertNotCalled(t, "ExecuteCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
 // TestExecutePreCheckCommand tests the ExecutePreCheckCommand function.
 func TestExecutePreCheckCommand(t *testing.T) {
 	tests := []struct {

--- a/pkg/notifications/shoutrrr.go
+++ b/pkg/notifications/shoutrrr.go
@@ -47,6 +47,9 @@ const shutdownGracePeriod = 50 * time.Millisecond
 // eventFieldRawCapacity is the initial close-brace buffer size for eventFieldMap.
 const eventFieldRawCapacity = 256
 
+// eventFieldRawMaxCapacity is the largest pooled close-brace buffer that is reused.
+const eventFieldRawMaxCapacity = 8 << 10
+
 // eventFieldRawPool reuses close-brace JSON buffers across hooked log events.
 var eventFieldRawPool = sync.Pool{
 	New: func() any {
@@ -955,9 +958,11 @@ func eventFieldMap(event *zerolog.Event) (map[string]any, time.Time, bool) {
 
 	err := dec.Decode(&fieldMap)
 
-	// Return the scratch buffer after Decode has finished reading it.
-	*rawPtr = raw
-	eventFieldRawPool.Put(rawPtr)
+	// Return only bounded buffers so oversized events do not stay in the pool.
+	if cap(raw) <= eventFieldRawMaxCapacity {
+		*rawPtr = raw[:0]
+		eventFieldRawPool.Put(rawPtr)
+	}
 
 	if err != nil {
 		return nil, now, false
@@ -1014,8 +1019,8 @@ func eventFieldMap(event *zerolog.Event) (map[string]any, time.Time, bool) {
 
 // send sends a message via the notification router.
 //
-// Cancellation before Send skips the delivery. An in-flight Send finishes on
-// the worker goroutine.
+// Cancellation before Send skips the delivery. An in-flight Send is abandoned
+// after shutdownGracePeriod so Close cannot block indefinitely.
 //
 // Parameters:
 //   - msg: Message to send.
@@ -1029,7 +1034,26 @@ func (n *shoutrrrTypeNotifier) send(msg string) {
 	default:
 	}
 
-	processSendErrors(n, n.Router.Send(msg, n.params))
+	errsCh := make(chan []error, 1)
+
+	go func() {
+		errsCh <- n.Router.Send(msg, n.params)
+	}()
+
+	select {
+	case errs := <-errsCh:
+		processSendErrors(n, errs)
+	case <-n.ctx.Done():
+		timer := time.NewTimer(shutdownGracePeriod)
+		defer timer.Stop()
+
+		select {
+		case errs := <-errsCh:
+			processSendErrors(n, errs)
+		case <-timer.C:
+			n.ll().Debug().Err(n.ctx.Err()).Msg("Notification send canceled")
+		}
+	}
 }
 
 // buildMessage constructs a notification message from data.

--- a/pkg/notifications/shoutrrr.go
+++ b/pkg/notifications/shoutrrr.go
@@ -44,6 +44,18 @@ const messageChannelBufferSize = 1000
 // This allows error logging to complete before canceling the context.
 const shutdownGracePeriod = 50 * time.Millisecond
 
+// eventFieldRawCapacity is the initial close-brace buffer size for eventFieldMap.
+const eventFieldRawCapacity = 256
+
+// eventFieldRawPool reuses close-brace JSON buffers across hooked log events.
+var eventFieldRawPool = sync.Pool{
+	New: func() any {
+		buf := make([]byte, 0, eventFieldRawCapacity)
+
+		return &buf
+	},
+}
+
 // router defines the interface for sending Shoutrrr notifications.
 //
 // It abstracts the underlying service implementation.
@@ -919,10 +931,22 @@ func eventFieldMap(event *zerolog.Event) (map[string]any, time.Time, bool) {
 
 	buf := unsafe.Slice((*byte)(rv.UnsafePointer()), rv.Len())
 
+	rawPtr, ok := eventFieldRawPool.Get().(*[]byte)
+	if !ok || rawPtr == nil {
+		buf := make([]byte, 0, eventFieldRawCapacity)
+		rawPtr = &buf
+	}
+
+	// Reset the pooled buffer without dropping its capacity.
+	raw := (*rawPtr)[:0]
+
+	if cap(raw) < len(buf)+1 {
+		raw = make([]byte, 0, len(buf)+1)
+	}
+
 	// Close the partial JSON object produced before the message is appended.
-	raw := make([]byte, len(buf)+1)
-	copy(raw, buf)
-	raw[len(buf)] = '}'
+	raw = append(raw, buf...)
+	raw = append(raw, '}')
 
 	var fieldMap map[string]any
 
@@ -930,6 +954,11 @@ func eventFieldMap(event *zerolog.Event) (map[string]any, time.Time, bool) {
 	dec.UseNumber()
 
 	err := dec.Decode(&fieldMap)
+
+	// Return the scratch buffer after Decode has finished reading it.
+	*rawPtr = raw
+	eventFieldRawPool.Put(rawPtr)
+
 	if err != nil {
 		return nil, now, false
 	}
@@ -985,20 +1014,22 @@ func eventFieldMap(event *zerolog.Event) (map[string]any, time.Time, bool) {
 
 // send sends a message via the notification router.
 //
+// Cancellation before Send skips the delivery. An in-flight Send finishes on
+// the worker goroutine.
+//
 // Parameters:
 //   - msg: Message to send.
 func (n *shoutrrrTypeNotifier) send(msg string) {
-	sendCh := make(chan []error, 1)
-	go func() {
-		sendCh <- n.Router.Send(msg, n.params)
-	}()
-
+	// Skip delivery when Close already canceled the worker.
 	select {
-	case errs := <-sendCh:
-		processSendErrors(n, errs)
 	case <-n.ctx.Done():
 		n.ll().Debug().Err(n.ctx.Err()).Msg("Notification send canceled")
+
+		return
+	default:
 	}
+
+	processSendErrors(n, n.Router.Send(msg, n.params))
 }
 
 // buildMessage constructs a notification message from data.
@@ -1019,20 +1050,17 @@ func (n *shoutrrrTypeNotifier) buildMessage(data Data) (string, error) {
 		dataSource = data.Entries // Use entries only for legacy mode.
 	}
 
-	// Log template processing start with nil-safe report access
-	containerCount := 0
-
+	// Log template processing start with nil-safe report access.
 	reportAvailable := data.Report != nil
-	if reportAvailable {
-		containerCount = len(data.Report.All())
-	}
 
-	log.Debug().
-		Bool("legacy_template", n.legacyTemplate).
-		Int("entries_count", len(data.Entries)).
-		Int("container_count", containerCount).
-		Bool("report_available", reportAvailable).
-		Msg("Starting template processing for notification message")
+	if log.GetLevel() <= zerolog.DebugLevel {
+		log.Debug().
+			Bool("legacy_template", n.legacyTemplate).
+			Int("entries_count", len(data.Entries)).
+			Int("container_count", reportCategoryCount(data.Report)).
+			Bool("report_available", reportAvailable).
+			Msg("Starting template processing for notification message")
+	}
 
 	// Execute template with data.
 	err := n.template.Execute(&body, dataSource)
@@ -1059,6 +1087,29 @@ func (n *shoutrrrTypeNotifier) buildMessage(data Data) (string, error) {
 	log.Debug().Str("message", msg).Msg("Generated notification message")
 
 	return msg, nil
+}
+
+// reportCategoryCount returns the sum of report category lengths without calling All().
+//
+// Categories can overlap, so the sum may exceed the deduplicated All() count.
+//
+// Parameters:
+//   - report: Session report, or nil.
+//
+// Returns:
+//   - int: Combined length of all report categories.
+func reportCategoryCount(report types.Report) int {
+	if report == nil {
+		return 0
+	}
+
+	return len(report.Scanned()) +
+		len(report.Updated()) +
+		len(report.Failed()) +
+		len(report.Skipped()) +
+		len(report.Stale()) +
+		len(report.Fresh()) +
+		len(report.Restarted())
 }
 
 // sendEntries sends batched entries and optional report.

--- a/pkg/notifications/shoutrrr_benchmark_test.go
+++ b/pkg/notifications/shoutrrr_benchmark_test.go
@@ -1,0 +1,30 @@
+package notifications
+
+import (
+	"io"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+type eventFieldMapHook struct{}
+
+func (eventFieldMapHook) Run(event *zerolog.Event, _ zerolog.Level, _ string) {
+	fields, _, extracted := eventFieldMap(event)
+	if !extracted || fields == nil {
+		return
+	}
+}
+
+func BenchmarkEventFieldMap(b *testing.B) {
+	log := zerolog.New(io.Discard).Hook(eventFieldMapHook{})
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		log.Info().
+			Str("container", "web").
+			Str("image", "app:latest").
+			Msg("Found new image")
+	}
+}

--- a/pkg/notifications/shoutrrr_test.go
+++ b/pkg/notifications/shoutrrr_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"sync"
@@ -19,6 +20,7 @@ import (
 	"github.com/onsi/gomega/gbytes"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	shoutrrrTypes "github.com/nicholas-fedor/shoutrrr/pkg/types"
@@ -944,9 +946,12 @@ func TestSlowNotificationNotSent(t *testing.T) {
 			// Good, channel is empty
 		}
 
-		// Cancel to clean up goroutines
+		// Cancel cannot interrupt an in-flight Router.Send. Unlock so Send returns
+		// and the worker can observe cancellation and exit.
 		shoutrrr.cancel()
-		// Wait for sendNotifications to exit
+
+		blockingRouter.unlock <- true
+
 		<-shoutrrr.done
 	})
 }
@@ -1729,4 +1734,89 @@ func TestCreateNotifier_AcceptsGotifyURLFromFileExpansion(t *testing.T) {
 	)
 
 	require.NotNil(t, notifier)
+}
+
+func TestReportCategoryCount(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 0, reportCategoryCount(nil))
+
+	report := categoryCountReport{
+		scanned:   make([]types.ContainerReport, 2),
+		updated:   make([]types.ContainerReport, 1),
+		restarted: make([]types.ContainerReport, 1),
+	}
+	assert.Equal(t, 4, reportCategoryCount(report))
+}
+
+func TestSend_CanceledBeforeSend(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	router := &countingRouter{}
+	notifier := &shoutrrrTypeNotifier{
+		Router: router,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	notifier.send("should not send")
+	assert.Equal(t, int32(0), router.sends.Load())
+}
+
+func TestEventFieldMap_NilEvent(t *testing.T) {
+	t.Parallel()
+
+	fields, _, ok := eventFieldMap(nil)
+	assert.False(t, ok)
+	assert.Nil(t, fields)
+}
+
+func TestEventFieldMap_NumbersAndTimestamp(t *testing.T) {
+	t.Parallel()
+
+	var captured map[string]any
+
+	hook := zerolog.HookFunc(func(event *zerolog.Event, _ zerolog.Level, _ string) {
+		fields, _, ok := eventFieldMap(event)
+		if ok {
+			captured = fields
+		}
+	})
+
+	log := zerolog.New(io.Discard).Hook(hook)
+	log.Info().
+		Int64("count", 42).
+		Float64("ratio", 1.5).
+		Str(zerolog.TimestampFieldName, "not-a-timestamp").
+		Msg("numbers")
+
+	require.NotNil(t, captured)
+	assert.Equal(t, int64(42), captured["count"])
+	assert.InDelta(t, 1.5, captured["ratio"], 0.001)
+}
+
+type categoryCountReport struct {
+	scanned, updated, failed, skipped, stale, fresh, restarted []types.ContainerReport
+}
+
+func (r categoryCountReport) Scanned() []types.ContainerReport   { return r.scanned }
+func (r categoryCountReport) Updated() []types.ContainerReport   { return r.updated }
+func (r categoryCountReport) Failed() []types.ContainerReport    { return r.failed }
+func (r categoryCountReport) Skipped() []types.ContainerReport   { return r.skipped }
+func (r categoryCountReport) Stale() []types.ContainerReport     { return r.stale }
+func (r categoryCountReport) Fresh() []types.ContainerReport     { return r.fresh }
+func (r categoryCountReport) Restarted() []types.ContainerReport { return r.restarted }
+func (r categoryCountReport) All() []types.ContainerReport       { return nil }
+
+type countingRouter struct {
+	sends atomic.Int32
+}
+
+func (c *countingRouter) Send(_ string, _ *shoutrrrTypes.Params) []error {
+	c.sends.Add(1)
+
+	return nil
 }

--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -1087,7 +1087,7 @@ func ExtractGetDigest(log *zerolog.Logger, resp *http.Response) (string, error) 
 	if len(bodyBytes) > maxManifestSize {
 		log.Debug().
 			Str("status", resp.Status).
-			Int("size", len(bodyBytes)).
+			Int("observed_size", len(bodyBytes)).
 			Int("limit", maxManifestSize).
 			Msg("Digest response body exceeds size limit")
 

--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -31,6 +31,9 @@ import (
 // allowing Watchtower to compare or fetch it without downloading the full manifest body.
 const ContentDigestHeader = "Docker-Content-Digest"
 
+// maxManifestSize is the maximum allowed size for a digest GET fallback body (1 MiB).
+const maxManifestSize = 1 << 20
+
 // Errors for digest retrieval operations.
 var (
 	// errMissingImageInfo indicates the container lacks image metadata, preventing digest operations.
@@ -47,6 +50,8 @@ var (
 	errFailedCreateRequest = errors.New("failed to create request")
 	// errFailedExecuteRequest indicates a failure to execute an HTTP request to the registry.
 	errFailedExecuteRequest = errors.New("failed to execute request")
+	// errManifestTooLarge indicates the digest GET fallback body exceeded the size limit.
+	errManifestTooLarge = errors.New("manifest response exceeds size limit")
 )
 
 // localOnlyImageCache records image name+ID pairs previously confirmed as local-only
@@ -1038,11 +1043,13 @@ func ExtractHeadDigest(log *zerolog.Logger, resp *http.Response) (string, error)
 // It first tries to retrieve the digest from the "Docker-Content-Digest" header.
 // If the header is missing, it falls back to parsing the response body as a JSON
 // manifest or as a plain text digest for non-standard registries.
+// The fallback body is limited to maxManifestSize.
 // When attempting JSON parsing, the Content-Type header must contain "application/json",
 // "application/vnd.oci", or "application/vnd.docker".
 // The digest is normalized for consistency.
 //
 // Parameters:
+//   - log: Logger for debug output.
 //   - resp: The HTTP response from a GET request containing headers and body.
 //
 // Returns:
@@ -1061,8 +1068,8 @@ func ExtractGetDigest(log *zerolog.Logger, resp *http.Response) (string, error) 
 		return normalizedDigest, nil
 	}
 
-	// Fallback: Try to read the response body.
-	bodyBytes, err := io.ReadAll(resp.Body)
+	// Fallback: read the body with a size limit. The extra byte detects overflow.
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxManifestSize+1))
 	if err != nil {
 		log.Debug().
 			Err(err).
@@ -1073,6 +1080,22 @@ func ExtractGetDigest(log *zerolog.Logger, resp *http.Response) (string, error) 
 			"%w: failed to read response body: %w",
 			errInvalidRegistryResponse,
 			err,
+		)
+	}
+
+	// Reject oversized bodies before parsing or converting to a string.
+	if len(bodyBytes) > maxManifestSize {
+		log.Debug().
+			Str("status", resp.Status).
+			Int("size", len(bodyBytes)).
+			Int("limit", maxManifestSize).
+			Msg("Digest response body exceeds size limit")
+
+		return "", fmt.Errorf(
+			"%w: %d bytes exceeds limit of %d bytes",
+			errManifestTooLarge,
+			len(bodyBytes),
+			maxManifestSize,
 		)
 	}
 

--- a/pkg/registry/digest/digest_test.go
+++ b/pkg/registry/digest/digest_test.go
@@ -1298,6 +1298,21 @@ func (e *errReadCloser) Close() error {
 	return nil
 }
 
+func TestExtractGetDigest_OversizedBody(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(strings.Repeat("a", maxManifestSize+2))),
+	}
+
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	got, err := ExtractGetDigest(testLog(), resp)
+	require.ErrorIs(t, err, errManifestTooLarge)
+	assert.Empty(t, got)
+}
+
 func TestMakeManifestRequest(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/registry/digest/digest_test.go
+++ b/pkg/registry/digest/digest_test.go
@@ -1298,19 +1298,49 @@ func (e *errReadCloser) Close() error {
 	return nil
 }
 
-func TestExtractGetDigest_OversizedBody(t *testing.T) {
-	resp := &http.Response{
-		StatusCode: http.StatusOK,
-		Status:     "200 OK",
-		Header:     http.Header{"Content-Type": []string{"application/json"}},
-		Body:       io.NopCloser(strings.NewReader(strings.Repeat("a", maxManifestSize+2))),
+func TestExtractGetDigest_ManifestSizeLimits(t *testing.T) {
+	const digestPrefix = "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+	tests := []struct {
+		name    string
+		size    int
+		wantErr error
+	}{
+		{
+			name: "accepts body of exactly maxManifestSize",
+			size: maxManifestSize,
+		},
+		{
+			name:    "rejects body of maxManifestSize plus one",
+			size:    maxManifestSize + 1,
+			wantErr: errManifestTooLarge,
+		},
 	}
 
-	t.Cleanup(func() { _ = resp.Body.Close() })
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := digestPrefix + strings.Repeat("a", tc.size-len(digestPrefix))
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header:     http.Header{"Content-Type": []string{"text/plain"}},
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}
 
-	got, err := ExtractGetDigest(testLog(), resp)
-	require.ErrorIs(t, err, errManifestTooLarge)
-	assert.Empty(t, got)
+			t.Cleanup(func() { _ = resp.Body.Close() })
+
+			got, err := ExtractGetDigest(testLog(), resp)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				assert.Empty(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, strings.TrimPrefix(body, "sha256:"), got)
+		})
+	}
 }
 
 func TestMakeManifestRequest(t *testing.T) {

--- a/pkg/registry/trust.go
+++ b/pkg/registry/trust.go
@@ -43,6 +43,8 @@ var (
 	errFailedLoadDockerConfig = errors.New("failed to load Docker config")
 	// errFailedMarshalAuthConfig indicates a failure to marshal the auth config to JSON.
 	errFailedMarshalAuthConfig = errors.New("failed to marshal auth config to JSON")
+	// errFailedGetCredentials indicates a failure to retrieve credentials from the Docker store.
+	errFailedGetCredentials = errors.New("failed to get registry credentials")
 )
 
 var (
@@ -302,7 +304,17 @@ func EncodedConfigCredentials(log *zerolog.Logger, imageRef string) (string, err
 
 	// Retrieve credentials from the config store.
 	credStore := CredentialsStore(*configFile)
-	credentials, _ := credStore.Get(server)
+
+	credentials, err := credStore.Get(server)
+	if err != nil {
+		log.Debug().
+			Err(err).
+			Str("image_ref", imageRef).
+			Str("server", server).
+			Msg("Failed to get registry credentials")
+
+		return "", fmt.Errorf("%w: %w", errFailedGetCredentials, err)
+	}
 
 	// Empty AuthConfig is a miss. Cache it so later lookups skip Load.
 	if !hasUsableRegistryCredentials(credentials) {

--- a/pkg/registry/trust.go
+++ b/pkg/registry/trust.go
@@ -6,7 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sync"
+	"time"
 
+	"github.com/maypok86/otter/v2"
+	"github.com/maypok86/otter/v2/stats"
 	"github.com/rs/zerolog"
 
 	dockerCliConfig "github.com/docker/cli/cli/config"
@@ -15,6 +20,15 @@ import (
 	dockerConfig "github.com/docker/cli/cli/config/types"
 
 	"github.com/nicholas-fedor/watchtower/pkg/registry/auth"
+)
+
+const (
+	// encodedAuthCacheMaximumSize is the maximum number of encoded auth entries.
+	encodedAuthCacheMaximumSize = 256
+	// encodedAuthCacheInitialCapacity is the initial otter cache capacity.
+	encodedAuthCacheInitialCapacity = 16
+	// encodedAuthTTL is how long encoded registry auth is reused.
+	encodedAuthTTL = 2 * time.Minute
 )
 
 // Errors for registry authentication operations.
@@ -30,6 +44,95 @@ var (
 	// errFailedMarshalAuthConfig indicates a failure to marshal the auth config to JSON.
 	errFailedMarshalAuthConfig = errors.New("failed to marshal auth config to JSON")
 )
+
+var (
+	// encodedAuthCache holds encoded Docker-config credentials by host and config dir.
+	encodedAuthCache *otter.Cache[string, encodedAuthEntry]
+	// encodedAuthCacheOnce initializes encodedAuthCache exactly once.
+	encodedAuthCacheOnce sync.Once
+)
+
+// encodedAuthEntry stores encoded credentials and the Docker config mtime.
+type encodedAuthEntry struct {
+	encoded string
+	mtime   int64
+}
+
+// encodedAuthExpiryCalculator applies encodedAuthTTL to otter cache entries.
+type encodedAuthExpiryCalculator struct{}
+
+// ExpireAfterCreate returns the TTL for a newly created auth cache entry.
+func (e *encodedAuthExpiryCalculator) ExpireAfterCreate(_ otter.Entry[string, encodedAuthEntry]) time.Duration {
+	return encodedAuthTTL
+}
+
+// ExpireAfterUpdate returns the TTL for an updated auth cache entry.
+func (e *encodedAuthExpiryCalculator) ExpireAfterUpdate(_ otter.Entry[string, encodedAuthEntry], _ encodedAuthEntry) time.Duration {
+	return encodedAuthTTL
+}
+
+// ExpireAfterRead preserves the remaining TTL when an auth cache entry is read.
+func (e *encodedAuthExpiryCalculator) ExpireAfterRead(entry otter.Entry[string, encodedAuthEntry]) time.Duration {
+	return entry.ExpiresAfter()
+}
+
+// initEncodedAuthCache initializes the encoded registry auth cache once.
+//
+// Otter construction failure panics because auth lookup cannot proceed without it.
+func initEncodedAuthCache() {
+	encodedAuthCacheOnce.Do(func() {
+		cache, err := otter.New(
+			&otter.Options[string, encodedAuthEntry]{
+				MaximumSize:      encodedAuthCacheMaximumSize,
+				InitialCapacity:  encodedAuthCacheInitialCapacity,
+				ExpiryCalculator: &encodedAuthExpiryCalculator{},
+				StatsRecorder:    stats.NewCounter(),
+			})
+		if err != nil {
+			panic("failed to initialize encoded auth cache: " + err.Error())
+		}
+
+		encodedAuthCache = cache
+	})
+}
+
+// resetEncodedAuthCache clears cached encoded auth entries.
+//
+// Tests use this to isolate Docker config mutations between cases.
+func resetEncodedAuthCache() {
+	initEncodedAuthCache()
+	encodedAuthCache.InvalidateAll()
+}
+
+// encodedAuthCacheKey builds a cache key from registry host and config directory.
+//
+// Parameters:
+//   - server: Registry host address.
+//   - configDir: Docker config directory.
+//
+// Returns:
+//   - string: Cache key unique to that host and config path.
+func encodedAuthCacheKey(server, configDir string) string {
+	return server + "\x00" + configDir
+}
+
+// configFileModTime returns the config.json mtime in nanoseconds, or 0 if missing.
+//
+// Parameters:
+//   - configDir: Docker config directory.
+//
+// Returns:
+//   - int64: File modification time in nanoseconds, or 0 when the file is absent.
+func configFileModTime(configDir string) int64 {
+	configPath := filepath.Join(filepath.Clean(configDir), "config.json")
+
+	info, err := os.Stat(configPath)
+	if err != nil {
+		return 0
+	}
+
+	return info.ModTime().UnixNano()
+}
 
 // EncodedAuth attempts to retrieve encoded authentication credentials for a given image name.
 //
@@ -117,7 +220,7 @@ func EncodedEnvAuth(log *zerolog.Logger) (string, error) {
 			Bool("has_username", true).
 			Msg("Loaded auth credentials from environment")
 
-		// Trace only non-sensitive presence indicators. Never log REPO_PASS.
+		// Trace only non-sensitive presence indicators. Never log password or tokens.
 		if log.GetLevel() == zerolog.TraceLevel {
 			log.Trace().
 				Bool("has_username", true).
@@ -137,39 +240,52 @@ func EncodedEnvAuth(log *zerolog.Logger) (string, error) {
 
 // EncodedConfigCredentials retrieves authentication credentials from the Docker config file.
 //
-// The Docker config must be mounted on the container.
+// Successful and empty lookups are cached by registry host and config directory.
+// The cache is invalidated when config.json mtime changes or the TTL expires.
+// Failed loads are not cached.
 //
 // Parameters:
+//   - log: Logger for debug output.
 //   - imageRef: Image reference string for registry lookup.
 //
 // Returns:
 //   - string: Base64-encoded credentials string if found, empty if none.
 //   - error: Non-nil if config loading or address retrieval fails, nil on success or if no auth is found.
 func EncodedConfigCredentials(log *zerolog.Logger, imageRef string) (string, error) {
-	// Set up logging fields for tracking.
-	fields := map[string]any{
-		"image_ref": imageRef,
-	}
-
 	// Get the registry server address from the image reference.
 	server, err := auth.GetRegistryAddress(log, imageRef)
 	if err != nil {
 		log.Debug().
 			Err(err).
-			Fields(fields).
+			Str("image_ref", imageRef).
 			Msg("Failed to get registry address")
 
 		return "", fmt.Errorf("%w: %w", errFailedGetRegistryAddress, err)
 	}
 
-	// Use DOCKER_CONFIG env var or default to root directory.
+	// Use DOCKER_CONFIG or default to the root directory.
 	configDir := os.Getenv("DOCKER_CONFIG")
 	if configDir == "" {
 		configDir = "/"
 
 		log.Debug().
-			Fields(fields).
+			Str("image_ref", imageRef).
 			Msg("No DOCKER_CONFIG set, using default directory")
+	}
+
+	initEncodedAuthCache()
+
+	mtime := configFileModTime(configDir)
+	cacheKey := encodedAuthCacheKey(server, configDir)
+
+	// Reuse encoded auth when the Docker config file has not changed.
+	if entry, ok := encodedAuthCache.GetIfPresent(cacheKey); ok && entry.mtime == mtime {
+		log.Debug().
+			Str("image_ref", imageRef).
+			Str("server", server).
+			Msg("Using cached registry auth credentials")
+
+		return entry.encoded, nil
 	}
 
 	// Load the Docker config file from the specified directory.
@@ -177,32 +293,33 @@ func EncodedConfigCredentials(log *zerolog.Logger, imageRef string) (string, err
 	if err != nil {
 		log.Debug().
 			Err(err).
-			Fields(fields).
+			Str("image_ref", imageRef).
 			Str("config_dir", configDir).
 			Msg("Failed to load Docker config")
 
 		return "", fmt.Errorf("%w: %w", errFailedLoadDockerConfig, err)
 	}
 
-	// Retrieve credentials from the config's store.
+	// Retrieve credentials from the config store.
 	credStore := CredentialsStore(*configFile)
 	credentials, _ := credStore.Get(server)
 
-	// Accept username+password, password-only tokens, or identity tokens from
-	// credential helpers (ECR and similar). Empty AuthConfig is a miss.
+	// Empty AuthConfig is a miss. Cache it so later lookups skip Load.
 	if !hasUsableRegistryCredentials(credentials) {
 		log.Debug().
-			Fields(fields).
+			Str("image_ref", imageRef).
 			Str("server", server).
 			Str("config_file", configFile.Filename).
 			Msg("No credentials found in config")
 
+		encodedAuthCache.Set(cacheKey, encodedAuthEntry{mtime: mtime})
+
 		return "", nil
 	}
 
-	// Log successful credential retrieval with non-sensitive presence flags only.
+	// Log successful retrieval with non-sensitive presence flags only.
 	log.Debug().
-		Fields(fields).
+		Str("image_ref", imageRef).
 		Bool("has_username", credentials.Username != "").
 		Bool("has_password", credentials.Password != "").
 		Bool("has_identity_tok", credentials.IdentityToken != "").
@@ -210,10 +327,9 @@ func EncodedConfigCredentials(log *zerolog.Logger, imageRef string) (string, err
 		Str("config_file", configFile.Filename).
 		Msg("Loaded auth credentials from config")
 
-	// Trace only non-sensitive presence indicators. Never log password or tokens.
 	if log.GetLevel() == zerolog.TraceLevel {
 		log.Trace().
-			Fields(fields).
+			Str("image_ref", imageRef).
 			Bool("has_username", credentials.Username != "").
 			Bool("has_password", credentials.Password != "").
 			Bool("has_identity_tok", credentials.IdentityToken != "").
@@ -221,8 +337,15 @@ func EncodedConfigCredentials(log *zerolog.Logger, imageRef string) (string, err
 			Msg("Using config credentials")
 	}
 
-	// Encode and return the auth config (includes IdentityToken when set).
-	return EncodeCredentials(log, credentials)
+	// Encode the auth config, including IdentityToken when set.
+	encoded, err := EncodeCredentials(log, credentials)
+	if err != nil {
+		return "", err
+	}
+
+	encodedAuthCache.Set(cacheKey, encodedAuthEntry{encoded: encoded, mtime: mtime})
+
+	return encoded, nil
 }
 
 // hasUsableRegistryCredentials reports whether AuthConfig carries material the

--- a/pkg/registry/trust_test.go
+++ b/pkg/registry/trust_test.go
@@ -756,17 +756,32 @@ func TestEncodedConfigCredentials_FailedLookupNotCached(t *testing.T) {
 	resetEncodedAuthCache()
 	t.Cleanup(resetEncodedAuthCache)
 
-	tempDir := writeTestDockerConfig(t, map[string]map[string]string{
-		"ghcr.io": {
-			"username": "later-user",
-			"password": "later-pass",
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+	require.NoError(t, os.WriteFile(configPath, []byte("{"), 0o600))
+
+	t.Setenv("DOCKER_CONFIG", tempDir)
+	t.Setenv("HOME", tempDir)
+	dockerCliConfig.SetDir(tempDir)
+
+	mtime := configFileModTime(tempDir)
+
+	empty, err := EncodedConfigCredentials(testLog(), "ghcr.io/org/app:latest")
+	require.Error(t, err)
+	require.ErrorIs(t, err, errFailedLoadDockerConfig)
+	assert.Empty(t, empty)
+
+	valid, err := json.Marshal(map[string]any{
+		"auths": map[string]any{
+			"ghcr.io": map[string]string{
+				"username": "later-user",
+				"password": "later-pass",
+			},
 		},
 	})
-	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
-
-	empty, err := EncodedConfigCredentials(testLog(), "")
-	require.Error(t, err)
-	assert.Empty(t, empty)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configPath, valid, 0o600))
+	require.NoError(t, os.Chtimes(configPath, time.Unix(0, mtime), time.Unix(0, mtime)))
 
 	got, err := EncodedConfigCredentials(testLog(), "ghcr.io/org/app:latest")
 	require.NoError(t, err)

--- a/pkg/registry/trust_test.go
+++ b/pkg/registry/trust_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/distribution/reference"
 	"github.com/stretchr/testify/assert"
@@ -704,6 +705,72 @@ func TestEncodedConfigCredentials_InvalidImageRef(t *testing.T) {
 	credentials, err := EncodedConfigCredentials(testLog(), "")
 	require.Error(t, err)
 	assert.Empty(t, credentials)
+}
+
+func TestEncodedConfigCredentials_CacheHitAndMtimeInvalidation(t *testing.T) {
+	resetEncodedAuthCache()
+	t.Cleanup(resetEncodedAuthCache)
+
+	tempDir := writeTestDockerConfig(t, map[string]map[string]string{
+		"ghcr.io": {
+			"username": "cache-user",
+			"password": "cache-pass",
+		},
+	})
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	first, err := EncodedConfigCredentials(testLog(), "ghcr.io/org/app:latest")
+	require.NoError(t, err)
+	require.NotEmpty(t, first)
+
+	second, err := EncodedConfigCredentials(testLog(), "ghcr.io/org/app:latest")
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+
+	configPath := filepath.Join(tempDir, "config.json")
+	updated, err := json.Marshal(map[string]any{
+		"auths": map[string]any{
+			"ghcr.io": map[string]string{
+				"username": "cache-user",
+				"password": "rotated-pass",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Ensure mtime changes even on coarse filesystems.
+	past := configFileModTime(tempDir) - int64(time.Second)
+	require.NoError(t, os.Chtimes(configPath, time.Unix(0, past), time.Unix(0, past)))
+	require.NoError(t, os.WriteFile(configPath, updated, 0o600))
+
+	future := time.Now().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(configPath, future, future))
+
+	third, err := EncodedConfigCredentials(testLog(), "ghcr.io/org/app:latest")
+	require.NoError(t, err)
+	require.NotEmpty(t, third)
+	assert.NotEqual(t, first, third)
+}
+
+func TestEncodedConfigCredentials_FailedLookupNotCached(t *testing.T) {
+	resetEncodedAuthCache()
+	t.Cleanup(resetEncodedAuthCache)
+
+	tempDir := writeTestDockerConfig(t, map[string]map[string]string{
+		"ghcr.io": {
+			"username": "later-user",
+			"password": "later-pass",
+		},
+	})
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	empty, err := EncodedConfigCredentials(testLog(), "")
+	require.Error(t, err)
+	assert.Empty(t, empty)
+
+	got, err := EncodedConfigCredentials(testLog(), "ghcr.io/org/app:latest")
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
 }
 
 // writeTestDockerConfig writes a Docker config.json with the given auths map

--- a/pkg/session/report.go
+++ b/pkg/session/report.go
@@ -110,21 +110,23 @@ func allFromSlices(
 	scanned, updated, restarted, failed, skipped, stale, fresh []types.ContainerReport,
 ) []types.ContainerReport {
 	// Calculate total capacity for all containers to pre-allocate slice efficiently.
-	allLen := len(scanned) + len(updated) + len(failed) + len(skipped) + len(stale) + len(fresh)
+	allLen := len(scanned) + len(updated) + len(restarted) + len(failed) + len(skipped) + len(stale) + len(fresh)
 	all := make([]types.ContainerReport, 0, allLen)
-	presentIDs := map[types.ContainerID][]string{} // Track container IDs to prevent duplicates
+	// Track container IDs to prevent duplicates.
+	presentIDs := make(map[types.ContainerID]struct{}, allLen)
 
 	// appendUnique adds containers from a slice only if they haven't been added before.
 	// This ensures deduplication while maintaining the priority order defined by the calling sequence.
 	appendUnique := func(reports []types.ContainerReport) {
 		for _, report := range reports {
-			_, found := presentIDs[report.ID()]
-			if found {
-				continue // Skip containers already added from higher-priority categories
+			if _, found := presentIDs[report.ID()]; found {
+				// Skip containers already added from higher-priority categories.
+				continue
 			}
 
 			all = append(all, report)
-			presentIDs[report.ID()] = nil // Mark this container ID as processed
+			// Mark this container ID as processed.
+			presentIDs[report.ID()] = struct{}{}
 		}
 	}
 

--- a/pkg/session/report_benchmark_test.go
+++ b/pkg/session/report_benchmark_test.go
@@ -1,0 +1,39 @@
+package session
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/nicholas-fedor/watchtower/pkg/types"
+)
+
+func BenchmarkAllFromSlices(b *testing.B) {
+	const n = 64
+
+	scanned := make([]types.ContainerReport, n)
+	updated := make([]types.ContainerReport, n/8)
+	restarted := make([]types.ContainerReport, n/8)
+	fresh := make([]types.ContainerReport, n/2)
+
+	for i := range scanned {
+		scanned[i] = &ContainerStatus{containerID: types.ContainerID("c" + strconv.Itoa(i))}
+	}
+
+	for i := range updated {
+		updated[i] = scanned[i]
+	}
+
+	for i := range restarted {
+		restarted[i] = scanned[n/8+i]
+	}
+
+	for i := range fresh {
+		fresh[i] = scanned[n/4+i]
+	}
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		_ = allFromSlices(scanned, updated, restarted, nil, nil, nil, fresh)
+	}
+}

--- a/pkg/session/report_benchmark_test.go
+++ b/pkg/session/report_benchmark_test.go
@@ -12,7 +12,6 @@ func BenchmarkAllFromSlices(b *testing.B) {
 
 	scanned := make([]types.ContainerReport, n)
 	updated := make([]types.ContainerReport, n/8)
-	restarted := make([]types.ContainerReport, n/8)
 	fresh := make([]types.ContainerReport, n/2)
 
 	for i := range scanned {
@@ -23,17 +22,35 @@ func BenchmarkAllFromSlices(b *testing.B) {
 		updated[i] = scanned[i]
 	}
 
-	for i := range restarted {
-		restarted[i] = scanned[n/8+i]
-	}
-
 	for i := range fresh {
 		fresh[i] = scanned[n/4+i]
 	}
 
-	b.ReportAllocs()
+	b.Run("reuseRestarted", func(b *testing.B) {
+		restarted := make([]types.ContainerReport, n/8)
+		for i := range restarted {
+			restarted[i] = scanned[n/8+i]
+		}
 
-	for b.Loop() {
-		_ = allFromSlices(scanned, updated, restarted, nil, nil, nil, fresh)
-	}
+		b.ReportAllocs()
+
+		for b.Loop() {
+			_ = allFromSlices(scanned, updated, restarted, nil, nil, nil, fresh)
+		}
+	})
+
+	b.Run("uniqueRestarted", func(b *testing.B) {
+		// Unique restarted IDs make the combined result larger than the old
+		// capacity of scanned+updated+fresh (64+8+32).
+		restarted := make([]types.ContainerReport, n)
+		for i := range restarted {
+			restarted[i] = &ContainerStatus{containerID: types.ContainerID("r" + strconv.Itoa(i))}
+		}
+
+		b.ReportAllocs()
+
+		for b.Loop() {
+			_ = allFromSlices(scanned, updated, restarted, nil, nil, nil, fresh)
+		}
+	})
 }


### PR DESCRIPTION
This PR cuts peak RSS and allocs/op on the update scan path without changing notification templates, recreate correctness, or fail-closed `notify=no` behavior. Unbounded pull, digest, and exec reads are capped, and repeated per-container work is cached or compiled once. Notification sends no longer block shutdown indefinitely, and lifecycle hooks now run only against the filtered scan snapshot.

## Problem

Each scan listed containers, inspected images, compiled filter regexes, loaded Docker config credentials, and called Docker `Info()` on hot paths. Pull progress and digest GET fallbacks used unbounded `ReadAll`, so large streams could spike RSS. Notification delivery allocated a goroutine and channel per send, and debug counts rebuilt the full deduplicated report via `All()`. Passing the unfiltered list into pre/post hooks also ran lifecycle commands on excluded containers.

## Solution

Drain or size-limit IO, then reuse scan-cycle results that do not change within a cycle or a short TTL. Encoded registry auth uses the existing otter cache pattern. Filters compile only patterns that need regex semantics. Image names, Docker `Info` mirrors, and image inspect results are cached with isolation and coalescing. Lifecycle hooks accept the filtered snapshot, including a valid empty set. Notification send stays on the worker and is abandoned after the shutdown grace period once canceled.

## Changes

- Bound pull progress, digest GET fallback, and exec capture so large bodies are not buffered
- Cache encoded registry auth, Docker Info mirrors, compiled filters, resolved image names, and cloned image inspect metadata
- Send notifications on the worker, pool bounded `eventFieldMap` buffers, and stop calling `Report.All()` for debug counts
- Pass the filtered scan snapshot into pre/post lifecycle checks and treat a non-nil empty list as final
- Add Ginkgo/ghttp coverage plus allocation benches for the changed hot paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate image processing and corrected container image updates.
  * Lifecycle checks now consistently use containers selected for an operation.
  * Improved canceled notification sends and empty lifecycle results.

* **Performance**
  * Added caching for image metadata, registry mirrors, and registry credentials.
  * Reduced repeated Docker requests and improved filter matching.

* **Reliability**
  * Limited command output and registry manifests to 1 MiB.
  * Reduced memory use while processing image-pull responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->