### PR TITLE
fix(ratelimit): pace throttled registry hosts without bursting advertised quotas

### DIFF
--- a/docs/advanced-features/image-cooldown/index.md
+++ b/docs/advanced-features/image-cooldown/index.md
@@ -309,8 +309,9 @@ Authenticating with a Docker Hub account raises the limit from 100 to 200 pulls,
 
 #### GitHub Container Registry (ghcr.io)
 
-GHCR.io does not publish explicit pull rate limits and currently provides free storage and bandwidth for container images.
-Observed limits are in the range of tens of thousands of requests per minute, which is well beyond what Watchtower's cooldown feature would generate under any realistic deployment.
+GHCR.io does not publish Docker Hub-style pull quotas. It does advertise an undocumented edge budget (observed as `allowed: 44000/minute` with a sub-second `retry-after`) that trips on bursts of concurrent requests, including anonymous pulls of `lscr.io` images hosted there.
+
+Watchtower treats that advertised figure as a fill rate, not a burst size: after a 429 it paces one request at a time for that host. Authenticating to the registry is still the most reliable way to leave a shared anonymous bucket.
 
 #### Per-Registry Impact Summary
 
@@ -319,7 +320,7 @@ Observed limits are in the range of tens of thousands of requests per minute, wh
 | Docker Hub (unauthenticated)    | 100 / 6 hours               | Moderate — may exceed limit with many containers on short intervals |
 | Docker Hub (authenticated free) | 200 / 6 hours               | Low — sufficient for most deployments                               |
 | Docker Hub (paid)               | Unlimited                   | None                                                                |
-| GHCR.io                         | ~44,000 / minute (observed) | None                                                                |
+| GHCR.io                         | ~44,000 / minute fill rate (small burst) | Low — paced after a 429; authenticate if you see retries |
 
 ### Monitor-Only Containers
 

