### PR TITLE
fix(cleanup): complete image removal after self-update SIGTERM

### DIFF
--- a/docs/notifications/templates/index.md
+++ b/docs/notifications/templates/index.md
@@ -85,6 +85,8 @@ Simple templates are used when the [`notification-report`](#notification_report)
     Started new container: {{$e.Data.container}} ({{with $e.Data.new_id}}{{.}}{{else}}unknown{{end}})
 {{- else if eq $msg "Removing image" -}}
     Removed stale image: {{with $e.Data.image_id}}{{.}}{{else}}unknown{{end}}
+{{- else if eq $msg "Failed to list containers for image usage check, skipping removal" -}}
+    Skipped image cleanup: {{with $e.Data.image_name}}{{.}}{{else}}unknown{{end}} ({{with $e.Data.image_id}}{{.}}{{else}}unknown{{end}}){{with $e.Data.error}}: {{.}}{{end}}
 {{- else if eq $msg "Detected multiple Watchtower instances - initiating cleanup" -}}
     Detected {{$e.Data.count}} Watchtower instances - initiating cleanup
 {{- else if $e.Data -}}
@@ -120,6 +122,8 @@ The [Template Preview Tool](../template-preview/index.md) uses the same template
     Started new container: {{$e.Data.container}} ({{with $e.Data.new_id}}{{.}}{{else}}unknown{{end}})
 {{- else if eq $msg "Removing image" -}}
     Removed stale image: {{with $e.Data.image_id}}{{.}}{{else}}unknown{{end}}
+{{- else if eq $msg "Failed to list containers for image usage check, skipping removal" -}}
+    Skipped image cleanup: {{with $e.Data.image_name}}{{.}}{{else}}unknown{{end}} ({{with $e.Data.image_id}}{{.}}{{else}}unknown{{end}}){{with $e.Data.error}}: {{.}}{{end}}
 {{- else if eq $msg "Detected multiple Watchtower instances - initiating cleanup" -}}
     Detected {{$e.Data.count}} Watchtower instances - initiating cleanup
 {{- else if $e.Data -}}

--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -121,6 +121,7 @@ func RunUpdatesWithNotifications(
 		params.Client,
 		updateConfig.Cleanup,
 		cleanupImageInfosPtr,
+		updateConfig.Timeout,
 	)
 
 	// Publish image cleanup event
@@ -350,12 +351,15 @@ func executeUpdate(log *zerolog.Logger, ctx context.Context,
 // When multiple containers share the same old image, the image is only removed once
 // (preventing duplicate "Removing image" log entries), but the returned slice includes
 // all container associations so that split-by-container notifications report correctly.
+// Docker calls use a detached timeout so SIGTERM after a Watchtower self-update
+// cannot abort leftover image removal.
 //
 // Parameters:
-//   - ctx: Context for cancellation and timeouts.
+//   - ctx: Parent session context. Cancellation is detached for Docker calls.
 //   - client: The Docker client instance used for container operations.
 //   - cleanup: Boolean indicating whether to perform image cleanup.
 //   - cleanupImageInfos: Slice of cleaned image info to be removed.
+//   - timeout: Bound for detached cleanup Docker calls. Non-positive uses the restart-policy fallback.
 //
 // Returns:
 //   - []types.RemovedImageInfo: Slice of successfully cleaned image info.
@@ -363,6 +367,7 @@ func performImageCleanup(log *zerolog.Logger, ctx context.Context,
 	client container.Client,
 	cleanup bool,
 	cleanupImageInfos []types.RemovedImageInfo,
+	timeout time.Duration,
 ) []types.RemovedImageInfo {
 	if !cleanup || len(cleanupImageInfos) == 0 {
 		return []types.RemovedImageInfo{}
@@ -373,7 +378,15 @@ func performImageCleanup(log *zerolog.Logger, ctx context.Context,
 	// when multiple containers share the same old image.
 	uniqueByImageID := deduplicateByImageID(cleanupImageInfos)
 
-	cleaned, err := RemoveImages(log, ctx, client, uniqueByImageID)
+	// Detach from the session context so SIGTERM after self-update cannot
+	// abort leftover image removal.
+	cleanupCtx, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx),
+		restartPolicyTimeout(timeout),
+	)
+	defer cancel()
+
+	cleaned, err := RemoveImages(log, cleanupCtx, client, uniqueByImageID)
 	if err != nil {
 		log.Warn().
 			Err(err).

--- a/internal/actions/actions_test.go
+++ b/internal/actions/actions_test.go
@@ -894,7 +894,7 @@ var _ = ginkgo.Describe("Actions", func() {
 	ginkgo.Describe("performImageCleanup", func() {
 		ginkgo.It("should return empty slice when cleanup is disabled", func() {
 			client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
-			cleanedImages := performImageCleanup(testLogger(), context.Background(), client, false, []types.RemovedImageInfo{})
+			cleanedImages := performImageCleanup(testLogger(), context.Background(), client, false, []types.RemovedImageInfo{}, 0)
 			gomega.Expect(cleanedImages).To(gomega.BeEmpty())
 		})
 
@@ -906,7 +906,7 @@ var _ = ginkgo.Describe("Actions", func() {
 					ImageName:     "test-image:v1.0",
 					ImageID:       types.ImageID("sha256:123"),
 				},
-			})
+			}, 0)
 			// The function should return the cleaned images when cleanup is enabled
 			gomega.Expect(cleanedImages).To(gomega.HaveLen(1))
 			gomega.Expect(cleanedImages[0].ContainerName).To(gomega.Equal("test-container"))
@@ -914,9 +914,25 @@ var _ = ginkgo.Describe("Actions", func() {
 
 		ginkgo.It("should return a valid slice when cleanup input is empty", func() {
 			client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
-			cleanedImages := performImageCleanup(testLogger(), context.Background(), client, true, []types.RemovedImageInfo{})
+			cleanedImages := performImageCleanup(testLogger(), context.Background(), client, true, []types.RemovedImageInfo{}, 0)
 			// Should return a valid slice even with empty input
 			gomega.Expect(cleanedImages).NotTo(gomega.BeNil())
+		})
+
+		ginkgo.It("should still remove images when the parent context is already canceled", func() {
+			client := mockActions.CreateMockClient(&mockActions.TestData{}, false, false)
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			cleanedImages := performImageCleanup(testLogger(), ctx, client, true, []types.RemovedImageInfo{
+				{
+					ContainerName: "test-container",
+					ImageName:     "test-image:v1.0",
+					ImageID:       types.ImageID("sha256:123"),
+				},
+			}, 0)
+			gomega.Expect(cleanedImages).To(gomega.HaveLen(1))
+			gomega.Expect(client.TestData.TriedToRemoveImageCount.Load()).To(gomega.Equal(int32(1)))
 		})
 	})
 

--- a/internal/actions/cleanup.go
+++ b/internal/actions/cleanup.go
@@ -781,7 +781,9 @@ func RemoveImages(log *zerolog.Logger, ctx context.Context,
 					Str("image_id", string(imageID)).
 					Str("image_name", image.ImageName).
 					Msg("Image is in use by active container, skipping removal")
-			case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			case ctx.Err() != nil,
+				errors.Is(err, context.Canceled),
+				errors.Is(err, context.DeadlineExceeded):
 				log.Debug().
 					Err(err).
 					Str("image_id", string(imageID)).

--- a/internal/actions/cleanup_test.go
+++ b/internal/actions/cleanup_test.go
@@ -1479,6 +1479,25 @@ var _ = ginkgo.Describe("CleanupImages", func() {
 		gomega.Expect(cleaned[0].ImageID).To(gomega.Equal(types.ImageID("image1")))
 	})
 
+	ginkgo.It("should treat a canceled context cause that is not context.Canceled as a non-error", func() {
+		mockClient := mockContainer.NewMockClient(ginkgo.GinkgoT())
+
+		cleanedImages := []types.RemovedImageInfo{
+			{ImageID: "image1", ImageName: "image1"},
+		}
+
+		canceledCtx, cancel := context.WithCancelCause(context.Background())
+		cancel(errors.New("terminated signal received"))
+
+		mockClient.EXPECT().
+			RemoveImageByID(canceledCtx, types.ImageID("image1"), "image1").
+			Return(errors.New("cannot verify image usage: terminated signal received"))
+
+		cleaned, err := RemoveImages(testLogger(), canceledCtx, mockClient, cleanedImages)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(cleaned).To(gomega.BeEmpty())
+	})
+
 	ginkgo.It("should treat 'conflict' errors as non-errors and not add to cleaned", func() {
 		mockClient := mockContainer.NewMockClient(ginkgo.GinkgoT())
 

--- a/internal/actions/ephemeral.go
+++ b/internal/actions/ephemeral.go
@@ -782,9 +782,10 @@ func removeOldContainer(
 // removeOldImage removes the predecessor Watchtower image after a successful
 // handoff. NotFound and in-use errors are skipped. Other failures are logged
 // and do not fail orchestration because the replacement is already running.
+// Docker calls use a detached timeout so SIGTERM cannot abort removal.
 //
 // Parameters:
-//   - ctx: Context for cancellation and timeouts.
+//   - ctx: Parent session context. Cancellation is detached for Docker calls.
 //   - client: Container client for Docker operations.
 //   - clog: Logger with container context fields.
 //   - imageID: ID of the predecessor image captured before create-image pinning.
@@ -805,7 +806,15 @@ func removeOldImage(
 		Str("image_name", imageName).
 		Msg("Removing old Watchtower image after ephemeral handoff")
 
-	err := client.RemoveImageByID(ctx, imageID, imageName)
+	// Detach from the session context so SIGTERM cannot abort predecessor
+	// image removal after the replacement is already running.
+	cleanupCtx, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx),
+		restartPolicyTimeout(0),
+	)
+	defer cancel()
+
+	err := client.RemoveImageByID(cleanupCtx, imageID, imageName)
 	if err == nil {
 		return
 	}
@@ -815,7 +824,8 @@ func removeOldImage(
 		cerrdefs.IsConflict(err),
 		errors.Is(err, container.ErrImageInUse),
 		errors.Is(err, context.Canceled),
-		errors.Is(err, context.DeadlineExceeded):
+		errors.Is(err, context.DeadlineExceeded),
+		cleanupCtx.Err() != nil:
 		clog.Debug().
 			Err(err).
 			Str("image_id", imageID.ShortID()).

--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -450,7 +450,8 @@ func (c imageClient) PullImage(
 
 // RemoveImageByID deletes an image from the Docker host.
 //
-// It removes the image with force and pruning, logging details if debug enabled.
+// It lists containers first to skip images still in use. Context cancellation
+// during that check or the removal itself is returned without a warning.
 //
 // Parameters:
 //   - ctx: Context for cancellation and timeout control.
@@ -471,6 +472,14 @@ func (c imageClient) RemoveImageByID(ctx context.Context, imageID types.ImageID,
 		dockerClient.ContainerListOptions{All: true},
 	)
 	if err != nil {
+		if ctx.Err() != nil {
+			clog.Debug().
+				Err(err).
+				Msg("Image usage check interrupted by cancellation, skipping removal")
+
+			return fmt.Errorf("cannot verify image usage: %w", ctx.Err())
+		}
+
 		clog.Warn().
 			Err(err).
 			Msg("Failed to list containers for image usage check, skipping removal")
@@ -503,6 +512,14 @@ func (c imageClient) RemoveImageByID(ctx context.Context, imageID types.ImageID,
 		},
 	)
 	if err != nil {
+		if ctx.Err() != nil {
+			clog.Debug().
+				Err(err).
+				Msg("Image removal interrupted by cancellation")
+
+			return fmt.Errorf("%w: %s: %w", errRemoveImageFailed, imageID, ctx.Err())
+		}
+
 		if cerrdefs.IsNotFound(err) {
 			clog.Debug().
 				Err(err).

--- a/pkg/container/image_test.go
+++ b/pkg/container/image_test.go
@@ -601,17 +601,20 @@ var _ = ginkgo.Describe("the client", func() {
 			})
 		})
 		ginkgo.Describe("RemoveImageByID", func() {
-			ginkgo.It("should return context.Canceled error", func() {
+			ginkgo.It("should return context.Canceled error without warning", func() {
 				imageID := util.GenerateRandomSHA256()
 
 				// Create a canceled context
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel() // Cancel immediately
 
-				c := &client{log: testLog(), api: mockClient}
+				log, logbuf := captureLog(zerolog.WarnLevel)
+				c := &client{log: log, api: mockClient}
 
 				err := c.RemoveImageByID(ctx, types.ImageID(imageID), "test-image")
 				gomega.Expect(err).To(gomega.MatchError(context.Canceled))
+				gomega.Expect(string(logbuf.Contents())).
+					NotTo(gomega.ContainSubstring("Failed to list containers for image usage check"))
 			})
 		})
 	})

--- a/pkg/notifications/common_templates.go
+++ b/pkg/notifications/common_templates.go
@@ -9,7 +9,9 @@ var commonTemplates = map[string]string{
 	// It iterates over .Entries, checking each entry's Message to format specific container lifecycle events.
 	// Handles messages: "Found new image" (new image available), "Stopping container" (stopping old container),
 	// "Started new container" (new container started), "Stopping linked container" (stopping linked container),
-	// "Started linked container" (linked container started), "Removing image" (image cleanup completed), "Container updated" (update completed),
+	// "Started linked container" (linked container started), "Removing image" (image cleanup completed),
+	// "Failed to list containers for image usage check, skipping removal" (image cleanup skipped),
+	// "Container updated" (update completed),
 	// "Image is within cooldown period - deferring update" (image too new for update), "Image age exceeds cooldown - eligible for update" (image old enough),
 	// "Image creation time unavailable - update check unavailable" (image age could not be determined from registry),
 	// "Detected multiple Watchtower instances - initiating cleanup" (multiple instances detected).
@@ -35,6 +37,8 @@ var commonTemplates = map[string]string{
     Started linked container: {{index $e.Data "container"}} ({{with (index $e.Data "new_id")}}{{.}}{{else}}unknown{{end}})
 {{- else if eq $msg "Removing image" -}}
     Cleaned up old image: {{with (index $e.Data "image_name")}}{{.}}{{else}}unknown{{end}} ({{with (index $e.Data "image_id")}}{{.}}{{else}}unknown{{end}})
+{{- else if eq $msg "Failed to list containers for image usage check, skipping removal" -}}
+    Skipped image cleanup: {{with (index $e.Data "image_name")}}{{.}}{{else}}unknown{{end}} ({{with (index $e.Data "image_id")}}{{.}}{{else}}unknown{{end}}){{with (index $e.Data "error")}}: {{.}}{{end}}
 {{- else if eq $msg "Container updated" -}}
     Updated container: {{with (index $e.Data "container")}}{{.}}{{else}}unknown{{end}} ({{with (index $e.Data "image")}}{{.}}{{else}}unknown{{end}}): {{with (index $e.Data "old_id")}}{{.}}{{else}}unknown{{end}} updated to {{with (index $e.Data "new_id")}}{{.}}{{else}}unknown{{end}}
 {{- else if eq $msg "Skipping Watchtower self-update in run-once mode" -}}

--- a/pkg/notifications/shoutrrr_test.go
+++ b/pkg/notifications/shoutrrr_test.go
@@ -252,6 +252,35 @@ updt1 (mock/updt1:latest): Updated
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(s).To(gomega.Equal("foo bar"))
 			})
+
+			ginkgo.It("should format image usage-check skips without dumping raw fields", func() {
+				shoutrrr := createTestNotifier(
+					[]string{},
+					zerolog.TraceLevel,
+					true,
+					StaticData{},
+					false,
+					time.Second,
+				)
+				entries := []*notificationEntry{
+					{
+						Message: "Failed to list containers for image usage check, skipping removal",
+						Data: map[string]any{
+							"error":      `Get "http://socket-proxy-write:2375/v1.55/containers/json?all=1": terminated signal received`,
+							"image_id":   "769846626f2f",
+							"image_name": "ghcr.io/amir20/dtop:latest",
+						},
+					},
+				}
+
+				s, err := shoutrrr.buildMessage(Data{Entries: entries})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(s).To(gomega.Equal(
+					"Skipped image cleanup: ghcr.io/amir20/dtop:latest (769846626f2f): " +
+						`Get "http://socket-proxy-write:2375/v1.55/containers/json?all=1": terminated signal received`,
+				))
+				gomega.Expect(s).NotTo(gomega.ContainSubstring(" | "))
+			})
 		})
 		ginkgo.When("given a valid custom template", func() {
 			ginkgo.It("should format the messages using the custom template", func() {

--- a/tools/tplprev/internal/notify/json_test.go
+++ b/tools/tplprev/internal/notify/json_test.go
@@ -68,7 +68,7 @@ func TestDataMarshalJSON(t *testing.T) {
 	}
 
 	payload := Data{
-		StaticData: StaticData{Title: "Title", Host: "Host"},
+		Title: "Title", Host: "Host",
 		Entries: []*Entry{
 			{
 				Message: "Found new image",
@@ -115,8 +115,8 @@ func TestDataMarshalJSONNilReport(t *testing.T) {
 	t.Parallel()
 
 	payload := Data{
-		StaticData: StaticData{Title: "Title", Host: "Host"},
-		Entries:    []*Entry{},
+		Title: "Title", Host: "Host",
+		Entries: []*Entry{},
 	}
 
 	bytes, err := json.Marshal(payload)

--- a/tools/tplprev/internal/preview/data.go
+++ b/tools/tplprev/internal/preview/data.go
@@ -213,6 +213,12 @@ func (p *PreviewData) dataForMessage(msg, name, image string) map[string]any {
 		return map[string]any{"container": name, "new_id": newID}
 	case "Removing image":
 		return map[string]any{"image_name": image, "image_id": oldID}
+	case "Failed to list containers for image usage check, skipping removal":
+		return map[string]any{
+			"image_name": image,
+			"image_id":   oldID,
+			"error":      "cannot verify image usage",
+		}
 	case "Container updated":
 		return map[string]any{
 			"container": name,

--- a/tools/tplprev/internal/preview/preview_strings.go
+++ b/tools/tplprev/internal/preview/preview_strings.go
@@ -92,7 +92,6 @@ var infoMessages = []string{
 	"Stopping linked container",
 	"Started linked container",
 	"Removing image",
-	"Failed to list containers for image usage check, skipping removal",
 	"Container updated",
 	"Detected multiple Watchtower instances - initiating cleanup",
 	"Successfully removed all excess Watchtower containers",
@@ -117,6 +116,7 @@ var warningMessages = []string{
 	"Failed to find new image",
 	"Failed to list containers",
 	"Failed to inspect container",
+	"Failed to list containers for image usage check, skipping removal",
 }
 
 var errorMessages = []string{

--- a/tools/tplprev/internal/preview/preview_strings.go
+++ b/tools/tplprev/internal/preview/preview_strings.go
@@ -92,6 +92,7 @@ var infoMessages = []string{
 	"Stopping linked container",
 	"Started linked container",
 	"Removing image",
+	"Failed to list containers for image usage check, skipping removal",
 	"Container updated",
 	"Detected multiple Watchtower instances - initiating cleanup",
 	"Successfully removed all excess Watchtower containers",

--- a/tools/tplprev/internal/templates/templates.go
+++ b/tools/tplprev/internal/templates/templates.go
@@ -27,6 +27,8 @@ var Templates = map[string]string{
     Started linked container: {{index $e.Data "container"}} ({{with (index $e.Data "new_id")}}{{.}}{{else}}unknown{{end}})
 {{- else if eq $msg "Removing image" -}}
     Cleaned up old image: {{with (index $e.Data "image_name")}}{{.}}{{else}}unknown{{end}} ({{with (index $e.Data "image_id")}}{{.}}{{else}}unknown{{end}})
+{{- else if eq $msg "Failed to list containers for image usage check, skipping removal" -}}
+    Skipped image cleanup: {{with (index $e.Data "image_name")}}{{.}}{{else}}unknown{{end}} ({{with (index $e.Data "image_id")}}{{.}}{{else}}unknown{{end}}){{with (index $e.Data "error")}}: {{.}}{{end}}
 {{- else if eq $msg "Container updated" -}}
     Updated container: {{with (index $e.Data "container")}}{{.}}{{else}}unknown{{end}} ({{with (index $e.Data "image")}}{{.}}{{else}}unknown{{end}}): {{with (index $e.Data "old_id")}}{{.}}{{else}}unknown{{end}} updated to {{with (index $e.Data "new_id")}}{{.}}{{else}}unknown{{end}}
 {{- else if eq $msg "Skipping Watchtower self-update in run-once mode" -}}


### PR DESCRIPTION
This PR keeps leftover image removal running after a Watchtower self-update sends SIGTERM to the predecessor, and formats usage-check skip notifications instead of dumping raw log fields.

## Problem

With `WATCHTOWER_CLEANUP=true`, image cleanup runs on the session `NotifyContext`. After a self-update starts the replacement, that context is canceled with `terminated signal received`. `RemoveImageByID` then fails the container-list usage check, warns, and skips removal of images only the dying process knows about. Those skips also hit the default-legacy notification fallback as `msg | key=value`.

## Solution

Detach cleanup Docker calls from the session signal context with a bounded timeout, treat context cancellation (including signal causes) as a debug skip, and add a dedicated template branch for usage-check skips.

## Changes

- Run `performImageCleanup` and ephemeral predecessor image removal on `context.WithoutCancel` plus a timeout
- Log usage-check and removal cancellation at Debug instead of Warn
- Classify `ctx.Err() != nil` as a non-error in `RemoveImages`
- Format `Skipped image cleanup: name (id): error` in the default-legacy template, docs, and tplprev