### PR TITLE
docs: more info for using socket proxies

### DIFF
--- a/docs/advanced-features/secure-connections/index.md
+++ b/docs/advanced-features/secure-connections/index.md
@@ -437,7 +437,11 @@ Docker socket proxies provide a security layer between applications and the Dock
 
 While this documentation focuses on TLS-based connections, socket proxies represent another approach for securing Docker daemon access in environments where full socket exposure is undesirable.
 
+Refer to the documentation for the [Docker Host URL](#docker_host_url) to connect Watchtower to a Docker socket proxy.
+
 The following projects are examples of Docker socket proxies:
 
 - <https://github.com/Tecnativa/docker-socket-proxy>{target="_blank" rel="noopener noreferrer"}
 - <https://github.com/11notes/docker-socket-proxy>{target="_blank" rel="noopener noreferrer"}
+- <https://github.com/linuxserver/docker-socket-proxy>{target="_blank" rel="noopener noreferrer"}
+- <https://github.com/wollomatic/socket-proxy>{target="_blank" rel="noopener noreferrer"}

--- a/docs/getting-started/usage/index.md
+++ b/docs/getting-started/usage/index.md
@@ -9,7 +9,7 @@ Watchtower is released as a container image, which makes getting started as simp
 
 ### Docker Socket Requirement
 
-Since Watchtower needs to interact with the Docker API in order to monitor and update containers, you need to mount `/var/run/docker.sock` to the Watchtower container with the `-v` flag.
+Since Watchtower needs to interact with the Docker API in order to monitor and update containers, you need to mount `/var/run/docker.sock` to the Watchtower container with the `-v` flag or specify a host with the `DOCKER_HOST` [variable](../../configuration/docker-connection/index.md#docker_host).
 
 ### Docker Engine Dependency
 

--- a/docs/http-api/overview/index.md
+++ b/docs/http-api/overview/index.md
@@ -137,7 +137,7 @@ The following endpoints can be enabled by using the[`http-api-endpoints`](../../
 
 Watchtower was originally designed to be a stateless application with direct access to the Docker socket.
 By having direct access to the Docker socket, the application effectively runs with root-level privileges.
-It is worth taking a moment to review and familiarize yourself with the [Docker Engine security documentation](https://docs.docker.com/engine/security/){target="_blank" rel="noopener noreferrer"} and explore other security tools such as [Docker socket proxies](../../advanced-features/secure-connections/index.md#docker_socket_proxies)
+It is worth taking a moment to review and familiarize yourself with the [Docker Engine security documentation](https://docs.docker.com/engine/security/){target="_blank" rel="noopener noreferrer"} and explore other security tools such as [Docker socket proxies](../../advanced-features/secure-connections/index.md#docker_socket_proxies).
 
 - !!! Warning "The HTTP API should never be directly exposed to the Internet!"
 - !!! Warning "Using the HTTP API without TLS encryption is insecure and not recommended!"

--- a/docs/http-api/overview/index.md
+++ b/docs/http-api/overview/index.md
@@ -137,7 +137,7 @@ The following endpoints can be enabled by using the[`http-api-endpoints`](../../
 
 Watchtower was originally designed to be a stateless application with direct access to the Docker socket.
 By having direct access to the Docker socket, the application effectively runs with root-level privileges.
-It is worth taking a moment to review and familiarize yourself with the [Docker Engine security documentation](https://docs.docker.com/engine/security/){target="_blank" rel="noopener noreferrer"}.
+It is worth taking a moment to review and familiarize yourself with the [Docker Engine security documentation](https://docs.docker.com/engine/security/){target="_blank" rel="noopener noreferrer"} and explore other security tools such as [Docker socket proxies](../../advanced-features/secure-connections/index.md#docker_socket_proxies)
 
 - !!! Warning "The HTTP API should never be directly exposed to the Internet!"
 - !!! Warning "Using the HTTP API without TLS encryption is insecure and not recommended!"


### PR DESCRIPTION
I was looking for which env var to use to set up a docker socket proxy and it was weirdly not that obvious. The search wasn't that useful either. So I made it more obvious with a few internal links.

I'm not sure if the [Limitations paragraph of the Epemeral self updates documentation](https://watchtower.nickfedor.com/v1.21.2/advanced-features/ephemeral-self-updates/#limitations) should also be edited with a mention of DOCKER_HOST.  Is this feature only compatible with a volume-mounted docker socket or does it work with a tcp docker host?