### PR TITLE
fix(notifications): format disk usage sizes in human-readable units

### DIFF
--- a/docs/notifications/templates/index.md
+++ b/docs/notifications/templates/index.md
@@ -90,13 +90,13 @@ Simple templates are used when the [`notification-report`](#notification_report)
 {{- else if eq $msg "Detected multiple Watchtower instances - initiating cleanup" -}}
     Detected {{$e.Data.count}} Watchtower instances - initiating cleanup
 {{- else if eq $msg "Docker image usage exceeds configured maximum" -}}
-    Docker image usage exceeds configured maximum: {{with $e.Data.usage}}{{.}}{{else}}unknown{{end}}/{{with $e.Data.max}}{{.}}{{else}}unknown{{end}} bytes used (reclaimable {{with $e.Data.reclaimable}}{{.}}{{else}}unknown{{end}}, {{with $e.Data.image_count}}{{.}}{{else}}unknown{{end}} images)
+    Docker image usage exceeds configured maximum: {{with $e.Data.usage}}{{FormatDiskSpace .}}{{else}}unknown{{end}} of {{with $e.Data.max}}{{FormatDiskSpace .}}{{else}}unknown{{end}} used ({{with $e.Data.reclaimable}}{{FormatDiskSpace .}}{{else}}unknown{{end}} reclaimable, {{with $e.Data.image_count}}{{.}}{{else}}unknown{{end}} images)
 {{- else if eq $msg "Docker image usage exceeds configured warning threshold" -}}
-    Docker image usage exceeds configured warning threshold: {{with $e.Data.usage}}{{.}}{{else}}unknown{{end}}/{{with $e.Data.warn}}{{.}}{{else}}unknown{{end}} bytes used (reclaimable {{with $e.Data.reclaimable}}{{.}}{{else}}unknown{{end}}, {{with $e.Data.image_count}}{{.}}{{else}}unknown{{end}} images)
+    Docker image usage exceeds configured warning threshold: {{with $e.Data.usage}}{{FormatDiskSpace .}}{{else}}unknown{{end}} of {{with $e.Data.warn}}{{FormatDiskSpace .}}{{else}}unknown{{end}} used ({{with $e.Data.reclaimable}}{{FormatDiskSpace .}}{{else}}unknown{{end}} reclaimable, {{with $e.Data.image_count}}{{.}}{{else}}unknown{{end}} images)
 {{- else if eq $msg "Failed to query Docker image disk usage" -}}
     Failed to query Docker image disk usage{{with $e.Data.error}}: {{.}}{{end}}
 {{- else if eq $msg "Docker image usage budget enabled" -}}
-    Docker image usage budget enabled: max {{with $e.Data.disk_space_max}}{{.}}{{else}}0{{end}} bytes, warn {{with $e.Data.disk_space_warn}}{{.}}{{else}}0{{end}} bytes
+    Docker image usage budget enabled: maximum {{with $e.Data.disk_space_max}}{{FormatDiskSpace .}}{{else}}0 B{{end}}, warning at {{with $e.Data.disk_space_warn}}{{FormatDiskSpace .}}{{else}}0 B{{end}}
 {{- else if $e.Data -}}
     {{$msg}} | {{range $k, $v := $e.Data -}}{{$k}}={{$v}} {{- end}}
 {{- else -}}
@@ -135,13 +135,13 @@ The [Template Preview Tool](../template-preview/index.md) uses the same template
 {{- else if eq $msg "Detected multiple Watchtower instances - initiating cleanup" -}}
     Detected {{$e.Data.count}} Watchtower instances - initiating cleanup
 {{- else if eq $msg "Docker image usage exceeds configured maximum" -}}
-    Docker image usage exceeds configured maximum: {{with $e.Data.usage}}{{.}}{{else}}unknown{{end}}/{{with $e.Data.max}}{{.}}{{else}}unknown{{end}} bytes used (reclaimable {{with $e.Data.reclaimable}}{{.}}{{else}}unknown{{end}}, {{with $e.Data.image_count}}{{.}}{{else}}unknown{{end}} images)
+    Docker image usage exceeds configured maximum: {{with $e.Data.usage}}{{FormatDiskSpace .}}{{else}}unknown{{end}} of {{with $e.Data.max}}{{FormatDiskSpace .}}{{else}}unknown{{end}} used ({{with $e.Data.reclaimable}}{{FormatDiskSpace .}}{{else}}unknown{{end}} reclaimable, {{with $e.Data.image_count}}{{.}}{{else}}unknown{{end}} images)
 {{- else if eq $msg "Docker image usage exceeds configured warning threshold" -}}
-    Docker image usage exceeds configured warning threshold: {{with $e.Data.usage}}{{.}}{{else}}unknown{{end}}/{{with $e.Data.warn}}{{.}}{{else}}unknown{{end}} bytes used (reclaimable {{with $e.Data.reclaimable}}{{.}}{{else}}unknown{{end}}, {{with $e.Data.image_count}}{{.}}{{else}}unknown{{end}} images)
+    Docker image usage exceeds configured warning threshold: {{with $e.Data.usage}}{{FormatDiskSpace .}}{{else}}unknown{{end}} of {{with $e.Data.warn}}{{FormatDiskSpace .}}{{else}}unknown{{end}} used ({{with $e.Data.reclaimable}}{{FormatDiskSpace .}}{{else}}unknown{{end}} reclaimable, {{with $e.Data.image_count}}{{.}}{{else}}unknown{{end}} images)
 {{- else if eq $msg "Failed to query Docker image disk usage" -}}
     Failed to query Docker image disk usage{{with $e.Data.error}}: {{.}}{{end}}
 {{- else if eq $msg "Docker image usage budget enabled" -}}
-    Docker image usage budget enabled: max {{with $e.Data.disk_space_max}}{{.}}{{else}}0{{end}} bytes, warn {{with $e.Data.disk_space_warn}}{{.}}{{else}}0{{end}} bytes
+    Docker image usage budget enabled: maximum {{with $e.Data.disk_space_max}}{{FormatDiskSpace .}}{{else}}0 B{{end}}, warning at {{with $e.Data.disk_space_warn}}{{FormatDiskSpace .}}{{else}}0 B{{end}}
 {{- else if $e.Data -}}
     {{$msg}} | {{range $k, $v := $e.Data -}}{{$k}}={{$v}} {{- end}}
 {{- else -}}

--- a/docs/notifications/templates/index.md
+++ b/docs/notifications/templates/index.md
@@ -90,9 +90,9 @@ Simple templates are used when the [`notification-report`](#notification_report)
 {{- else if eq $msg "Detected multiple Watchtower instances - initiating cleanup" -}}
     Detected {{$e.Data.count}} Watchtower instances - initiating cleanup
 {{- else if eq $msg "Docker image usage exceeds configured maximum" -}}
-    Docker image usage exceeds configured maximum: {{with $e.Data.usage}}{{FormatDiskSpace .}}{{else}}unknown{{end}} of {{with $e.Data.max}}{{FormatDiskSpace .}}{{else}}unknown{{end}} used ({{with $e.Data.reclaimable}}{{FormatDiskSpace .}}{{else}}unknown{{end}} reclaimable, {{with $e.Data.image_count}}{{.}}{{else}}unknown{{end}} images)
+    Docker image usage exceeds configured maximum: {{if HasKey $e.Data "usage"}}{{FormatDiskSpace (index $e.Data "usage")}}{{else}}unknown{{end}} of {{if HasKey $e.Data "max"}}{{FormatDiskSpace (index $e.Data "max")}}{{else}}unknown{{end}} used ({{if HasKey $e.Data "reclaimable"}}{{FormatDiskSpace (index $e.Data "reclaimable")}}{{else}}unknown{{end}} reclaimable, {{if HasKey $e.Data "image_count"}}{{index $e.Data "image_count"}}{{else}}unknown{{end}} images)
 {{- else if eq $msg "Docker image usage exceeds configured warning threshold" -}}
-    Docker image usage exceeds configured warning threshold: {{with $e.Data.usage}}{{FormatDiskSpace .}}{{else}}unknown{{end}} of {{with $e.Data.warn}}{{FormatDiskSpace .}}{{else}}unknown{{end}} used ({{with $e.Data.reclaimable}}{{FormatDiskSpace .}}{{else}}unknown{{end}} reclaimable, {{with $e.Data.image_count}}{{.}}{{else}}unknown{{end}} images)
+    Docker image usage exceeds configured warning threshold: {{if HasKey $e.Data "usage"}}{{FormatDiskSpace (index $e.Data "usage")}}{{else}}unknown{{end}} of {{if HasKey $e.Data "warn"}}{{FormatDiskSpace (index $e.Data "warn")}}{{else}}unknown{{end}} used ({{if HasKey $e.Data "reclaimable"}}{{FormatDiskSpace (index $e.Data "reclaimable")}}{{else}}unknown{{end}} reclaimable, {{if HasKey $e.Data "image_count"}}{{index $e.Data "image_count"}}{{else}}unknown{{end}} images)
 {{- else if eq $msg "Failed to query Docker image disk usage" -}}
     Failed to query Docker image disk usage{{with $e.Data.error}}: {{.}}{{end}}
 {{- else if eq $msg "Docker image usage budget enabled" -}}
@@ -135,9 +135,9 @@ The [Template Preview Tool](../template-preview/index.md) uses the same template
 {{- else if eq $msg "Detected multiple Watchtower instances - initiating cleanup" -}}
     Detected {{$e.Data.count}} Watchtower instances - initiating cleanup
 {{- else if eq $msg "Docker image usage exceeds configured maximum" -}}
-    Docker image usage exceeds configured maximum: {{with $e.Data.usage}}{{FormatDiskSpace .}}{{else}}unknown{{end}} of {{with $e.Data.max}}{{FormatDiskSpace .}}{{else}}unknown{{end}} used ({{with $e.Data.reclaimable}}{{FormatDiskSpace .}}{{else}}unknown{{end}} reclaimable, {{with $e.Data.image_count}}{{.}}{{else}}unknown{{end}} images)
+    Docker image usage exceeds configured maximum: {{if HasKey $e.Data "usage"}}{{FormatDiskSpace (index $e.Data "usage")}}{{else}}unknown{{end}} of {{if HasKey $e.Data "max"}}{{FormatDiskSpace (index $e.Data "max")}}{{else}}unknown{{end}} used ({{if HasKey $e.Data "reclaimable"}}{{FormatDiskSpace (index $e.Data "reclaimable")}}{{else}}unknown{{end}} reclaimable, {{if HasKey $e.Data "image_count"}}{{index $e.Data "image_count"}}{{else}}unknown{{end}} images)
 {{- else if eq $msg "Docker image usage exceeds configured warning threshold" -}}
-    Docker image usage exceeds configured warning threshold: {{with $e.Data.usage}}{{FormatDiskSpace .}}{{else}}unknown{{end}} of {{with $e.Data.warn}}{{FormatDiskSpace .}}{{else}}unknown{{end}} used ({{with $e.Data.reclaimable}}{{FormatDiskSpace .}}{{else}}unknown{{end}} reclaimable, {{with $e.Data.image_count}}{{.}}{{else}}unknown{{end}} images)
+    Docker image usage exceeds configured warning threshold: {{if HasKey $e.Data "usage"}}{{FormatDiskSpace (index $e.Data "usage")}}{{else}}unknown{{end}} of {{if HasKey $e.Data "warn"}}{{FormatDiskSpace (index $e.Data "warn")}}{{else}}unknown{{end}} used ({{if HasKey $e.Data "reclaimable"}}{{FormatDiskSpace (index $e.Data "reclaimable")}}{{else}}unknown{{end}} reclaimable, {{if HasKey $e.Data "image_count"}}{{index $e.Data "image_count"}}{{else}}unknown{{end}} images)
 {{- else if eq $msg "Failed to query Docker image disk usage" -}}
     Failed to query Docker image disk usage{{with $e.Data.error}}: {{.}}{{end}}
 {{- else if eq $msg "Docker image usage budget enabled" -}}

--- a/internal/util/diskspace.go
+++ b/internal/util/diskspace.go
@@ -214,3 +214,61 @@ func splitDiskSpaceValueAndUnit(size string) (string, string) {
 
 	return strings.TrimSpace(size[:end]), size[end:]
 }
+
+// FormatDiskSpace formats a byte count as a compact decimal size string.
+//
+// Values below 1000 bytes stay in bytes. Larger values use KB, MB, GB, TB, or PB
+// (powers of 1000) to match ParseDiskSpace decimal units. Exact multiples are
+// whole numbers. Other values use up to two decimal places with trailing zeros
+// trimmed.
+//
+// Parameters:
+//   - bytes: Size in bytes. Negative values are formatted with a leading minus.
+//
+// Returns:
+//   - string: Human-readable size such as "10 GB" or "512 B".
+func FormatDiskSpace(bytes int64) string {
+	if bytes < 0 {
+		return "-" + FormatDiskSpace(-bytes)
+	}
+
+	units := []struct {
+		suffix string
+		size   int64
+	}{
+		{"PB", petabyteMultiplier},
+		{"TB", terabyteMultiplier},
+		{"GB", gigabyteMultiplier},
+		{"MB", megabyteMultiplier},
+		{"KB", kilobyteMultiplier},
+	}
+
+	for _, unit := range units {
+		if bytes >= unit.size {
+			return formatDiskSpaceAmount(bytes, unit.size, unit.suffix)
+		}
+	}
+
+	return strconv.FormatInt(bytes, 10) + " B"
+}
+
+// formatDiskSpaceAmount formats bytes as a decimal quantity of the given unit.
+//
+// Parameters:
+//   - bytes: Size in bytes. Must be non-negative.
+//   - size: Unit multiplier in bytes.
+//   - suffix: Unit label such as "GB".
+//
+// Returns:
+//   - string: Quantity and unit separated by a space.
+func formatDiskSpaceAmount(bytes, size int64, suffix string) string {
+	if bytes%size == 0 {
+		return strconv.FormatInt(bytes/size, 10) + " " + suffix
+	}
+
+	formatted := strconv.FormatFloat(float64(bytes)/float64(size), 'f', 2, 64)
+	formatted = strings.TrimRight(formatted, "0")
+	formatted = strings.TrimRight(formatted, ".")
+
+	return formatted + " " + suffix
+}

--- a/internal/util/diskspace.go
+++ b/internal/util/diskspace.go
@@ -3,6 +3,7 @@ package util
 import (
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"strconv"
 	"strings"
@@ -228,6 +229,10 @@ func splitDiskSpaceValueAndUnit(size string) (string, string) {
 // Returns:
 //   - string: Human-readable size such as "10 GB" or "512 B".
 func FormatDiskSpace(bytes int64) string {
+	if bytes == math.MinInt64 {
+		return "-" + FormatDiskSpace(math.MaxInt64)
+	}
+
 	if bytes < 0 {
 		return "-" + FormatDiskSpace(-bytes)
 	}

--- a/internal/util/diskspace_test.go
+++ b/internal/util/diskspace_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -88,6 +89,7 @@ func TestFormatDiskSpace(t *testing.T) {
 		{name: "exact terabyte", bytes: 1_000_000_000_000, want: "1 TB"},
 		{name: "exact petabyte", bytes: 1_000_000_000_000_000, want: "1 PB"},
 		{name: "negative gigabyte", bytes: -10_000_000_000, want: "-10 GB"},
+		{name: "min int64", bytes: math.MinInt64, want: "-9223.37 PB"},
 	}
 
 	for _, tc := range tests {

--- a/internal/util/diskspace_test.go
+++ b/internal/util/diskspace_test.go
@@ -67,3 +67,34 @@ func TestParseDiskSpace(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatDiskSpace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		bytes int64
+		want  string
+	}{
+		{name: "zero", bytes: 0, want: "0 B"},
+		{name: "bytes", bytes: 512, want: "512 B"},
+		{name: "999 bytes", bytes: 999, want: "999 B"},
+		{name: "exact kilobyte", bytes: 1000, want: "1 KB"},
+		{name: "fractional kilobyte", bytes: 1536, want: "1.54 KB"},
+		{name: "exact megabyte", bytes: 2_000_000, want: "2 MB"},
+		{name: "exact gigabyte", bytes: 10_000_000_000, want: "10 GB"},
+		{name: "warning gigabytes", bytes: 8_000_000_000, want: "8 GB"},
+		{name: "decimal gigabyte", bytes: 1_500_000_000, want: "1.5 GB"},
+		{name: "exact terabyte", bytes: 1_000_000_000_000, want: "1 TB"},
+		{name: "exact petabyte", bytes: 1_000_000_000_000_000, want: "1 PB"},
+		{name: "negative gigabyte", bytes: -10_000_000_000, want: "-10 GB"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, FormatDiskSpace(tc.bytes))
+		})
+	}
+}

--- a/pkg/notifications/common_templates.go
+++ b/pkg/notifications/common_templates.go
@@ -64,13 +64,13 @@ var commonTemplates = map[string]string{
 {{- else if eq $msg "Only checking containers in scope" -}}
     Only checking containers in scope: {{index $e.Data "scope"}}
 {{- else if eq $msg "Docker image usage exceeds configured maximum" -}}
-    Docker image usage exceeds configured maximum: {{if HasKey $e.Data "usage"}}{{index $e.Data "usage"}}{{else}}unknown{{end}}/{{if HasKey $e.Data "max"}}{{index $e.Data "max"}}{{else}}unknown{{end}} bytes used (reclaimable {{if HasKey $e.Data "reclaimable"}}{{index $e.Data "reclaimable"}}{{else}}unknown{{end}}, {{if HasKey $e.Data "image_count"}}{{index $e.Data "image_count"}}{{else}}unknown{{end}} images)
+    Docker image usage exceeds configured maximum: {{if HasKey $e.Data "usage"}}{{FormatDiskSpace (index $e.Data "usage")}}{{else}}unknown{{end}} of {{if HasKey $e.Data "max"}}{{FormatDiskSpace (index $e.Data "max")}}{{else}}unknown{{end}} used ({{if HasKey $e.Data "reclaimable"}}{{FormatDiskSpace (index $e.Data "reclaimable")}}{{else}}unknown{{end}} reclaimable, {{if HasKey $e.Data "image_count"}}{{index $e.Data "image_count"}}{{else}}unknown{{end}} images)
 {{- else if eq $msg "Docker image usage exceeds configured warning threshold" -}}
-    Docker image usage exceeds configured warning threshold: {{if HasKey $e.Data "usage"}}{{index $e.Data "usage"}}{{else}}unknown{{end}}/{{if HasKey $e.Data "warn"}}{{index $e.Data "warn"}}{{else}}unknown{{end}} bytes used (reclaimable {{if HasKey $e.Data "reclaimable"}}{{index $e.Data "reclaimable"}}{{else}}unknown{{end}}, {{if HasKey $e.Data "image_count"}}{{index $e.Data "image_count"}}{{else}}unknown{{end}} images)
+    Docker image usage exceeds configured warning threshold: {{if HasKey $e.Data "usage"}}{{FormatDiskSpace (index $e.Data "usage")}}{{else}}unknown{{end}} of {{if HasKey $e.Data "warn"}}{{FormatDiskSpace (index $e.Data "warn")}}{{else}}unknown{{end}} used ({{if HasKey $e.Data "reclaimable"}}{{FormatDiskSpace (index $e.Data "reclaimable")}}{{else}}unknown{{end}} reclaimable, {{if HasKey $e.Data "image_count"}}{{index $e.Data "image_count"}}{{else}}unknown{{end}} images)
 {{- else if eq $msg "Failed to query Docker image disk usage" -}}
     Failed to query Docker image disk usage{{with (index $e.Data "error")}}: {{.}}{{end}}
 {{- else if eq $msg "Docker image usage budget enabled" -}}
-    Docker image usage budget enabled: max {{if HasKey $e.Data "disk_space_max"}}{{index $e.Data "disk_space_max"}}{{else}}0{{end}} bytes, warn {{if HasKey $e.Data "disk_space_warn"}}{{index $e.Data "disk_space_warn"}}{{else}}0{{end}} bytes
+    Docker image usage budget enabled: maximum {{if HasKey $e.Data "disk_space_max"}}{{FormatDiskSpace (index $e.Data "disk_space_max")}}{{else}}0 B{{end}}, warning at {{if HasKey $e.Data "disk_space_warn"}}{{FormatDiskSpace (index $e.Data "disk_space_warn")}}{{else}}0 B{{end}}
 {{- else if $e.Data -}}
     {{- /* For messages with data, show message and key=value pairs */ -}}
     {{$msg}} | {{range $k, $v := $e.Data}}{{$k}}={{$v}} {{end}}

--- a/pkg/notifications/funcs.go
+++ b/pkg/notifications/funcs.go
@@ -109,7 +109,7 @@ func int64FromAny(value any) (int64, bool) {
 
 		return int64(typed), true
 	case float64:
-		if typed > math.MaxInt64 || typed < math.MinInt64 {
+		if math.IsNaN(typed) || typed >= float64(math.MaxInt64) || typed < float64(math.MinInt64) {
 			return 0, false
 		}
 

--- a/pkg/notifications/funcs.go
+++ b/pkg/notifications/funcs.go
@@ -3,12 +3,15 @@ package notifications
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"text/template"
 	"time"
 
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+
+	"github.com/nicholas-fedor/watchtower/internal/util"
 )
 
 // Funcs defines utility functions for notification templates.
@@ -20,6 +23,7 @@ var Funcs = template.FuncMap{
 	"Title":           cases.Title(language.AmericanEnglish).String,
 	"RFC1123":         formatRFC1123,
 	"HasKey":          hasKey,
+	"FormatDiskSpace": formatDiskSpace,
 }
 
 // hasKey reports whether key is present in m.
@@ -61,4 +65,63 @@ func formatRFC1123(value string) string {
 	}
 
 	return timestamp.Format(time.RFC1123)
+}
+
+// formatDiskSpace formats a template value as a human-readable disk size.
+//
+// Numeric values use decimal units from util.FormatDiskSpace. Non-numeric
+// values, including nil, return "unknown".
+//
+// Parameters:
+//   - value: Template value, typically an int64 byte count from log data.
+//
+// Returns:
+//   - string: Human-readable size such as "10 GB", or "unknown".
+func formatDiskSpace(value any) string {
+	bytes, ok := int64FromAny(value)
+	if !ok {
+		return "unknown"
+	}
+
+	return util.FormatDiskSpace(bytes)
+}
+
+// int64FromAny converts common numeric template values to int64.
+//
+// Parameters:
+//   - value: Value from log data or JSON decoding.
+//
+// Returns:
+//   - int64: Converted integer when the value is a supported numeric type.
+//   - bool: False when the value is missing, non-numeric, or out of range.
+func int64FromAny(value any) (int64, bool) {
+	switch typed := value.(type) {
+	case int:
+		return int64(typed), true
+	case int32:
+		return int64(typed), true
+	case int64:
+		return typed, true
+	case uint64:
+		if typed > math.MaxInt64 {
+			return 0, false
+		}
+
+		return int64(typed), true
+	case float64:
+		if typed > math.MaxInt64 || typed < math.MinInt64 {
+			return 0, false
+		}
+
+		return int64(typed), true
+	case json.Number:
+		parsed, err := typed.Int64()
+		if err != nil {
+			return 0, false
+		}
+
+		return parsed, true
+	default:
+		return 0, false
+	}
 }

--- a/pkg/notifications/funcs_test.go
+++ b/pkg/notifications/funcs_test.go
@@ -24,6 +24,8 @@ func TestFormatDiskSpace(t *testing.T) {
 		{name: "nil", value: nil, want: "unknown"},
 		{name: "string", value: "10GB", want: "unknown"},
 		{name: "uint64 overflow", value: uint64(math.MaxInt64) + 1, want: "unknown"},
+		{name: "float64 nan", value: math.NaN(), want: "unknown"},
+		{name: "float64 max int64", value: float64(1 << 63), want: "unknown"},
 	}
 
 	for _, tc := range tests {

--- a/pkg/notifications/funcs_test.go
+++ b/pkg/notifications/funcs_test.go
@@ -1,0 +1,36 @@
+package notifications
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatDiskSpace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{name: "int64 gigabytes", value: int64(10_000_000_000), want: "10 GB"},
+		{name: "int megabytes", value: 2_000_000, want: "2 MB"},
+		{name: "float64 gigabytes", value: float64(8_000_000_000), want: "8 GB"},
+		{name: "json number", value: json.Number("40000000000"), want: "40 GB"},
+		{name: "zero", value: int64(0), want: "0 B"},
+		{name: "nil", value: nil, want: "unknown"},
+		{name: "string", value: "10GB", want: "unknown"},
+		{name: "uint64 overflow", value: uint64(math.MaxInt64) + 1, want: "unknown"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, formatDiskSpace(tc.value))
+		})
+	}
+}

--- a/pkg/notifications/shoutrrr_test.go
+++ b/pkg/notifications/shoutrrr_test.go
@@ -337,19 +337,19 @@ updt1 (mock/updt1:latest): Updated
 				s, err := shoutrrr.buildMessage(Data{Entries: entries})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(s).To(gomega.ContainSubstring(
-					"Docker image usage exceeds configured maximum: 10000/10000 bytes used (reclaimable 2000, 4 images)",
+					"Docker image usage exceeds configured maximum: 10 KB of 10 KB used (2 KB reclaimable, 4 images)",
 				))
 				gomega.Expect(s).To(gomega.ContainSubstring(
-					"Docker image usage exceeds configured warning threshold: 8000/8000 bytes used (reclaimable 2000, 4 images)",
+					"Docker image usage exceeds configured warning threshold: 8 KB of 8 KB used (2 KB reclaimable, 4 images)",
 				))
 				gomega.Expect(s).To(gomega.ContainSubstring(
 					"Failed to query Docker image disk usage: df unavailable",
 				))
 				gomega.Expect(s).To(gomega.ContainSubstring(
-					"Docker image usage budget enabled: max 40000000000 bytes, warn 32000000000 bytes",
+					"Docker image usage budget enabled: maximum 40 GB, warning at 32 GB",
 				))
 				gomega.Expect(s).To(gomega.ContainSubstring(
-					"Docker image usage exceeds configured maximum: 0/0 bytes used (reclaimable 0, 0 images)",
+					"Docker image usage exceeds configured maximum: 0 B of 0 B used (0 B reclaimable, 0 images)",
 				))
 				gomega.Expect(s).NotTo(gomega.ContainSubstring("unknown"))
 				gomega.Expect(s).NotTo(gomega.ContainSubstring(" | "))

--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -1038,7 +1038,7 @@ func ExtractHeadDigest(log *zerolog.Logger, resp *http.Response) (string, error)
 	digest := resp.Header.Get(ContentDigestHeader)
 	if digest == "" {
 		// Log and return an error if the digest is missing, including auth details for debugging.
-		wwwAuthHeader := resp.Header.Get("www-authenticate")
+		wwwAuthHeader := resp.Header.Get("WWW-Authenticate")
 		log.Debug().
 			Str("status", resp.Status).
 			Str("auth_header", wwwAuthHeader).

--- a/pkg/registry/digest/digest_integration_test.go
+++ b/pkg/registry/digest/digest_integration_test.go
@@ -120,7 +120,7 @@ var _ = ginkgo.Describe("Digests", func() {
 			return "", fmt.Errorf(
 				"registry responded with invalid HEAD request: status %q, auth: %q",
 				resp.Status,
-				resp.Header.Get("Www-Authenticate"),
+				resp.Header.Get("WWW-Authenticate"),
 			)
 		}
 

--- a/tools/tplprev/internal/preview/render_test.go
+++ b/tools/tplprev/internal/preview/render_test.go
@@ -79,7 +79,7 @@ func TestRenderDefaultLegacyDiskSpaceMessages(t *testing.T) {
 	assert.Contains(
 		t,
 		result,
-		"Docker image usage exceeds configured maximum: 32000000000/40000000000 bytes used (reclaimable 4000000000, 12 images)",
+		"Docker image usage exceeds configured maximum: 32 GB of 40 GB used (4 GB reclaimable, 12 images)",
 	)
 	assert.Contains(t, result, "Failed to query Docker image disk usage: daemon disk usage unavailable")
 	assert.NotContains(t, result, " | ")

--- a/tools/tplprev/internal/templates/funcs.go
+++ b/tools/tplprev/internal/templates/funcs.go
@@ -172,7 +172,7 @@ func int64FromAny(value any) (int64, bool) {
 
 		return int64(typed), true
 	case float64:
-		if typed > math.MaxInt64 || typed < math.MinInt64 {
+		if math.IsNaN(typed) || typed >= float64(math.MaxInt64) || typed < float64(math.MinInt64) {
 			return 0, false
 		}
 
@@ -197,6 +197,10 @@ func int64FromAny(value any) (int64, bool) {
 // Returns:
 //   - string: Human-readable size such as "10 GB" or "512 B".
 func formatDiskSpaceBytes(bytes int64) string {
+	if bytes == math.MinInt64 {
+		return "-" + formatDiskSpaceBytes(math.MaxInt64)
+	}
+
 	if bytes < 0 {
 		return "-" + formatDiskSpaceBytes(-bytes)
 	}

--- a/tools/tplprev/internal/templates/funcs.go
+++ b/tools/tplprev/internal/templates/funcs.go
@@ -4,6 +4,8 @@ package templates
 import (
 	"encoding/json"
 	"fmt"
+	"math"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -12,6 +14,14 @@ import (
 	"golang.org/x/text/language"
 
 	"github.com/nicholas-fedor/tplprev/internal/report"
+)
+
+const (
+	kilobyteMultiplier int64 = 1000
+	megabyteMultiplier       = 1000 * kilobyteMultiplier
+	gigabyteMultiplier       = 1000 * megabyteMultiplier
+	terabyteMultiplier       = 1000 * gigabyteMultiplier
+	petabyteMultiplier       = 1000 * terabyteMultiplier
 )
 
 // Funcs defines a set of utility functions for use in notification templates.
@@ -23,6 +33,7 @@ var Funcs = template.FuncMap{
 	"Title":           cases.Title(language.AmericanEnglish).String,
 	"RFC1123":         formatRFC1123,
 	"HasKey":          hasKey,
+	"FormatDiskSpace": formatDiskSpace,
 }
 
 // hasKey reports whether key is present in m.
@@ -120,4 +131,100 @@ func formatRFC1123(value string) string {
 	}
 
 	return timestamp.Format(time.RFC1123)
+}
+
+// formatDiskSpace formats a template value as a human-readable disk size.
+//
+// Parameters:
+//   - value: Template value, typically an int64 byte count from log data.
+//
+// Returns:
+//   - string: Human-readable size such as "10 GB", or "unknown".
+func formatDiskSpace(value any) string {
+	bytes, ok := int64FromAny(value)
+	if !ok {
+		return "unknown"
+	}
+
+	return formatDiskSpaceBytes(bytes)
+}
+
+// int64FromAny converts common numeric template values to int64.
+//
+// Parameters:
+//   - value: Value from log data or JSON decoding.
+//
+// Returns:
+//   - int64: Converted integer when the value is a supported numeric type.
+//   - bool: False when the value is missing, non-numeric, or out of range.
+func int64FromAny(value any) (int64, bool) {
+	switch typed := value.(type) {
+	case int:
+		return int64(typed), true
+	case int32:
+		return int64(typed), true
+	case int64:
+		return typed, true
+	case uint64:
+		if typed > math.MaxInt64 {
+			return 0, false
+		}
+
+		return int64(typed), true
+	case float64:
+		if typed > math.MaxInt64 || typed < math.MinInt64 {
+			return 0, false
+		}
+
+		return int64(typed), true
+	case json.Number:
+		parsed, err := typed.Int64()
+		if err != nil {
+			return 0, false
+		}
+
+		return parsed, true
+	default:
+		return 0, false
+	}
+}
+
+// formatDiskSpaceBytes formats a byte count as a compact decimal size string.
+//
+// Parameters:
+//   - bytes: Size in bytes. Negative values are formatted with a leading minus.
+//
+// Returns:
+//   - string: Human-readable size such as "10 GB" or "512 B".
+func formatDiskSpaceBytes(bytes int64) string {
+	if bytes < 0 {
+		return "-" + formatDiskSpaceBytes(-bytes)
+	}
+
+	units := []struct {
+		suffix string
+		size   int64
+	}{
+		{"PB", petabyteMultiplier},
+		{"TB", terabyteMultiplier},
+		{"GB", gigabyteMultiplier},
+		{"MB", megabyteMultiplier},
+		{"KB", kilobyteMultiplier},
+	}
+
+	for _, unit := range units {
+		if bytes >= unit.size {
+			if bytes%unit.size == 0 {
+				return strconv.FormatInt(bytes/unit.size, 10) + " " + unit.suffix
+			}
+
+			formatted := strconv.FormatFloat(float64(bytes)/float64(unit.size), 'f', 2, 64)
+			formatted = strings.TrimRight(formatted, "0")
+			formatted = strings.TrimRight(formatted, ".")
+
+			return formatted + " " + unit.suffix
+		}
+	}
+
+	return strconv.FormatInt(bytes, 10) + " B"
 }

--- a/tools/tplprev/internal/templates/funcs_test.go
+++ b/tools/tplprev/internal/templates/funcs_test.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,9 @@ func TestFormatDiskSpace(t *testing.T) {
 	assert.Equal(t, "10 GB", formatDiskSpace(int64(10_000_000_000)))
 	assert.Equal(t, "0 B", formatDiskSpace(int64(0)))
 	assert.Equal(t, "unknown", formatDiskSpace(nil))
+	assert.Equal(t, "unknown", formatDiskSpace(math.NaN()))
+	assert.Equal(t, "unknown", formatDiskSpace(float64(1<<63)))
+	assert.Equal(t, "-9223.37 PB", formatDiskSpace(int64(math.MinInt64)))
 }
 
 func TestFormatRFC1123(t *testing.T) {

--- a/tools/tplprev/internal/templates/funcs_test.go
+++ b/tools/tplprev/internal/templates/funcs_test.go
@@ -23,6 +23,14 @@ func TestToJSON(t *testing.T) {
 	assert.Contains(t, got, `"title": "Title"`)
 }
 
+func TestFormatDiskSpace(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "10 GB", formatDiskSpace(int64(10_000_000_000)))
+	assert.Equal(t, "0 B", formatDiskSpace(int64(0)))
+	assert.Equal(t, "unknown", formatDiskSpace(nil))
+}
+
 func TestFormatRFC1123(t *testing.T) {
 	t.Parallel()
 

--- a/tools/tplprev/internal/templates/templates.go
+++ b/tools/tplprev/internal/templates/templates.go
@@ -50,13 +50,13 @@ var Templates = map[string]string{
 {{- else if eq $msg "Only checking containers in scope" -}}
     Only checking containers in scope: {{index $e.Data "scope"}}
 {{- else if eq $msg "Docker image usage exceeds configured maximum" -}}
-    Docker image usage exceeds configured maximum: {{if HasKey $e.Data "usage"}}{{index $e.Data "usage"}}{{else}}unknown{{end}}/{{if HasKey $e.Data "max"}}{{index $e.Data "max"}}{{else}}unknown{{end}} bytes used (reclaimable {{if HasKey $e.Data "reclaimable"}}{{index $e.Data "reclaimable"}}{{else}}unknown{{end}}, {{if HasKey $e.Data "image_count"}}{{index $e.Data "image_count"}}{{else}}unknown{{end}} images)
+    Docker image usage exceeds configured maximum: {{if HasKey $e.Data "usage"}}{{FormatDiskSpace (index $e.Data "usage")}}{{else}}unknown{{end}} of {{if HasKey $e.Data "max"}}{{FormatDiskSpace (index $e.Data "max")}}{{else}}unknown{{end}} used ({{if HasKey $e.Data "reclaimable"}}{{FormatDiskSpace (index $e.Data "reclaimable")}}{{else}}unknown{{end}} reclaimable, {{if HasKey $e.Data "image_count"}}{{index $e.Data "image_count"}}{{else}}unknown{{end}} images)
 {{- else if eq $msg "Docker image usage exceeds configured warning threshold" -}}
-    Docker image usage exceeds configured warning threshold: {{if HasKey $e.Data "usage"}}{{index $e.Data "usage"}}{{else}}unknown{{end}}/{{if HasKey $e.Data "warn"}}{{index $e.Data "warn"}}{{else}}unknown{{end}} bytes used (reclaimable {{if HasKey $e.Data "reclaimable"}}{{index $e.Data "reclaimable"}}{{else}}unknown{{end}}, {{if HasKey $e.Data "image_count"}}{{index $e.Data "image_count"}}{{else}}unknown{{end}} images)
+    Docker image usage exceeds configured warning threshold: {{if HasKey $e.Data "usage"}}{{FormatDiskSpace (index $e.Data "usage")}}{{else}}unknown{{end}} of {{if HasKey $e.Data "warn"}}{{FormatDiskSpace (index $e.Data "warn")}}{{else}}unknown{{end}} used ({{if HasKey $e.Data "reclaimable"}}{{FormatDiskSpace (index $e.Data "reclaimable")}}{{else}}unknown{{end}} reclaimable, {{if HasKey $e.Data "image_count"}}{{index $e.Data "image_count"}}{{else}}unknown{{end}} images)
 {{- else if eq $msg "Failed to query Docker image disk usage" -}}
     Failed to query Docker image disk usage{{with (index $e.Data "error")}}: {{.}}{{end}}
 {{- else if eq $msg "Docker image usage budget enabled" -}}
-    Docker image usage budget enabled: max {{if HasKey $e.Data "disk_space_max"}}{{index $e.Data "disk_space_max"}}{{else}}0{{end}} bytes, warn {{if HasKey $e.Data "disk_space_warn"}}{{index $e.Data "disk_space_warn"}}{{else}}0{{end}} bytes
+    Docker image usage budget enabled: maximum {{if HasKey $e.Data "disk_space_max"}}{{FormatDiskSpace (index $e.Data "disk_space_max")}}{{else}}0 B{{end}}, warning at {{if HasKey $e.Data "disk_space_warn"}}{{FormatDiskSpace (index $e.Data "disk_space_warn")}}{{else}}0 B{{end}}
 {{- else if $e.Data -}}
     {{- /* For messages with data, show message and key=value pairs */ -}}
     {{$msg}} | {{range $k, $v := $e.Data}}{{$k}}={{$v}} {{end}}


### PR DESCRIPTION
This PR makes disk-usage notifications show sizes in human-readable units instead of raw byte counts. Budget, warning, and exceeded-max messages now use decimal units, and custom templates can format sizes with FormatDiskSpace.

An unrelated digest HEAD lookup spelling change to WWW-Authenticate is included. Header.Get remains case-insensitive.

## Problem

Disk-usage notifications printed unformatted byte counts, for example `max 10000000000 bytes, warn 8000000000 bytes`.

## Solution

Add a decimal size formatter and use it in the default-legacy template so notification text matches how disk-space options are configured.

## Changes

- Format budget, warning, and exceeded-max notification sizes as compact decimal units
- Add FormatDiskSpace for notification templates and util.FormatDiskSpace for byte formatting
- Mirror the helper and default-legacy template in the template preview tool
- Update notification template examples