### PR TITLE
refactor: rename Viper config locals from vip to vCfg

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -77,18 +77,18 @@ var (
 func Load(log *zerolog.Logger, cmd *cobra.Command, args []string) (Config, error) {
 	flagSet := cmd.PersistentFlags()
 
-	vip := viper.New()
+	vCfg := viper.New()
 
-	err := flags.BindAll(vip, flagSet, flags.AllSpecs())
+	err := flags.BindAll(vCfg, flagSet, flags.AllSpecs())
 	if err != nil {
 		return Config{}, fmt.Errorf("bind configuration: %w", err)
 	}
 
 	cfg := Config{}
 
-	cfg.Docker = loadDocker(vip)
-	cfg.Client = loadClient(vip)
-	cfg.Compatibility = loadCompat(vip)
+	cfg.Docker = loadDocker(vCfg)
+	cfg.Client = loadClient(vCfg)
+	cfg.Compatibility = loadCompat(vCfg)
 
 	// Keep client and compat CPU/memory fields aligned for projections.
 	if cfg.Client.CPUCopyMode == "" {
@@ -99,25 +99,25 @@ func Load(log *zerolog.Logger, cmd *cobra.Command, args []string) (Config, error
 		cfg.Client.DisableMemorySwappiness = cfg.Compatibility.DisableMemorySwappiness
 	}
 
-	cfg.Schedule = loadSchedule(vip)
-	cfg.Mode = loadMode(vip)
+	cfg.Schedule = loadSchedule(vCfg)
+	cfg.Mode = loadMode(vCfg)
 
-	cfg.Update, err = loadUpdate(log, vip, flagSet)
+	cfg.Update, err = loadUpdate(log, vCfg, flagSet)
 	if err != nil {
 		return Config{}, err
 	}
 
-	cfg.Lifecycle = loadLifecycle(vip)
+	cfg.Lifecycle = loadLifecycle(vCfg)
 
-	cfg.Filter, err = loadFilter(log, vip, flagSet, args)
+	cfg.Filter, err = loadFilter(log, vCfg, flagSet, args)
 	if err != nil {
 		return Config{}, err
 	}
 
-	cfg.Registry = loadRegistry(vip)
-	cfg.API = loadAPI(vip, flagSet)
-	cfg.Notify = loadNotify(vip, flagSet)
-	cfg.Logging = loadLogging(vip)
+	cfg.Registry = loadRegistry(vCfg)
+	cfg.API = loadAPI(vCfg, flagSet)
+	cfg.Notify = loadNotify(vCfg, flagSet)
+	cfg.Logging = loadLogging(vCfg)
 
 	err = validate(log, cfg)
 	if err != nil {
@@ -128,57 +128,57 @@ func Load(log *zerolog.Logger, cmd *cobra.Command, args []string) (Config, error
 }
 
 // loadDocker reads Docker connection settings from Viper after BindAll.
-func loadDocker(v *viper.Viper) docker.Docker {
+func loadDocker(vCfg *viper.Viper) docker.Docker {
 	return docker.Docker{
-		Host:       v.GetString("host"),
-		TLSVerify:  v.GetBool("tlsverify"),
-		APIVersion: strings.Trim(v.GetString("api-version"), "\""),
-		CertPath:   v.GetString("cert-path"),
+		Host:       vCfg.GetString("host"),
+		TLSVerify:  vCfg.GetBool("tlsverify"),
+		APIVersion: strings.Trim(vCfg.GetString("api-version"), "\""),
+		CertPath:   vCfg.GetString("cert-path"),
 	}
 }
 
 // loadClient reads Docker client construction settings from Viper.
-func loadClient(vip *viper.Viper) client.Client {
+func loadClient(vCfg *viper.Viper) client.Client {
 	return client.Client{
-		IncludeStopped:    vip.GetBool("include-stopped"),
-		IncludeRestarting: vip.GetBool("include-restarting"),
-		ReviveStopped:     vip.GetBool("revive-stopped"),
-		RemoveVolumes:     vip.GetBool("remove-volumes"),
-		WarnOnHeadFailure: vip.GetString("warn-on-head-failure"),
+		IncludeStopped:    vCfg.GetBool("include-stopped"),
+		IncludeRestarting: vCfg.GetBool("include-restarting"),
+		ReviveStopped:     vCfg.GetBool("revive-stopped"),
+		RemoveVolumes:     vCfg.GetBool("remove-volumes"),
+		WarnOnHeadFailure: vCfg.GetString("warn-on-head-failure"),
 	}
 }
 
 // loadCompat reads runtime compatibility settings from Viper.
-func loadCompat(vip *viper.Viper) compatibility.Compatibility {
+func loadCompat(vCfg *viper.Viper) compatibility.Compatibility {
 	return compatibility.Compatibility{
-		DisableMemorySwappiness: vip.GetBool("disable-memory-swappiness"),
-		CPUCopyMode:             vip.GetString("cpu-copy-mode"),
+		DisableMemorySwappiness: vCfg.GetBool("disable-memory-swappiness"),
+		CPUCopyMode:             vCfg.GetString("cpu-copy-mode"),
 	}
 }
 
 // loadSchedule reads schedule settings from Viper.
-func loadSchedule(vip *viper.Viper) schedule.Schedule {
+func loadSchedule(vCfg *viper.Viper) schedule.Schedule {
 	return schedule.Schedule{
-		IntervalSeconds: vip.GetInt("interval"),
-		Spec:            vip.GetString("schedule"),
-		UpdateOnStart:   vip.GetBool("update-on-start"),
+		IntervalSeconds: vCfg.GetInt("interval"),
+		Spec:            vCfg.GetString("schedule"),
+		UpdateOnStart:   vCfg.GetBool("update-on-start"),
 	}
 }
 
 // loadMode reads process mode settings from Viper.
-func loadMode(vip *viper.Viper) mode.Mode {
+func loadMode(vCfg *viper.Viper) mode.Mode {
 	return mode.Mode{
-		RunOnce:                vip.GetBool("run-once"),
-		HealthCheck:            vip.GetBool("health-check"),
-		Porcelain:              vip.GetString("porcelain"),
-		SelfUpdateOrchestrator: vip.GetBool("self-update-orchestrator"),
-		NoStartupMessage:       vip.GetBool("no-startup-message"),
+		RunOnce:                vCfg.GetBool("run-once"),
+		HealthCheck:            vCfg.GetBool("health-check"),
+		Porcelain:              vCfg.GetString("porcelain"),
+		SelfUpdateOrchestrator: vCfg.GetBool("self-update-orchestrator"),
+		NoStartupMessage:       vCfg.GetBool("no-startup-message"),
 	}
 }
 
 // loadUpdate reads update policy settings from Viper.
-func loadUpdate(log *zerolog.Logger, vip *viper.Viper, flagSet *pflag.FlagSet) (update.Update, error) {
-	stopTimeout := durationValue(vip, flagSet, "stop-timeout", []string{"WATCHTOWER_TIMEOUT"})
+func loadUpdate(log *zerolog.Logger, vCfg *viper.Viper, flagSet *pflag.FlagSet) (update.Update, error) {
+	stopTimeout := durationValue(vCfg, flagSet, "stop-timeout", []string{"WATCHTOWER_TIMEOUT"})
 
 	if stopTimeout < 0 {
 		return update.Update{}, ErrNegativeStopTimeout
@@ -190,7 +190,7 @@ func loadUpdate(log *zerolog.Logger, vip *viper.Viper, flagSet *pflag.FlagSet) (
 			Msg("WATCHTOWER_TIMEOUT is less than 1 second")
 	}
 
-	cooldownStr := vip.GetString("cooldown-delay")
+	cooldownStr := vCfg.GetString("cooldown-delay")
 
 	var cooldown time.Duration
 
@@ -207,8 +207,8 @@ func loadUpdate(log *zerolog.Logger, vip *viper.Viper, flagSet *pflag.FlagSet) (
 		cooldown = parsed
 	}
 
-	maxRaw := vip.GetString("disk-space-max")
-	warnRaw := vip.GetString("disk-space-warn")
+	maxRaw := vCfg.GetString("disk-space-max")
+	warnRaw := vCfg.GetString("disk-space-warn")
 
 	maxBytes, warnBytes, err := resolveDiskSpaceThresholds(maxRaw, warnRaw)
 	if err != nil {
@@ -216,16 +216,16 @@ func loadUpdate(log *zerolog.Logger, vip *viper.Viper, flagSet *pflag.FlagSet) (
 	}
 
 	return update.Update{
-		Cleanup:             vip.GetBool("cleanup"),
-		NoPull:              vip.GetBool("no-pull"),
-		NoRestart:           vip.GetBool("no-restart"),
-		MonitorOnly:         vip.GetBool("monitor-only"),
-		RollingRestart:      vip.GetBool("rolling-restart"),
+		Cleanup:             vCfg.GetBool("cleanup"),
+		NoPull:              vCfg.GetBool("no-pull"),
+		NoRestart:           vCfg.GetBool("no-restart"),
+		MonitorOnly:         vCfg.GetBool("monitor-only"),
+		RollingRestart:      vCfg.GetBool("rolling-restart"),
 		StopTimeout:         stopTimeout,
 		CooldownDelay:       cooldown,
-		UseComposeDependsOn: vip.GetBool("use-compose-depends-on"),
-		LabelPrecedence:     vip.GetBool("label-take-precedence"),
-		EphemeralSelfUpdate: vip.GetBool("ephemeral-self-update"),
+		UseComposeDependsOn: vCfg.GetBool("use-compose-depends-on"),
+		LabelPrecedence:     vCfg.GetBool("label-take-precedence"),
+		EphemeralSelfUpdate: vCfg.GetBool("ephemeral-self-update"),
 		DiskSpaceMax:        maxRaw,
 		DiskSpaceWarn:       warnRaw,
 		DiskSpaceMaxBytes:   maxBytes,
@@ -313,18 +313,18 @@ func parseDiskSpaceWarn(raw string, maxBytes int64) (int64, error) {
 }
 
 // loadLifecycle reads lifecycle hook settings from Viper.
-func loadLifecycle(vip *viper.Viper) lifecycle.Lifecycle {
+func loadLifecycle(vCfg *viper.Viper) lifecycle.Lifecycle {
 	return lifecycle.Lifecycle{
-		Enabled: vip.GetBool("enable-lifecycle-hooks"),
-		UID:     vip.GetInt("lifecycle-uid"),
-		GID:     vip.GetInt("lifecycle-gid"),
+		Enabled: vCfg.GetBool("enable-lifecycle-hooks"),
+		UID:     vCfg.GetInt("lifecycle-uid"),
+		GID:     vCfg.GetInt("lifecycle-gid"),
 	}
 }
 
 // normalizedStringSlice loads a list flag/env value and applies normalize to each element.
 //
 // Parameters:
-//   - vip: Bound Viper instance.
+//   - vCfg: Bound Viper instance.
 //   - flagSet: Parsed flag set.
 //   - name: Flag name.
 //   - envKeys: Environment variable aliases.
@@ -334,14 +334,14 @@ func loadLifecycle(vip *viper.Viper) lifecycle.Lifecycle {
 // Returns:
 //   - []string: Normalized list (empty when unset).
 func normalizedStringSlice(
-	vip *viper.Viper,
+	vCfg *viper.Viper,
 	flagSet *pflag.FlagSet,
 	name string,
 	envKeys []string,
 	parse spec.ListParseKind,
 	normalize func(string) string,
 ) []string {
-	values := stringSliceValue(vip, flagSet, name, envKeys, parse)
+	values := stringSliceValue(vCfg, flagSet, name, envKeys, parse)
 	for i := range values {
 		values[i] = normalize(values[i])
 	}
@@ -350,43 +350,43 @@ func normalizedStringSlice(
 }
 
 // loadFilter reads filter settings, normalizes names, and builds the predicate.
-func loadFilter(log *zerolog.Logger, vip *viper.Viper, flagSet *pflag.FlagSet, args []string) (filter.Filter, error) {
-	labelEnable := vip.GetBool("label-enable")
+func loadFilter(log *zerolog.Logger, vCfg *viper.Viper, flagSet *pflag.FlagSet, args []string) (filter.Filter, error) {
+	labelEnable := vCfg.GetBool("label-enable")
 
 	disableContainers := normalizedStringSlice(
-		vip, flagSet, "disable-containers",
+		vCfg, flagSet, "disable-containers",
 		[]string{"WATCHTOWER_DISABLE_CONTAINERS"},
 		spec.ListCommaOrSpace,
 		util.NormalizeContainerName,
 	)
 
 	monitorImages := normalizedStringSlice(
-		vip, flagSet, "monitor-image-names",
+		vCfg, flagSet, "monitor-image-names",
 		[]string{"WATCHTOWER_MONITOR_IMAGE_NAMES"},
 		spec.ListCommaOrSpace,
 		strings.TrimSpace,
 	)
 
 	skipImages := normalizedStringSlice(
-		vip, flagSet, "skip-image-names",
+		vCfg, flagSet, "skip-image-names",
 		[]string{"WATCHTOWER_SKIP_IMAGE_NAMES"},
 		spec.ListCommaOrSpace,
 		strings.TrimSpace,
 	)
 
 	enableByLabel := stringSliceValue(
-		vip, flagSet, "enable-containers-by-label",
+		vCfg, flagSet, "enable-containers-by-label",
 		[]string{"WATCHTOWER_ENABLE_CONTAINERS_BY_LABEL"},
 		spec.ListCommaOnly,
 	)
 
 	disableByLabel := stringSliceValue(
-		vip, flagSet, "disable-containers-by-label",
+		vCfg, flagSet, "disable-containers-by-label",
 		[]string{"WATCHTOWER_DISABLE_CONTAINERS_BY_LABEL"},
 		spec.ListCommaOnly,
 	)
 
-	scope := vip.GetString("scope")
+	scope := vCfg.GetString("scope")
 
 	names := make([]string, len(args))
 	for i, name := range args {
@@ -423,53 +423,53 @@ func loadFilter(log *zerolog.Logger, vip *viper.Viper, flagSet *pflag.FlagSet, a
 }
 
 // loadRegistry reads registry TLS settings from Viper.
-func loadRegistry(vip *viper.Viper) registry.Registry {
+func loadRegistry(vCfg *viper.Viper) registry.Registry {
 	return registry.Registry{
-		TLSSkip:       vip.GetBool("registry-tls-skip"),
-		TLSMinVersion: vip.GetString("registry-tls-min-version"),
+		TLSSkip:       vCfg.GetBool("registry-tls-skip"),
+		TLSMinVersion: vCfg.GetString("registry-tls-min-version"),
 	}
 }
 
 // loadAPI reads HTTP API settings from Viper.
-func loadAPI(vip *viper.Viper, flagSet *pflag.FlagSet) api.API {
+func loadAPI(vCfg *viper.Viper, flagSet *pflag.FlagSet) api.API {
 	return api.API{
 		Endpoints: stringSliceValue(
-			vip, flagSet, "http-api-endpoints",
+			vCfg, flagSet, "http-api-endpoints",
 			[]string{"WATCHTOWER_HTTP_API_ENDPOINTS"},
 			spec.ListCommaOrSpace,
 		),
-		LegacyUpdate:     vip.GetBool("http-api-update"),
-		LegacyMetrics:    vip.GetBool("http-api-metrics"),
-		LegacyContainers: vip.GetBool("http-api-containers"),
-		Host:             vip.GetString("http-api-host"),
+		LegacyUpdate:     vCfg.GetBool("http-api-update"),
+		LegacyMetrics:    vCfg.GetBool("http-api-metrics"),
+		LegacyContainers: vCfg.GetBool("http-api-containers"),
+		Host:             vCfg.GetString("http-api-host"),
 		HostChanged:      flagChanged(flagSet, "http-api-host"),
-		Port:             vip.GetString("http-api-port"),
+		Port:             vCfg.GetString("http-api-port"),
 		PortChanged:      flagChanged(flagSet, "http-api-port"),
-		Token:            vip.GetString("http-api-token"),
-		EventsToken:      vip.GetString("http-api-events-token"),
-		PeriodicPolls:    vip.GetBool("http-api-periodic-polls"),
-		RateLimit:        vip.GetInt("http-api-rate-limit"),
+		Token:            vCfg.GetString("http-api-token"),
+		EventsToken:      vCfg.GetString("http-api-events-token"),
+		PeriodicPolls:    vCfg.GetBool("http-api-periodic-polls"),
+		RateLimit:        vCfg.GetInt("http-api-rate-limit"),
 		RateLimitChanged: flagChanged(flagSet, "http-api-rate-limit"),
-		TLSCert:          vip.GetString("http-api-tls-cert"),
-		TLSKey:           vip.GetString("http-api-tls-key"),
+		TLSCert:          vCfg.GetString("http-api-tls-cert"),
+		TLSKey:           vCfg.GetString("http-api-tls-key"),
 		TrustedProxies: stringSliceValue(
-			vip, flagSet, "http-api-trusted-proxies",
+			vCfg, flagSet, "http-api-trusted-proxies",
 			[]string{"WATCHTOWER_HTTP_API_TRUSTED_PROXIES"},
 			spec.ListCommaOrSpace,
 		),
-		ProxyHeader: vip.GetString("http-api-proxy-header"),
+		ProxyHeader: vCfg.GetString("http-api-proxy-header"),
 		CORSOrigins: stringSliceValue(
-			vip, flagSet, "http-api-cors-origins",
+			vCfg, flagSet, "http-api-cors-origins",
 			[]string{"WATCHTOWER_HTTP_API_CORS_ORIGINS"},
 			spec.ListCommaOrSpace,
 		),
 		CheckTimeout: durationValue(
-			vip, flagSet, "http-api-check-timeout",
+			vCfg, flagSet, "http-api-check-timeout",
 			[]string{"WATCHTOWER_HTTP_API_CHECK_TIMEOUT"},
 		),
 		CheckTimeoutChanged: flagChanged(flagSet, "http-api-check-timeout"),
 		UpdateTimeout: durationValue(
-			vip, flagSet, "http-api-update-timeout",
+			vCfg, flagSet, "http-api-update-timeout",
 			[]string{"WATCHTOWER_HTTP_API_UPDATE_TIMEOUT"},
 		),
 		UpdateTimeoutChanged: flagChanged(flagSet, "http-api-update-timeout"),
@@ -477,64 +477,64 @@ func loadAPI(vip *viper.Viper, flagSet *pflag.FlagSet) api.API {
 }
 
 // loadNotify reads notification settings from Viper.
-func loadNotify(vip *viper.Viper, flagSet *pflag.FlagSet) notify.Notify {
+func loadNotify(vCfg *viper.Viper, flagSet *pflag.FlagSet) notify.Notify {
 	return notify.Notify{
 		URLs: stringSliceValue(
-			vip, flagSet, "notification-url",
+			vCfg, flagSet, "notification-url",
 			[]string{"WATCHTOWER_NOTIFICATION_URL"},
 			spec.ListNotificationURLs,
 		),
 		LegacyTypes: stringSliceValue(
-			vip, flagSet, "notifications",
+			vCfg, flagSet, "notifications",
 			[]string{"WATCHTOWER_NOTIFICATIONS"},
 			spec.ListCommaOrSpace,
 		),
-		Level:            vip.GetString("notifications-level"),
-		Template:         vip.GetString("notification-template"),
-		TemplateFile:     vip.GetString("notification-template-file"),
-		Report:           vip.GetBool("notification-report"),
-		SplitByContainer: vip.GetBool("notification-split-by-container"),
-		SkipTitle:        vip.GetBool("notification-skip-title"),
-		LogStdout:        vip.GetBool("notification-log-stdout"),
-		DelaySeconds:     vip.GetInt("notifications-delay"),
-		Hostname:         vip.GetString("notifications-hostname"),
-		TitleTag:         vip.GetString("notification-title-tag"),
-		EmailSubjectTag:  vip.GetString("notification-email-subjecttag"),
+		Level:            vCfg.GetString("notifications-level"),
+		Template:         vCfg.GetString("notification-template"),
+		TemplateFile:     vCfg.GetString("notification-template-file"),
+		Report:           vCfg.GetBool("notification-report"),
+		SplitByContainer: vCfg.GetBool("notification-split-by-container"),
+		SkipTitle:        vCfg.GetBool("notification-skip-title"),
+		LogStdout:        vCfg.GetBool("notification-log-stdout"),
+		DelaySeconds:     vCfg.GetInt("notifications-delay"),
+		Hostname:         vCfg.GetString("notifications-hostname"),
+		TitleTag:         vCfg.GetString("notification-title-tag"),
+		EmailSubjectTag:  vCfg.GetString("notification-email-subjecttag"),
 		Legacy: notify.Legacy{
-			EmailFrom:           vip.GetString("notification-email-from"),
-			EmailTo:             vip.GetString("notification-email-to"),
-			EmailServer:         vip.GetString("notification-email-server"),
-			EmailUser:           vip.GetString("notification-email-server-user"),
-			EmailPassword:       vip.GetString("notification-email-server-password"),
-			EmailPort:           vip.GetInt("notification-email-server-port"),
-			EmailTLSSkipVerify:  vip.GetBool("notification-email-server-tls-skip-verify"),
-			EmailDelay:          vip.GetInt("notification-email-delay"),
-			SlackHookURL:        vip.GetString("notification-slack-hook-url"),
-			SlackIdentifier:     vip.GetString("notification-slack-identifier"),
-			SlackChannel:        vip.GetString("notification-slack-channel"),
-			SlackIconEmoji:      vip.GetString("notification-slack-icon-emoji"),
-			SlackIconURL:        vip.GetString("notification-slack-icon-url"),
-			MSTeamsHook:         vip.GetString("notification-msteams-hook"),
-			GotifyURL:           vip.GetString("notification-gotify-url"),
-			GotifyToken:         vip.GetString("notification-gotify-token"),
-			GotifyTLSSkipVerify: vip.GetBool("notification-gotify-tls-skip-verify"),
+			EmailFrom:           vCfg.GetString("notification-email-from"),
+			EmailTo:             vCfg.GetString("notification-email-to"),
+			EmailServer:         vCfg.GetString("notification-email-server"),
+			EmailUser:           vCfg.GetString("notification-email-server-user"),
+			EmailPassword:       vCfg.GetString("notification-email-server-password"),
+			EmailPort:           vCfg.GetInt("notification-email-server-port"),
+			EmailTLSSkipVerify:  vCfg.GetBool("notification-email-server-tls-skip-verify"),
+			EmailDelay:          vCfg.GetInt("notification-email-delay"),
+			SlackHookURL:        vCfg.GetString("notification-slack-hook-url"),
+			SlackIdentifier:     vCfg.GetString("notification-slack-identifier"),
+			SlackChannel:        vCfg.GetString("notification-slack-channel"),
+			SlackIconEmoji:      vCfg.GetString("notification-slack-icon-emoji"),
+			SlackIconURL:        vCfg.GetString("notification-slack-icon-url"),
+			MSTeamsHook:         vCfg.GetString("notification-msteams-hook"),
+			GotifyURL:           vCfg.GetString("notification-gotify-url"),
+			GotifyToken:         vCfg.GetString("notification-gotify-token"),
+			GotifyTLSSkipVerify: vCfg.GetBool("notification-gotify-tls-skip-verify"),
 		},
 	}
 }
 
 // loadLogging reads logging settings from Viper.
-func loadLogging(vip *viper.Viper) logging.Logging {
-	format := vip.GetString("log-format")
+func loadLogging(vCfg *viper.Viper) logging.Logging {
+	format := vCfg.GetString("log-format")
 	if format == "" {
 		format = "auto"
 	}
 
 	return logging.Logging{
-		Level:   vip.GetString("log-level"),
+		Level:   vCfg.GetString("log-level"),
 		Format:  format,
-		Debug:   vip.GetBool("debug"),
-		Trace:   vip.GetBool("trace"),
-		NoColor: vip.GetBool("no-color"),
+		Debug:   vCfg.GetBool("debug"),
+		Trace:   vCfg.GetBool("trace"),
+		NoColor: vCfg.GetBool("no-color"),
 	}
 }
 

--- a/internal/config/viper_get.go
+++ b/internal/config/viper_get.go
@@ -20,7 +20,7 @@ import (
 // number, it is treated as seconds (legacy WATCHTOWER_TIMEOUT behavior).
 //
 // Parameters:
-//   - v: Bound Viper instance.
+//   - vCfg: Bound Viper instance.
 //   - flagSet: Parsed flag set (for Changed checks).
 //   - name: Flag name.
 //   - envKeys: Environment keys bound to this flag.
@@ -28,7 +28,7 @@ import (
 // Returns:
 //   - time.Duration: Resolved duration.
 func durationValue(
-	vip *viper.Viper,
+	vCfg *viper.Viper,
 	flagSet *pflag.FlagSet,
 	name string,
 	envKeys []string,
@@ -75,7 +75,7 @@ func durationValue(
 		}
 	}
 
-	return vip.GetDuration(name)
+	return vCfg.GetDuration(name)
 }
 
 // bareSeconds parses a pure numeric string as seconds.
@@ -101,7 +101,7 @@ func bareSeconds(raw string) (time.Duration, error) {
 // stringSliceValue reads a string list using the FlagSpec ListParse strategy.
 //
 // Parameters:
-//   - v: Bound Viper instance.
+//   - vCfg: Bound Viper instance.
 //   - flagSet: Parsed flag set.
 //   - name: Flag name.
 //   - envKeys: Environment keys bound to this flag.
@@ -110,7 +110,7 @@ func bareSeconds(raw string) (time.Duration, error) {
 // Returns:
 //   - []string: Resolved list (never nil).
 func stringSliceValue(
-	vip *viper.Viper,
+	vCfg *viper.Viper,
 	flagSet *pflag.FlagSet,
 	name string,
 	envKeys []string,
@@ -140,7 +140,7 @@ func stringSliceValue(
 		return spec.ParseList(raw, parse)
 	}
 
-	vals := vip.GetStringSlice(name)
+	vals := vCfg.GetStringSlice(name)
 	if vals == nil {
 		return []string{}
 	}

--- a/internal/config/viper_get_test.go
+++ b/internal/config/viper_get_test.go
@@ -14,7 +14,7 @@ import (
 // TestStringSliceValue_ChangedFlagWinsOverEnv verifies that stringSliceValue
 // reads the flag when Changed=true instead of falling back to os.Getenv.
 func TestStringSliceValue_ChangedFlagWinsOverEnv(t *testing.T) {
-	vip := viper.New()
+	vCfg := viper.New()
 	flagSet := pflag.NewFlagSet(t.Name(), pflag.ContinueOnError)
 
 	flagSet.StringArray("test-flag", []string{}, "")
@@ -28,7 +28,7 @@ func TestStringSliceValue_ChangedFlagWinsOverEnv(t *testing.T) {
 	t.Setenv("TEST_NOTIFICATION_URL", "/run/secrets/WATCHTOWER_NOTIFICATION_URL")
 
 	result := stringSliceValue(
-		vip,
+		vCfg,
 		flagSet,
 		"test-flag",
 		[]string{"TEST_NOTIFICATION_URL"},
@@ -42,7 +42,7 @@ func TestStringSliceValue_ChangedFlagWinsOverEnv(t *testing.T) {
 // TestStringSliceValue_UnchangedFlagFallsBackToEnv verifies that stringSliceValue
 // falls back to os.Getenv when the flag value is unchanged.
 func TestStringSliceValue_UnchangedFlagFallsBackToEnv(t *testing.T) {
-	vip := viper.New()
+	vCfg := viper.New()
 	flagSet := pflag.NewFlagSet(t.Name(), pflag.ContinueOnError)
 
 	flagSet.StringArray("test-flag", []string{}, "")
@@ -54,7 +54,7 @@ func TestStringSliceValue_UnchangedFlagFallsBackToEnv(t *testing.T) {
 	t.Setenv("TEST_NOTIFICATION_URL", "/run/secrets/WATCHTOWER_NOTIFICATION_URL")
 
 	result := stringSliceValue(
-		vip,
+		vCfg,
 		flagSet,
 		"test-flag",
 		[]string{"TEST_NOTIFICATION_URL"},
@@ -68,7 +68,7 @@ func TestStringSliceValue_UnchangedFlagFallsBackToEnv(t *testing.T) {
 // TestStringSliceValue_ViperGetStringSliceIsFinalFallback verifies that stringSliceValue
 // falls back to Viper when neither the flag nor env provide a value.
 func TestStringSliceValue_ViperGetStringSliceIsFinalFallback(t *testing.T) {
-	vip := viper.New()
+	vCfg := viper.New()
 	flagSet := pflag.NewFlagSet(t.Name(), pflag.ContinueOnError)
 
 	flagSet.StringArray("test-flag", []string{}, "")
@@ -81,10 +81,10 @@ func TestStringSliceValue_ViperGetStringSliceIsFinalFallback(t *testing.T) {
 	t.Setenv("TEST_NOTIFICATION_URL", "")
 
 	// Set value via viper (simulating a config file).
-	vip.Set("test-flag", []string{"smtp://user:pass@host:25"})
+	vCfg.Set("test-flag", []string{"smtp://user:pass@host:25"})
 
 	result := stringSliceValue(
-		vip,
+		vCfg,
 		flagSet,
 		"test-flag",
 		[]string{"TEST_NOTIFICATION_URL"},

--- a/internal/flags/bind.go
+++ b/internal/flags/bind.go
@@ -26,15 +26,15 @@ var (
 // env values participate through BindEnv without baking into pflag defaults.
 //
 // Parameters:
-//   - vip: Local Viper instance for this process load.
+//   - vCfg: Local Viper instance for this process load.
 //   - flagSet: Parsed persistent flag set.
 //   - specs: Aggregated domain flag specifications.
 //
 // Returns:
 //   - error: Non-nil when a bind or default application fails.
-func BindAll(vip *viper.Viper, flagSet *pflag.FlagSet, specs []spec.FlagSpec) error {
+func BindAll(vCfg *viper.Viper, flagSet *pflag.FlagSet, specs []spec.FlagSpec) error {
 	for _, flagSpec := range specs {
-		err := applyDefault(vip, flagSpec)
+		err := applyDefault(vCfg, flagSpec)
 		if err != nil {
 			return fmt.Errorf("default %s: %w", flagSpec.Name, err)
 		}
@@ -44,7 +44,7 @@ func BindAll(vip *viper.Viper, flagSet *pflag.FlagSet, specs []spec.FlagSpec) er
 			return fmt.Errorf("%w: %q", ErrFlagNotRegistered, flagSpec.Name)
 		}
 
-		err = vip.BindPFlag(flagSpec.Name, flag)
+		err = vCfg.BindPFlag(flagSpec.Name, flag)
 		if err != nil {
 			return fmt.Errorf("bind flag %s: %w", flagSpec.Name, err)
 		}
@@ -68,7 +68,7 @@ func BindAll(vip *viper.Viper, flagSet *pflag.FlagSet, specs []spec.FlagSpec) er
 		bindArgs = append(bindArgs, flagSpec.Name)
 		bindArgs = append(bindArgs, envAliases...)
 
-		err = vip.BindEnv(bindArgs...)
+		err = vCfg.BindEnv(bindArgs...)
 		if err != nil {
 			return fmt.Errorf("bind env %s -> %v: %w", flagSpec.Name, envAliases, err)
 		}
@@ -80,12 +80,12 @@ func BindAll(vip *viper.Viper, flagSet *pflag.FlagSet, specs []spec.FlagSpec) er
 // applyDefault sets the Viper default for a FlagSpec.
 //
 // Parameters:
-//   - vip: Viper instance.
+//   - vCfg: Viper instance.
 //   - flagSpec: Flag specification.
 //
 // Returns:
 //   - error: Non-nil when the default type is unsupported.
-func applyDefault(vip *viper.Viper, flagSpec spec.FlagSpec) error {
+func applyDefault(vCfg *viper.Viper, flagSpec spec.FlagSpec) error {
 	switch flagSpec.Kind {
 	case spec.KindBool:
 		b, ok := flagSpec.Default.(bool)
@@ -93,30 +93,30 @@ func applyDefault(vip *viper.Viper, flagSpec spec.FlagSpec) error {
 			return fmt.Errorf("%w: bool %s", ErrInvalidFlagDefault, flagSpec.Name)
 		}
 
-		vip.SetDefault(flagSpec.Name, b)
+		vCfg.SetDefault(flagSpec.Name, b)
 	case spec.KindString:
 		str, _ := flagSpec.Default.(string)
-		vip.SetDefault(flagSpec.Name, str)
+		vCfg.SetDefault(flagSpec.Name, str)
 	case spec.KindInt:
 		n, ok := flagSpec.Default.(int)
 		if !ok && flagSpec.Default != nil {
 			return fmt.Errorf("%w: int %s", ErrInvalidFlagDefault, flagSpec.Name)
 		}
 
-		vip.SetDefault(flagSpec.Name, n)
+		vCfg.SetDefault(flagSpec.Name, n)
 	case spec.KindDuration:
 		d, ok := flagSpec.Default.(time.Duration)
 		if !ok && flagSpec.Default != nil {
 			return fmt.Errorf("%w: duration %s", ErrInvalidFlagDefault, flagSpec.Name)
 		}
 
-		vip.SetDefault(flagSpec.Name, d)
+		vCfg.SetDefault(flagSpec.Name, d)
 	case spec.KindStringSlice, spec.KindStringArray:
 		switch typed := flagSpec.Default.(type) {
 		case []string:
-			vip.SetDefault(flagSpec.Name, typed)
+			vCfg.SetDefault(flagSpec.Name, typed)
 		case nil:
-			vip.SetDefault(flagSpec.Name, []string{})
+			vCfg.SetDefault(flagSpec.Name, []string{})
 		default:
 			return fmt.Errorf("%w: string slice %s", ErrInvalidFlagDefault, flagSpec.Name)
 		}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -125,17 +125,17 @@ func EnvConfig(log *zerolog.Logger, cmd *cobra.Command) error {
 	flagSet := cmd.PersistentFlags()
 
 	// Resolve Docker settings via Viper (flag > env > static default) after BindAll.
-	vip := viper.New()
+	vCfg := viper.New()
 
-	err := BindAll(vip, flagSet, docker.Specs())
+	err := BindAll(vCfg, flagSet, docker.Specs())
 	if err != nil {
 		return fmt.Errorf("bind docker flags: %w", err)
 	}
 
-	host := vip.GetString("host")
-	tls := vip.GetBool("tlsverify")
-	version := strings.Trim(vip.GetString("api-version"), "\"")
-	certPath := vip.GetString("cert-path")
+	host := vCfg.GetString("host")
+	tls := vCfg.GetBool("tlsverify")
+	version := strings.Trim(vCfg.GetString("api-version"), "\"")
+	certPath := vCfg.GetString("cert-path")
 
 	// Convert tcp:// to https:// when TLS is enabled.
 	if tls && strings.HasPrefix(host, "tcp://") {


### PR DESCRIPTION
This PR renames local Viper instances from `vip` to `vCfg` in configuration loading and flag binding. The new name states that the value is the Viper config for the process load. Behavior is unchanged.

## Problem

Viper instances in `internal/config` and `internal/flags` were named `vip`, with `loadDocker` using `v`. That name does not describe the value, and the names were not consistent.

## Solution

Use `vCfg` for every local Viper instance in those packages, including `loadDocker`, and match the parameter comments to the new name.

## Changes

- Rename `vip` to `vCfg` in `internal/config/load.go`, `viper_get.go`, `viper_get_test.go`, `internal/flags/bind.go`, and `internal/flags/flags.go`
- Rename `loadDocker`'s `v` parameter to `vCfg`
- Update related parameter comments