### PR TITLE
fix(ephemeral): support cleanup flag in ephemeral self-update orchestrator

### DIFF
--- a/internal/actions/actions_internal_test.go
+++ b/internal/actions/actions_internal_test.go
@@ -140,6 +140,43 @@ var _ = ginkgo.Describe("restartStaleContainer", func() {
 		gomega.Expect(client.TestData.RenameContainerCount.Load()).To(gomega.Equal(int32(0)))
 		gomega.Expect(newID).NotTo(gomega.BeEmpty())
 	})
+
+	ginkgo.It("should treat ephemeral self-update as a completed handoff", func() {
+		client := mockActions.CreateMockClient(
+			&mockActions.TestData{
+				Containers: []types.Container{
+					mockActions.CreateMockContainerWithConfig(
+						"watchtower",
+						"/watchtower",
+						"watchtower:latest",
+						true,
+						false,
+						time.Now(),
+						&dockerContainer.Config{
+							Labels: map[string]string{
+								"com.centurylinklabs.watchtower": "true",
+							},
+						}),
+				},
+				Staleness: map[string]bool{
+					"watchtower": true,
+				},
+			},
+			false,
+			false,
+		)
+		params := types.UpdateParams{
+			EphemeralSelfUpdate: true,
+			Cleanup:             true,
+		}
+		testContainer := client.TestData.Containers[0]
+		newID, renamed, err := restartStaleContainer(testLogger(), context.Background(), testContainer, client, params)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(renamed).To(gomega.BeTrue())
+		gomega.Expect(newID).To(gomega.BeEmpty())
+		gomega.Expect(client.TestData.RenameContainerCount.Load()).To(gomega.Equal(int32(0)))
+		gomega.Expect(client.TestData.LastCleanup).To(gomega.BeTrue())
+	})
 })
 
 var _ = ginkgo.Describe("handleUpdateResult", func() {

--- a/internal/actions/cleanup.go
+++ b/internal/actions/cleanup.go
@@ -781,6 +781,12 @@ func RemoveImages(log *zerolog.Logger, ctx context.Context,
 					Str("image_id", string(imageID)).
 					Str("image_name", image.ImageName).
 					Msg("Image is in use by active container, skipping removal")
+			case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+				log.Debug().
+					Err(err).
+					Str("image_id", string(imageID)).
+					Str("image_name", image.ImageName).
+					Msg("Image removal interrupted by cancellation, skipping")
 			default:
 				log.Debug().
 					Err(err).

--- a/internal/actions/cleanup_test.go
+++ b/internal/actions/cleanup_test.go
@@ -1460,6 +1460,25 @@ var _ = ginkgo.Describe("CleanupImages", func() {
 		gomega.Expect(cleaned[0].ImageID).To(gomega.Equal(types.ImageID("image1")))
 	})
 
+	ginkgo.It("should treat context cancellation as a non-error and not add to cleaned", func() {
+		mockClient := mockContainer.NewMockClient(ginkgo.GinkgoT())
+
+		cleanedImages := []types.RemovedImageInfo{
+			{ImageID: "image1", ImageName: "image1"},
+			{ImageID: "image2", ImageName: "image2"},
+		}
+
+		mockClient.EXPECT().RemoveImageByID(mock.Anything, types.ImageID("image1"), "image1").Return(nil)
+		mockClient.EXPECT().
+			RemoveImageByID(context.Background(), types.ImageID("image2"), "image2").
+			Return(context.Canceled)
+
+		cleaned, err := RemoveImages(testLogger(), context.Background(), mockClient, cleanedImages)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(cleaned).To(gomega.HaveLen(1))
+		gomega.Expect(cleaned[0].ImageID).To(gomega.Equal(types.ImageID("image1")))
+	})
+
 	ginkgo.It("should treat 'conflict' errors as non-errors and not add to cleaned", func() {
 		mockClient := mockContainer.NewMockClient(ginkgo.GinkgoT())
 

--- a/internal/actions/ephemeral.go
+++ b/internal/actions/ephemeral.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -58,7 +59,8 @@ var (
 //  3. Creates a new container from the new image with the same config
 //  4. Starts the new container
 //  5. Removes the old container
-//  6. Exits (AutoRemove cleans up the orchestrator)
+//  6. When cleanup is enabled, removes the unused predecessor image
+//  7. Exits (AutoRemove cleans up the orchestrator)
 //
 // This function returns immediately after starting the orchestrator. The
 // orchestrator handles the full replacement sequence asynchronously. The
@@ -77,7 +79,8 @@ var (
 //
 // Returns:
 //   - types.ContainerID: Empty string (the new container's ID is not known to the caller).
-//   - bool: False (old container is removed, not renamed).
+//   - bool: True so the dying process skips image cleanup. The orchestrator
+//     removes the old container and, when cleanup is enabled, the old image.
 //   - error: Non-nil if orchestrator creation fails.
 func EphemeralSelfUpdate(log *zerolog.Logger, ctx context.Context,
 	client container.Client,
@@ -142,6 +145,7 @@ func EphemeralSelfUpdate(log *zerolog.Logger, ctx context.Context,
 		sourceContainer,
 		newImage,
 		newChain,
+		config.Cleanup,
 	)
 	if err != nil {
 		clog.Error().
@@ -173,10 +177,11 @@ func EphemeralSelfUpdate(log *zerolog.Logger, ctx context.Context,
 	// stopped. Callers must handle the ephemeral case specially (skip health checks
 	// and post-update hooks since the old process exits before the new container exists).
 	//
-	// Return false for "renamed" because in the ephemeral flow the old container
-	// IS removed (not renamed). This allows cleanup image info to be collected
-	// for the old image, unlike the rename path where the old container persists.
-	return "", false, nil
+	// Return true for "renamed" so the dying process does not collect the old
+	// image for cleanup. This process is about to be stopped and still uses that
+	// image. The orchestrator removes the old container and, when cleanup is
+	// enabled, the old image after the replacement is running.
+	return "", true, nil
 }
 
 // RunOrchestrator executes the orchestrator mode for self-update.
@@ -194,6 +199,7 @@ func EphemeralSelfUpdate(log *zerolog.Logger, ctx context.Context,
 //  6. START NEW: Start the new Watchtower container
 //  7. VERIFY: Confirm the new container is running
 //  8. REMOVE OLD: Delete the renamed predecessor
+//  9. REMOVE OLD IMAGE: When cleanup is enabled, delete the unused predecessor image
 //
 // Stop before create releases published host ports. Rename keeps the stopped
 // predecessor for recovery if create or start fails (restore name and start).
@@ -211,7 +217,7 @@ func RunOrchestrator(log *zerolog.Logger, ctx context.Context, client container.
 	clog.Debug().Msg("Starting Watchtower self-update orchestrator")
 
 	// Read environment variables.
-	oldID, newImage, originalName, containerChain, err := readOrchestratorEnv()
+	oldID, newImage, originalName, containerChain, cleanup, err := readOrchestratorEnv()
 	if err != nil {
 		clog.Fatal().
 			Err(err).
@@ -223,6 +229,7 @@ func RunOrchestrator(log *zerolog.Logger, ctx context.Context, client container.
 		Str("new_image", newImage).
 		Str("original_name", originalName).
 		Str("container_chain", containerChain).
+		Bool("cleanup", cleanup).
 		Msg("Read orchestrator environment variables")
 
 	// Create a timeout context for the entire orchestration.
@@ -239,6 +246,7 @@ func RunOrchestrator(log *zerolog.Logger, ctx context.Context, client container.
 		newImage,
 		originalName,
 		containerChain,
+		cleanup,
 	)
 	// Determine exit code and log result.
 	exitCode := 0
@@ -265,11 +273,12 @@ func RunOrchestrator(log *zerolog.Logger, ctx context.Context, client container.
 //   - string: New image reference.
 //   - string: Original container name.
 //   - string: Container chain for lineage tracking.
+//   - bool: Whether old-image cleanup is enabled.
 //   - error: Non-nil if any required variable is missing.
-func readOrchestratorEnv() (string, string, string, string, error) {
+func readOrchestratorEnv() (string, string, string, string, bool, error) {
 	oldID := os.Getenv("WT_ORCHESTRATOR_OLD_ID")
 	if oldID == "" {
-		return "", "", "", "", fmt.Errorf(
+		return "", "", "", "", false, fmt.Errorf(
 			"%w: WT_ORCHESTRATOR_OLD_ID",
 			errOrchestratorMissingEnv,
 		)
@@ -277,7 +286,7 @@ func readOrchestratorEnv() (string, string, string, string, error) {
 
 	newImage := os.Getenv("WT_ORCHESTRATOR_NEW_IMAGE")
 	if newImage == "" {
-		return "", "", "", "", fmt.Errorf(
+		return "", "", "", "", false, fmt.Errorf(
 			"%w: WT_ORCHESTRATOR_NEW_IMAGE",
 			errOrchestratorMissingEnv,
 		)
@@ -285,7 +294,7 @@ func readOrchestratorEnv() (string, string, string, string, error) {
 
 	originalName := os.Getenv("WT_ORCHESTRATOR_ORIGINAL_NAME")
 	if originalName == "" {
-		return "", "", "", "", fmt.Errorf(
+		return "", "", "", "", false, fmt.Errorf(
 			"%w: WT_ORCHESTRATOR_ORIGINAL_NAME",
 			errOrchestratorMissingEnv,
 		)
@@ -293,7 +302,9 @@ func readOrchestratorEnv() (string, string, string, string, error) {
 
 	containerChain := os.Getenv("WT_ORCHESTRATOR_CONTAINER_CHAIN")
 
-	return oldID, newImage, originalName, containerChain, nil
+	cleanup, _ := strconv.ParseBool(os.Getenv("WT_ORCHESTRATOR_CLEANUP"))
+
+	return oldID, newImage, originalName, containerChain, cleanup, nil
 }
 
 // orchestrateSelfUpdate performs the container replacement sequence for a
@@ -307,6 +318,7 @@ func readOrchestratorEnv() (string, string, string, string, error) {
 //  5. Create and start the new container under the original name.
 //  6. Verify the new container is running.
 //  7. Remove the renamed predecessor.
+//  8. When cleanup is enabled, remove the unused predecessor image.
 //
 // Stop before create releases published host ports. Rename keeps the stopped
 // predecessor available for recovery. On create/start/verify failure after
@@ -319,6 +331,7 @@ func readOrchestratorEnv() (string, string, string, string, error) {
 //   - newImage: Image reference for the new container.
 //   - originalName: Original container name to preserve on the new container.
 //   - containerChain: Container chain label for lineage tracking.
+//   - cleanup: Remove the old image after the predecessor container is gone.
 //
 // Returns:
 //   - error: Non-nil if any step in the orchestration fails.
@@ -328,6 +341,7 @@ func orchestrateSelfUpdate(log *zerolog.Logger, ctx context.Context,
 	newImage string,
 	originalName string,
 	containerChain string,
+	cleanup bool,
 ) error {
 	clogVal := log.With().
 		Str("old_id", oldID).
@@ -346,6 +360,10 @@ func orchestrateSelfUpdate(log *zerolog.Logger, ctx context.Context,
 	if err != nil {
 		return err
 	}
+
+	// Capture before pinContainerCreateImage overwrites the cached image name.
+	oldImageID := oldContainer.ImageID()
+	oldImageName := oldContainer.ImageName()
 
 	pinContainerCreateImage(oldContainer, newImage, clog)
 
@@ -400,6 +418,10 @@ func orchestrateSelfUpdate(log *zerolog.Logger, ctx context.Context,
 				Err(removeErr).
 				Msg("New Watchtower is running but cleanup of the old container failed")
 		}
+	}
+
+	if cleanup {
+		removeOldImage(ctx, client, clog, oldImageID, oldImageName)
 	}
 
 	// Emit the actual new container ID at Info level so notification templates
@@ -755,6 +777,57 @@ func removeOldContainer(
 	clog.Debug().Msg("Old container removed")
 
 	return nil
+}
+
+// removeOldImage removes the predecessor Watchtower image after a successful
+// handoff. NotFound and in-use errors are skipped. Other failures are logged
+// and do not fail orchestration because the replacement is already running.
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeouts.
+//   - client: Container client for Docker operations.
+//   - clog: Logger with container context fields.
+//   - imageID: ID of the predecessor image captured before create-image pinning.
+//   - imageName: Name of the predecessor image captured before create-image pinning.
+func removeOldImage(
+	ctx context.Context,
+	client container.Client,
+	clog *zerolog.Logger,
+	imageID types.ImageID,
+	imageName string,
+) {
+	if imageID == "" {
+		return
+	}
+
+	clog.Debug().
+		Str("image_id", imageID.ShortID()).
+		Str("image_name", imageName).
+		Msg("Removing old Watchtower image after ephemeral handoff")
+
+	err := client.RemoveImageByID(ctx, imageID, imageName)
+	if err == nil {
+		return
+	}
+
+	switch {
+	case cerrdefs.IsNotFound(err),
+		cerrdefs.IsConflict(err),
+		errors.Is(err, container.ErrImageInUse),
+		errors.Is(err, context.Canceled),
+		errors.Is(err, context.DeadlineExceeded):
+		clog.Debug().
+			Err(err).
+			Str("image_id", imageID.ShortID()).
+			Str("image_name", imageName).
+			Msg("Skipped old Watchtower image removal")
+	default:
+		clog.Warn().
+			Err(err).
+			Str("image_id", imageID.ShortID()).
+			Str("image_name", imageName).
+			Msg("New Watchtower is running but cleanup of the old image failed")
+	}
 }
 
 // createAndStartNewContainer creates and starts a new container using the old

--- a/internal/actions/ephemeral_internal_test.go
+++ b/internal/actions/ephemeral_internal_test.go
@@ -9,10 +9,12 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
+	cerrdefs "github.com/containerd/errdefs"
 	dockerContainer "github.com/moby/moby/api/types/container"
 	dockerNetwork "github.com/moby/moby/api/types/network"
 
 	mockActions "github.com/nicholas-fedor/watchtower/internal/actions/mocks"
+	"github.com/nicholas-fedor/watchtower/pkg/container"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
@@ -101,6 +103,7 @@ var _ = ginkgo.Describe("orchestrateSelfUpdate handoff", func() {
 			"watchtower:v2",
 			"watchtower",
 			"",
+			false,
 		)
 
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -152,6 +155,7 @@ var _ = ginkgo.Describe("orchestrateSelfUpdate handoff", func() {
 			"watchtower:v2",
 			"watchtower",
 			"",
+			false,
 		)
 
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -184,6 +188,7 @@ var _ = ginkgo.Describe("orchestrateSelfUpdate handoff", func() {
 			"watchtower:v2",
 			"watchtower",
 			"",
+			false,
 		)
 
 		gomega.Expect(err).To(gomega.HaveOccurred())
@@ -213,6 +218,7 @@ var _ = ginkgo.Describe("orchestrateSelfUpdate handoff", func() {
 			"watchtower:v2",
 			"watchtower",
 			"",
+			false,
 		)
 
 		gomega.Expect(err).To(gomega.HaveOccurred())
@@ -257,6 +263,7 @@ var _ = ginkgo.Describe("orchestrateSelfUpdate handoff", func() {
 			"watchtower:v2",
 			"watchtower",
 			"",
+			false,
 		)
 
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -283,6 +290,7 @@ var _ = ginkgo.Describe("orchestrateSelfUpdate handoff", func() {
 			"watchtower:v2",
 			"watchtower",
 			chain,
+			false,
 		)
 
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -291,5 +299,110 @@ var _ = ginkgo.Describe("orchestrateSelfUpdate handoff", func() {
 		gotChain, present := client.TestData.LastStartedContainer.GetContainerChain()
 		gomega.Expect(present).To(gomega.BeTrue())
 		gomega.Expect(gotChain).To(gomega.Equal(chain))
+	})
+
+	ginkgo.It("removes the old image after a successful handoff when cleanup is enabled", func() {
+		old := createEphemeralHandoffContainer("wt-old-cleanup", nil)
+
+		client := mockActions.CreateMockClient(
+			&mockActions.TestData{
+				Containers: []types.Container{old},
+			},
+			false,
+			false,
+		)
+
+		err := orchestrateSelfUpdate(testLogger(),
+			context.Background(),
+			client,
+			"wt-old-cleanup",
+			"watchtower:v2",
+			"watchtower",
+			"",
+			true,
+		)
+
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(client.TestData.TriedToRemoveImageCount.Load()).To(gomega.Equal(int32(1)))
+		gomega.Expect(client.TestData.RemoveContainerCount.Load()).To(gomega.BeNumerically(">=", int32(1)))
+	})
+
+	ginkgo.It("does not remove the old image when cleanup is disabled", func() {
+		old := createEphemeralHandoffContainer("wt-old-no-cleanup", nil)
+
+		client := mockActions.CreateMockClient(
+			&mockActions.TestData{
+				Containers: []types.Container{old},
+			},
+			false,
+			false,
+		)
+
+		err := orchestrateSelfUpdate(testLogger(),
+			context.Background(),
+			client,
+			"wt-old-no-cleanup",
+			"watchtower:v2",
+			"watchtower",
+			"",
+			false,
+		)
+
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(client.TestData.TriedToRemoveImageCount.Load()).To(gomega.Equal(int32(0)))
+	})
+
+	ginkgo.It("treats an in-use old image as a non-fatal skip", func() {
+		old := createEphemeralHandoffContainer("wt-old-in-use", nil)
+
+		client := mockActions.CreateMockClient(
+			&mockActions.TestData{
+				Containers:       []types.Container{old},
+				FailedImageIDs:   []types.ImageID{old.ImageID()},
+				RemoveImageError: container.ErrImageInUse,
+			},
+			false,
+			false,
+		)
+
+		err := orchestrateSelfUpdate(testLogger(),
+			context.Background(),
+			client,
+			"wt-old-in-use",
+			"watchtower:v2",
+			"watchtower",
+			"",
+			true,
+		)
+
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(client.TestData.TriedToRemoveImageCount.Load()).To(gomega.Equal(int32(1)))
+	})
+
+	ginkgo.It("treats a missing old image as a non-fatal skip", func() {
+		old := createEphemeralHandoffContainer("wt-old-missing-image", nil)
+
+		client := mockActions.CreateMockClient(
+			&mockActions.TestData{
+				Containers:       []types.Container{old},
+				FailedImageIDs:   []types.ImageID{old.ImageID()},
+				RemoveImageError: cerrdefs.ErrNotFound,
+			},
+			false,
+			false,
+		)
+
+		err := orchestrateSelfUpdate(testLogger(),
+			context.Background(),
+			client,
+			"wt-old-missing-image",
+			"watchtower:v2",
+			"watchtower",
+			"",
+			true,
+		)
+
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(client.TestData.TriedToRemoveImageCount.Load()).To(gomega.Equal(int32(1)))
 	})
 })

--- a/internal/actions/ephemeral_test.go
+++ b/internal/actions/ephemeral_test.go
@@ -51,7 +51,7 @@ func createDefaultMockClient(td *mockActions.TestData) mockActions.MockClient {
 
 var _ = ginkgo.Describe("EphemeralSelfUpdate", func() {
 	ginkgo.When("the orchestrator is created successfully", func() {
-		ginkgo.It("should return empty container ID and false (not renamed)", func() {
+		ginkgo.It("should return empty container ID and true so the dying process skips cleanup", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
@@ -70,7 +70,7 @@ var _ = ginkgo.Describe("EphemeralSelfUpdate", func() {
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(newID).To(gomega.BeEmpty())
-			gomega.Expect(renamed).To(gomega.BeFalse())
+			gomega.Expect(renamed).To(gomega.BeTrue())
 		})
 	})
 
@@ -94,7 +94,7 @@ var _ = ginkgo.Describe("EphemeralSelfUpdate", func() {
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(newID).To(gomega.BeEmpty())
-			gomega.Expect(renamed).To(gomega.BeFalse())
+			gomega.Expect(renamed).To(gomega.BeTrue())
 
 			// Verify the orchestrator's chain was set to the source container ID.
 			gomega.Expect(client.TestData.LastContainerChain).To(
@@ -132,7 +132,7 @@ var _ = ginkgo.Describe("EphemeralSelfUpdate", func() {
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(newID).To(gomega.BeEmpty())
-			gomega.Expect(renamed).To(gomega.BeFalse())
+			gomega.Expect(renamed).To(gomega.BeTrue())
 
 			// Verify the orchestrator's chain has the source ID appended to the existing chain.
 			gomega.Expect(client.TestData.LastContainerChain).To(
@@ -176,6 +176,30 @@ var _ = ginkgo.Describe("EphemeralSelfUpdate", func() {
 		})
 	})
 
+	ginkgo.When("cleanup is enabled on the update params", func() {
+		ginkgo.It("should pass cleanup=true to the orchestrator", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			sourceContainer := createDefaultMockContainer("source-cleanup", map[string]string{
+				"com.centurylinklabs.watchtower": "true",
+			})
+
+			client := createDefaultMockClient(&mockActions.TestData{})
+
+			_, renamed, err := actions.EphemeralSelfUpdate(testLogger(),
+				ctx,
+				client,
+				sourceContainer,
+				types.UpdateParams{Cleanup: true},
+			)
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(renamed).To(gomega.BeTrue())
+			gomega.Expect(client.TestData.LastCleanup).To(gomega.BeTrue())
+		})
+	})
+
 	// EphemeralSelfUpdate only starts the orchestrator. Replacement is asynchronous.
 	ginkgo.When("the orchestrator launches successfully", func() {
 		ginkgo.It("returns without performing stop or start on the source client path", func() {
@@ -197,7 +221,7 @@ var _ = ginkgo.Describe("EphemeralSelfUpdate", func() {
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(newID).To(gomega.BeEmpty())
-			gomega.Expect(renamed).To(gomega.BeFalse())
+			gomega.Expect(renamed).To(gomega.BeTrue())
 			gomega.Expect(client.TestData.StopContainerCount.Load()).To(gomega.Equal(int32(0)))
 			gomega.Expect(client.TestData.StartContainerCount.Load()).To(gomega.Equal(int32(0)))
 			gomega.Expect(client.TestData.RenameContainerCount.Load()).To(gomega.Equal(int32(0)))

--- a/internal/actions/mocks/client.go
+++ b/internal/actions/mocks/client.go
@@ -66,6 +66,7 @@ type TestData struct {
 	RemoveContainerCount        atomic.Int32                  // Number of times RemoveContainer was called.
 	SimulatedLatency            time.Duration                 // Simulated latency for operations (default 0 for fast tests, set for context cancellation tests).
 	LastContainerChain          string                        // Last container chain passed to CreateEphemeralOrchestrator.
+	LastCleanup                 bool                          // Last cleanup flag passed to CreateEphemeralOrchestrator.
 	LastUpdateConfig            *dockerContainer.UpdateConfig // Last UpdateContainer config received.
 	LastStartedContainer        types.Container               // Last container passed to StartContainer.
 	LastStartedContainerID      types.ContainerID             // ID returned by the last successful StartContainer call.
@@ -552,12 +553,14 @@ func (client MockClient) CreateEphemeralOrchestrator(
 	_ types.Container,
 	_ string,
 	containerChain string,
+	cleanup bool,
 ) (types.ContainerID, error) {
 	if err := client.checkContextCancellation(ctx); err != nil {
 		return "", err
 	}
 
 	client.TestData.LastContainerChain = containerChain
+	client.TestData.LastCleanup = cleanup
 
 	return types.ContainerID("mock-ephemeral-orchestrator"), nil
 }

--- a/internal/actions/update_watchtower_test.go
+++ b/internal/actions/update_watchtower_test.go
@@ -70,6 +70,52 @@ var _ = ginkgo.Describe("Watchtower container handling", func() {
 				To(gomega.Equal(int32(1)), "IsContainerStale should be called once for Watchtower")
 		})
 
+		ginkgo.It("should not collect Watchtower image cleanup during ephemeral self-update", func() {
+			client := mockActions.CreateMockClient(
+				&mockActions.TestData{
+					Containers: []types.Container{
+						mockActions.CreateMockContainerWithConfig(
+							"watchtower",
+							"/watchtower",
+							"watchtower:latest",
+							true,
+							false,
+							time.Now(),
+							&dockerContainer.Config{
+								Labels: map[string]string{
+									"com.centurylinklabs.watchtower": "true",
+								},
+							}),
+					},
+					Staleness: map[string]bool{
+						"watchtower": true,
+					},
+				},
+				false,
+				false,
+			)
+			report, cleanupImageInfos, err := actions.Update(testLogger(),
+				context.Background(),
+				client,
+				types.UpdateParams{
+					Cleanup:             true,
+					EphemeralSelfUpdate: true,
+					Filter:              filters.WatchtowerContainersFilter,
+					CPUCopyMode:         "auto",
+					PullFailureDelay:    10 * time.Millisecond,
+				},
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(report.Updated()).To(gomega.HaveLen(1))
+			gomega.Expect(cleanupImageInfos).
+				To(gomega.BeEmpty(), "Dying process must not collect the Watchtower image for cleanup")
+			gomega.Expect(client.TestData.TriedToRemoveImageCount.Load()).
+				To(gomega.Equal(int32(0)), "RemoveImageByID should not be called during Update")
+			gomega.Expect(client.TestData.RenameContainerCount.Load()).
+				To(gomega.Equal(int32(0)), "RenameContainer should not be called for ephemeral self-update")
+			gomega.Expect(client.TestData.LastCleanup).To(gomega.BeTrue())
+		})
+
 		ginkgo.It("should skip rename with no-restart for Watchtower", func() {
 			client := mockActions.CreateMockClient(
 				&mockActions.TestData{

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -341,6 +341,7 @@ type Client interface {
 	//   - sourceContainer: The current Watchtower container being replaced.
 	//   - newImage: The image reference for the new Watchtower container.
 	//   - containerChain: The container chain label for lineage tracking.
+	//   - cleanup: When true, the orchestrator removes the old image after handoff.
 	//
 	// Returns:
 	//   - types.ContainerID: ID of the ephemeral orchestrator container.
@@ -350,6 +351,7 @@ type Client interface {
 		sourceContainer types.Container,
 		newImage string,
 		containerChain string,
+		cleanup bool,
 	) (types.ContainerID, error)
 
 	// StartContainerByID starts a container by its ID directly.

--- a/pkg/container/ephemeral.go
+++ b/pkg/container/ephemeral.go
@@ -29,6 +29,8 @@ const (
 	orchestratorOriginalNameEnv = "WT_ORCHESTRATOR_ORIGINAL_NAME"
 	// orchestratorContainerChainEnv is the environment variable key for the container chain label.
 	orchestratorContainerChainEnv = "WT_ORCHESTRATOR_CONTAINER_CHAIN"
+	// orchestratorCleanupEnv is the environment variable key for old-image cleanup.
+	orchestratorCleanupEnv = "WT_ORCHESTRATOR_CLEANUP"
 	// orchestratorCleanupTimeout is the timeout for cleanup operations on failed orchestrator creation.
 	orchestratorCleanupTimeout = 5 * time.Second
 )
@@ -105,6 +107,7 @@ type DockerConnectionConfig struct {
 //   - sourceContainer: Current Watchtower container being replaced.
 //   - newImage: Image reference for the new Watchtower container.
 //   - containerChain: Container chain label for lineage tracking.
+//   - cleanup: When true, the orchestrator removes the old image after handoff.
 //
 // Returns:
 //   - types.ContainerID: ID of the ephemeral orchestrator container.
@@ -114,6 +117,7 @@ func (c *client) CreateEphemeralOrchestrator(
 	sourceContainer types.Container,
 	newImage string,
 	containerChain string,
+	cleanup bool,
 ) (types.ContainerID, error) {
 	clogVal := c.log.With().
 		Str("source_container", sourceContainer.Name()).
@@ -137,7 +141,7 @@ func (c *client) CreateEphemeralOrchestrator(
 		Msg("Extracted Docker connection configuration")
 
 	// Build the orchestrator container configuration with Docker env vars.
-	config := buildOrchestratorConfig(sourceContainer, newImage, containerChain, connConfig)
+	config := buildOrchestratorConfig(sourceContainer, newImage, containerChain, connConfig, cleanup)
 
 	// Build the host configuration with appropriate socket/TLS mounts.
 	// The orchestrator inherits the source container's NetworkMode to ensure
@@ -235,6 +239,7 @@ func (c *client) CreateEphemeralOrchestrator(
 //   - newImage: Image reference for the new container.
 //   - containerChain: Container chain label for lineage tracking.
 //   - connConfig: Docker connection configuration extracted from the source container.
+//   - cleanup: When true, the orchestrator removes the old image after handoff.
 //
 // Returns:
 //   - *dockerContainer.Config: The container configuration.
@@ -243,6 +248,7 @@ func buildOrchestratorConfig(
 	newImage string,
 	containerChain string,
 	connConfig *DockerConnectionConfig,
+	cleanup bool,
 ) *dockerContainer.Config {
 	// Build the environment variables with orchestrator-specific values.
 	env := []string{
@@ -250,6 +256,7 @@ func buildOrchestratorConfig(
 		fmt.Sprintf("%s=%s", orchestratorNewImageEnv, newImage),
 		fmt.Sprintf("%s=%s", orchestratorOriginalNameEnv, sourceContainer.Name()),
 		fmt.Sprintf("%s=%s", orchestratorContainerChainEnv, containerChain),
+		fmt.Sprintf("%s=%t", orchestratorCleanupEnv, cleanup),
 	}
 
 	// Forward Docker connection environment variables to maintain parity with the source.

--- a/pkg/container/ephemeral_test.go
+++ b/pkg/container/ephemeral_test.go
@@ -371,7 +371,7 @@ var _ = ginkgo.Describe("Ephemeral Orchestrator", func() {
 					SocketBind: "/var/run/docker.sock:/var/run/docker.sock",
 				}
 
-				config := buildOrchestratorConfig(source, "watchtower:v2", "old1,old2", connConfig)
+				config := buildOrchestratorConfig(source, "watchtower:v2", "old1,old2", connConfig, false)
 
 				gomega.Expect(config).NotTo(gomega.BeNil())
 				gomega.Expect(config.Image).To(gomega.Equal("watchtower:v2"))
@@ -391,10 +391,29 @@ var _ = ginkgo.Describe("Ephemeral Orchestrator", func() {
 				gomega.Expect(config.Env).To(gomega.ContainElement(
 					"WT_ORCHESTRATOR_CONTAINER_CHAIN=old1,old2",
 				))
+				gomega.Expect(config.Env).To(gomega.ContainElement(
+					"WT_ORCHESTRATOR_CLEANUP=false",
+				))
 
 				// Verify the orchestrator label is set but the watchtower label is NOT set.
 				gomega.Expect(config.Labels).To(gomega.HaveKeyWithValue(OrchestratorLabel, "true"))
 				gomega.Expect(config.Labels).NotTo(gomega.HaveKey("com.centurylinklabs.watchtower"))
+			})
+		})
+
+		ginkgo.When("cleanup is enabled", func() {
+			ginkgo.It("should set WT_ORCHESTRATOR_CLEANUP to true", func() {
+				source := MockContainer(
+					WithID("abc123"),
+					WithName("watchtower"),
+					WithImageName("watchtower:latest"),
+				)
+
+				config := buildOrchestratorConfig(source, "watchtower:v2", "", nil, true)
+
+				gomega.Expect(config.Env).To(gomega.ContainElement(
+					"WT_ORCHESTRATOR_CLEANUP=true",
+				))
 			})
 		})
 
@@ -410,7 +429,7 @@ var _ = ginkgo.Describe("Ephemeral Orchestrator", func() {
 					SocketBind: "/var/run/docker.sock:/var/run/docker.sock",
 				}
 
-				config := buildOrchestratorConfig(source, "watchtower:v2", "", connConfig)
+				config := buildOrchestratorConfig(source, "watchtower:v2", "", connConfig, false)
 
 				gomega.Expect(config.Env).To(gomega.ContainElement(
 					"WT_ORCHESTRATOR_CONTAINER_CHAIN=",
@@ -433,7 +452,7 @@ var _ = ginkgo.Describe("Ephemeral Orchestrator", func() {
 					IsLocal:    false,
 				}
 
-				config := buildOrchestratorConfig(source, "watchtower:v2", "chain1", connConfig)
+				config := buildOrchestratorConfig(source, "watchtower:v2", "chain1", connConfig, false)
 
 				gomega.Expect(config.Env).To(gomega.ContainElement(
 					"DOCKER_HOST=tcp://remote:2375",
@@ -458,7 +477,7 @@ var _ = ginkgo.Describe("Ephemeral Orchestrator", func() {
 					WithImageName("watchtower:latest"),
 				)
 
-				config := buildOrchestratorConfig(source, "watchtower:v2", "chain1", nil)
+				config := buildOrchestratorConfig(source, "watchtower:v2", "chain1", nil, false)
 
 				// Should still have orchestrator env vars but no Docker env vars.
 				gomega.Expect(config.Env).To(gomega.ContainElement(
@@ -665,7 +684,7 @@ var _ = ginkgo.Describe("Ephemeral Orchestrator", func() {
 
 			ginkgo.It("should return the orchestrator container ID", func() {
 				orchestratorID, err := testClient.CreateEphemeralOrchestrator(
-					ctx, source, "watchtower:v2", "chain1",
+					ctx, source, "watchtower:v2", "chain1", false,
 				)
 
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -687,7 +706,7 @@ var _ = ginkgo.Describe("Ephemeral Orchestrator", func() {
 
 			ginkgo.It("should return an error wrapping ErrEphemeralCreateFailed", func() {
 				orchestratorID, err := testClient.CreateEphemeralOrchestrator(
-					ctx, source, "watchtower:v2", "chain1",
+					ctx, source, "watchtower:v2", "chain1", false,
 				)
 
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring(
@@ -743,7 +762,7 @@ var _ = ginkgo.Describe("Ephemeral Orchestrator", func() {
 
 			ginkgo.It("should attempt cleanup and return ErrEphemeralStartFailed", func() {
 				orchestratorID, err := testClient.CreateEphemeralOrchestrator(
-					ctx, source, "watchtower:v2", "chain1",
+					ctx, source, "watchtower:v2", "chain1", false,
 				)
 
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring(

--- a/pkg/container/mocks/Client.go
+++ b/pkg/container/mocks/Client.go
@@ -191,8 +191,8 @@ func (_c *MockClient_CreateContainer_Call) RunAndReturn(run func(ctx context.Con
 }
 
 // CreateEphemeralOrchestrator provides a mock function for the type MockClient
-func (_mock *MockClient) CreateEphemeralOrchestrator(ctx context.Context, sourceContainer types.Container, newImage string, containerChain string) (types.ContainerID, error) {
-	ret := _mock.Called(ctx, sourceContainer, newImage, containerChain)
+func (_mock *MockClient) CreateEphemeralOrchestrator(ctx context.Context, sourceContainer types.Container, newImage string, containerChain string, cleanup bool) (types.ContainerID, error) {
+	ret := _mock.Called(ctx, sourceContainer, newImage, containerChain, cleanup)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateEphemeralOrchestrator")
@@ -200,16 +200,16 @@ func (_mock *MockClient) CreateEphemeralOrchestrator(ctx context.Context, source
 
 	var r0 types.ContainerID
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, types.Container, string, string) (types.ContainerID, error)); ok {
-		return returnFunc(ctx, sourceContainer, newImage, containerChain)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, types.Container, string, string, bool) (types.ContainerID, error)); ok {
+		return returnFunc(ctx, sourceContainer, newImage, containerChain, cleanup)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, types.Container, string, string) types.ContainerID); ok {
-		r0 = returnFunc(ctx, sourceContainer, newImage, containerChain)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, types.Container, string, string, bool) types.ContainerID); ok {
+		r0 = returnFunc(ctx, sourceContainer, newImage, containerChain, cleanup)
 	} else {
 		r0 = ret.Get(0).(types.ContainerID)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, types.Container, string, string) error); ok {
-		r1 = returnFunc(ctx, sourceContainer, newImage, containerChain)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, types.Container, string, string, bool) error); ok {
+		r1 = returnFunc(ctx, sourceContainer, newImage, containerChain, cleanup)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -226,11 +226,12 @@ type MockClient_CreateEphemeralOrchestrator_Call struct {
 //   - sourceContainer types.Container
 //   - newImage string
 //   - containerChain string
-func (_e *MockClient_Expecter) CreateEphemeralOrchestrator(ctx any, sourceContainer any, newImage any, containerChain any) *MockClient_CreateEphemeralOrchestrator_Call {
-	return &MockClient_CreateEphemeralOrchestrator_Call{Call: _e.mock.On("CreateEphemeralOrchestrator", ctx, sourceContainer, newImage, containerChain)}
+//   - cleanup bool
+func (_e *MockClient_Expecter) CreateEphemeralOrchestrator(ctx any, sourceContainer any, newImage any, containerChain any, cleanup any) *MockClient_CreateEphemeralOrchestrator_Call {
+	return &MockClient_CreateEphemeralOrchestrator_Call{Call: _e.mock.On("CreateEphemeralOrchestrator", ctx, sourceContainer, newImage, containerChain, cleanup)}
 }
 
-func (_c *MockClient_CreateEphemeralOrchestrator_Call) Run(run func(ctx context.Context, sourceContainer types.Container, newImage string, containerChain string)) *MockClient_CreateEphemeralOrchestrator_Call {
+func (_c *MockClient_CreateEphemeralOrchestrator_Call) Run(run func(ctx context.Context, sourceContainer types.Container, newImage string, containerChain string, cleanup bool)) *MockClient_CreateEphemeralOrchestrator_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -248,11 +249,16 @@ func (_c *MockClient_CreateEphemeralOrchestrator_Call) Run(run func(ctx context.
 		if args[3] != nil {
 			arg3 = args[3].(string)
 		}
+		var arg4 bool
+		if args[4] != nil {
+			arg4 = args[4].(bool)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -263,7 +269,7 @@ func (_c *MockClient_CreateEphemeralOrchestrator_Call) Return(containerID types.
 	return _c
 }
 
-func (_c *MockClient_CreateEphemeralOrchestrator_Call) RunAndReturn(run func(ctx context.Context, sourceContainer types.Container, newImage string, containerChain string) (types.ContainerID, error)) *MockClient_CreateEphemeralOrchestrator_Call {
+func (_c *MockClient_CreateEphemeralOrchestrator_Call) RunAndReturn(run func(ctx context.Context, sourceContainer types.Container, newImage string, containerChain string, cleanup bool) (types.ContainerID, error)) *MockClient_CreateEphemeralOrchestrator_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
This PR corrects a race condition within Watchtower's ephemeral self-update process by preventing the old container from trying to remove the old image while it is still in use.

## Problem

Ephemeral self-update starts the orchestrator and returns `renamed=false`, so the dying process collects the old Watchtower image and calls `RemoveImageByID`. The orchestrator then SIGTERMs that process, `createSignalContext` cancels the update context, and `ContainerList` fails with `terminated signal received`. Even without the race, the old image is still in use. The orchestrator removed the predecessor container but never the image, and startup cleanup skips image collection when the container is already gone.

## Solution

Treat ephemeral handoff like rename (`renamed=true`) so the dying process skips Watchtower image cleanup. Pass `WATCHTOWER_CLEANUP` through `WT_ORCHESTRATOR_CLEANUP` and have the orchestrator remove the predecessor image after a successful handoff. Treat context cancellation during `RemoveImages` as a non-fatal skip so mixed update sessions do not warn when SIGTERM interrupts leftover removals.

## Changes

- Return `renamed=true` from `EphemeralSelfUpdate` so the dying process does not collect the Watchtower image
- Pass a cleanup flag into `CreateEphemeralOrchestrator` and remove the old image after the predecessor container is gone
- Treat `context.Canceled` and `context.DeadlineExceeded` as non-fatal in `RemoveImages`
- Add coverage for handoff, orchestrator image removal, in-use/not-found skips, and cancelled image cleanup