### PR TITLE
fix(registry): handle registry 429 rate limits with backoff and token bucket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ go 1.26.6
 retract [v1.7.2, v1.7.9]
 
 require (
+	github.com/cenkalti/backoff/v7 v7.0.0
 	github.com/containerd/errdefs v1.0.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v29.7.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtn
 github.com/andybalholm/brotli v1.2.2/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/cenkalti/backoff/v7 v7.0.0 h1:ZP+QAaaOnVUHo+ufFpZ835hbT3x2fy+h2lecVEosZ6A=
+github.com/cenkalti/backoff/v7 v7.0.0/go.mod h1:qcKBGwsu4hpxHtQ8tWYsQ+ifzx2+sS+Xx/3jfe30lI8=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/distribution/reference"
 	"github.com/rs/zerolog"
@@ -30,13 +31,17 @@ const (
 	// WarnAuto indicates warnings should be logged for HEAD request failures based on registry heuristics.
 	WarnAuto WarningStrategy = "auto"
 
-	// maxConcurrentPulls caps simultaneous ImagePull calls so digest checks can
-	// stay parallel without bursting registry blob downloads.
+	// maxConcurrentPulls caps simultaneous ImagePull calls per registry host
+	// so digest checks can stay parallel without bursting blob downloads
+	// against one registry.
 	maxConcurrentPulls = 1
 )
 
-// pullSlots serializes layer pulls across the parallel staleness-check workers.
-var pullSlots = make(chan struct{}, maxConcurrentPulls)
+// pullSlots serializes layer pulls per registry host.
+var (
+	pullSlotsMu sync.Mutex
+	pullSlots   = map[string]chan struct{}{}
+)
 
 // IsImagePinnedByDigest reports whether imageName is an immutable digest reference.
 //
@@ -668,8 +673,8 @@ func (c imageClient) shouldSkipPull(
 // performImagePull executes a full image pull.
 //
 // It pulls the image and reads the response to ensure completion.
-// The process-wide pull slot is held only around the daemon ImagePull
-// so host cooldown sleeps do not block pulls to other registries.
+// The per-host pull slot is held only around the daemon ImagePull
+// so cooldown sleeps and pulls to other registries stay unblocked.
 //
 // Parameters:
 //   - ctx: Context for operation control.
@@ -696,16 +701,14 @@ func (c imageClient) performImagePull(
 		clog.Debug().
 			Err(hostErr).
 			Msg("Failed to resolve registry host for rate limiting")
-
-		pullHost = imageName
 	}
 
 	pullErr := ratelimit.Do(ctx, clog, pullHost, func() error {
-		err := acquirePullSlot(ctx)
+		err := acquirePullSlot(ctx, pullHost)
 		if err != nil {
 			return err
 		}
-		defer releasePullSlot()
+		defer releasePullSlot(pullHost)
 
 		response, err := c.api.ImagePull(ctx, imageName, opts)
 		if err != nil {
@@ -769,32 +772,56 @@ func (c imageClient) performImagePull(
 	return nil
 }
 
-// acquirePullSlot waits for a pull concurrency slot.
+// pullSlotFor returns the per-host pull slot channel, creating it when missing.
+//
+// Parameters:
+//   - host: Registry host key. Empty hosts share one unknown-host slot.
+//
+// Returns:
+//   - chan struct{}: Buffered slot channel with capacity maxConcurrentPulls.
+func pullSlotFor(host string) chan struct{} {
+	pullSlotsMu.Lock()
+	defer pullSlotsMu.Unlock()
+
+	slot := pullSlots[host]
+	if slot == nil {
+		slot = make(chan struct{}, maxConcurrentPulls)
+		pullSlots[host] = slot
+	}
+
+	return slot
+}
+
+// acquirePullSlot waits for a pull concurrency slot for host.
 //
 // Parameters:
 //   - ctx: Context that can cancel the wait.
+//   - host: Registry host whose slot should be acquired.
 //
 // Returns:
 //   - error: ctx.Err() when canceled. Nil when a slot was acquired.
-func acquirePullSlot(ctx context.Context) error {
+func acquirePullSlot(ctx context.Context, host string) error {
 	ctxErr := ctx.Err()
 	if ctxErr != nil {
 		return fmt.Errorf("image pull slot wait canceled: %w", ctxErr)
 	}
 
 	select {
-	case pullSlots <- struct{}{}:
+	case pullSlotFor(host) <- struct{}{}:
 		return nil
 	case <-ctx.Done():
 		return fmt.Errorf("image pull slot wait canceled: %w", ctx.Err())
 	}
 }
 
-// releasePullSlot returns a pull concurrency slot.
+// releasePullSlot returns a pull concurrency slot for host.
 //
-// The caller must have acquired a slot with acquirePullSlot.
-func releasePullSlot() {
-	<-pullSlots
+// The caller must have acquired a slot with acquirePullSlot for the same host.
+//
+// Parameters:
+//   - host: Registry host whose slot should be released.
+func releasePullSlot(host string) {
+	<-pullSlotFor(host)
 }
 
 // warnOnHeadFailed decides whether to warn about failed HEAD requests during image pulls.

--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -710,10 +710,20 @@ func (c imageClient) performImagePull(
 		}
 		defer releasePullSlot(pullHost)
 
+		// A sibling pull may have recorded a 429 after this attempt passed Wait
+		// and while it was queued on the slot. Recheck cooldown without taking
+		// another quota token.
+		cooldownErr := ratelimit.WaitCooldown(ctx, pullHost)
+		if cooldownErr != nil {
+			return fmt.Errorf("image pull cooldown wait: %w", cooldownErr)
+		}
+
 		response, err := c.api.ImagePull(ctx, imageName, opts)
 		if err != nil {
 			info := ratelimit.FromErrorMessage(err.Error())
 			if info != nil {
+				ratelimit.Observe(pullHost, info)
+
 				return info
 			}
 
@@ -747,6 +757,7 @@ func (c imageClient) performImagePull(
 		if waitErr != nil {
 			info := ratelimit.FromErrorMessage(waitErr.Error())
 			if info != nil {
+				ratelimit.Observe(pullHost, info)
 				clog.Warn().
 					Err(info).
 					Msg("Registry rate limited image pull")

--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/distribution/reference"
@@ -16,7 +15,9 @@ import (
 	dockerClient "github.com/moby/moby/client"
 
 	"github.com/nicholas-fedor/watchtower/pkg/registry"
+	"github.com/nicholas-fedor/watchtower/pkg/registry/auth"
 	"github.com/nicholas-fedor/watchtower/pkg/registry/digest"
+	"github.com/nicholas-fedor/watchtower/pkg/registry/ratelimit"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
@@ -28,7 +29,14 @@ const (
 	WarnNever WarningStrategy = "never"
 	// WarnAuto indicates warnings should be logged for HEAD request failures based on registry heuristics.
 	WarnAuto WarningStrategy = "auto"
+
+	// maxConcurrentPulls caps simultaneous ImagePull calls so digest checks can
+	// stay parallel without bursting registry blob downloads.
+	maxConcurrentPulls = 1
 )
+
+// pullSlots serializes layer pulls across the parallel staleness-check workers.
+var pullSlots = make(chan struct{}, maxConcurrentPulls)
 
 // IsImagePinnedByDigest reports whether imageName is an immutable digest reference.
 //
@@ -416,7 +424,12 @@ func (c imageClient) PullImage(
 	}
 
 	// Skip the pull if the digest matches the current image (or local-only).
-	if c.shouldSkipPull(ctx, sourceContainer, opts.RegistryAuth, warnOnHeadFailed, fields) {
+	skip, skipErr := c.shouldSkipPull(ctx, sourceContainer, opts.RegistryAuth, warnOnHeadFailed, fields)
+	if skipErr != nil {
+		return skipErr
+	}
+
+	if skip {
 		return nil
 	}
 
@@ -578,19 +591,20 @@ func newImageClient(api dockerClient.APIClient, log *zerolog.Logger) imageClient
 // Parameters:
 //   - ctx: Context for operation control.
 //   - sourceContainer: Container to check.
-//   - auth: Registry authentication credentials.
+//   - registryAuth: Registry authentication credentials.
 //   - warnOnHeadFailed: Strategy for logging warnings on HEAD request failures.
 //   - fields: Logging fields for context.
 //
 // Returns:
 //   - bool: True if pull can be skipped, false otherwise.
+//   - error: Non-nil when a registry rate limit should abort the pull.
 func (c imageClient) shouldSkipPull(
 	ctx context.Context,
 	sourceContainer types.Container,
 	registryAuth string,
 	warnOnHeadFailed WarningStrategy,
 	fields map[string]any,
-) bool {
+) (bool, error) {
 	clogVal := c.logger().With().
 		Fields(fields).
 		Logger()
@@ -620,6 +634,12 @@ func (c imageClient) shouldSkipPull(
 	}
 
 	switch {
+	case ratelimit.Is(err):
+		clog.Warn().
+			Err(err).
+			Msg("Registry rate limited digest check. Aborting pull")
+
+		return false, fmt.Errorf("digest check rate limited: %w", err)
 	case err != nil:
 		// Digest retrieval failed. Log based on warning strategy and proceed with pull.
 		headLevel := zerolog.DebugLevel
@@ -631,23 +651,25 @@ func (c imageClient) shouldSkipPull(
 			Err(err).
 			Msg("Digest retrieval failed, falling back to full pull")
 
-		return false
+		return false, nil
 	case match:
 		// Digests match (or local-only image treated as up-to-date). No pull needed.
 		clog.Debug().Msg("Digest match, skipping pull")
 
-		return true
+		return true, nil
 	default:
 		// Digests differ. Proceed with pull.
 		clog.Debug().Msg("Digest mismatch, proceeding with pull")
 
-		return false
+		return false, nil
 	}
 }
 
 // performImagePull executes a full image pull.
 //
 // It pulls the image and reads the response to ensure completion.
+// The process-wide pull slot is held only around the daemon ImagePull
+// so host cooldown sleeps do not block pulls to other registries.
 //
 // Parameters:
 //   - ctx: Context for operation control.
@@ -669,48 +691,110 @@ func (c imageClient) performImagePull(
 	clog := &clogVal
 	clog.Debug().Msg("Initiating image pull")
 
-	// Start the image pull.
-	response, err := c.api.ImagePull(ctx, imageName, opts)
-	if err != nil {
-		// Differentiate error types for appropriate logging and handling.
-		// Auth failures and missing images return distinct sentinel errors
-		// so callers can programmatically distinguish error categories.
-		switch {
-		case cerrdefs.IsUnauthorized(err):
-			clog.Warn().
-				Err(err).
-				Msg("Image pull failed: authentication required")
-
-			return fmt.Errorf("%w: %s: %w", ErrPullImageUnauthorized, imageName, err)
-		case cerrdefs.IsNotFound(err):
-			clog.Debug().
-				Err(err).
-				Msg("Image pull failed: image not found in registry")
-
-			return fmt.Errorf("%w: %s: %w", ErrPullImageNotFound, imageName, err)
-		default:
-			clog.Debug().
-				Err(err).
-				Msg("Failed to initiate image pull")
-
-			return fmt.Errorf("%w: %s: %w", errPullImageFailed, imageName, err)
-		}
-	}
-	defer response.Close()
-
-	// Drain the progress stream so the daemon finishes the pull without buffering it.
-	_, err = io.Copy(io.Discard, response)
-	if err != nil {
+	pullHost, hostErr := auth.GetRegistryAddress(clog, imageName)
+	if hostErr != nil || pullHost == "" {
 		clog.Debug().
-			Err(err).
-			Msg("Failed to read image pull response")
+			Err(hostErr).
+			Msg("Failed to resolve registry host for rate limiting")
 
-		return fmt.Errorf("%w: %s: %w", errReadPullResponseFailed, imageName, err)
+		pullHost = imageName
 	}
 
-	clog.Debug().Msg("Image pull completed")
+	pullErr := ratelimit.Do(ctx, clog, pullHost, func() error {
+		err := acquirePullSlot(ctx)
+		if err != nil {
+			return err
+		}
+		defer releasePullSlot()
+
+		response, err := c.api.ImagePull(ctx, imageName, opts)
+		if err != nil {
+			info := ratelimit.FromErrorMessage(err.Error())
+			if info != nil {
+				return info
+			}
+
+			// Differentiate error types for appropriate logging and handling.
+			// Auth failures and missing images return distinct sentinel errors
+			// so callers can programmatically distinguish error categories.
+			switch {
+			case cerrdefs.IsUnauthorized(err):
+				clog.Warn().
+					Err(err).
+					Msg("Image pull failed: authentication required")
+
+				return fmt.Errorf("%w: %s: %w", ErrPullImageUnauthorized, imageName, err)
+			case cerrdefs.IsNotFound(err):
+				clog.Debug().
+					Err(err).
+					Msg("Image pull failed: image not found in registry")
+
+				return fmt.Errorf("%w: %s: %w", ErrPullImageNotFound, imageName, err)
+			default:
+				clog.Debug().
+					Err(err).
+					Msg("Failed to initiate image pull")
+
+				return fmt.Errorf("%w: %s: %w", errPullImageFailed, imageName, err)
+			}
+		}
+		defer response.Close()
+
+		waitErr := response.Wait(ctx)
+		if waitErr != nil {
+			info := ratelimit.FromErrorMessage(waitErr.Error())
+			if info != nil {
+				clog.Warn().
+					Err(info).
+					Msg("Registry rate limited image pull")
+
+				return info
+			}
+
+			clog.Debug().
+				Err(waitErr).
+				Msg("Failed to read image pull response")
+
+			return fmt.Errorf("%w: %s: %w", errReadPullResponseFailed, imageName, waitErr)
+		}
+
+		clog.Debug().Msg("Image pull completed")
+
+		return nil
+	})
+	if pullErr != nil {
+		return fmt.Errorf("image pull: %w", pullErr)
+	}
 
 	return nil
+}
+
+// acquirePullSlot waits for a pull concurrency slot.
+//
+// Parameters:
+//   - ctx: Context that can cancel the wait.
+//
+// Returns:
+//   - error: ctx.Err() when canceled. Nil when a slot was acquired.
+func acquirePullSlot(ctx context.Context) error {
+	ctxErr := ctx.Err()
+	if ctxErr != nil {
+		return fmt.Errorf("image pull slot wait canceled: %w", ctxErr)
+	}
+
+	select {
+	case pullSlots <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("image pull slot wait canceled: %w", ctx.Err())
+	}
+}
+
+// releasePullSlot returns a pull concurrency slot.
+//
+// The caller must have acquired a slot with acquirePullSlot.
+func releasePullSlot() {
+	<-pullSlots
 }
 
 // warnOnHeadFailed decides whether to warn about failed HEAD requests during image pulls.

--- a/pkg/container/image_test.go
+++ b/pkg/container/image_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -26,6 +25,7 @@ import (
 	"github.com/nicholas-fedor/watchtower/internal/util"
 	mockContainer "github.com/nicholas-fedor/watchtower/pkg/container/mocks"
 	"github.com/nicholas-fedor/watchtower/pkg/registry/digest"
+	"github.com/nicholas-fedor/watchtower/pkg/registry/ratelimit"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
@@ -193,14 +193,12 @@ var _ = ginkgo.Describe("the client", func() {
 	})
 
 	ginkgo.When("draining an image pull progress stream", func() {
-		ginkgo.It("consumes the full stream without retaining the body", func() {
-			const streamSize = 2 << 20
-
+		ginkgo.It("waits for a successful JSON progress stream", func() {
 			mockServer.AllowUnhandledRequests = true
 			mockServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("POST", gomega.MatchRegexp("/images/create")),
-					ghttp.RespondWith(http.StatusOK, strings.Repeat("x", streamSize)),
+					ghttp.RespondWith(http.StatusOK, `{"status":"Pulling fs layer"}`+"\n"+`{"status":"Download complete"}`+"\n"),
 				),
 			)
 
@@ -212,6 +210,116 @@ var _ = ginkgo.Describe("the client", func() {
 				nil,
 			)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+		ginkgo.It("returns a rate-limit error when the stream reports toomanyrequests", func() {
+			ratelimit.ResetForTest()
+
+			mockServer.AllowUnhandledRequests = true
+			mockServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", gomega.MatchRegexp("/images/create")),
+					ghttp.RespondWith(
+						http.StatusOK,
+						`{"status":"Pulling fs layer"}`+"\n"+
+							`{"errorDetail":{"message":"toomanyrequests: retry-after: 2h, allowed: 44000/minute"},"error":"toomanyrequests: retry-after: 2h, allowed: 44000/minute"}`+"\n",
+					),
+				),
+			)
+
+			i := newImageClient(mockClient, testLog())
+			err := i.performImagePull(
+				context.Background(),
+				"ghcr.io/linuxserver/nginx:latest",
+				dockerClient.ImagePullOptions{},
+				nil,
+			)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(ratelimit.Is(err)).To(gomega.BeTrue())
+		})
+		ginkgo.It("returns a rate-limit error when ImagePull fails with toomanyrequests", func() {
+			ratelimit.ResetForTest()
+
+			mockServer.AllowUnhandledRequests = true
+			mockServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", gomega.MatchRegexp("/images/create")),
+					ghttp.RespondWith(http.StatusTooManyRequests, `{"message":"toomanyrequests: retry-after: 2h, allowed: 44000/minute"}`),
+				),
+			)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			i := newImageClient(mockClient, testLog())
+			err := i.performImagePull(
+				ctx,
+				"ghcr.io/linuxserver/nginx:latest",
+				dockerClient.ImagePullOptions{},
+				nil,
+			)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(ratelimit.Is(err)).To(gomega.BeTrue())
+		})
+	})
+
+	ginkgo.When("the pull slot context is canceled", func() {
+		ginkgo.It("does not acquire a slot", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			err := acquirePullSlot(ctx)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(errors.Is(err, context.Canceled)).To(gomega.BeTrue())
+		})
+	})
+
+	ginkgo.When("a host is in rate-limit cooldown", func() {
+		ginkgo.It("does not hold the pull slot during the wait", func() {
+			ratelimit.ResetForTest()
+			defer ratelimit.ResetForTest()
+
+			ratelimit.Observe("ghcr.io", &ratelimit.Error{RetryAfter: 800 * time.Millisecond})
+
+			mockServer.AllowUnhandledRequests = true
+			mockServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", gomega.MatchRegexp("/images/create")),
+					ghttp.RespondWith(http.StatusOK, `{"status":"Download complete"}`+"\n"),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", gomega.MatchRegexp("/images/create")),
+					ghttp.RespondWith(http.StatusOK, `{"status":"Download complete"}`+"\n"),
+				),
+			)
+
+			i := newImageClient(mockClient, testLog())
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			blocked := make(chan error, 1)
+			go func() {
+				blocked <- i.performImagePull(
+					ctx,
+					"ghcr.io/linuxserver/nginx:latest",
+					dockerClient.ImagePullOptions{},
+					nil,
+				)
+			}()
+
+			time.Sleep(50 * time.Millisecond)
+
+			started := time.Now()
+			err := i.performImagePull(
+				ctx,
+				"registry.example.com/app:latest",
+				dockerClient.ImagePullOptions{},
+				nil,
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(time.Since(started)).To(gomega.BeNumerically("<", 300*time.Millisecond))
+
+			gomega.Eventually(blocked).Should(gomega.Receive(gomega.BeNil()))
 		})
 	})
 

--- a/pkg/container/image_test.go
+++ b/pkg/container/image_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"sync/atomic"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -328,6 +329,76 @@ var _ = ginkgo.Describe("the client", func() {
 			gomega.Expect(time.Since(started)).To(gomega.BeNumerically("<", 300*time.Millisecond))
 
 			gomega.Eventually(blocked, 3*time.Second).Should(gomega.Receive(gomega.BeNil()))
+		})
+		ginkgo.It("does not start a queued same-host pull during Retry-After cooldown", func() {
+			ratelimit.ResetForTest()
+			defer ratelimit.ResetForTest()
+
+			firstEntered := make(chan struct{})
+			releaseFirst := make(chan struct{})
+			secondStarted := make(chan time.Time, 1)
+
+			var pulls atomic.Int32
+
+			mockServer.AllowUnhandledRequests = true
+			mockServer.RouteToHandler("POST", regexp.MustCompile(`/images/create`), func(w http.ResponseWriter, _ *http.Request) {
+				if pulls.Add(1) == 1 {
+					close(firstEntered)
+					<-releaseFirst
+					w.WriteHeader(http.StatusTooManyRequests)
+					_, _ = w.Write([]byte(`{"message":"toomanyrequests: retry-after: 1s, allowed: 44000/minute"}`))
+
+					return
+				}
+
+				select {
+				case secondStarted <- time.Now():
+				default:
+				}
+
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"status":"Download complete"}` + "\n"))
+			})
+
+			i := newImageClient(mockClient, testLog())
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			firstErr := make(chan error, 1)
+			go func() {
+				firstErr <- i.performImagePull(
+					ctx,
+					"ghcr.io/linuxserver/nginx:latest",
+					dockerClient.ImagePullOptions{},
+					nil,
+				)
+			}()
+
+			gomega.Eventually(firstEntered).Should(gomega.BeClosed())
+
+			secondErr := make(chan error, 1)
+			go func() {
+				secondErr <- i.performImagePull(
+					ctx,
+					"ghcr.io/linuxserver/radarr:latest",
+					dockerClient.ImagePullOptions{},
+					nil,
+				)
+			}()
+
+			time.Sleep(50 * time.Millisecond)
+
+			released := time.Now()
+
+			close(releaseFirst)
+
+			var started time.Time
+			gomega.Eventually(secondStarted, 3*time.Second).Should(gomega.Receive(&started))
+			gomega.Expect(started.Sub(released)).To(gomega.BeNumerically(">=", 800*time.Millisecond))
+
+			gomega.Eventually(firstErr, 3*time.Second).Should(gomega.Receive())
+			gomega.Eventually(secondErr, 3*time.Second).Should(gomega.Receive(gomega.BeNil()))
 		})
 	})
 

--- a/pkg/container/image_test.go
+++ b/pkg/container/image_test.go
@@ -213,6 +213,7 @@ var _ = ginkgo.Describe("the client", func() {
 		})
 		ginkgo.It("returns a rate-limit error when the stream reports toomanyrequests", func() {
 			ratelimit.ResetForTest()
+			defer ratelimit.ResetForTest()
 
 			mockServer.AllowUnhandledRequests = true
 			mockServer.AppendHandlers(
@@ -238,6 +239,7 @@ var _ = ginkgo.Describe("the client", func() {
 		})
 		ginkgo.It("returns a rate-limit error when ImagePull fails with toomanyrequests", func() {
 			ratelimit.ResetForTest()
+			defer ratelimit.ResetForTest()
 
 			mockServer.AllowUnhandledRequests = true
 			mockServer.AppendHandlers(
@@ -267,9 +269,15 @@ var _ = ginkgo.Describe("the client", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 
-			err := acquirePullSlot(ctx)
+			err := acquirePullSlot(ctx, "ghcr.io")
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(errors.Is(err, context.Canceled)).To(gomega.BeTrue())
+		})
+		ginkgo.It("uses a distinct slot per registry host", func() {
+			ghcr := pullSlotFor("ghcr.io")
+			hub := pullSlotFor("index.docker.io")
+			gomega.Expect(ghcr).NotTo(gomega.BeIdenticalTo(hub))
+			gomega.Expect(pullSlotFor("ghcr.io")).To(gomega.BeIdenticalTo(ghcr))
 		})
 	})
 
@@ -319,7 +327,7 @@ var _ = ginkgo.Describe("the client", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(time.Since(started)).To(gomega.BeNumerically("<", 300*time.Millisecond))
 
-			gomega.Eventually(blocked).Should(gomega.Receive(gomega.BeNil()))
+			gomega.Eventually(blocked, 3*time.Second).Should(gomega.Receive(gomega.BeNil()))
 		})
 	})
 

--- a/pkg/registry/age.go
+++ b/pkg/registry/age.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/nicholas-fedor/watchtower/internal/meta"
 	"github.com/nicholas-fedor/watchtower/pkg/registry/auth"
+	"github.com/nicholas-fedor/watchtower/pkg/registry/ratelimit"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
@@ -132,14 +133,26 @@ func FetchImageCreationTime(log *zerolog.Logger,
 	// Use the cached HTTP client for registry requests.
 	client := auth.NewAuthClient(log)
 
+	limitHost, hostErr := auth.GetRegistryAddress(log, container.ImageName())
+	if hostErr != nil || limitHost == "" {
+		log.Debug().
+			Err(hostErr).
+			Fields(fields).
+			Msg("Failed to resolve registry host for rate limiting")
+
+		limitHost = container.ImageName()
+	}
+
 	// Obtain an authentication token and challenge host for the registry.
-	result, err := auth.GetToken(log,
-		ctx,
-		container,
-		registryAuth,
-		client,
-		"",
-	)
+	result, err := ratelimit.DoValue(ctx, log, limitHost, func() (auth.TokenResult, error) {
+		return auth.GetToken(log,
+			ctx,
+			container,
+			registryAuth,
+			client,
+			"",
+		)
+	})
 	if err != nil {
 		log.Debug().
 			Err(err).
@@ -441,6 +454,13 @@ func retryManifestRequest(log *zerolog.Logger,
 				"",
 				"",
 				fmt.Errorf("%w: %w", errFetchManifestFailed, err)
+		}
+
+		rateErr := registryRateLimitError(resp)
+		if rateErr != nil {
+			resp.Body.Close()
+
+			return nil, "", "", rateErr
 		}
 
 		if resp.StatusCode != http.StatusOK {
@@ -910,6 +930,13 @@ func fetchPlatformManifestWithRetry(log *zerolog.Logger,
 		}
 
 		// Handle non-success responses with retry logic.
+		rateErr := registryRateLimitError(resp)
+		if rateErr != nil {
+			resp.Body.Close()
+
+			return "", "", rateErr
+		}
+
 		if resp.StatusCode != http.StatusOK {
 			status := resp.StatusCode
 			resp.Body.Close()
@@ -1296,6 +1323,13 @@ func fetchConfigBlob(log *zerolog.Logger,
 		}
 	}
 
+	rateErr := registryRateLimitError(resp)
+	if rateErr != nil {
+		resp.Body.Close()
+
+		return nil, rateErr
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		resp.Body.Close()
 		log.Debug().
@@ -1312,6 +1346,27 @@ func fetchConfigBlob(log *zerolog.Logger,
 	}
 
 	return resp.Body, nil
+}
+
+// registryRateLimitError returns a rate-limit error when the registry responded 429.
+//
+// The parsed error is recorded on the host limiter so sibling age fetches honor
+// the same cooldown.
+//
+// Parameters:
+//   - resp: HTTP response from a registry request.
+//
+// Returns:
+//   - error: Parsed rate-limit error, or nil when the status is not 429.
+func registryRateLimitError(resp *http.Response) error {
+	if resp == nil || resp.StatusCode != http.StatusTooManyRequests {
+		return nil
+	}
+
+	info := ratelimit.FromResponse(resp, ratelimit.ReadBody(resp, ratelimit.DefaultBodyLimit))
+	ratelimit.Observe(info.Host, info)
+
+	return info
 }
 
 // isIndexMediaType checks if the media type indicates an image index (multi-platform).

--- a/pkg/registry/age.go
+++ b/pkg/registry/age.go
@@ -139,8 +139,6 @@ func FetchImageCreationTime(log *zerolog.Logger,
 			Err(hostErr).
 			Fields(fields).
 			Msg("Failed to resolve registry host for rate limiting")
-
-		limitHost = container.ImageName()
 	}
 
 	// Obtain an authentication token and challenge host for the registry.

--- a/pkg/registry/age_test.go
+++ b/pkg/registry/age_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -19,11 +20,44 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/nicholas-fedor/watchtower/internal/logging"
+	"github.com/nicholas-fedor/watchtower/pkg/registry/ratelimit"
 	mockTypes "github.com/nicholas-fedor/watchtower/pkg/types/mocks"
 )
 
 func testLog() *zerolog.Logger {
 	return logging.NopLogger()
+}
+
+func TestRegistryRateLimitError(t *testing.T) {
+	ratelimit.ResetForTest()
+	t.Cleanup(ratelimit.ResetForTest)
+
+	assert.NoError(t, registryRateLimitError(nil))
+	assert.NoError(t, registryRateLimitError(&http.Response{
+		StatusCode: http.StatusOK,
+		Body:       http.NoBody,
+	}))
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://ghcr.io/v2/linuxserver/nginx/manifests/latest", nil)
+	require.NoError(t, err)
+
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{"Retry-After": []string{"2"}},
+		Body:       io.NopCloser(strings.NewReader("toomanyrequests: retry-after: 331.163µs, allowed: 44000/minute")),
+		Request:    req,
+	}
+
+	got := registryRateLimitError(resp)
+	require.Error(t, got)
+	require.ErrorIs(t, got, ratelimit.ErrRateLimited)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+
+	waitErr := ratelimit.Wait(ctx, "ghcr.io")
+	require.Error(t, waitErr)
+	assert.ErrorIs(t, waitErr, context.DeadlineExceeded)
 }
 
 // newMockContainer creates a mockery-generated mock Container with the given image name.

--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/nicholas-fedor/watchtower/internal/meta"
+	"github.com/nicholas-fedor/watchtower/pkg/registry/ratelimit"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
@@ -529,6 +530,12 @@ func GetToken(
 		return TokenResult{}, fmt.Errorf("%w: %w", errFailedExecuteChallengeRequest, err)
 	}
 	defer response.Body.Close()
+
+	if response.StatusCode == http.StatusTooManyRequests {
+		body := ratelimit.ReadBody(response, ratelimit.DefaultBodyLimit)
+
+		return TokenResult{}, ratelimit.FromResponse(response, body)
+	}
 
 	// Detect if the request was redirected by comparing the complete final URL.
 	redirected := response.Request.URL.String() != challengeURL.String()

--- a/pkg/registry/auth/auth_test.go
+++ b/pkg/registry/auth/auth_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	mockAuth "github.com/nicholas-fedor/watchtower/pkg/registry/auth/mocks"
+	"github.com/nicholas-fedor/watchtower/pkg/registry/ratelimit"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 	mockTypes "github.com/nicholas-fedor/watchtower/pkg/types/mocks"
 )
@@ -773,6 +774,26 @@ func TestGetToken(t *testing.T) {
 			wantErr:     true,
 			errContains: "failed to execute challenge request",
 		},
+		{
+			name:         "challenge 429 returns rate-limit error",
+			container:    newRemoteContainer(t),
+			registryAuth: "",
+			endpoint:     "",
+			setupMock: func(mockClient *mockAuth.MockClient) {
+				challengeURL, _ := url.Parse("https://index.docker.io/v2/")
+				mockClient.On("Do", mock.Anything).Return(&http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Body: io.NopCloser(strings.NewReader(
+						"toomanyrequests: retry-after: 331.163µs, allowed: 44000/minute",
+					)),
+					Header:  http.Header{"Retry-After": []string{"7200"}},
+					Request: &http.Request{URL: challengeURL},
+				}, nil).Once()
+			},
+			want:        TokenResult{},
+			wantErr:     true,
+			errContains: "registry rate limited",
+		},
 	}
 
 	for _, tt := range tests {
@@ -790,6 +811,10 @@ func TestGetToken(t *testing.T) {
 
 				if tt.errContains != "" {
 					assert.Contains(t, err.Error(), tt.errContains)
+				}
+
+				if tt.errContains == "registry rate limited" {
+					require.ErrorIs(t, err, ratelimit.ErrRateLimited)
 				}
 
 				return

--- a/pkg/registry/auth/bearer.go
+++ b/pkg/registry/auth/bearer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/spf13/viper"
 
+	"github.com/nicholas-fedor/watchtower/pkg/registry/ratelimit"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
@@ -266,6 +267,12 @@ func performBearerTokenFetch(log *zerolog.Logger,
 
 	// Reject non-success responses before reading the body to avoid
 	// attempting to parse error pages as bearer token JSON.
+	if authResponse.StatusCode == http.StatusTooManyRequests {
+		body := ratelimit.ReadBody(authResponse, ratelimit.DefaultBodyLimit)
+
+		return "", time.Time{}, ratelimit.FromResponse(authResponse, body)
+	}
+
 	if authResponse.StatusCode < http.StatusOK || authResponse.StatusCode >= http.StatusMultipleChoices {
 		return "", time.Time{}, fmt.Errorf(
 			"%w: status %s",

--- a/pkg/registry/auth/bearer_test.go
+++ b/pkg/registry/auth/bearer_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	mockAuth "github.com/nicholas-fedor/watchtower/pkg/registry/auth/mocks"
+	"github.com/nicholas-fedor/watchtower/pkg/registry/ratelimit"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
@@ -679,6 +680,10 @@ func Test_performBearerTokenFetch(t *testing.T) {
 			got, _, err := performBearerTokenFetch(testLog(), ctx, tt.authURL, tt.imageName, tt.auth, mockClient)
 			if tt.wantErr {
 				assert.Error(t, err)
+
+				if tt.onDo != nil && tt.onDo.StatusCode == http.StatusTooManyRequests {
+					require.ErrorIs(t, err, ratelimit.ErrRateLimited)
+				}
 
 				return
 			}

--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nicholas-fedor/watchtower/internal/meta"
 	"github.com/nicholas-fedor/watchtower/pkg/registry/auth"
 	"github.com/nicholas-fedor/watchtower/pkg/registry/manifest"
+	"github.com/nicholas-fedor/watchtower/pkg/registry/ratelimit"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
@@ -608,13 +609,26 @@ func fetchDigest(log *zerolog.Logger,
 		}
 
 		// Obtain an authentication token from the current endpoint.
-		result, err := auth.GetToken(log,
-			ctx,
-			container,
-			registryAuth,
-			client,
-			endpoint,
-		)
+		limitHost, hostErr := auth.GetRegistryAddress(log, container.ImageName())
+		if hostErr != nil || limitHost == "" {
+			log.Debug().
+				Err(hostErr).
+				Fields(fields).
+				Fields(epFields).
+				Msg("Failed to resolve registry host for rate limiting")
+
+			limitHost = container.ImageName()
+		}
+
+		result, err := ratelimit.DoValue(ctx, log, limitHost, func() (auth.TokenResult, error) {
+			return auth.GetToken(log,
+				ctx,
+				container,
+				registryAuth,
+				client,
+				endpoint,
+			)
+		})
 		if err != nil {
 			log.Debug().
 				Err(err).
@@ -622,6 +636,10 @@ func fetchDigest(log *zerolog.Logger,
 				Fields(epFields).
 				Msg("Failed to get token from endpoint")
 			lastErr = fmt.Errorf("%w: %w", errFailedGetToken, err)
+
+			if ratelimit.Is(err) {
+				return "", lastErr
+			}
 
 			continue
 		}
@@ -686,56 +704,49 @@ func fetchDigest(log *zerolog.Logger,
 			Str("url", manifestURL).
 			Msg("Fetching digest")
 
-		// Create the HTTP request for the manifest.
-		req, err := makeManifestRequest(ctx, method, manifestURL, token)
-		if err != nil {
-			log.Debug().
-				Err(err).
-				Fields(fields).
-				Fields(epFields).
-				Str("method", method).
-				Str("url", manifestURL).
-				Msg("Failed to create request")
-			lastErr = err
-
-			continue
-		}
-
-		// Execute the initial request.
-		resp, err := client.Do(req)
-		if err != nil {
-			log.Debug().
-				Err(err).
-				Fields(fields).
-				Fields(epFields).
-				Str("method", method).
-				Str("url", manifestURL).
-				Msg("Failed to execute request")
-			lastErr = fmt.Errorf("%w: %w", errFailedExecuteRequest, err)
-
-			continue
-		}
-
-		// Handle the manifest response, checking for redirects and extracting digest.
-		digest, updatedURL, retry, err := HandleManifestResponse(log,
-			resp,
-			method,
-			originalHost,
-			challengeHost,
-			redirected,
-			parsedURL,
-			parsedURL.Host,
+		var (
+			digest     string
+			updatedURL string
+			retry      bool
 		)
-		_ = resp.Body.Close()
 
+		err = ratelimit.Do(ctx, log, parsedURL.Host, func() error {
+			req, reqErr := makeManifestRequest(ctx, method, manifestURL, token)
+			if reqErr != nil {
+				return reqErr
+			}
+
+			resp, doErr := client.Do(req)
+			if doErr != nil {
+				return fmt.Errorf("%w: %w", errFailedExecuteRequest, doErr)
+			}
+
+			var handleErr error
+
+			digest, updatedURL, retry, handleErr = HandleManifestResponse(log,
+				resp,
+				method,
+				originalHost,
+				challengeHost,
+				redirected,
+				parsedURL,
+				parsedURL.Host,
+			)
+			_ = resp.Body.Close()
+
+			return handleErr
+		})
 		if err != nil {
 			log.Debug().
 				Err(err).
 				Fields(fields).
 				Fields(epFields).
-				Str("status", resp.Status).
 				Msg("Failed to handle manifest response")
 			lastErr = err
+
+			if ratelimit.Is(err) {
+				return "", lastErr
+			}
 
 			continue
 		}
@@ -766,6 +777,10 @@ func fetchDigest(log *zerolog.Logger,
 					Str("retry_url", updatedURL).
 					Msg("Failed to retry manifest request")
 				lastErr = err
+
+				if ratelimit.Is(err) {
+					return "", lastErr
+				}
 
 				continue
 			}
@@ -823,6 +838,16 @@ func HandleManifestResponse(log *zerolog.Logger,
 	log.Debug().
 		Fields(fields).
 		Msg("Handling manifest response")
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		body := ratelimit.ReadBody(resp, ratelimit.DefaultBodyLimit)
+
+		log.Debug().
+			Fields(fields).
+			Msg("Registry returned 429 for manifest request")
+
+		return "", "", false, ratelimit.FromResponse(resp, body)
+	}
 
 	var manifestURL string
 
@@ -1301,29 +1326,40 @@ func retryManifestRequest(
 	parsedURL *url.URL,
 	client auth.Client,
 ) (string, error) {
-	req, err := makeManifestRequest(ctx, method, updatedURL, token)
-	if err != nil {
-		return "", err
-	}
+	var digest string
 
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("%w: %w", errFailedExecuteRequest, err)
-	}
+	err := ratelimit.Do(ctx, log, parsedURL.Host, func() error {
+		req, reqErr := makeManifestRequest(ctx, method, updatedURL, token)
+		if reqErr != nil {
+			return reqErr
+		}
 
-	defer func() { _ = resp.Body.Close() }()
+		resp, doErr := client.Do(req)
+		if doErr != nil {
+			return fmt.Errorf("%w: %w", errFailedExecuteRequest, doErr)
+		}
 
-	digest, _, _, err := HandleManifestResponse(log,
-		resp,
-		method,
-		originalHost,
-		challengeHost,
-		redirected,
-		parsedURL,
-		parsedURL.Host,
-	)
+		defer func() { _ = resp.Body.Close() }()
+
+		got, _, _, handleErr := HandleManifestResponse(log,
+			resp,
+			method,
+			originalHost,
+			challengeHost,
+			redirected,
+			parsedURL,
+			parsedURL.Host,
+		)
+		if handleErr != nil {
+			return handleErr
+		}
+
+		digest = got
+
+		return nil
+	})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("manifest retry: %w", err)
 	}
 
 	return digest, nil

--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -616,8 +616,6 @@ func fetchDigest(log *zerolog.Logger,
 				Fields(fields).
 				Fields(epFields).
 				Msg("Failed to resolve registry host for rate limiting")
-
-			limitHost = container.ImageName()
 		}
 
 		result, err := ratelimit.DoValue(ctx, log, limitHost, func() (auth.TokenResult, error) {

--- a/pkg/registry/digest/digest_test.go
+++ b/pkg/registry/digest/digest_test.go
@@ -217,6 +217,7 @@ func TestCompareDigestWithRemote(t *testing.T) {
 
 func TestCompareDigestWithRemote_Head429DoesNotFallBackToGET(t *testing.T) {
 	ratelimit.ResetForTest()
+	t.Cleanup(ratelimit.ResetForTest)
 
 	viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
 	t.Cleanup(func() {

--- a/pkg/registry/digest/digest_test.go
+++ b/pkg/registry/digest/digest_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/nicholas-fedor/watchtower/internal/logging"
 	mockAuth "github.com/nicholas-fedor/watchtower/pkg/registry/auth/mocks"
+	"github.com/nicholas-fedor/watchtower/pkg/registry/ratelimit"
 	mockTypes "github.com/nicholas-fedor/watchtower/pkg/types/mocks"
 )
 
@@ -211,6 +213,165 @@ func TestCompareDigestWithRemote(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, match)
 	assert.Equal(t, "sha256:"+remoteHash, remoteDigest)
+}
+
+func TestCompareDigestWithRemote_Head429DoesNotFallBackToGET(t *testing.T) {
+	ratelimit.ResetForTest()
+
+	viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+	t.Cleanup(func() {
+		viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+	})
+
+	mc := mockTypes.NewMockContainer(t)
+	mc.On("Name").Return("radarr")
+	mc.On("HasImageInfo").Return(true)
+	mc.On("ImageInfo").Return(&dockerImage.InspectResponse{
+		RepoDigests: []string{
+			"lscr.io/linuxserver/radarr@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+	})
+
+	var getManifests atomic.Int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/manifests/") {
+			getManifests.Add(1)
+
+			t.Errorf("HEAD 429 must not fall back to GET of %s", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+
+			return
+		}
+
+		if r.Method == http.MethodHead && strings.Contains(r.URL.Path, "/manifests/") {
+			w.Header().Set("Retry-After", "7200")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte("toomanyrequests: retry-after: 331.163µs, allowed: 44000/minute"))
+
+			return
+		}
+
+		if r.Method == http.MethodGet && (r.URL.Path == "/v2/" || r.URL.Path == "/v2") {
+			w.WriteHeader(http.StatusOK)
+
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	parts := strings.SplitN(server.URL, "://", 2)
+	host := parts[len(parts)-1]
+	mc.On("ImageName").Return(host + "/linuxserver/radarr:latest")
+
+	match, _, err := CompareDigestWithRemote(testLog(), context.Background(), mc, "", server.URL)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ratelimit.ErrRateLimited)
+	assert.False(t, match)
+	assert.Equal(t, int64(0), getManifests.Load())
+}
+
+// TestCompareDigestWithRemote_Retry429DoesNotContinueToNextEndpoint is a
+// regression test for a 429 on the challenge-host retry. That error must abort
+// the endpoint loop instead of trying the next mirror.
+func TestCompareDigestWithRemote_Retry429DoesNotContinueToNextEndpoint(t *testing.T) {
+	ratelimit.ResetForTest()
+	t.Cleanup(ratelimit.ResetForTest)
+
+	viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", true)
+	t.Cleanup(func() {
+		viper.Set("WATCHTOWER_REGISTRY_TLS_SKIP", false)
+	})
+
+	mc := mockTypes.NewMockContainer(t)
+	mc.On("Name").Return("radarr")
+	mc.On("HasImageInfo").Return(true)
+	mc.On("ImageInfo").Return(&dockerImage.InspectResponse{
+		RepoDigests: []string{
+			"lscr.io/linuxserver/radarr@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+	})
+
+	var (
+		primaryHeads atomic.Int64
+		mirrorHeads  atomic.Int64
+	)
+
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && (r.URL.Path == "/v2/" || r.URL.Path == "/v2") {
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf(
+				`Bearer realm="http://%s/token",service="test-service",scope="repository:linuxserver/radarr:pull"`,
+				r.Host,
+			))
+			w.WriteHeader(http.StatusUnauthorized)
+
+			return
+		}
+
+		if r.Method == http.MethodGet && r.URL.Path == "/token" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"token":"test-token"}`))
+
+			return
+		}
+
+		if r.Method == http.MethodHead && strings.Contains(r.URL.Path, "/manifests/") {
+			if primaryHeads.Add(1) == 1 {
+				w.WriteHeader(http.StatusUnauthorized)
+
+				return
+			}
+
+			w.Header().Set("Retry-After", "7200")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte("toomanyrequests: retry-after: 331.163µs, allowed: 44000/minute"))
+
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer primary.Close()
+
+	mirror := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead && strings.Contains(r.URL.Path, "/manifests/") {
+			mirrorHeads.Add(1)
+			w.Header().Set("Docker-Content-Digest", "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+			w.WriteHeader(http.StatusOK)
+
+			return
+		}
+
+		if r.Method == http.MethodGet && (r.URL.Path == "/v2/" || r.URL.Path == "/v2") {
+			w.WriteHeader(http.StatusOK)
+
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mirror.Close()
+
+	parts := strings.SplitN(primary.URL, "://", 2)
+	host := parts[len(parts)-1]
+	mc.On("ImageName").Return(host + "/linuxserver/radarr:latest")
+
+	match, _, err := CompareDigestWithRemote(
+		testLog(),
+		context.Background(),
+		mc,
+		"",
+		primary.URL,
+		mirror.URL,
+	)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ratelimit.ErrRateLimited)
+	assert.False(t, match)
+	assert.GreaterOrEqual(t, primaryHeads.Load(), int64(2))
+	assert.Equal(t, int64(0), mirrorHeads.Load())
 }
 
 // TestCompareDigestWithRemote_LocalOnly404 is a regression test for locally built
@@ -999,6 +1160,48 @@ func TestHandleManifestResponse(t *testing.T) {
 			expectedRetry: true,
 			wantErr:       false,
 		},
+		{
+			name:   "HEAD 429 returns rate-limit error without GET fallback",
+			method: http.MethodHead,
+			setupResponse: func() *http.Response {
+				return &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Status:     "429 Too Many Requests",
+					Header:     http.Header{"Retry-After": []string{"2"}},
+					Body: io.NopCloser(strings.NewReader(
+						"toomanyrequests: retry-after: 331.163µs, allowed: 44000/minute",
+					)),
+					Request: &http.Request{URL: mustParseURL("https://ghcr.io/v2/linuxserver/nginx/manifests/latest")},
+				}
+			},
+			originalHost:  "ghcr.io",
+			challengeHost: "",
+			redirected:    false,
+			parsedURL:     mustParseURL("https://ghcr.io/v2/linuxserver/nginx/manifests/latest"),
+			currentHost:   "ghcr.io",
+			wantErr:       true,
+		},
+		{
+			name:   "GET 429 returns rate-limit error",
+			method: http.MethodGet,
+			setupResponse: func() *http.Response {
+				return &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Status:     "429 Too Many Requests",
+					Header:     http.Header{"Retry-After": []string{"2"}},
+					Body: io.NopCloser(strings.NewReader(
+						"toomanyrequests: retry-after: 331.163µs, allowed: 44000/minute",
+					)),
+					Request: &http.Request{URL: mustParseURL("https://ghcr.io/v2/linuxserver/nginx/manifests/latest")},
+				}
+			},
+			originalHost:  "ghcr.io",
+			challengeHost: "",
+			redirected:    false,
+			parsedURL:     mustParseURL("https://ghcr.io/v2/linuxserver/nginx/manifests/latest"),
+			currentHost:   "ghcr.io",
+			wantErr:       true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1018,6 +1221,10 @@ func TestHandleManifestResponse(t *testing.T) {
 			)
 			if tt.wantErr {
 				require.Error(t, err)
+
+				if resp.StatusCode == http.StatusTooManyRequests {
+					require.ErrorIs(t, err, ratelimit.ErrRateLimited)
+				}
 
 				return
 			}
@@ -1435,6 +1642,7 @@ func TestRetryManifestRequest(t *testing.T) {
 		setupClient func(t *testing.T) *mockAuth.MockClient
 		expected    string
 		wantErr     bool
+		rateLimited bool
 	}{
 		{
 			name:       "returns digest from successful retry response",
@@ -1493,10 +1701,39 @@ func TestRetryManifestRequest(t *testing.T) {
 			expected: "",
 			wantErr:  true,
 		},
+		{
+			name:       "returns rate-limit error on 429",
+			method:     http.MethodHead,
+			updatedURL: "https://registry.example.com/v2/manifests/latest",
+			token:      "",
+			setupClient: func(t *testing.T) *mockAuth.MockClient {
+				t.Helper()
+
+				header := http.Header{}
+				header.Set("Retry-After", "7200")
+
+				mc := mockAuth.NewMockClient(t)
+				mc.On("Do", mock.Anything).Return(&http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Status:     "429 Too Many Requests",
+					Header:     header,
+					Body:       io.NopCloser(strings.NewReader("toomanyrequests: retry-after: 2h, allowed: 44000/minute")),
+					Request:    &http.Request{URL: mustParseURL("https://registry.example.com/v2/manifests/latest")},
+				}, nil)
+
+				return mc
+			},
+			expected:    "",
+			wantErr:     true,
+			rateLimited: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ratelimit.ResetForTest()
+			t.Cleanup(ratelimit.ResetForTest)
+
 			client := tt.setupClient(t)
 
 			got, err := retryManifestRequest(testLog(), context.Background(),
@@ -1512,6 +1749,7 @@ func TestRetryManifestRequest(t *testing.T) {
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Empty(t, got)
+				assert.Equal(t, tt.rateLimited, ratelimit.Is(err))
 
 				return
 			}

--- a/pkg/registry/doc.go
+++ b/pkg/registry/doc.go
@@ -5,6 +5,7 @@
 //   - age: Fetches image creation time from registry config blobs for cooldown support.
 //   - auth: Manages registry authentication (token fetching, challenge handling).
 //   - digest: Retrieves and compares image digests via HTTP requests.
+//   - ratelimit: Parses registry 429 responses and retries them with backoff.
 //   - helpers: Utilities for registry address parsing and digest normalization.
 //   - manifest: Constructs manifest URLs for digest fetching.
 //   - registry: Configures pull options, API consumption checks, and image age fetching.

--- a/pkg/registry/ratelimit/doc.go
+++ b/pkg/registry/ratelimit/doc.go
@@ -1,0 +1,5 @@
+// Package ratelimit parses registry 429 responses and retries them with backoff.
+//
+// It honors HTTP Retry-After headers, GHCR-style body quotas such as
+// "allowed: 44000/minute", and Docker pull-stream toomanyrequests messages.
+package ratelimit

--- a/pkg/registry/ratelimit/error.go
+++ b/pkg/registry/ratelimit/error.go
@@ -1,0 +1,123 @@
+package ratelimit
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrRateLimited indicates a registry rejected a request for exceeding its rate limit.
+var ErrRateLimited = errors.New("registry rate limited")
+
+const (
+	// minHonorWait is the floor applied to tiny Retry-After values such as 331µs.
+	minHonorWait = 100 * time.Millisecond
+	// maxHonorWait is the longest Retry-After this process will sleep in one update cycle.
+	maxHonorWait = 30 * time.Second
+	// maxRetryTries is the attempt cap passed to cenkalti/backoff.
+	maxRetryTries = 5
+	// maxRetryElapsed bounds how long a single operation keeps retrying 429s.
+	maxRetryElapsed = 30 * time.Second
+	// DefaultBodyLimit is how many response bytes we read when parsing a 429.
+	DefaultBodyLimit = 4096
+	// retryAfterCaptureCount is the expected regex group count for retry-after.
+	retryAfterCaptureCount = 2
+	// allowedCaptureCount is the expected regex group count for allowed quotas.
+	allowedCaptureCount = 3
+	// rateLimitMinGroups is the minimum RateLimit-Limit regex group count.
+	rateLimitMinGroups = 2
+)
+
+// Error is a registry 429 with the wait and quota the registry advertised.
+type Error struct {
+	// StatusCode is the HTTP status when the limit came from an HTTP response.
+	StatusCode int
+	// RetryAfter is the wait parsed from Retry-After or the response body.
+	RetryAfter time.Duration
+	// Allowed is the advertised request budget. Zero when the registry omitted it.
+	Allowed int
+	// AllowedWindow is the period for Allowed. Zero when the registry omitted it.
+	AllowedWindow time.Duration
+	// Host is the registry host that produced the limit when known.
+	Host string
+	// Message is the raw registry or Docker-stream text.
+	Message string
+}
+
+// Error describes the rate limit for logs and error wrapping.
+//
+// Returns:
+//   - string: Human-readable rate-limit error.
+func (e *Error) Error() string {
+	if e == nil {
+		return ErrRateLimited.Error()
+	}
+
+	if e.Allowed > 0 && e.AllowedWindow > 0 {
+		return fmt.Sprintf(
+			"%s: retry-after %s allowed %d per %s",
+			ErrRateLimited.Error(),
+			e.RetryAfter,
+			e.Allowed,
+			e.AllowedWindow,
+		)
+	}
+
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("%s: retry-after %s", ErrRateLimited.Error(), e.RetryAfter)
+	}
+
+	if e.Message != "" {
+		return fmt.Sprintf("%s: %s", ErrRateLimited.Error(), e.Message)
+	}
+
+	return ErrRateLimited.Error()
+}
+
+// Unwrap exposes ErrRateLimited so errors.Is matches.
+//
+// Returns:
+//   - error: The sentinel rate-limit error.
+func (e *Error) Unwrap() error {
+	return ErrRateLimited
+}
+
+// Is reports whether err is a registry rate-limit error.
+//
+// Parameters:
+//   - err: Error to inspect. May be wrapped.
+//
+// Returns:
+//   - bool: True when err unwraps to ErrRateLimited.
+func Is(err error) bool {
+	return errors.Is(err, ErrRateLimited)
+}
+
+// Decision converts a parsed 429 into a sleep or a give-up.
+//
+// Tiny Retry-After values are raised to minHonorWait so a 331µs GHCR token
+// does not cause an immediate retry. Waits longer than maxHonorWait are not
+// slept in-process. The next scheduled Watchtower run can try again.
+//
+// Parameters:
+//   - info: Parsed rate-limit details. Nil uses the minimum wait.
+//
+// Returns:
+//   - time.Duration: How long to wait before the next attempt.
+//   - bool: True when the caller should stop retrying this cycle.
+func Decision(info *Error) (time.Duration, bool) {
+	wait := minHonorWait
+	if info != nil && info.RetryAfter > 0 {
+		wait = info.RetryAfter
+	}
+
+	if wait > maxHonorWait {
+		return 0, true
+	}
+
+	if wait < minHonorWait {
+		wait = minHonorWait
+	}
+
+	return wait, false
+}

--- a/pkg/registry/ratelimit/error.go
+++ b/pkg/registry/ratelimit/error.go
@@ -24,8 +24,6 @@ const (
 	retryAfterCaptureCount = 2
 	// allowedCaptureCount is the expected regex group count for allowed quotas.
 	allowedCaptureCount = 3
-	// rateLimitMinGroups is the minimum RateLimit-Limit regex group count.
-	rateLimitMinGroups = 2
 )
 
 // Error is a registry 429 with the wait and quota the registry advertised.

--- a/pkg/registry/ratelimit/error_test.go
+++ b/pkg/registry/ratelimit/error_test.go
@@ -1,0 +1,68 @@
+package ratelimit
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  *Error
+		want string
+	}{
+		{
+			name: "nil receiver uses the sentinel",
+			err:  nil,
+			want: ErrRateLimited.Error(),
+		},
+		{
+			name: "includes retry-after and allowed budget",
+			err: &Error{
+				RetryAfter:    2 * time.Second,
+				Allowed:       44000,
+				AllowedWindow: time.Minute,
+			},
+			want: "registry rate limited: retry-after 2s allowed 44000 per 1m0s",
+		},
+		{
+			name: "includes retry-after only",
+			err:  &Error{RetryAfter: 5 * time.Second},
+			want: "registry rate limited: retry-after 5s",
+		},
+		{
+			name: "includes raw message",
+			err:  &Error{Message: "toomanyrequests"},
+			want: "registry rate limited: toomanyrequests",
+		},
+		{
+			name: "empty fields use the sentinel",
+			err:  &Error{},
+			want: ErrRateLimited.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, tt.err.Error())
+		})
+	}
+}
+
+func TestIsMatchesWrappedRateLimit(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("digest check rate limited: %w", ErrRateLimited)
+	require.True(t, Is(wrapped))
+	assert.False(t, Is(errors.New("connection refused")))
+	assert.False(t, Is(nil))
+}

--- a/pkg/registry/ratelimit/limiter.go
+++ b/pkg/registry/ratelimit/limiter.go
@@ -125,6 +125,39 @@ func Wait(ctx context.Context, host string) error {
 	}
 }
 
+// WaitCooldown blocks until host is outside its 429 cooldown.
+//
+// Unlike Wait, this does not reserve a quota token. Callers that already
+// passed Wait use it to recheck cooldown after a lock or slot handoff.
+//
+// Parameters:
+//   - ctx: Context that can cancel the wait.
+//   - host: Registry host. Empty hosts return immediately.
+//
+// Returns:
+//   - error: ctx.Err() when canceled. Nil when the caller may proceed.
+func WaitCooldown(ctx context.Context, host string) error {
+	if host == "" {
+		return nil
+	}
+
+	for {
+		wait := nextCooldownWait(host)
+		if wait <= 0 {
+			return nil
+		}
+
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+
+			return fmt.Errorf("registry rate-limit wait canceled: %w", ctx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
 // nextWait computes how long the caller must wait before contacting host.
 //
 // Parameters:
@@ -158,6 +191,25 @@ func nextWait(host string) time.Duration {
 	perToken := max(state.window/time.Duration(state.allowed), time.Millisecond)
 
 	return perToken
+}
+
+// nextCooldownWait returns remaining 429 cooldown for host without taking a token.
+//
+// Parameters:
+//   - host: Registry host whose cooldown should be inspected.
+//
+// Returns:
+//   - time.Duration: Sleep before the next request. Zero when there is no cooldown.
+func nextCooldownWait(host string) time.Duration {
+	hostsMu.Lock()
+	defer hostsMu.Unlock()
+
+	state := hosts[host]
+	if state == nil || !time.Now().Before(state.cooldownUntil) {
+		return 0
+	}
+
+	return time.Until(state.cooldownUntil)
 }
 
 // hostLocked returns the per-host limiter state, creating it when missing.

--- a/pkg/registry/ratelimit/limiter.go
+++ b/pkg/registry/ratelimit/limiter.go
@@ -109,11 +109,7 @@ func Wait(ctx context.Context, host string) error {
 	}
 
 	for {
-		wait, err := nextWait(host)
-		if err != nil {
-			return err
-		}
-
+		wait := nextWait(host)
 		if wait <= 0 {
 			return nil
 		}
@@ -136,8 +132,7 @@ func Wait(ctx context.Context, host string) error {
 //
 // Returns:
 //   - time.Duration: Sleep before the next request. Zero when the caller may proceed.
-//   - error: Reserved for future wait failures. Currently always nil.
-func nextWait(host string) (time.Duration, error) {
+func nextWait(host string) time.Duration {
 	hostsMu.Lock()
 	defer hostsMu.Unlock()
 
@@ -145,11 +140,11 @@ func nextWait(host string) (time.Duration, error) {
 	now := time.Now()
 
 	if now.Before(state.cooldownUntil) {
-		return time.Until(state.cooldownUntil), nil
+		return time.Until(state.cooldownUntil)
 	}
 
 	if state.allowed <= 0 || state.window <= 0 {
-		return 0, nil
+		return 0
 	}
 
 	state.refillLocked(now)
@@ -157,12 +152,12 @@ func nextWait(host string) (time.Duration, error) {
 	if state.tokens >= 1 {
 		state.tokens--
 
-		return 0, nil
+		return 0
 	}
 
 	perToken := max(state.window/time.Duration(state.allowed), time.Millisecond)
 
-	return perToken, nil
+	return perToken
 }
 
 // hostLocked returns the per-host limiter state, creating it when missing.

--- a/pkg/registry/ratelimit/limiter.go
+++ b/pkg/registry/ratelimit/limiter.go
@@ -1,0 +1,216 @@
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// hostState holds the cooldown and token-bucket budget for one registry host.
+type hostState struct {
+	// cooldownUntil is when the next request to this host may proceed.
+	cooldownUntil time.Time
+	// allowed is the advertised request budget. Zero when unknown.
+	allowed int
+	// window is the period for allowed. Zero when unknown.
+	window time.Duration
+	// tokens is the remaining budget in the current window.
+	tokens float64
+	// lastRefill is when tokens were last replenished.
+	lastRefill time.Time
+}
+
+var (
+	hostsMu sync.Mutex
+	hosts   = map[string]*hostState{}
+)
+
+// ResetForTest clears per-host cooldown and quota state.
+//
+// Tests call this so one case cannot leak a cooldown into the next.
+func ResetForTest() {
+	hostsMu.Lock()
+	defer hostsMu.Unlock()
+
+	hosts = map[string]*hostState{}
+}
+
+// Observe records a 429 against host so later Wait calls honor it.
+//
+// Parameters:
+//   - host: Registry host. Empty values are ignored.
+//   - info: Parsed 429. Nil values are ignored.
+func Observe(host string, info *Error) {
+	if host == "" || info == nil {
+		return
+	}
+
+	hostsMu.Lock()
+	defer hostsMu.Unlock()
+
+	state := hostLocked(host)
+
+	cooldown := min(info.RetryAfter, maxHonorWait)
+
+	if cooldown > 0 && cooldown < minHonorWait {
+		cooldown = minHonorWait
+	}
+
+	if cooldown > 0 {
+		until := time.Now().Add(cooldown)
+		if until.After(state.cooldownUntil) {
+			state.cooldownUntil = until
+		}
+	}
+
+	if info.Allowed > 0 && info.AllowedWindow > 0 {
+		state.allowed = info.Allowed
+		state.window = info.AllowedWindow
+		state.tokens = 0
+		state.lastRefill = time.Now()
+	}
+}
+
+// ObserveSuccess refreshes host's advertised budget after a successful request.
+//
+// Token reservation happens in Wait. This only refills so a success does not
+// spend a second token.
+//
+// Parameters:
+//   - host: Registry host. Empty values are ignored.
+func ObserveSuccess(host string) {
+	if host == "" {
+		return
+	}
+
+	hostsMu.Lock()
+	defer hostsMu.Unlock()
+
+	state := hosts[host]
+	if state == nil || state.allowed <= 0 || state.window <= 0 {
+		return
+	}
+
+	state.refillLocked(time.Now())
+}
+
+// Wait blocks until host is outside its 429 cooldown and has budget.
+//
+// Parameters:
+//   - ctx: Context that can cancel the wait.
+//   - host: Registry host. Empty hosts return immediately.
+//
+// Returns:
+//   - error: ctx.Err() when canceled. Nil when the caller may proceed.
+func Wait(ctx context.Context, host string) error {
+	if host == "" {
+		return nil
+	}
+
+	for {
+		wait, err := nextWait(host)
+		if err != nil {
+			return err
+		}
+
+		if wait <= 0 {
+			return nil
+		}
+
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+
+			return fmt.Errorf("registry rate-limit wait canceled: %w", ctx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+// nextWait computes how long the caller must wait before contacting host.
+//
+// Parameters:
+//   - host: Registry host whose cooldown and quota should be inspected.
+//
+// Returns:
+//   - time.Duration: Sleep before the next request. Zero when the caller may proceed.
+//   - error: Reserved for future wait failures. Currently always nil.
+func nextWait(host string) (time.Duration, error) {
+	hostsMu.Lock()
+	defer hostsMu.Unlock()
+
+	state := hostLocked(host)
+	now := time.Now()
+
+	if now.Before(state.cooldownUntil) {
+		return time.Until(state.cooldownUntil), nil
+	}
+
+	if state.allowed <= 0 || state.window <= 0 {
+		return 0, nil
+	}
+
+	state.refillLocked(now)
+
+	if state.tokens >= 1 {
+		state.tokens--
+
+		return 0, nil
+	}
+
+	perToken := max(state.window/time.Duration(state.allowed), time.Millisecond)
+
+	return perToken, nil
+}
+
+// hostLocked returns the per-host limiter state, creating it when missing.
+//
+// The caller must hold hostsMu.
+//
+// Parameters:
+//   - host: Registry host key.
+//
+// Returns:
+//   - *hostState: Existing or newly created state for host.
+func hostLocked(host string) *hostState {
+	state := hosts[host]
+	if state == nil {
+		state = &hostState{lastRefill: time.Now()}
+		hosts[host] = state
+	}
+
+	return state
+}
+
+// refillLocked adds tokens earned since the last refill.
+//
+// The caller must hold hostsMu.
+//
+// Parameters:
+//   - now: Current time used to compute earned tokens.
+func (s *hostState) refillLocked(now time.Time) {
+	if s.allowed <= 0 || s.window <= 0 {
+		return
+	}
+
+	if s.lastRefill.IsZero() {
+		s.lastRefill = now
+		s.tokens = float64(s.allowed)
+
+		return
+	}
+
+	elapsed := now.Sub(s.lastRefill)
+	if elapsed <= 0 {
+		return
+	}
+
+	s.tokens += float64(elapsed) / float64(s.window) * float64(s.allowed)
+	if s.tokens > float64(s.allowed) {
+		s.tokens = float64(s.allowed)
+	}
+
+	s.lastRefill = now
+}

--- a/pkg/registry/ratelimit/limiter_test.go
+++ b/pkg/registry/ratelimit/limiter_test.go
@@ -1,0 +1,173 @@
+package ratelimit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitRespectsHostCooldown(t *testing.T) {
+	ResetForTest()
+
+	Observe("ghcr.io", &Error{RetryAfter: 80 * time.Millisecond})
+
+	started := time.Now()
+	err := Wait(t.Context(), "ghcr.io")
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, time.Since(started), 70*time.Millisecond)
+}
+
+func TestWaitDoesNotBlockOtherHosts(t *testing.T) {
+	ResetForTest()
+
+	Observe("ghcr.io", &Error{RetryAfter: time.Hour})
+
+	started := time.Now()
+	err := Wait(t.Context(), "index.docker.io")
+	require.NoError(t, err)
+	assert.Less(t, time.Since(started), 50*time.Millisecond)
+}
+
+func TestWaitHonorsAllowedBudget(t *testing.T) {
+	ResetForTest()
+
+	Observe("ghcr.io", &Error{
+		Allowed:       2,
+		AllowedWindow: 200 * time.Millisecond,
+	})
+
+	require.NoError(t, Wait(t.Context(), "ghcr.io"))
+	require.NoError(t, Wait(t.Context(), "ghcr.io"))
+
+	started := time.Now()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	err := Wait(ctx, "ghcr.io")
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, time.Since(started), 80*time.Millisecond)
+}
+
+func TestWaitEmptyHostReturnsImmediately(t *testing.T) {
+	ResetForTest()
+
+	started := time.Now()
+	err := Wait(t.Context(), "")
+	require.NoError(t, err)
+	assert.Less(t, time.Since(started), 20*time.Millisecond)
+}
+
+func TestObserveIgnoresEmptyHostAndNilInfo(t *testing.T) {
+	ResetForTest()
+
+	Observe("", &Error{RetryAfter: time.Hour})
+	Observe("ghcr.io", nil)
+
+	started := time.Now()
+
+	require.NoError(t, Wait(t.Context(), "ghcr.io"))
+	assert.Less(t, time.Since(started), 20*time.Millisecond)
+}
+
+func TestObserveDoesNotShrinkExistingCooldown(t *testing.T) {
+	ResetForTest()
+
+	Observe("ghcr.io", &Error{RetryAfter: 80 * time.Millisecond})
+	Observe("ghcr.io", &Error{RetryAfter: time.Millisecond})
+
+	started := time.Now()
+
+	require.NoError(t, Wait(t.Context(), "ghcr.io"))
+	assert.GreaterOrEqual(t, time.Since(started), 70*time.Millisecond)
+}
+
+func TestObserveSuccessIgnoresUnknownHost(t *testing.T) {
+	ResetForTest()
+
+	ObserveSuccess("")
+	ObserveSuccess("ghcr.io")
+
+	require.NoError(t, Wait(t.Context(), "ghcr.io"))
+}
+
+func TestObserveSuccessDoesNotConsumeReservedToken(t *testing.T) {
+	ResetForTest()
+
+	Observe("ghcr.io", &Error{
+		Allowed:       2,
+		AllowedWindow: 200 * time.Millisecond,
+	})
+
+	time.Sleep(220 * time.Millisecond)
+	require.NoError(t, Wait(t.Context(), "ghcr.io"))
+	ObserveSuccess("ghcr.io")
+
+	started := time.Now()
+
+	require.NoError(t, Wait(t.Context(), "ghcr.io"))
+	assert.Less(t, time.Since(started), 50*time.Millisecond)
+}
+
+func TestRefillLocked(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing budget is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		state := &hostState{}
+		state.refillLocked(time.Now())
+		assert.InDelta(t, 0.0, state.tokens, 0.001)
+	})
+
+	t.Run("zero last refill starts at full budget", func(t *testing.T) {
+		t.Parallel()
+
+		state := &hostState{allowed: 5, window: time.Second}
+		state.refillLocked(time.Now())
+		assert.InDelta(t, 5.0, state.tokens, 0.001)
+	})
+
+	t.Run("future last refill does not change tokens", func(t *testing.T) {
+		t.Parallel()
+
+		now := time.Now()
+		state := &hostState{
+			allowed:    5,
+			window:     time.Second,
+			tokens:     2,
+			lastRefill: now.Add(time.Second),
+		}
+		state.refillLocked(now)
+		assert.InDelta(t, 2.0, state.tokens, 0.001)
+	})
+
+	t.Run("caps tokens at the advertised budget", func(t *testing.T) {
+		t.Parallel()
+
+		state := &hostState{
+			allowed:    10,
+			window:     time.Second,
+			tokens:     9,
+			lastRefill: time.Now().Add(-time.Hour),
+		}
+		state.refillLocked(time.Now())
+		assert.InDelta(t, 10.0, state.tokens, 0.001)
+	})
+}
+
+func TestWaitCancelsWithContext(t *testing.T) {
+	ResetForTest()
+
+	Observe("ghcr.io", &Error{RetryAfter: 5 * time.Second})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+
+	err := Wait(ctx, "ghcr.io")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}

--- a/pkg/registry/ratelimit/limiter_test.go
+++ b/pkg/registry/ratelimit/limiter_test.go
@@ -52,6 +52,57 @@ func TestWaitHonorsAllowedBudget(t *testing.T) {
 	assert.GreaterOrEqual(t, time.Since(started), 80*time.Millisecond)
 }
 
+func TestWaitCooldownRespectsHostCooldown(t *testing.T) {
+	ResetForTest()
+
+	Observe("ghcr.io", &Error{RetryAfter: 80 * time.Millisecond})
+
+	started := time.Now()
+	err := WaitCooldown(t.Context(), "ghcr.io")
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, time.Since(started), 70*time.Millisecond)
+}
+
+func TestWaitCooldownDoesNotConsumeQuotaToken(t *testing.T) {
+	ResetForTest()
+
+	Observe("ghcr.io", &Error{
+		Allowed:       2,
+		AllowedWindow: 200 * time.Millisecond,
+	})
+
+	time.Sleep(220 * time.Millisecond)
+	require.NoError(t, WaitCooldown(t.Context(), "ghcr.io"))
+
+	started := time.Now()
+
+	require.NoError(t, Wait(t.Context(), "ghcr.io"))
+	require.NoError(t, Wait(t.Context(), "ghcr.io"))
+	assert.Less(t, time.Since(started), 50*time.Millisecond)
+}
+
+func TestWaitCooldownEmptyHostReturnsImmediately(t *testing.T) {
+	ResetForTest()
+
+	started := time.Now()
+	err := WaitCooldown(t.Context(), "")
+	require.NoError(t, err)
+	assert.Less(t, time.Since(started), 20*time.Millisecond)
+}
+
+func TestWaitCooldownCancelsWithContext(t *testing.T) {
+	ResetForTest()
+
+	Observe("ghcr.io", &Error{RetryAfter: 5 * time.Second})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+
+	err := WaitCooldown(ctx, "ghcr.io")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
 func TestWaitEmptyHostReturnsImmediately(t *testing.T) {
 	ResetForTest()
 

--- a/pkg/registry/ratelimit/parse.go
+++ b/pkg/registry/ratelimit/parse.go
@@ -13,7 +13,9 @@ var (
 	retryAfterBody = regexp.MustCompile(`(?i)retry-after:\s*([0-9]+(?:\.[0-9]+)?(?:ns|us|µs|μs|ms|s|m|h))`)
 	allowedBody    = regexp.MustCompile(`(?i)allowed:\s*([0-9]+)\s*/\s*(seconds?|secs?|minutes?|mins?|hours?|hrs?)`)
 	rateLimitLimit = regexp.MustCompile(`(?i)([0-9]+)(?:\s*,\s*[0-9]+)*\s*(?:;\s*w=([0-9]+))?`)
-	status429      = regexp.MustCompile(`(?i)\b429\b`)
+	status429      = regexp.MustCompile(
+		`(?i)(?:\b(?:https?|status(?:\s+code)?)\s*[:\-]?\s*429\b|\breturned\s+429\b|\b429\s+(?:too many|error|response))`,
+	)
 )
 
 // ParseRetryAfterHeader parses an HTTP Retry-After header.
@@ -196,8 +198,8 @@ func ReadBody(resp *http.Response, limit int64) []byte {
 
 // looksRateLimited reports whether message looks like a registry 429.
 //
-// A bare 429 is matched as a whole token so digest hashes and ports that
-// contain those digits are ignored.
+// A bare 429 is recognized only with HTTP or status context so byte counts,
+// ports, and digest hashes are ignored.
 //
 // Parameters:
 //   - message: Registry body or Docker pull-stream error text.
@@ -249,7 +251,7 @@ func parseRateLimitLimit(header string) (int, time.Duration) {
 	}
 
 	match := rateLimitLimit.FindStringSubmatch(header)
-	if len(match) < rateLimitMinGroups {
+	if match == nil {
 		return 0, 0
 	}
 
@@ -260,7 +262,7 @@ func parseRateLimitLimit(header string) (int, time.Duration) {
 
 	window := time.Duration(0)
 
-	if len(match) > 2 && match[2] != "" {
+	if match[2] != "" {
 		seconds, convErr := strconv.Atoi(match[2])
 		if convErr == nil && seconds > 0 {
 			window = time.Duration(seconds) * time.Second

--- a/pkg/registry/ratelimit/parse.go
+++ b/pkg/registry/ratelimit/parse.go
@@ -1,0 +1,271 @@
+package ratelimit
+
+import (
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	retryAfterBody = regexp.MustCompile(`(?i)retry-after:\s*([0-9]+(?:\.[0-9]+)?(?:ns|us|µs|μs|ms|s|m|h))`)
+	allowedBody    = regexp.MustCompile(`(?i)allowed:\s*([0-9]+)\s*/\s*(seconds?|secs?|minutes?|mins?|hours?|hrs?)`)
+	rateLimitLimit = regexp.MustCompile(`(?i)([0-9]+)(?:\s*,\s*[0-9]+)*\s*(?:;\s*w=([0-9]+))?`)
+	status429      = regexp.MustCompile(`(?i)\b429\b`)
+)
+
+// ParseRetryAfterHeader parses an HTTP Retry-After header.
+//
+// It accepts a delta-seconds integer or an HTTP-date.
+// Dates in the past and a value of 0 are treated as absent.
+//
+// Parameters:
+//   - header: Raw Retry-After header value.
+//
+// Returns:
+//   - time.Duration: How long to wait.
+//   - bool: True when the header contained a usable wait.
+func ParseRetryAfterHeader(header string) (time.Duration, bool) {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return 0, false
+	}
+
+	seconds, parseErr := strconv.ParseInt(header, 10, 64)
+	if parseErr == nil {
+		if seconds <= 0 {
+			return 0, false
+		}
+
+		return time.Duration(seconds) * time.Second, true
+	}
+
+	when, err := http.ParseTime(header)
+	if err != nil {
+		return 0, false
+	}
+
+	wait := time.Until(when)
+	if wait <= 0 {
+		return 0, false
+	}
+
+	return wait, true
+}
+
+// ParseQuotaMessage extracts retry-after and allowed-quota fields from a registry body.
+//
+// It understands GHCR-style text such as
+// "toomanyrequests: retry-after: 331.163µs, allowed: 44000/minute".
+//
+// Parameters:
+//   - message: Response body or Docker pull-stream error text.
+//
+// Returns:
+//   - time.Duration: Parsed retry-after. Zero when absent.
+//   - int: Advertised request budget. Zero when absent.
+//   - time.Duration: Window for the budget. Zero when absent.
+func ParseQuotaMessage(message string) (time.Duration, int, time.Duration) {
+	var (
+		retryAfter time.Duration
+		allowed    int
+		window     time.Duration
+	)
+
+	if match := retryAfterBody.FindStringSubmatch(message); len(match) == retryAfterCaptureCount {
+		parsed, parseErr := time.ParseDuration(match[1])
+		if parseErr == nil {
+			retryAfter = parsed
+		}
+	}
+
+	if match := allowedBody.FindStringSubmatch(message); len(match) == allowedCaptureCount {
+		n, convErr := strconv.Atoi(match[1])
+		if convErr == nil {
+			allowed = n
+			window = parseQuotaWindow(match[2])
+		}
+	}
+
+	return retryAfter, allowed, window
+}
+
+// FromResponse builds a rate-limit error from an HTTP response and optional body.
+//
+// Header Retry-After wins over a body retry-after because it is the protocol
+// signal. Body "allowed" values win over RateLimit-Limit when both are present
+// because GHCR puts the live budget in the body.
+//
+// Parameters:
+//   - resp: HTTP response. Must not be nil.
+//   - body: Already-read body bytes. May be empty.
+//
+// Returns:
+//   - *Error: Parsed rate-limit error.
+func FromResponse(resp *http.Response, body []byte) *Error {
+	info := &Error{
+		StatusCode: http.StatusTooManyRequests,
+		Message:    strings.TrimSpace(string(body)),
+	}
+	if resp != nil {
+		info.StatusCode = resp.StatusCode
+
+		if resp.Request != nil && resp.Request.URL != nil {
+			info.Host = resp.Request.URL.Host
+		}
+
+		if wait, ok := ParseRetryAfterHeader(resp.Header.Get("Retry-After")); ok {
+			info.RetryAfter = wait
+		}
+
+		if allowed, window := parseRateLimitLimit(resp.Header.Get("Ratelimit-Limit")); allowed > 0 {
+			info.Allowed = allowed
+			info.AllowedWindow = window
+		}
+
+		if info.Allowed == 0 {
+			if allowed, window := parseRateLimitLimit(resp.Header.Get("X-Ratelimit-Limit")); allowed > 0 {
+				info.Allowed = allowed
+				info.AllowedWindow = window
+			}
+		}
+	}
+
+	retryAfter, allowed, window := ParseQuotaMessage(info.Message)
+	if info.RetryAfter == 0 {
+		info.RetryAfter = retryAfter
+	}
+
+	if allowed > 0 {
+		info.Allowed = allowed
+		info.AllowedWindow = window
+	}
+
+	return info
+}
+
+// FromErrorMessage builds a rate-limit error from Docker pull-stream text.
+//
+// Parameters:
+//   - message: Stream error or registry body. Empty or unrelated text returns nil.
+//
+// Returns:
+//   - *Error: Parsed rate-limit error, or nil when the message is not a 429.
+func FromErrorMessage(message string) *Error {
+	if !looksRateLimited(message) {
+		return nil
+	}
+
+	retryAfter, allowed, window := ParseQuotaMessage(message)
+
+	return &Error{
+		StatusCode:    http.StatusTooManyRequests,
+		RetryAfter:    retryAfter,
+		Allowed:       allowed,
+		AllowedWindow: window,
+		Message:       strings.TrimSpace(message),
+	}
+}
+
+// ReadBody reads a small prefix of resp.Body for rate-limit parsing.
+//
+// Parameters:
+//   - resp: HTTP response. May be nil.
+//   - limit: Maximum bytes to read. Values below 1 use 4 KiB.
+//
+// Returns:
+//   - []byte: Body prefix. Empty when the response has no body.
+func ReadBody(resp *http.Response, limit int64) []byte {
+	if resp == nil || resp.Body == nil {
+		return nil
+	}
+
+	if limit < 1 {
+		limit = DefaultBodyLimit
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, limit))
+	if err != nil {
+		return body
+	}
+
+	return body
+}
+
+// looksRateLimited reports whether message looks like a registry 429.
+//
+// A bare 429 is matched as a whole token so digest hashes and ports that
+// contain those digits are ignored.
+//
+// Parameters:
+//   - message: Registry body or Docker pull-stream error text.
+//
+// Returns:
+//   - bool: True when the text contains a rate-limit marker.
+func looksRateLimited(message string) bool {
+	lower := strings.ToLower(message)
+
+	return strings.Contains(lower, "toomanyrequests") ||
+		strings.Contains(lower, "too many requests") ||
+		status429.MatchString(lower)
+}
+
+// parseQuotaWindow maps an allowed-quota unit word to a duration.
+//
+// Parameters:
+//   - unit: Unit from an "allowed: N/unit" field such as minute or hour.
+//
+// Returns:
+//   - time.Duration: Matching window. Zero when the unit is unknown.
+func parseQuotaWindow(unit string) time.Duration {
+	switch strings.ToLower(unit) {
+	case "second", "seconds", "sec", "secs":
+		return time.Second
+	case "minute", "minutes", "min", "mins":
+		return time.Minute
+	case "hour", "hours", "hr", "hrs":
+		return time.Hour
+	default:
+		return 0
+	}
+}
+
+// parseRateLimitLimit parses a RateLimit-Limit or X-RateLimit-Limit header.
+//
+// The header may look like "100;w=3600" or "3000, 3000;w=60".
+//
+// Parameters:
+//   - header: Raw rate-limit header value.
+//
+// Returns:
+//   - int: Advertised request budget. Zero when the header is unusable.
+//   - time.Duration: Window from the w= parameter. Zero when absent.
+func parseRateLimitLimit(header string) (int, time.Duration) {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return 0, 0
+	}
+
+	match := rateLimitLimit.FindStringSubmatch(header)
+	if len(match) < rateLimitMinGroups {
+		return 0, 0
+	}
+
+	allowed, err := strconv.Atoi(match[1])
+	if err != nil || allowed <= 0 {
+		return 0, 0
+	}
+
+	window := time.Duration(0)
+
+	if len(match) > 2 && match[2] != "" {
+		seconds, convErr := strconv.Atoi(match[2])
+		if convErr == nil && seconds > 0 {
+			window = time.Duration(seconds) * time.Second
+		}
+	}
+
+	return allowed, window
+}

--- a/pkg/registry/ratelimit/parse_test.go
+++ b/pkg/registry/ratelimit/parse_test.go
@@ -385,6 +385,8 @@ func TestFromErrorMessageRecognizesPhrases(t *testing.T) {
 
 	require.NotNil(t, FromErrorMessage("Too Many Requests from registry"))
 	require.NotNil(t, FromErrorMessage("registry returned 429"))
+	require.NotNil(t, FromErrorMessage("HTTP 429 from registry"))
+	require.NotNil(t, FromErrorMessage("status: 429"))
 }
 
 func TestFromErrorMessageIgnoresUnrelatedErrors(t *testing.T) {
@@ -395,6 +397,8 @@ func TestFromErrorMessageIgnoresUnrelatedErrors(t *testing.T) {
 	assert.Nil(t, FromErrorMessage("sha256:abcdef429abcdef"))
 	assert.Nil(t, FromErrorMessage("dial tcp 127.0.0.1:4290: connect: connection refused"))
 	assert.Nil(t, FromErrorMessage("wrote 1429 bytes"))
+	assert.Nil(t, FromErrorMessage("wrote 429 bytes"))
+	assert.Nil(t, FromErrorMessage("dial tcp 10.0.0.1:429: connect: connection refused"))
 }
 
 func TestDecisionCapsTinyAndHugeRetryAfter(t *testing.T) {

--- a/pkg/registry/ratelimit/parse_test.go
+++ b/pkg/registry/ratelimit/parse_test.go
@@ -1,0 +1,443 @@
+package ratelimit
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRetryAfterHeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		header string
+		want   time.Duration
+		wantOK bool
+	}{
+		{
+			name:   "integer seconds",
+			header: "5",
+			want:   5 * time.Second,
+			wantOK: true,
+		},
+		{
+			name:   "zero seconds is not a wait",
+			header: "0",
+			want:   0,
+			wantOK: false,
+		},
+		{
+			name:   "empty header",
+			header: "",
+			wantOK: false,
+		},
+		{
+			name:   "invalid text",
+			header: "soon",
+			wantOK: false,
+		},
+		{
+			name:   "http date in the future",
+			header: time.Now().UTC().Add(8 * time.Second).Format(http.TimeFormat),
+			wantOK: true,
+		},
+		{
+			name:   "http date in the past is not a wait",
+			header: time.Now().UTC().Add(-time.Minute).Format(http.TimeFormat),
+			wantOK: false,
+		},
+		{
+			name:   "negative seconds is not a wait",
+			header: "-1",
+			wantOK: false,
+		},
+		{
+			name:   "whitespace around integer seconds",
+			header: "  3  ",
+			want:   3 * time.Second,
+			wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := ParseRetryAfterHeader(tt.header)
+			assert.Equal(t, tt.wantOK, ok)
+
+			if !tt.wantOK {
+				return
+			}
+
+			if tt.want > 0 {
+				assert.Equal(t, tt.want, got)
+
+				return
+			}
+
+			assert.Greater(t, got, 4*time.Second)
+			assert.Less(t, got, 12*time.Second)
+		})
+	}
+}
+
+func TestParseQuotaMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		message    string
+		retryAfter time.Duration
+		allowed    int
+		window     time.Duration
+	}{
+		{
+			name:       "ghcr toomanyrequests with microseconds and per minute quota",
+			message:    "toomanyrequests: retry-after: 331.163µs, allowed: 44000/minute",
+			retryAfter: 331163 * time.Nanosecond,
+			allowed:    44000,
+			window:     time.Minute,
+		},
+		{
+			name:       "ghcr milliseconds",
+			message:    "toomanyrequests: retry-after: 1.15031ms, allowed: 44000/minute",
+			retryAfter: time.Duration(1.15031 * float64(time.Millisecond)),
+			allowed:    44000,
+			window:     time.Minute,
+		},
+		{
+			name:    "plain toomanyrequests without details",
+			message: "toomanyrequests",
+		},
+		{
+			name:    "empty message",
+			message: "",
+		},
+		{
+			name:    "allowed per hour",
+			message: "allowed: 100/hour",
+			allowed: 100,
+			window:  time.Hour,
+		},
+		{
+			name:    "allowed per second",
+			message: "allowed: 10/second",
+			allowed: 10,
+			window:  time.Second,
+		},
+		{
+			name:    "allowed per secs",
+			message: "allowed: 10/secs",
+			allowed: 10,
+			window:  time.Second,
+		},
+		{
+			name:    "allowed per mins",
+			message: "allowed: 20/mins",
+			allowed: 20,
+			window:  time.Minute,
+		},
+		{
+			name:    "allowed per hrs",
+			message: "allowed: 5/hrs",
+			allowed: 5,
+			window:  time.Hour,
+		},
+		{
+			name:    "allowed per minutes",
+			message: "allowed: 8/minutes",
+			allowed: 8,
+			window:  time.Minute,
+		},
+		{
+			name:    "allowed per min",
+			message: "allowed: 8/min",
+			allowed: 8,
+			window:  time.Minute,
+		},
+		{
+			name:    "allowed per hours",
+			message: "allowed: 3/hours",
+			allowed: 3,
+			window:  time.Hour,
+		},
+		{
+			name:    "allowed per sec",
+			message: "allowed: 15/sec",
+			allowed: 15,
+			window:  time.Second,
+		},
+		{
+			name:    "allowed per seconds",
+			message: "allowed: 15/seconds",
+			allowed: 15,
+			window:  time.Second,
+		},
+		{
+			name:    "unknown allowed unit is ignored",
+			message: "allowed: 5/fortnight",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			retryAfter, allowed, window := ParseQuotaMessage(tt.message)
+			assert.InDelta(t, float64(tt.retryAfter), float64(retryAfter), float64(time.Microsecond))
+			assert.Equal(t, tt.allowed, allowed)
+			assert.Equal(t, tt.window, window)
+		})
+	}
+}
+
+func TestFromResponse(t *testing.T) {
+	t.Parallel()
+
+	header := make(http.Header)
+	header.Set("Retry-After", "2")
+	header.Set("Ratelimit-Limit", "100;w=3600")
+
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     header,
+		Body: io.NopCloser(strings.NewReader(
+			`toomanyrequests: retry-after: 331.163µs, allowed: 44000/minute`,
+		)),
+		Request: &http.Request{},
+	}
+
+	got := FromResponse(resp, []byte("toomanyrequests: retry-after: 331.163µs, allowed: 44000/minute"))
+	require.NotNil(t, got)
+	require.ErrorIs(t, got, ErrRateLimited)
+	assert.Equal(t, http.StatusTooManyRequests, got.StatusCode)
+	assert.Equal(t, 2*time.Second, got.RetryAfter)
+	assert.Equal(t, 44000, got.Allowed)
+	assert.Equal(t, time.Minute, got.AllowedWindow)
+}
+
+func TestFromErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	got := FromErrorMessage(
+		"error pulling image configuration: toomanyrequests: retry-after: 160.574µs, allowed: 44000/minute",
+	)
+	require.NotNil(t, got)
+	require.ErrorIs(t, got, ErrRateLimited)
+	assert.Equal(t, 44000, got.Allowed)
+	assert.Equal(t, time.Minute, got.AllowedWindow)
+	assert.Greater(t, got.RetryAfter, time.Duration(0))
+}
+
+func TestFromResponseUsesHeaderQuotaWhenBodyHasNone(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodHead, "https://ghcr.io/v2/linuxserver/nginx/manifests/latest", nil)
+	require.NoError(t, err)
+
+	header := make(http.Header)
+	header.Set("Retry-After", "4")
+	header.Set("X-Ratelimit-Limit", "3000, 3000;w=60")
+
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     header,
+		Body:       http.NoBody,
+		Request:    req,
+	}
+
+	got := FromResponse(resp, nil)
+	require.NotNil(t, got)
+	assert.Equal(t, "ghcr.io", got.Host)
+	assert.Equal(t, 4*time.Second, got.RetryAfter)
+	assert.Equal(t, 3000, got.Allowed)
+	assert.Equal(t, time.Minute, got.AllowedWindow)
+}
+
+func TestFromResponseNilResponseUsesBody(t *testing.T) {
+	t.Parallel()
+
+	got := FromResponse(nil, []byte("toomanyrequests: retry-after: 250ms, allowed: 100/hour"))
+	require.NotNil(t, got)
+	assert.Equal(t, 250*time.Millisecond, got.RetryAfter)
+	assert.Equal(t, 100, got.Allowed)
+	assert.Equal(t, time.Hour, got.AllowedWindow)
+}
+
+func TestFromResponsePrefersHeaderRetryAfterOverBody(t *testing.T) {
+	t.Parallel()
+
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{"Retry-After": []string{"9"}},
+		Body:       http.NoBody,
+	}
+
+	got := FromResponse(resp, []byte("toomanyrequests: retry-after: 331.163µs, allowed: 44000/minute"))
+	require.NotNil(t, got)
+	assert.Equal(t, 9*time.Second, got.RetryAfter)
+	assert.Equal(t, 44000, got.Allowed)
+}
+
+func TestFromResponseUsesRateLimitLimitHeader(t *testing.T) {
+	t.Parallel()
+
+	header := make(http.Header)
+	header.Set("Ratelimit-Limit", "100;w=3600")
+
+	got := FromResponse(&http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     header,
+		Body:       http.NoBody,
+	}, nil)
+	require.NotNil(t, got)
+	assert.Equal(t, 100, got.Allowed)
+	assert.Equal(t, time.Hour, got.AllowedWindow)
+}
+
+func TestParseRateLimitLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		header  string
+		allowed int
+		window  time.Duration
+	}{
+		{
+			name:    "empty",
+			header:  "",
+			allowed: 0,
+		},
+		{
+			name:    "docker hub style",
+			header:  "100;w=3600",
+			allowed: 100,
+			window:  time.Hour,
+		},
+		{
+			name:    "comma pair with window",
+			header:  "3000, 3000;w=60",
+			allowed: 3000,
+			window:  time.Minute,
+		},
+		{
+			name:    "budget without window",
+			header:  "50",
+			allowed: 50,
+		},
+		{
+			name:   "zero budget",
+			header: "0;w=60",
+		},
+		{
+			name:   "non numeric",
+			header: "unlimited",
+		},
+		{
+			name:    "invalid window is ignored",
+			header:  "10;w=nope",
+			allowed: 10,
+		},
+		{
+			name:    "zero window is ignored",
+			header:  "10;w=0",
+			allowed: 10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			allowed, window := parseRateLimitLimit(tt.header)
+			assert.Equal(t, tt.allowed, allowed)
+			assert.Equal(t, tt.window, window)
+		})
+	}
+}
+
+func TestReadBody(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, ReadBody(nil, 16))
+	assert.Nil(t, ReadBody(&http.Response{}, 16))
+
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader("toomanyrequests extra"))}
+	assert.Equal(t, "toomanyrequests extra", string(ReadBody(resp, 0)))
+
+	resp = &http.Response{Body: io.NopCloser(strings.NewReader("abcdefghij"))}
+	assert.Equal(t, "abcde", string(ReadBody(resp, 5)))
+
+	failing := &http.Response{Body: failingReadCloser{}}
+	assert.Empty(t, ReadBody(failing, 16))
+}
+
+func TestFromErrorMessageRecognizesPhrases(t *testing.T) {
+	t.Parallel()
+
+	require.NotNil(t, FromErrorMessage("Too Many Requests from registry"))
+	require.NotNil(t, FromErrorMessage("registry returned 429"))
+}
+
+func TestFromErrorMessageIgnoresUnrelatedErrors(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, FromErrorMessage("failed to pull image: connection refused"))
+	assert.Nil(t, FromErrorMessage(""))
+	assert.Nil(t, FromErrorMessage("sha256:abcdef429abcdef"))
+	assert.Nil(t, FromErrorMessage("dial tcp 127.0.0.1:4290: connect: connection refused"))
+	assert.Nil(t, FromErrorMessage("wrote 1429 bytes"))
+}
+
+func TestDecisionCapsTinyAndHugeRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	wait, giveUp := Decision(&Error{RetryAfter: 331 * time.Microsecond})
+	assert.False(t, giveUp)
+	assert.Equal(t, minHonorWait, wait)
+
+	wait, giveUp = Decision(&Error{RetryAfter: 2 * time.Hour})
+	assert.True(t, giveUp)
+	assert.Equal(t, time.Duration(0), wait)
+
+	wait, giveUp = Decision(&Error{RetryAfter: 5 * time.Second})
+	assert.False(t, giveUp)
+	assert.Equal(t, 5*time.Second, wait)
+
+	wait, giveUp = Decision(nil)
+	assert.False(t, giveUp)
+	assert.Equal(t, minHonorWait, wait)
+}
+
+// failingReadCloser fails on the first Read so ReadBody can exercise its error path.
+type failingReadCloser struct{}
+
+// Read always fails.
+//
+// Parameters:
+//   - p: Unused destination buffer.
+//
+// Returns:
+//   - int: Bytes read. Always 0.
+//   - error: Always a read failure.
+func (failingReadCloser) Read(_ []byte) (int, error) {
+	return 0, errReadFailed
+}
+
+// Close satisfies io.ReadCloser.
+//
+// Returns:
+//   - error: Always nil.
+func (failingReadCloser) Close() error {
+	return nil
+}
+
+var errReadFailed = io.ErrUnexpectedEOF

--- a/pkg/registry/ratelimit/retry.go
+++ b/pkg/registry/ratelimit/retry.go
@@ -1,0 +1,138 @@
+package ratelimit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/cenkalti/backoff/v7"
+	"github.com/rs/zerolog"
+)
+
+// Do retries operation when the registry returns a 429 that is worth retrying.
+//
+// Permanent errors are not retried. A Retry-After longer than maxHonorWait
+// stops retries so the next Watchtower cycle can try again.
+//
+// Parameters:
+//   - ctx: Context that bounds the retry loop.
+//   - log: Logger for retry notices. May be nil.
+//   - host: Registry host used for shared cooldown and quota.
+//   - operation: Function to run. It should return a rate-limit Error on 429.
+//
+// Returns:
+//   - error: The last operation error, or ctx.Err() when canceled.
+func Do(ctx context.Context, log *zerolog.Logger, host string, operation func() error) error {
+	_, err := DoValue(ctx, log, host, func() (struct{}, error) {
+		return struct{}{}, operation()
+	})
+
+	return err
+}
+
+// DoValue is Do with a successful result.
+//
+// Parameters:
+//   - ctx: Context that bounds the retry loop.
+//   - log: Logger for retry notices. May be nil.
+//   - host: Registry host used for shared cooldown and quota.
+//   - operation: Function to run.
+//
+// Returns:
+//   - T: Value from a successful attempt.
+//   - error: The last operation error, or ctx.Err() when canceled.
+func DoValue[T any](
+	ctx context.Context,
+	log *zerolog.Logger,
+	host string,
+	operation func() (T, error),
+) (T, error) {
+	var zero T
+
+	ctxErr := ctx.Err()
+	if ctxErr != nil {
+		return zero, fmt.Errorf("rate-limit retry canceled: %w", ctxErr)
+	}
+
+	exp := backoff.NewExponentialBackOff()
+	exp.InitialInterval = minHonorWait
+	exp.MaxInterval = maxHonorWait
+
+	result, err := backoff.Retry(ctx, func() (T, error) {
+		waitErr := Wait(ctx, host)
+		if waitErr != nil {
+			return zero, backoff.Permanent(waitErr)
+		}
+
+		value, opErr := operation()
+		if opErr == nil {
+			ObserveSuccess(host)
+
+			return value, nil
+		}
+
+		info, ok := errors.AsType[*Error](opErr)
+		if !ok && !Is(opErr) {
+			return zero, backoff.Permanent(opErr)
+		}
+
+		if ok {
+			if info.Host == "" {
+				info.Host = host
+			}
+
+			Observe(host, info)
+		}
+
+		wait, giveUp := Decision(info)
+		if giveUp {
+			return zero, backoff.Permanent(opErr)
+		}
+
+		if log != nil {
+			log.Warn().
+				Str("host", host).
+				Dur("retry_after", wait).
+				Msg("Registry rate limited. Retrying after delay")
+		}
+
+		return zero, backoff.RetryAfter(wait, opErr)
+	},
+		backoff.WithBackOff(exp),
+		backoff.WithMaxTries(maxRetryTries),
+		backoff.WithMaxElapsedTime(maxRetryElapsed),
+	)
+	if err == nil {
+		return result, nil
+	}
+
+	return result, lastOperationError(err)
+}
+
+// lastOperationError unwraps a cenkalti RetryError to the last operation error.
+//
+// Context cancellation on the retry loop is preferred over the last 429 so
+// callers can distinguish a canceled wait from a rate limit.
+//
+// Parameters:
+//   - err: Error returned by backoff.Retry. May be a *backoff.RetryError.
+//
+// Returns:
+//   - error: Last operation error, the context cause, or err unchanged.
+func lastOperationError(err error) error {
+	retryErr := backoff.AsRetryError(err)
+	if retryErr == nil {
+		return err
+	}
+
+	if retryErr.Cause != nil &&
+		(errors.Is(retryErr.Cause, context.Canceled) || errors.Is(retryErr.Cause, context.DeadlineExceeded)) {
+		return retryErr.Cause
+	}
+
+	if retryErr.LastErr != nil {
+		return retryErr.LastErr
+	}
+
+	return err
+}

--- a/pkg/registry/ratelimit/retry_test.go
+++ b/pkg/registry/ratelimit/retry_test.go
@@ -1,0 +1,170 @@
+package ratelimit
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testLog returns a discarded logger for retry unit tests.
+//
+// Returns:
+//   - *zerolog.Logger: Nop logger that writes nothing.
+func testLog() *zerolog.Logger {
+	logger := zerolog.Nop()
+
+	return &logger
+}
+
+func TestDoRetriesRateLimitedOperations(t *testing.T) {
+	ResetForTest()
+
+	var attempts atomic.Int32
+
+	err := Do(t.Context(), testLog(), "ghcr.io", func() error {
+		if attempts.Add(1) < 3 {
+			return &Error{RetryAfter: minHonorWait, Allowed: 44000, AllowedWindow: time.Minute}
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), attempts.Load())
+}
+
+func TestDoDoesNotRetryPermanentErrors(t *testing.T) {
+	ResetForTest()
+
+	var attempts atomic.Int32
+
+	permanent := errors.New("manifest not found")
+
+	err := Do(t.Context(), testLog(), "ghcr.io", func() error {
+		attempts.Add(1)
+
+		return permanent
+	})
+	require.ErrorIs(t, err, permanent)
+	assert.Equal(t, int32(1), attempts.Load())
+}
+
+func TestDoGivesUpWhenRetryAfterExceedsHonorWindow(t *testing.T) {
+	ResetForTest()
+
+	var attempts atomic.Int32
+
+	err := Do(t.Context(), testLog(), "ghcr.io", func() error {
+		attempts.Add(1)
+
+		return &Error{RetryAfter: 2 * time.Hour}
+	})
+	require.ErrorIs(t, err, ErrRateLimited)
+	assert.Equal(t, int32(1), attempts.Load())
+}
+
+func TestDoValueReturnsSuccessfulResult(t *testing.T) {
+	ResetForTest()
+
+	got, err := DoValue(t.Context(), testLog(), "ghcr.io", func() (string, error) {
+		return "digest", nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "digest", got)
+}
+
+func TestDoRetriesWrappedSentinelWithoutTypedError(t *testing.T) {
+	ResetForTest()
+
+	var attempts atomic.Int32
+
+	err := Do(t.Context(), nil, "ghcr.io", func() error {
+		if attempts.Add(1) < 2 {
+			return errors.New("registry rate limited: " + ErrRateLimited.Error())
+		}
+
+		return nil
+	})
+	// A plain string is not errors.Is(ErrRateLimited), so it must be permanent.
+	require.Error(t, err)
+	assert.Equal(t, int32(1), attempts.Load())
+}
+
+func TestDoRetriesWrappedErrRateLimited(t *testing.T) {
+	ResetForTest()
+
+	var attempts atomic.Int32
+
+	err := Do(t.Context(), nil, "ghcr.io", func() error {
+		if attempts.Add(1) < 2 {
+			return errors.Join(ErrRateLimited)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), attempts.Load())
+}
+
+func TestDoValueConsumesOneTokenPerAttempt(t *testing.T) {
+	ResetForTest()
+
+	Observe("ghcr.io", &Error{
+		Allowed:       2,
+		AllowedWindow: 200 * time.Millisecond,
+	})
+
+	time.Sleep(220 * time.Millisecond)
+
+	got, err := DoValue(t.Context(), testLog(), "ghcr.io", func() (string, error) {
+		return "ok", nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ok", got)
+
+	started := time.Now()
+
+	require.NoError(t, Wait(t.Context(), "ghcr.io"))
+	assert.Less(t, time.Since(started), 50*time.Millisecond)
+}
+
+func TestDoValueHonorsHostWaitCancellation(t *testing.T) {
+	ResetForTest()
+
+	Observe("ghcr.io", &Error{RetryAfter: 5 * time.Second})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+
+	_, err := DoValue(ctx, testLog(), "ghcr.io", func() (string, error) {
+		return "unused", nil
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestLastOperationErrorPassesThroughPlainErrors(t *testing.T) {
+	t.Parallel()
+
+	plain := errors.New("not a retry error")
+	assert.Equal(t, plain, lastOperationError(plain))
+	assert.NoError(t, lastOperationError(nil))
+}
+
+func TestDoStopsWhenContextCanceled(t *testing.T) {
+	ResetForTest()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := Do(ctx, testLog(), "ghcr.io", func() error {
+		return &Error{RetryAfter: minHonorWait}
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/pkg/registry/ratelimit/retry_test.go
+++ b/pkg/registry/ratelimit/retry_test.go
@@ -78,7 +78,7 @@ func TestDoValueReturnsSuccessfulResult(t *testing.T) {
 	assert.Equal(t, "digest", got)
 }
 
-func TestDoRetriesWrappedSentinelWithoutTypedError(t *testing.T) {
+func TestDoTreatsSentinelTextWithoutWrappingAsPermanent(t *testing.T) {
 	ResetForTest()
 
 	var attempts atomic.Int32


### PR DESCRIPTION
This PR stops parallel staleness checks from turning a registry 429 response into GET fallbacks and full image pulls. Digest, auth, and age fetches honor Retry-After and advertised quotas, and layer pulls are serialized so blob downloads no longer burst with the HEAD worker pool.

## Problem

#1958 parallelized staleness checks with up to 20 workers. Each worker can HEAD a manifest, fall back to GET, then call ImagePull. A registry 429 on HEAD was treated as a generic digest failure, so Watchtower retried with GET and then a full pull. Docker stream 429s were also lost because the pull response was drained with `io.Copy` instead of `Wait()`. Hosts such as GHCR, including `lscr.io/linuxserver` images, then returned `toomanyrequests` with `retry-after` and `allowed: 44000/minute`.

## Solution

Add `pkg/registry/ratelimit` to parse Retry-After headers, GHCR body quotas, and Docker pull-stream `toomanyrequests` text. A typed rate-limit error aborts the digest path (no GET fallback, no full pull) and stops the mirror retry loop. Auth, digest, and age fetches retry with `cenkalti/backoff` while honoring Retry-After (100ms floor, 30s cap) and a per-host token bucket. Layer pulls stay serialized at one at a time, and the pull slot is held only around the daemon `ImagePull` so cooldown sleeps do not block other registries.

## Changes

- Added `pkg/registry/ratelimit` for 429 parsing, per-host cooldown, quota tokens, and backoff retries
- Treated digest and auth 429s as fatal for the current cycle instead of falling back to GET or `ImagePull`
- Serialized `ImagePull` behind a single slot acquired only around the daemon pull
- Observed cooldown age-fetch 429s on the same host limiter
- Added unit and Ginkgo coverage for parse, retry, digest abort, pull-slot, and stream 429 paths