--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -657,7 +657,7 @@ func (c imageClient) shouldSkipPull(
 
 	switch {
 	case ratelimit.Is(err):
-		clog.Warn().
+		clog.Debug().
 			Err(err).
 			Msg("Registry rate limited digest check. Aborting pull")
 
@@ -775,7 +775,7 @@ func (c imageClient) performImagePull(
 			info := ratelimit.FromErrorMessage(waitErr.Error())
 			if info != nil {
 				ratelimit.Observe(pullHost, info)
-				clog.Warn().
+				clog.Debug().
 					Err(info).
 					Msg("Registry rate limited image pull")
 

--- a/pkg/registry/ratelimit/doc.go
+++ b/pkg/registry/ratelimit/doc.go
@@ -1,5 +1,9 @@
 // Package ratelimit parses registry 429 responses and retries them with backoff.
 //
-// It honors HTTP Retry-After headers, GHCR-style body quotas such as
-// "allowed: 44000/minute", and Docker pull-stream toomanyrequests messages.
+// It honors HTTP Retry-After headers, body quotas, such as "allowed: 44000/minute"
+// and Docker pull-stream toomanyrequests messages.
+// Advertised quotas are treated as a fill rate.
+// After a throttle, each host is limited to one outstanding token so concurrent
+// checks cannot dump the advertised budget in a burst.
+// In-cycle retries are logged at the debug level and giving up is a warning.
 package ratelimit

--- a/pkg/registry/ratelimit/error.go
+++ b/pkg/registry/ratelimit/error.go
@@ -24,6 +24,8 @@ const (
 	retryAfterCaptureCount = 2
 	// allowedCaptureCount is the expected regex group count for allowed quotas.
 	allowedCaptureCount = 3
+	// equalJitterDivisor splits a wait into the equal-jitter half range.
+	equalJitterDivisor = 2
 )
 
 // Error is a registry 429 with the wait and quota the registry advertised.

--- a/pkg/registry/ratelimit/limiter.go
+++ b/pkg/registry/ratelimit/limiter.go
@@ -11,10 +11,12 @@ import (
 type hostState struct {
 	// cooldownUntil is when the next request to this host may proceed.
 	cooldownUntil time.Time
-	// allowed is the advertised request budget. Zero when unknown.
+	// allowed is the advertised fill rate numerator. Zero when unknown.
 	allowed int
 	// window is the period for allowed. Zero when unknown.
 	window time.Duration
+	// burst is the maximum tokens held. Zero uses the advertised allowance.
+	burst int
 	// tokens is the remaining budget in the current window.
 	tokens float64
 	// lastRefill is when tokens were last replenished.
@@ -38,6 +40,11 @@ func ResetForTest() {
 
 // Observe records a 429 against host so later Wait calls honor it.
 //
+// Advertised "allowed: N/window" values are treated as a fill rate, not a
+// burst size. After a throttle, the host is limited to one outstanding token
+// so concurrent waiters cannot dump the advertised budget at once.
+// Cooldown time does not accrue tokens.
+//
 // Parameters:
 //   - host: Registry host. Empty values are ignored.
 //   - info: Parsed 429. Nil values are ignored.
@@ -50,6 +57,7 @@ func Observe(host string, info *Error) {
 	defer hostsMu.Unlock()
 
 	state := hostLocked(host)
+	now := time.Now()
 
 	cooldown := min(info.RetryAfter, maxHonorWait)
 
@@ -58,24 +66,39 @@ func Observe(host string, info *Error) {
 	}
 
 	if cooldown > 0 {
-		until := time.Now().Add(cooldown)
+		until := now.Add(cooldown)
 		if until.After(state.cooldownUntil) {
 			state.cooldownUntil = until
 		}
 	}
 
+	state.burst = 1
+	state.tokens = 1
+
+	if state.cooldownUntil.After(now) {
+		state.lastRefill = state.cooldownUntil
+	} else {
+		state.lastRefill = now
+	}
+
 	if info.Allowed > 0 && info.AllowedWindow > 0 {
 		state.allowed = info.Allowed
 		state.window = info.AllowedWindow
-		state.tokens = 0
-		state.lastRefill = time.Now()
+	} else if state.allowed <= 0 || state.window <= 0 {
+		window := cooldown
+		if window <= 0 {
+			window = minHonorWait
+		}
+
+		state.allowed = 1
+		state.window = window
 	}
 }
 
-// ObserveSuccess refreshes host's advertised budget after a successful request.
+// ObserveSuccess refreshes host's fill-rate tokens after a successful request.
 //
-// Token reservation happens in Wait. This only refills so a success does not
-// spend a second token.
+// Token reservation happens in Wait. This only refills up to the burst cap so
+// a success does not spend a second token or restore a pre-throttle dump.
 //
 // Parameters:
 //   - host: Registry host. Empty values are ignored.
@@ -244,7 +267,7 @@ func (s *hostState) refillLocked(now time.Time) {
 
 	if s.lastRefill.IsZero() {
 		s.lastRefill = now
-		s.tokens = float64(s.allowed)
+		s.tokens = s.tokenCap()
 
 		return
 	}
@@ -255,9 +278,25 @@ func (s *hostState) refillLocked(now time.Time) {
 	}
 
 	s.tokens += float64(elapsed) / float64(s.window) * float64(s.allowed)
-	if s.tokens > float64(s.allowed) {
-		s.tokens = float64(s.allowed)
+	if ceiling := s.tokenCap(); s.tokens > ceiling {
+		s.tokens = ceiling
 	}
 
 	s.lastRefill = now
+}
+
+// tokenCap is the maximum tokens this host may hold.
+//
+// After a throttle, burst is 1 so an advertised fill rate cannot rebuild a
+// large dump of tokens. Before any throttle, burst is 0 and the cap is the
+// advertised budget when a quota is present.
+//
+// Returns:
+//   - float64: Token ceiling used by refillLocked.
+func (s *hostState) tokenCap() float64 {
+	if s.burst > 0 {
+		return float64(s.burst)
+	}
+
+	return float64(s.allowed)
 }

--- a/pkg/registry/ratelimit/limiter_test.go
+++ b/pkg/registry/ratelimit/limiter_test.go
@@ -2,6 +2,7 @@ package ratelimit
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -71,12 +72,10 @@ func TestWaitCooldownDoesNotConsumeQuotaToken(t *testing.T) {
 		AllowedWindow: 200 * time.Millisecond,
 	})
 
-	time.Sleep(220 * time.Millisecond)
 	require.NoError(t, WaitCooldown(t.Context(), "ghcr.io"))
 
 	started := time.Now()
 
-	require.NoError(t, Wait(t.Context(), "ghcr.io"))
 	require.NoError(t, Wait(t.Context(), "ghcr.io"))
 	assert.Less(t, time.Since(started), 50*time.Millisecond)
 }
@@ -145,7 +144,7 @@ func TestObserveSuccessIgnoresUnknownHost(t *testing.T) {
 	require.NoError(t, Wait(t.Context(), "ghcr.io"))
 }
 
-func TestObserveSuccessDoesNotConsumeReservedToken(t *testing.T) {
+func TestObserveSuccessDoesNotGiftExtraToken(t *testing.T) {
 	ResetForTest()
 
 	Observe("ghcr.io", &Error{
@@ -153,14 +152,13 @@ func TestObserveSuccessDoesNotConsumeReservedToken(t *testing.T) {
 		AllowedWindow: 200 * time.Millisecond,
 	})
 
-	time.Sleep(220 * time.Millisecond)
 	require.NoError(t, Wait(t.Context(), "ghcr.io"))
 	ObserveSuccess("ghcr.io")
 
 	started := time.Now()
 
 	require.NoError(t, Wait(t.Context(), "ghcr.io"))
-	assert.Less(t, time.Since(started), 50*time.Millisecond)
+	assert.GreaterOrEqual(t, time.Since(started), 80*time.Millisecond)
 }
 
 func TestRefillLocked(t *testing.T) {
@@ -208,6 +206,20 @@ func TestRefillLocked(t *testing.T) {
 		state.refillLocked(time.Now())
 		assert.InDelta(t, 10.0, state.tokens, 0.001)
 	})
+
+	t.Run("caps tokens at burst after a throttle", func(t *testing.T) {
+		t.Parallel()
+
+		state := &hostState{
+			allowed:    44000,
+			window:     time.Minute,
+			burst:      1,
+			tokens:     0,
+			lastRefill: time.Now().Add(-time.Second),
+		}
+		state.refillLocked(time.Now())
+		assert.InDelta(t, 1.0, state.tokens, 0.001)
+	})
 }
 
 func TestWaitCancelsWithContext(t *testing.T) {
@@ -221,4 +233,111 @@ func TestWaitCancelsWithContext(t *testing.T) {
 	err := Wait(ctx, "ghcr.io")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestWaitSerializesAfterQuotaThrottle(t *testing.T) {
+	ResetForTest()
+
+	Observe("registry.example", &Error{
+		RetryAfter:    521600 * time.Nanosecond,
+		Allowed:       44000,
+		AllowedWindow: time.Minute,
+	})
+
+	require.NoError(t, Wait(t.Context(), "registry.example"))
+
+	started := time.Now()
+
+	const waiters = 20
+
+	var wg sync.WaitGroup
+
+	for range waiters {
+		wg.Go(func() {
+			assert.NoError(t, Wait(t.Context(), "registry.example"))
+		})
+	}
+
+	wg.Wait()
+
+	elapsed := time.Since(started)
+	t.Logf("20 concurrent Wait() after quota throttle completed in %s", elapsed)
+	assert.GreaterOrEqual(t, elapsed, 15*time.Millisecond)
+}
+
+func TestWaitSerializesAfterRetryAfterOnlyThrottle(t *testing.T) {
+	ResetForTest()
+
+	Observe("registry.example", &Error{RetryAfter: 80 * time.Millisecond})
+
+	require.NoError(t, Wait(t.Context(), "registry.example"))
+
+	started := time.Now()
+
+	const waiters = 4
+
+	var wg sync.WaitGroup
+
+	for range waiters {
+		wg.Go(func() {
+			assert.NoError(t, Wait(t.Context(), "registry.example"))
+		})
+	}
+
+	wg.Wait()
+
+	elapsed := time.Since(started)
+	t.Logf("4 concurrent Wait() after Retry-After-only throttle completed in %s", elapsed)
+	assert.GreaterOrEqual(t, elapsed, 200*time.Millisecond)
+}
+
+func TestWaitUnthrottledHostStaysImmediate(t *testing.T) {
+	ResetForTest()
+
+	started := time.Now()
+
+	const waiters = 20
+
+	var wg sync.WaitGroup
+
+	for range waiters {
+		wg.Go(func() {
+			assert.NoError(t, Wait(t.Context(), "registry.example"))
+		})
+	}
+
+	wg.Wait()
+
+	assert.Less(t, time.Since(started), 20*time.Millisecond)
+}
+
+func TestWaitDoesNotAccrueBurstDuringCooldown(t *testing.T) {
+	ResetForTest()
+
+	Observe("registry.example", &Error{
+		RetryAfter:    80 * time.Millisecond,
+		Allowed:       44000,
+		AllowedWindow: time.Minute,
+	})
+
+	require.NoError(t, Wait(t.Context(), "registry.example"))
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond)
+	defer cancel()
+
+	granted := 0
+
+	for {
+		err := Wait(ctx, "registry.example")
+		if err != nil {
+			break
+		}
+
+		granted++
+		if granted > 5 {
+			break
+		}
+	}
+
+	assert.LessOrEqual(t, granted, 1)
 }

--- a/pkg/registry/ratelimit/retry.go
+++ b/pkg/registry/ratelimit/retry.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand/v2"
+	"time"
 
 	"github.com/cenkalti/backoff/v7"
 	"github.com/rs/zerolog"
@@ -58,6 +60,8 @@ func DoValue[T any](
 	exp.InitialInterval = minHonorWait
 	exp.MaxInterval = maxHonorWait
 
+	attempt := 0
+
 	result, err := backoff.Retry(ctx, func() (T, error) {
 		waitErr := Wait(ctx, host)
 		if waitErr != nil {
@@ -85,12 +89,16 @@ func DoValue[T any](
 		}
 
 		wait, giveUp := Decision(info)
-		if giveUp {
+
+		attempt++
+		if giveUp || attempt >= maxRetryTries {
 			return zero, backoff.Permanent(opErr)
 		}
 
+		wait = jitterWait(wait)
+
 		if log != nil {
-			log.Warn().
+			log.Debug().
 				Str("host", host).
 				Dur("retry_after", wait).
 				Msg("Registry rate limited. Retrying after delay")
@@ -106,7 +114,15 @@ func DoValue[T any](
 		return result, nil
 	}
 
-	return result, lastOperationError(err)
+	err = lastOperationError(err)
+	if log != nil && Is(err) {
+		log.Warn().
+			Err(err).
+			Str("host", host).
+			Msg("Registry rate limited. Stopping retries")
+	}
+
+	return result, err
 }
 
 // lastOperationError unwraps a cenkalti RetryError to the last operation error.
@@ -135,4 +151,31 @@ func lastOperationError(err error) error {
 	}
 
 	return err
+}
+
+// jitterWait adds nonnegative jitter so concurrent retries do not wake together.
+//
+// The Decision wait is the minimum. Extra delay is in
+// [0, wait/equalJitterDivisor], capped so the result does not exceed
+// maxHonorWait. Zero and negative waits are unchanged.
+//
+// Parameters:
+//   - wait: Decision wait before the next attempt.
+//
+// Returns:
+//   - time.Duration: Jittered wait, never shorter than wait when wait > 0.
+func jitterWait(wait time.Duration) time.Duration {
+	if wait <= 0 {
+		return wait
+	}
+
+	room := maxHonorWait - wait
+	if room <= 0 {
+		return wait
+	}
+
+	spread := min(wait/equalJitterDivisor, room)
+
+	//nolint:gosec // Jitter only needs to desynchronize retries, not be cryptographic.
+	return wait + time.Duration(rand.Int64N(int64(spread)+1))
 }

--- a/pkg/registry/ratelimit/retry_test.go
+++ b/pkg/registry/ratelimit/retry_test.go
@@ -1,6 +1,7 @@
 package ratelimit
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"sync/atomic"
@@ -20,6 +21,72 @@ func testLog() *zerolog.Logger {
 	logger := zerolog.Nop()
 
 	return &logger
+}
+
+func TestJitterWaitDoesNotShortenDecisionWait(t *testing.T) {
+	t.Parallel()
+
+	wait := 100 * time.Millisecond
+	seen := map[time.Duration]struct{}{}
+	maxExtra := wait / equalJitterDivisor
+
+	for range 200 {
+		got := jitterWait(wait)
+		assert.GreaterOrEqual(t, got, wait)
+		assert.LessOrEqual(t, got, wait+maxExtra)
+		seen[got] = struct{}{}
+	}
+
+	assert.Greater(t, len(seen), 1)
+}
+
+func TestJitterWaitLeavesZeroUnchanged(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, time.Duration(0), jitterWait(0))
+}
+
+func TestJitterWaitDoesNotExceedHonorWindow(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, maxHonorWait, jitterWait(maxHonorWait))
+}
+
+func TestDoLogsRetryAtDebug(t *testing.T) {
+	ResetForTest()
+
+	var buf bytes.Buffer
+
+	log := zerolog.New(&buf)
+
+	var attempts atomic.Int32
+
+	err := Do(t.Context(), &log, "registry.example", func() error {
+		if attempts.Add(1) < 2 {
+			return &Error{RetryAfter: minHonorWait}
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), `"level":"debug"`)
+	assert.Contains(t, buf.String(), "Registry rate limited. Retrying after delay")
+	assert.NotContains(t, buf.String(), `"level":"warn"`)
+}
+
+func TestDoLogsExhaustionAtWarn(t *testing.T) {
+	ResetForTest()
+
+	var buf bytes.Buffer
+
+	log := zerolog.New(&buf)
+
+	err := Do(t.Context(), &log, "registry.example", func() error {
+		return &Error{RetryAfter: minHonorWait}
+	})
+	require.ErrorIs(t, err, ErrRateLimited)
+	assert.Contains(t, buf.String(), `"level":"warn"`)
+	assert.Contains(t, buf.String(), "Registry rate limited. Stopping retries")
 }
 
 func TestDoRetriesRateLimitedOperations(t *testing.T) {
@@ -119,8 +186,6 @@ func TestDoValueConsumesOneTokenPerAttempt(t *testing.T) {
 		AllowedWindow: 200 * time.Millisecond,
 	})
 
-	time.Sleep(220 * time.Millisecond)
-
 	got, err := DoValue(t.Context(), testLog(), "ghcr.io", func() (string, error) {
 		return "ok", nil
 	})
@@ -130,7 +195,7 @@ func TestDoValueConsumesOneTokenPerAttempt(t *testing.T) {
 	started := time.Now()
 
 	require.NoError(t, Wait(t.Context(), "ghcr.io"))
-	assert.Less(t, time.Since(started), 50*time.Millisecond)
+	assert.GreaterOrEqual(t, time.Since(started), 80*time.Millisecond)
 }
 
 func TestDoValueHonorsHostWaitCancellation(t *testing.T) {


### PR DESCRIPTION
This PR stops a registry 429 from turning an advertised per-window budget into a burst of concurrent retries. Throttled hosts are paced one request at a time, Retry-After is never shortened, and in-cycle retry noise stays off the default log. Unthrottled registries are unchanged.

## Problem

Parallel staleness checks plus the token bucket from #2187 could turn a single 429 into a stampede. Registries that advertise a large `allowed: N/window` with a short `retry-after` (observed on GHCR for `lscr.io` images, including discussion #2259) were modeled as if that figure were burst capacity. After the 100ms floor, dozens of waiters proceeded together, walked back into the same limit, and spammed Warn logs on every retry. v1.21.2 made those throttles visible and retryable (#2230); however, it did not stop the herd.

## Solution

Enable Watchtower to dynamically revert to sequential checks when the registry host responds with a 429.

Treat advertised quotas as a fill rate. After any 429, cap that host at one token, do not accrue tokens during cooldown checks, and honor the Decision wait as a minimum while adding only nonnegative jitter. Hosts that have never throttled keep the existing concurrent check path. In-cycle retries log at a debug level and a warning is emitted once when retries stop.

## Changes

- Cap throttled hosts at a one-token burst and refill from the advertised fill rate
- Start the refill clock at the cooldown deadline so the honor wait cannot rebuild a dump of tokens
- Add nonnegative jitter on Retry-After without shortening the server-directed wait
- Demote in-cycle retry and pull-throttle lines to debug; warn once when giving up
- Cover serialization, cooldown refill, jitter, and log-level behavior; correct the GHCR cooldown docs