### PR TITLE
ci: publish docs on stable tag releases

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -24,7 +24,7 @@ on:
     types: [published]
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: publish-docs
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -2,7 +2,18 @@
 name: Publish Documentation
 
 on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to deploy (e.g., v1.21.1). Leave empty for dev."
+        required: false
+        type: string
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to deploy (e.g., v1.21.1). Leave empty for dev."
+        required: false
+        type: string
   push:
     branches: [main]
     paths:
@@ -61,17 +72,6 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14.7"
-          cache: "pip"
-          cache-dependency-path: |
-            build/mkdocs/docs-requirements.txt
-
-      - name: Setup Cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          key: mkdocs-material-${{ hashFiles('build/mkdocs/docs-requirements.txt') }}
-          path: .cache
-          restore-keys: |
-            mkdocs-material-
 
       - name: Install mkdocs
         run: |
@@ -81,9 +81,13 @@ jobs:
         id: mike
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           if [[ "${{ github.event_name }}" == "release" ]]; then
             echo "version=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+            echo "aliases=latest" >> "$GITHUB_OUTPUT"
+          elif [[ -n "${INPUT_VERSION}" ]]; then
+            echo "version=${INPUT_VERSION}" >> "$GITHUB_OUTPUT"
             echo "aliases=latest" >> "$GITHUB_OUTPUT"
           else
             echo "version=dev" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -23,6 +23,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: read # Set default read-only permissions
 

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -47,3 +47,14 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/update-go-docs.yaml
+
+  publish-docs:
+    name: Publish Documentation
+    needs: [build]
+    if: ${{ !inputs.DRY_RUN }}
+    permissions:
+      contents: write
+      actions: read
+    uses: ./.github/workflows/publish-docs.yaml
+    with:
+      version: ${{ github.ref_name }}

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -51,7 +51,7 @@ jobs:
   publish-docs:
     name: Publish Documentation
     needs: [build]
-    if: ${{ !inputs.DRY_RUN }}
+    if: ${{ !inputs.DRY_RUN && github.ref_type == 'tag' }}
     permissions:
       contents: write
       actions: read


### PR DESCRIPTION
This PR corrects the CI workflows to update the documentation site when a version tag is pushed, instead of waiting for a GitHub Release event that GoReleaser cannot chain. Tag-push releases now call the docs workflow with the tag name so mike can retarget the `latest` alias.

## Problem

Pushing a version tag runs Release Production, and GoReleaser publishes the GitHub Release with `GITHUB_TOKEN`. That token cannot trigger other workflows, so Publish Documentation never runs.

## Solution

Call Publish Documentation from Release Production after a successful build, passing `${{ github.ref_name }}`. Accept that version on `workflow_call` and `workflow_dispatch`, and deploy it with the `latest` alias. 

Caching is also dropped from this publishing workflow to address a cache poisoning issue flagged by zizmor.

## Changes

- Invoke `publish-docs` from `release-stable.yaml` with the tag name after build
- Add a `version` input to Publish Documentation for reusable and manual runs
- Deploy a provided version with `--update-aliases latest`; empty still deploys `dev`
- Remove pip cache and `actions/cache` from the docs publishing job