### PR TITLE
fix: include skipped containers in scan summaries

### DIFF
--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -164,11 +164,12 @@ func RunUpdatesWithNotifications(
 
 	// Publish scan completed event
 	if params.EventBroadcaster != nil {
-		scanned, updated, failed := 0, 0, 0
+		scanned, updated, failed, skipped := 0, 0, 0, 0
 		if result != nil {
 			scanned = len(result.Scanned())
 			updated = len(result.Updated())
 			failed = len(result.Failed())
+			skipped = len(result.Skipped())
 		}
 
 		params.EventBroadcaster.Publish(events.Event{
@@ -178,6 +179,7 @@ func RunUpdatesWithNotifications(
 				Scanned: scanned,
 				Updated: updated,
 				Failed:  failed,
+				Skipped: skipped,
 			},
 		})
 	}
@@ -743,7 +745,8 @@ func notifySkippedCooldownContainers(
 // process logger. The line carries notify=no so the Shoutrrr hook does not send
 // a second notification after SendNotification has already flushed the session
 // batch. Without that field, legacy templates would emit a standalone
-// "Update session completed" message with only the scanned, updated, and failed counts.
+// "Update session completed" message with only the scanned, updated, failed,
+// and skipped counts.
 //
 // Parameters:
 //   - log: Process logger. Required and must be non-nil.
@@ -760,6 +763,7 @@ func generateAndLogMetric(log *zerolog.Logger, result types.Report) *metrics.Met
 		Int("scanned", metricResults.Scanned).
 		Int("updated", metricResults.Updated).
 		Int("failed", metricResults.Failed).
+		Int("skipped", metricResults.Skipped).
 		Msg("Update session completed")
 
 	return metricResults

--- a/internal/actions/actions_test.go
+++ b/internal/actions/actions_test.go
@@ -990,6 +990,41 @@ var _ = ginkgo.Describe("Actions", func() {
 
 			gomega.Expect(found).To(gomega.BeTrue())
 		})
+
+		ginkgo.It("should log skipped count on the session completion line", func() {
+			mockReport := mockTypes.NewMockReport(ginkgo.GinkgoT())
+			skippedA := mockTypes.NewMockContainerReport(ginkgo.GinkgoT())
+			skippedB := mockTypes.NewMockContainerReport(ginkgo.GinkgoT())
+
+			mockReport.EXPECT().Scanned().Return(make([]types.ContainerReport, 23))
+			mockReport.EXPECT().Updated().Return([]types.ContainerReport{})
+			mockReport.EXPECT().Failed().Return([]types.ContainerReport{})
+			mockReport.EXPECT().Restarted().Return([]types.ContainerReport{})
+			mockReport.EXPECT().Skipped().Return([]types.ContainerReport{skippedA, skippedB})
+
+			log, buf := newCaptureLogger()
+			metric := generateAndLogMetric(log, mockReport)
+
+			gomega.Expect(metric.Skipped).To(gomega.Equal(2))
+			gomega.Expect(metric.Scanned).To(gomega.Equal(23))
+
+			var found bool
+
+			for _, entry := range parseJSONLogEntries(buf) {
+				if entry["message"] != "Update session completed" {
+					continue
+				}
+
+				found = true
+
+				gomega.Expect(entry["skipped"]).To(gomega.BeEquivalentTo(2))
+				gomega.Expect(entry["scanned"]).To(gomega.BeEquivalentTo(23))
+				gomega.Expect(entry["updated"]).To(gomega.BeEquivalentTo(0))
+				gomega.Expect(entry["failed"]).To(gomega.BeEquivalentTo(0))
+			}
+
+			gomega.Expect(found).To(gomega.BeTrue())
+		})
 	})
 
 	ginkgo.Describe("Multiple Concurrent Scopes", func() {

--- a/internal/api/handlers/events/events.go
+++ b/internal/api/handlers/events/events.go
@@ -64,6 +64,7 @@ type ScanCompletedData struct {
 	Scanned int `json:"scanned"`
 	Updated int `json:"updated"`
 	Failed  int `json:"failed"`
+	Skipped int `json:"skipped"`
 }
 
 // ScanFailedData carries details about a scan that encountered an error.

--- a/internal/api/handlers/events/events_test.go
+++ b/internal/api/handlers/events/events_test.go
@@ -35,12 +35,12 @@ func TestEvent_JSONRoundTrip(t *testing.T) {
 func TestScanCompletedData_JSON(t *testing.T) {
 	t.Parallel()
 
-	data := ScanCompletedData{Scanned: 5, Updated: 2, Failed: 1}
+	data := ScanCompletedData{Scanned: 23, Updated: 0, Failed: 0, Skipped: 5}
 
 	raw, err := json.Marshal(data)
 	require.NoError(t, err)
 
-	assert.Equal(t, []byte(`{"scanned":5,"updated":2,"failed":1}`), raw)
+	assert.JSONEq(t, `{"scanned":23,"updated":0,"failed":0,"skipped":5}`, string(raw))
 }
 
 func TestScanFailedData_JSON(t *testing.T) {


### PR DESCRIPTION
This PR adds skipped-container counts to the scan completion log and the `scan_completed` SSE payload so a skip no longer looks like a clean run.

## Problem

Skipped containers are already tracked on the session report, in metrics, and on `/v1/status`, but the Info `Update session completed` line and the `scan_completed` event only report `scanned`, `updated`, and `failed`. A skip therefore appears as `scanned=23 updated=0 failed=0`.

## Solution

Include `skipped` on the completion log from `metrics.NewMetric`, and add `Skipped` to `ScanCompletedData` when publishing `scan_completed`.

## Changes

- Log `skipped` on the Info completion line
- Add `Skipped` to `ScanCompletedData` and set it from `result.Skipped()`
- Cover the completion log and `ScanCompletedData` JSON