### PR TITLE
feat(notifications): add JSON porcelain output format

### DIFF
--- a/docs/configuration/logging-and-output/index.md
+++ b/docs/configuration/logging-and-output/index.md
@@ -72,12 +72,12 @@ Environment Variable: NO_COLOR
 
 ## Programmatic Output (Porcelain)
 
-Outputs session results in a machine-readable format (version specified by `VERSION`).
+Outputs session results in a machine-readable format.
 
 ```text
             Argument: --porcelain, -P
 Environment Variable: WATCHTOWER_PORCELAIN
-     Possible Values: v1
+     Possible Values: v1, json
              Default: None
 ```
 
@@ -87,5 +87,33 @@ Environment Variable: WATCHTOWER_PORCELAIN
     --notification-url logger://
     --notification-log-stdout
     --notification-report
-    --notification-template porcelain.VERSION.summary-no-log
     ```
+
+For `v1`, the template is `porcelain.v1.summary-no-log`, producing one container per line.
+
+For `json`, the template is `porcelain.json`, producing a JSON document:
+
+```json
+{
+  "containers": [
+    {
+      "name": "nginx",
+      "image": "nginx:latest",
+      "image_id": "abc123",
+      "latest_image_id": "def456",
+      "state": "Updated",
+      "update_available": true
+    }
+  ]
+}
+```
+
+Fields:
+
+- `name` — container name
+- `image` — image name with tag
+- `image_id` — current short image ID
+- `latest_image_id` — latest short image ID
+- `state` — container state (`Updated`, `Fresh`, `Failed`, `Skipped`, `Restarted`)
+- `update_available` — whether an update is available
+- `error` — error message if any (omitted when empty)

--- a/docs/configuration/logging-and-output/index.md
+++ b/docs/configuration/logging-and-output/index.md
@@ -114,6 +114,6 @@ Fields:
 - `image` — image name with tag
 - `image_id` — current short image ID
 - `latest_image_id` — latest short image ID
-- `state` — container state (`Updated`, `Fresh`, `Failed`, `Skipped`, `Restarted`)
+- `state` — container state (`Updated`, `Fresh`, `Failed`, `Skipped`, `Restarted`, `Stale`)
 - `update_available` — whether an update is available
 - `error` — error message if any (omitted when empty)

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -455,10 +455,12 @@ func ProcessFlagAliases(log *zerolog.Logger, flags *pflag.FlagSet) {
 	}
 
 	if porcelain != "" {
-		if porcelain != "v1" {
+		switch porcelain {
+		case "v1", "json":
+		default:
 			log.Fatal().
 				Str("version", porcelain).
-				Msg("Unknown porcelain version, supported: v1")
+				Msg("Unknown porcelain version, supported: v1, json")
 		}
 
 		err := appendFlagValue(log, flags, "notification-url", "logger://")
@@ -469,7 +471,13 @@ func ProcessFlagAliases(log *zerolog.Logger, flags *pflag.FlagSet) {
 		setFlagIfDefault(log, flags, "notification-log-stdout", "true")
 		setFlagIfDefault(log, flags, "notification-report", "true")
 
-		tpl := fmt.Sprintf("porcelain.%s.summary-no-log", porcelain)
+		var tpl string
+		if porcelain == "v1" {
+			tpl = "porcelain.v1.summary-no-log"
+		} else {
+			tpl = "porcelain.json"
+		}
+
 		setFlagIfDefault(log, flags, "notification-template", tpl)
 		log.Debug().
 			Str("porcelain", porcelain).

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -653,6 +653,31 @@ func TestProcessFlagAliases(t *testing.T) {
 			},
 		},
 		{
+			name: "porcelain json with interval",
+			flags: []string{
+				"--porcelain", "json",
+				"--interval", "10",
+			},
+			checks: func(t *testing.T, flags *pflag.FlagSet) {
+				t.Helper()
+
+				urls, _ := flags.GetStringArray("notification-url")
+				assert.Contains(t, urls, "logger://")
+
+				logStdout, _ := flags.GetBool("notification-log-stdout")
+				assert.True(t, logStdout)
+
+				report, _ := flags.GetBool("notification-report")
+				assert.True(t, report)
+
+				template, _ := flags.GetString("notification-template")
+				assert.Equal(t, "porcelain.json", template)
+
+				sched, _ := flags.GetString("schedule")
+				assert.Equal(t, "@every 10s", sched)
+			},
+		},
+		{
 			name:    "log level from environment",
 			envVars: map[string]string{"WATCHTOWER_DEBUG": "true"},
 			checks: func(t *testing.T, flags *pflag.FlagSet) {
@@ -715,7 +740,7 @@ func TestProcessFlagAliases_FatalCases(t *testing.T) {
 		{
 			name:       "invalid porcelain version",
 			helperCase: "invalid-porcelain",
-			wantDiag:   "Unknown porcelain version, supported: v1",
+			wantDiag:   "Unknown porcelain version, supported: v1, json",
 		},
 	}
 

--- a/internal/flags/mode/register.go
+++ b/internal/flags/mode/register.go
@@ -33,7 +33,7 @@ func Specs() []spec.FlagSpec {
 			Kind:      spec.KindString,
 			Default:   "",
 			EnvKeys:   []string{"WATCHTOWER_PORCELAIN"},
-			Help:      `Write session results to stdout using a stable versioned format. Supported values: "v1"`,
+			Help:      `Write session results to stdout using a stable versioned format. Supported values: "v1", "json"`,
 		},
 		{
 			Name:    "no-startup-message",

--- a/pkg/notifications/common_templates.go
+++ b/pkg/notifications/common_templates.go
@@ -127,4 +127,9 @@ var commonTemplates = map[string]string{
 	// Useful for integrations that need structured data.
 	// Expects any data structure that can be JSON marshaled (typically the full report or entries).
 	`json.v1`: `{{ . | ToJSON }}`,
+
+	// "porcelain.json" template outputs the update report as a stable JSON document with per-container details.
+	// It omits log entries and focuses on the report: name, image, image_id, latest_image_id, state, update_available, and error.
+	// Expects .Report with an All() method returning []ContainerReport.
+	`porcelain.json`: `{{ .Report | ToPorcelainJSON }}`,
 }

--- a/pkg/notifications/funcs.go
+++ b/pkg/notifications/funcs.go
@@ -13,11 +13,12 @@ import (
 
 // Funcs defines utility functions for notification templates.
 var Funcs = template.FuncMap{
-	"ToUpper": strings.ToUpper,
-	"ToLower": strings.ToLower,
-	"ToJSON":  toJSON,
-	"Title":   cases.Title(language.AmericanEnglish).String,
-	"RFC1123": formatRFC1123,
+	"ToUpper":         strings.ToUpper,
+	"ToLower":         strings.ToLower,
+	"ToJSON":          toJSON,
+	"ToPorcelainJSON": ToPorcelainJSON,
+	"Title":           cases.Title(language.AmericanEnglish).String,
+	"RFC1123":         formatRFC1123,
 }
 
 // toJSON marshals a value to a formatted JSON string for use in templates.

--- a/pkg/notifications/porcelain.go
+++ b/pkg/notifications/porcelain.go
@@ -35,11 +35,12 @@ func ToPorcelainReport(sourceReport types.Report) PorcelainReport {
 		return PorcelainReport{Containers: make([]PorcelainContainer, 0)}
 	}
 
+	allContainers := sourceReport.All()
 	report := PorcelainReport{
-		Containers: make([]PorcelainContainer, 0, len(sourceReport.All())),
+		Containers: make([]PorcelainContainer, 0, len(allContainers)),
 	}
 
-	for _, containerReport := range sourceReport.All() {
+	for _, containerReport := range allContainers {
 		container := PorcelainContainer{
 			Name:            containerReport.Name(),
 			Image:           containerReport.ImageName(),

--- a/pkg/notifications/porcelain.go
+++ b/pkg/notifications/porcelain.go
@@ -1,0 +1,77 @@
+package notifications
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/nicholas-fedor/watchtower/pkg/types"
+)
+
+// PorcelainContainer represents a single container in the porcelain JSON report.
+type PorcelainContainer struct {
+	Name            string `json:"name"`
+	Image           string `json:"image"`
+	ImageID         string `json:"image_id"`
+	LatestImageID   string `json:"latest_image_id"`
+	State           string `json:"state"`
+	UpdateAvailable bool   `json:"update_available"`
+	Error           string `json:"error,omitempty"`
+}
+
+// PorcelainReport is the top-level JSON structure for --porcelain json.
+type PorcelainReport struct {
+	Containers []PorcelainContainer `json:"containers"`
+}
+
+// ToPorcelainReport converts a types.Report into a PorcelainReport.
+//
+// Parameters:
+//   - sourceReport: Source report.
+//
+// Returns:
+//   - PorcelainReport: JSON-ready report.
+func ToPorcelainReport(sourceReport types.Report) PorcelainReport {
+	if sourceReport == nil {
+		return PorcelainReport{Containers: make([]PorcelainContainer, 0)}
+	}
+
+	report := PorcelainReport{
+		Containers: make([]PorcelainContainer, 0, len(sourceReport.All())),
+	}
+
+	for _, containerReport := range sourceReport.All() {
+		container := PorcelainContainer{
+			Name:            containerReport.Name(),
+			Image:           containerReport.ImageName(),
+			ImageID:         containerReport.CurrentImageID().ShortID(),
+			LatestImageID:   containerReport.LatestImageID().ShortID(),
+			State:           containerReport.State(),
+			UpdateAvailable: containerReport.CurrentImageID() != containerReport.LatestImageID(),
+		}
+		if err := containerReport.Error(); err != "" {
+			container.Error = err
+		}
+
+		report.Containers = append(report.Containers, container)
+	}
+
+	return report
+}
+
+// ToPorcelainJSON marshals a types.Report to an indented JSON string for templates.
+//
+// Parameters:
+//   - sourceReport: Source report.
+//
+// Returns:
+//   - string: Indented JSON or error string if marshaling fails.
+func ToPorcelainJSON(sourceReport types.Report) string {
+	report := ToPorcelainReport(sourceReport)
+
+	bytes, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("failed to marshal porcelain JSON: %v", err)
+	}
+
+	return string(bytes)
+}

--- a/pkg/notifications/porcelain_test.go
+++ b/pkg/notifications/porcelain_test.go
@@ -1,0 +1,28 @@
+package notifications
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToPorcelainReport_NilInput(t *testing.T) {
+	t.Parallel()
+
+	report := ToPorcelainReport(nil)
+
+	assert.Empty(t, report.Containers)
+	assert.Empty(t, report.Containers)
+}
+
+func TestToPorcelainJSON_NilInput(t *testing.T) {
+	t.Parallel()
+
+	result := ToPorcelainJSON(nil)
+
+	require.NotEmpty(t, result)
+	assert.JSONEq(t, `{
+  "containers": []
+}`, result)
+}

--- a/pkg/notifications/shoutrrr_test.go
+++ b/pkg/notifications/shoutrrr_test.go
@@ -149,6 +149,43 @@ updt1 (mock/updt1:latest): Updated
 		})
 	})
 
+	ginkgo.When("rendering porcelain JSON", func() {
+		ginkgo.It("should produce valid JSON with container details", func() {
+			data := mockDataFromStates(session.UpdatedState, session.FreshState, session.FailedState)
+			result := getTemplatedResult(`porcelain.json`, false, data)
+
+			gomega.Expect(result).To(gomega.MatchJSON(`{
+				"containers": [
+					{
+						"name": "updt1",
+						"image": "mock/updt1:latest",
+						"image_id": "01d110000000",
+						"latest_image_id": "d0a110000000",
+						"state": "Updated",
+						"update_available": true
+					},
+					{
+						"name": "fail1",
+						"image": "mock/fail1:latest",
+						"image_id": "01d210000000",
+						"latest_image_id": "d0a210000000",
+						"state": "Failed",
+						"update_available": true,
+						"error": "accidentally the whole container"
+					},
+					{
+						"name": "frsh1",
+						"image": "mock/frsh1:latest",
+						"image_id": "01d310000000",
+						"latest_image_id": "01d310000000",
+						"state": "Fresh",
+						"update_available": false
+					}
+				]
+			}`))
+		})
+	})
+
 	ginkgo.When("adding a log hook", func() {
 		ginkgo.When("it has not been added before", func() {
 			ginkgo.It("should start receiving via RegisterHook", func() {

--- a/tools/tplprev/internal/preview/render_test.go
+++ b/tools/tplprev/internal/preview/render_test.go
@@ -136,3 +136,22 @@ func TestRenderParseError(t *testing.T) {
 	_, err := Render("{{ .Report", nil, nil)
 	require.Error(t, err)
 }
+
+func TestRenderPorcelainJSONWithNilReport(t *testing.T) {
+	t.Parallel()
+
+	result, err := Render(
+		templates.Templates["porcelain.json"],
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result), &decoded))
+	require.Contains(t, decoded, "containers")
+
+	containers, ok := decoded["containers"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, containers)
+}

--- a/tools/tplprev/internal/templates/funcs.go
+++ b/tools/tplprev/internal/templates/funcs.go
@@ -58,31 +58,32 @@ func toPorcelainJSON(v any) string {
 		return "{\n  \"containers\": []\n}"
 	}
 
-	r, ok := v.(report.Report)
+	sourceReport, ok := v.(report.Report)
 	if !ok {
 		return "failed to marshal porcelain JSON: input is not a report.Report"
 	}
 
-	pr := porcelainReport{
-		Containers: make([]porcelainContainer, 0, len(r.All())),
+	report := porcelainReport{
+		Containers: make([]porcelainContainer, 0, len(sourceReport.All())),
 	}
 
-	for _, cr := range r.All() {
+	for _, containerReport := range sourceReport.All() {
 		container := porcelainContainer{
-			Name:            cr.Name(),
-			Image:           cr.ImageName(),
-			ImageID:         cr.CurrentImageID().ShortID(),
-			LatestImageID:   cr.LatestImageID().ShortID(),
-			State:           cr.State(),
-			UpdateAvailable: cr.CurrentImageID() != cr.LatestImageID(),
+			Name:            containerReport.Name(),
+			Image:           containerReport.ImageName(),
+			ImageID:         containerReport.CurrentImageID().ShortID(),
+			LatestImageID:   containerReport.LatestImageID().ShortID(),
+			State:           containerReport.State(),
+			UpdateAvailable: containerReport.CurrentImageID() != containerReport.LatestImageID(),
 		}
-		if err := cr.Error(); err != "" {
+		if err := containerReport.Error(); err != "" {
 			container.Error = err
 		}
-		pr.Containers = append(pr.Containers, container)
+
+		report.Containers = append(report.Containers, container)
 	}
 
-	bytes, err := json.MarshalIndent(pr, "", "  ")
+	bytes, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
 		return fmt.Sprintf("failed to marshal porcelain JSON: %v", err)
 	}

--- a/tools/tplprev/internal/templates/funcs.go
+++ b/tools/tplprev/internal/templates/funcs.go
@@ -10,15 +10,18 @@ import (
 
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+
+	"github.com/nicholas-fedor/tplprev/internal/report"
 )
 
 // Funcs defines a set of utility functions for use in notification templates.
 var Funcs = template.FuncMap{
-	"ToUpper": strings.ToUpper,
-	"ToLower": strings.ToLower,
-	"ToJSON":  toJSON,
-	"Title":   cases.Title(language.AmericanEnglish).String,
-	"RFC1123": formatRFC1123,
+	"ToUpper":         strings.ToUpper,
+	"ToLower":         strings.ToLower,
+	"ToJSON":          toJSON,
+	"ToPorcelainJSON": toPorcelainJSON,
+	"Title":           cases.Title(language.AmericanEnglish).String,
+	"RFC1123":         formatRFC1123,
 }
 
 // toJSON marshals a value to a formatted JSON string for use in templates.
@@ -27,6 +30,61 @@ func toJSON(v any) string {
 	bytes, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		return fmt.Sprintf("failed to marshal JSON in notification template: %v", err)
+	}
+
+	return string(bytes)
+}
+
+// porcelainContainer represents a single container in the porcelain JSON report.
+type porcelainContainer struct {
+	Name            string `json:"name"`
+	Image           string `json:"image"`
+	ImageID         string `json:"image_id"`
+	LatestImageID   string `json:"latest_image_id"`
+	State           string `json:"state"`
+	UpdateAvailable bool   `json:"update_available"`
+	Error           string `json:"error,omitempty"`
+}
+
+// porcelainReport is the top-level JSON structure for porcelain JSON output.
+type porcelainReport struct {
+	Containers []porcelainContainer `json:"containers"`
+}
+
+// toPorcelainJSON marshals a report.Report to an indented JSON string for templates.
+// If marshaling fails, it returns an error message as the string.
+func toPorcelainJSON(v any) string {
+	if v == nil {
+		return "{\n  \"containers\": []\n}"
+	}
+
+	r, ok := v.(report.Report)
+	if !ok {
+		return "failed to marshal porcelain JSON: input is not a report.Report"
+	}
+
+	pr := porcelainReport{
+		Containers: make([]porcelainContainer, 0, len(r.All())),
+	}
+
+	for _, cr := range r.All() {
+		container := porcelainContainer{
+			Name:            cr.Name(),
+			Image:           cr.ImageName(),
+			ImageID:         cr.CurrentImageID().ShortID(),
+			LatestImageID:   cr.LatestImageID().ShortID(),
+			State:           cr.State(),
+			UpdateAvailable: cr.CurrentImageID() != cr.LatestImageID(),
+		}
+		if err := cr.Error(); err != "" {
+			container.Error = err
+		}
+		pr.Containers = append(pr.Containers, container)
+	}
+
+	bytes, err := json.MarshalIndent(pr, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("failed to marshal porcelain JSON: %v", err)
 	}
 
 	return string(bytes)

--- a/tools/tplprev/internal/templates/templates.go
+++ b/tools/tplprev/internal/templates/templates.go
@@ -101,6 +101,8 @@ var Templates = map[string]string{
 {{- end -}}`,
 
 	"json.v1": `{{ . | ToJSON }}`,
