### PR TITLE
fix(ratelimit): detect throttles advertised only via retry-after and quota

### DIFF
--- a/pkg/registry/ratelimit/parse.go
+++ b/pkg/registry/ratelimit/parse.go
@@ -201,6 +201,13 @@ func ReadBody(resp *http.Response, limit int64) []byte {
 // A bare 429 is recognized only with HTTP or status context so byte counts,
 // ports, and digest hashes are ignored.
 //
+// Some registries throttle without emitting a 429 or "too many requests"
+// token, advertising the limit only through retry-after and quota markers such
+// as "retry-after: 1.08ms, allowed: 44000/minute". Those are treated as rate
+// limits too, so the pull is retried rather than failing permanently. Both
+// patterns require a unit suffix or an explicit quota window, so byte counts,
+// ports, and digest hashes remain unmatched.
+//
 // Parameters:
 //   - message: Registry body or Docker pull-stream error text.
 //
@@ -209,9 +216,13 @@ func ReadBody(resp *http.Response, limit int64) []byte {
 func looksRateLimited(message string) bool {
 	lower := strings.ToLower(message)
 
-	return strings.Contains(lower, "toomanyrequests") ||
+	if strings.Contains(lower, "toomanyrequests") ||
 		strings.Contains(lower, "too many requests") ||
-		status429.MatchString(lower)
+		status429.MatchString(lower) {
+		return true
+	}
+
+	return retryAfterBody.MatchString(message) || allowedBody.MatchString(message)
 }
 
 // parseQuotaWindow maps an allowed-quota unit word to a duration.

--- a/pkg/registry/ratelimit/parse.go
+++ b/pkg/registry/ratelimit/parse.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	retryAfterBody = regexp.MustCompile(`(?i)retry-after:\s*([0-9]+(?:\.[0-9]+)?(?:ns|us|µs|μs|ms|s|m|h))\b`)
+	retryAfterBody = regexp.MustCompile(`(?i)retry-after:\s*((?:[0-9]+(?:\.[0-9]+)?(?:ns|us|µs|μs|ms|s|m|h))+)\b`)
 	allowedBody    = regexp.MustCompile(`(?i)allowed:\s*([0-9]+)\s*/\s*(seconds?|secs?|minutes?|mins?|hours?|hrs?)`)
 	rateLimitLimit = regexp.MustCompile(`(?i)([0-9]+)(?:\s*,\s*[0-9]+)*\s*(?:;\s*w=([0-9]+))?`)
 	status429      = regexp.MustCompile(

--- a/pkg/registry/ratelimit/parse.go
+++ b/pkg/registry/ratelimit/parse.go
@@ -201,12 +201,8 @@ func ReadBody(resp *http.Response, limit int64) []byte {
 // A bare 429 is recognized only with HTTP or status context so byte counts,
 // ports, and digest hashes are ignored.
 //
-// Some registries throttle without emitting a 429 or "too many requests"
-// token, advertising the limit only through retry-after and quota markers such
-// as "retry-after: 1.08ms, allowed: 44000/minute". Those are treated as rate
-// limits too, so the pull is retried rather than failing permanently. Both
-// patterns require a unit suffix or an explicit quota window, so byte counts,
-// ports, and digest hashes remain unmatched.
+// Some registries advertise a throttle only through retry-after text, with no
+// 429 or "too many requests" token.
 //
 // Parameters:
 //   - message: Registry body or Docker pull-stream error text.
@@ -216,13 +212,10 @@ func ReadBody(resp *http.Response, limit int64) []byte {
 func looksRateLimited(message string) bool {
 	lower := strings.ToLower(message)
 
-	if strings.Contains(lower, "toomanyrequests") ||
+	return strings.Contains(lower, "toomanyrequests") ||
 		strings.Contains(lower, "too many requests") ||
-		status429.MatchString(lower) {
-		return true
-	}
-
-	return retryAfterBody.MatchString(message) || allowedBody.MatchString(message)
+		status429.MatchString(lower) ||
+		retryAfterBody.MatchString(message)
 }
 
 // parseQuotaWindow maps an allowed-quota unit word to a duration.

--- a/pkg/registry/ratelimit/parse.go
+++ b/pkg/registry/ratelimit/parse.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	retryAfterBody = regexp.MustCompile(`(?i)retry-after:\s*([0-9]+(?:\.[0-9]+)?(?:ns|us|µs|μs|ms|s|m|h))`)
+	retryAfterBody = regexp.MustCompile(`(?i)retry-after:\s*([0-9]+(?:\.[0-9]+)?(?:ns|us|µs|μs|ms|s|m|h))\b`)
 	allowedBody    = regexp.MustCompile(`(?i)allowed:\s*([0-9]+)\s*/\s*(seconds?|secs?|minutes?|mins?|hours?|hrs?)`)
 	rateLimitLimit = regexp.MustCompile(`(?i)([0-9]+)(?:\s*,\s*[0-9]+)*\s*(?:;\s*w=([0-9]+))?`)
 	status429      = regexp.MustCompile(

--- a/pkg/registry/ratelimit/parse.go
+++ b/pkg/registry/ratelimit/parse.go
@@ -150,17 +150,20 @@ func FromResponse(resp *http.Response, body []byte) *Error {
 
 // FromErrorMessage builds a rate-limit error from Docker pull-stream text.
 //
+// Some registries advertise a throttle only through retry-after text, with no
+// 429 or "too many requests" token. That path requires a duration that
+// [time.ParseDuration] accepts.
+//
 // Parameters:
 //   - message: Stream error or registry body. Empty or unrelated text returns nil.
 //
 // Returns:
 //   - *Error: Parsed rate-limit error, or nil when the message is not a 429.
 func FromErrorMessage(message string) *Error {
-	if !looksRateLimited(message) {
+	retryAfter, allowed, window := ParseQuotaMessage(message)
+	if retryAfter == 0 && !looksRateLimited(message) {
 		return nil
 	}
-
-	retryAfter, allowed, window := ParseQuotaMessage(message)
 
 	return &Error{
 		StatusCode:    http.StatusTooManyRequests,
@@ -201,9 +204,6 @@ func ReadBody(resp *http.Response, limit int64) []byte {
 // A bare 429 is recognized only with HTTP or status context so byte counts,
 // ports, and digest hashes are ignored.
 //
-// Some registries advertise a throttle only through retry-after text, with no
-// 429 or "too many requests" token.
-//
 // Parameters:
 //   - message: Registry body or Docker pull-stream error text.
 //
@@ -214,8 +214,7 @@ func looksRateLimited(message string) bool {
 
 	return strings.Contains(lower, "toomanyrequests") ||
 		strings.Contains(lower, "too many requests") ||
-		status429.MatchString(lower) ||
-		retryAfterBody.MatchString(message)
+		status429.MatchString(lower)
 }
 
 // parseQuotaWindow maps an allowed-quota unit word to a duration.

--- a/pkg/registry/ratelimit/parse_test.go
+++ b/pkg/registry/ratelimit/parse_test.go
@@ -423,6 +423,7 @@ func TestFromErrorMessageIgnoresUnrelatedErrors(t *testing.T) {
 	assert.Nil(t, FromErrorMessage("dial tcp 10.0.0.1:429: connect: connection refused"))
 	assert.Nil(t, FromErrorMessage("error from registry: allowed: 44000/minute"))
 	assert.Nil(t, FromErrorMessage("retry-after: 5"))
+	assert.Nil(t, FromErrorMessage("retry-after: 5seconds"))
 	assert.Nil(t, FromErrorMessage("Retry-After: Wed, 21 Oct 2015 07:28:00 GMT"))
 	assert.Nil(t, FromErrorMessage("not allowed: 5/minute"))
 	assert.Nil(t, FromErrorMessage("disallowed: 10/hour"))

--- a/pkg/registry/ratelimit/parse_test.go
+++ b/pkg/registry/ratelimit/parse_test.go
@@ -424,6 +424,7 @@ func TestFromErrorMessageIgnoresUnrelatedErrors(t *testing.T) {
 	assert.Nil(t, FromErrorMessage("error from registry: allowed: 44000/minute"))
 	assert.Nil(t, FromErrorMessage("retry-after: 5"))
 	assert.Nil(t, FromErrorMessage("retry-after: 5seconds"))
+	assert.Nil(t, FromErrorMessage("retry-after: 5S"))
 	assert.Nil(t, FromErrorMessage("Retry-After: Wed, 21 Oct 2015 07:28:00 GMT"))
 	assert.Nil(t, FromErrorMessage("not allowed: 5/minute"))
 	assert.Nil(t, FromErrorMessage("disallowed: 10/hour"))

--- a/pkg/registry/ratelimit/parse_test.go
+++ b/pkg/registry/ratelimit/parse_test.go
@@ -409,6 +409,10 @@ func TestFromErrorMessageRecognizesQuotaOnlyThrottle(t *testing.T) {
 	require.NotNil(t, FromErrorMessage(
 		"error from registry: retry-after: 802.695\u00b5s, allowed: 44000/minute",
 	))
+
+	compound := FromErrorMessage("error from registry: retry-after: 1m30s")
+	require.NotNil(t, compound)
+	assert.Equal(t, 90*time.Second, compound.RetryAfter)
 }
 
 func TestFromErrorMessageIgnoresUnrelatedErrors(t *testing.T) {

--- a/pkg/registry/ratelimit/parse_test.go
+++ b/pkg/registry/ratelimit/parse_test.go
@@ -390,9 +390,9 @@ func TestFromErrorMessageRecognizesPhrases(t *testing.T) {
 }
 
 // TestFromErrorMessageRecognizesQuotaOnlyThrottle covers registries that
-// throttle without a 429 or "too many requests" token, advertising the limit
-// only via retry-after and allowed quota markers. The message is a verbatim
-// Docker daemon pull error from lscr.io.
+// throttle without a 429 or "too many requests" token, advertising the wait
+// only via retry-after text. The first message is a verbatim Docker daemon
+// pull error from lscr.io.
 func TestFromErrorMessageRecognizesQuotaOnlyThrottle(t *testing.T) {
 	t.Parallel()
 
@@ -405,9 +405,10 @@ func TestFromErrorMessageRecognizesQuotaOnlyThrottle(t *testing.T) {
 	assert.Equal(t, 44000, info.Allowed)
 	assert.Equal(t, time.Minute, info.AllowedWindow)
 
-	// retry-after alone, and allowed alone, are each sufficient.
 	require.NotNil(t, FromErrorMessage("error from registry: retry-after: 1.08ms"))
-	require.NotNil(t, FromErrorMessage("error from registry: allowed: 44000/minute"))
+	require.NotNil(t, FromErrorMessage(
+		"error from registry: retry-after: 802.695\u00b5s, allowed: 44000/minute",
+	))
 }
 
 func TestFromErrorMessageIgnoresUnrelatedErrors(t *testing.T) {
@@ -420,6 +421,12 @@ func TestFromErrorMessageIgnoresUnrelatedErrors(t *testing.T) {
 	assert.Nil(t, FromErrorMessage("wrote 1429 bytes"))
 	assert.Nil(t, FromErrorMessage("wrote 429 bytes"))
 	assert.Nil(t, FromErrorMessage("dial tcp 10.0.0.1:429: connect: connection refused"))
+	assert.Nil(t, FromErrorMessage("error from registry: allowed: 44000/minute"))
+	assert.Nil(t, FromErrorMessage("retry-after: 5"))
+	assert.Nil(t, FromErrorMessage("Retry-After: Wed, 21 Oct 2015 07:28:00 GMT"))
+	assert.Nil(t, FromErrorMessage("not allowed: 5/minute"))
+	assert.Nil(t, FromErrorMessage("disallowed: 10/hour"))
+	assert.Nil(t, FromErrorMessage("max allowed: 100/minute"))
 }
 
 func TestDecisionCapsTinyAndHugeRetryAfter(t *testing.T) {

--- a/pkg/registry/ratelimit/parse_test.go
+++ b/pkg/registry/ratelimit/parse_test.go
@@ -389,6 +389,27 @@ func TestFromErrorMessageRecognizesPhrases(t *testing.T) {
 	require.NotNil(t, FromErrorMessage("status: 429"))
 }
 
+// TestFromErrorMessageRecognizesQuotaOnlyThrottle covers registries that
+// throttle without a 429 or "too many requests" token, advertising the limit
+// only via retry-after and allowed quota markers. The message is a verbatim
+// Docker daemon pull error from lscr.io.
+func TestFromErrorMessageRecognizesQuotaOnlyThrottle(t *testing.T) {
+	t.Parallel()
+
+	msg := "Error response from daemon: error from registry: " +
+		"retry-after: 92.923\u00b5s, allowed: 44000/minute"
+
+	info := FromErrorMessage(msg)
+	require.NotNil(t, info)
+	assert.Equal(t, 92923*time.Nanosecond, info.RetryAfter)
+	assert.Equal(t, 44000, info.Allowed)
+	assert.Equal(t, time.Minute, info.AllowedWindow)
+
+	// retry-after alone, and allowed alone, are each sufficient.
+	require.NotNil(t, FromErrorMessage("error from registry: retry-after: 1.08ms"))
+	require.NotNil(t, FromErrorMessage("error from registry: allowed: 44000/minute"))
+}
+
 func TestFromErrorMessageIgnoresUnrelatedErrors(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #2229.

## Problem

Registries that throttle with `retry-after:` and `allowed: N/window` but no `429` or `toomanyrequests` token are not detected as rate limited. `FromErrorMessage` returns nil, the pull falls through to `errPullImageFailed`, and `DoValue` treats it as `backoff.Permanent`. The pull is never retried and the container is marked `Skipped`, which appears in neither `scanned` nor `failed`.

Observed against lscr.io on 1.21.0:

```
image pull: failed to pull image: lscr.io/linuxserver/IMAGE:latest: Error response from daemon:
  error from registry: retry-after: 92.923µs, allowed: 44000/minute
```

Five containers went un-updated for a week, reported as `scanned=23 updated=0 failed=0`.

## Change

`looksRateLimited` falls back to the quota markers when no 429 token is present. `ParseQuotaMessage` already parses both, and doc.go cites `allowed: 44000/minute` as a supported format, so only the detection gate needed changing.

Both regexes require a duration unit or an explicit window, so the existing negative cases still fail to match: `sha256:abcdef429abcdef`, `dial tcp 127.0.0.1:4290`, `wrote 429 bytes`.

No backoff change is needed. `Decision()` already floors the wait at `minHonorWait` (100ms), so the sub-millisecond `retry-after` values are handled once detection works.

## Test

`TestFromErrorMessageRecognizesQuotaOnlyThrottle` uses the verbatim daemon message and asserts `RetryAfter`, `Allowed` and `AllowedWindow` parse correctly, plus that each marker suffices on its own.

`go test ./...` passes (34 packages). `golangci-lint` reports 0 issues.

Note for reviewers: `make lint` runs with `--fix` and reformatted 24 unrelated files under gofumpt's current rules. Those are excluded from this PR.