+
+	"porcelain.json": `{{ .Report | ToPorcelainJSON }}`,
 }
 
 // Lookup returns a named builtin template.

--- a/tools/tplprev/internal/templates/templates_test.go
+++ b/tools/tplprev/internal/templates/templates_test.go
@@ -18,6 +18,7 @@ func TestLookup(t *testing.T) {
 		{give: "default-legacy", wantFound: true},
 		{give: "json.v1", wantFound: true},
 		{give: "porcelain.v1.summary-no-log", wantFound: true},
+		{give: "porcelain.json", wantFound: true},
 		{give: "missing", wantFound: false},
 		{give: "", wantFound: false},
 	}
@@ -46,6 +47,7 @@ func TestNames(t *testing.T) {
 		"default",
 		"default-legacy",
 		"json.v1",
+		"porcelain.json",
 		"porcelain.v1.summary-no-log",
 	}, Names())
 }


### PR DESCRIPTION
This PR adds `--porcelain json` support so consumers can receive Watchtower update-check results as stable, structured JSON instead of parsing text output. It also updates the `tplprev` preview tool to support the new template and function.

## Problem

Users consuming Watchtower update-check results from other services or dashboards must parse the existing `--porcelain v1` text output to determine per-container update availability, state, and image IDs. That text format is brittle for programmatic consumers.

## Solution

Introduce a new `json` porcelain format that renders the report through a dedicated `porcelain.json` template using `ToPorcelainJSON`. The function converts `types.Report` into a `PorcelainReport` containing short image IDs, state strings, and an `update_available` boolean. Nil reports are handled safely and produce valid JSON with an empty `containers` array.

## Changes

- Add `PorcelainContainer` and `PorcelainReport` types in `pkg/notifications/porcelain.go`
- Register `ToPorcelainJSON` template function and `porcelain.json` template
- Extend `--porcelain` flag validation in `internal/flags/flags.go` to accept `json`
- Update `--porcelain` help text and documentation
- Add tests for nil report handling, template rendering, and flag alias behavior
- Update `tplprev` templates and preview rendering to support `porcelain.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON output support for porcelain mode alongside the existing `v1` format.
  * JSON reports include container image details, state, update availability, and optional error information.
  * JSON output is consistently formatted and excludes log entries.
  * Added validation and help text for supported porcelain output formats.

* **Documentation**
  * Updated configuration guidance with supported formats, templates, and JSON field definitions.

* **Bug Fixes**
  * Empty or unavailable reports now return valid JSON with an empty container list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->