### PR TITLE
fix(container): match network_mode links across Compose projects

### DIFF
--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -851,11 +851,12 @@ func UpdateImplicitRestart(log *zerolog.Logger, allContainers,
 	byID := make(map[types.ContainerID]types.Container, len(allContainers))
 
 	// Key restart tracking by the canonical identifier (ResolveContainerIdentifier)
-	// so that links produced by c.Links() can be matched directly. We also record
-	// the bare .Name() as an alias to improve exact-match resilience across
-	// different naming conventions (explicit container_name vs. Compose defaults,
-	// with or without replica suffixes).
-	restartByIdentifier := make(map[string]bool, len(allContainers)+len(allContainers))
+	// so that links produced by c.Links() can be matched directly. Also record
+	// the bare Name() and the Docker ID. Inspect stores network_mode as
+	// container:<id> until list rewrite turns that into a name.
+	const restartIndexCapacityFactor = 3
+
+	restartByIdentifier := make(map[string]bool, len(allContainers)*restartIndexCapacityFactor)
 
 	for _, c := range allContainers {
 		byID[c.ID()] = c
@@ -880,12 +881,17 @@ func UpdateImplicitRestart(log *zerolog.Logger, allContainers,
 
 		restartByIdentifier[resolvedID] = c.ToRestart()
 
-		// Also index by bare name for better exact matching in mixed scenarios
 		bareName := c.Name()
 		if bareName != "" && bareName != resolvedID {
-			_, exists := restartByIdentifier[bareName]
-			if !exists {
+			if _, exists := restartByIdentifier[bareName]; !exists {
 				restartByIdentifier[bareName] = c.ToRestart()
+			}
+		}
+
+		containerID := string(c.ID())
+		if containerID != "" && containerID != resolvedID && containerID != bareName {
+			if _, exists := restartByIdentifier[containerID]; !exists {
+				restartByIdentifier[containerID] = c.ToRestart()
 			}
 		}
 	}
@@ -1089,12 +1095,19 @@ func linkedIdentifierMarkedForRestart(log *zerolog.Logger, links []string,
 			}
 		}
 
-		if restartByIdentifier[link] {
-			log.Debug().
-				Str("found_restarting_identifier", link).
-				Msg("Found restarting linked container via exact match")
+		if restarting, exists := restartByIdentifier[link]; exists {
+			if restarting {
+				log.Debug().
+					Str("found_restarting_identifier", link).
+					Msg("Found restarting linked container via exact match")
 
-			return link
+				return link
+			}
+
+			// The named container exists and is not restarting. Do not
+			// suffix-match a different container that happens to end with
+			// this name.
+			continue
 		}
 
 		// Collect only the identifiers that are currently marked for restart.

--- a/internal/actions/update_dependencies_test.go
+++ b/internal/actions/update_dependencies_test.go
@@ -2235,6 +2235,150 @@ var _ = ginkgo.Describe("the update action", func() {
 					To(gomega.Equal([]string{"net-proxy", "web-app"}))
 			},
 		)
+
+		// Cross-project container_name: network_mode holds the provider's
+		// real name, which does not belong to the dependent's Compose project.
+		ginkgo.It(
+			"should stop and start cross-project network_mode peers in dependency order",
+			func() {
+				gluetun := mockActions.CreateMockContainerWithConfig(
+					"gluetun",
+					"/gluetun",
+					"gluetun:latest",
+					true,
+					false,
+					time.Now().AddDate(0, 0, -1),
+					&dockerContainer.Config{
+						Labels: map[string]string{
+							"com.docker.compose.project":            "gluetun",
+							"com.docker.compose.service":            "vpn",
+							"com.centurylinklabs.watchtower.enable": "true",
+						},
+						ExposedPorts: dockerNetwork.PortSet{},
+					},
+				)
+
+				qbittorrent := mockActions.CreateMockContainerWithConfig(
+					"qbittorrent",
+					"/qbittorrent",
+					"qbittorrent:latest",
+					true,
+					false,
+					time.Now().AddDate(0, 0, -1),
+					&dockerContainer.Config{
+						Labels: map[string]string{
+							"com.docker.compose.project":            "qbittorrent",
+							"com.docker.compose.service":            "app",
+							"com.centurylinklabs.watchtower.enable": "true",
+						},
+						ExposedPorts: dockerNetwork.PortSet{},
+					},
+				)
+				qbittorrent.ContainerInfo().HostConfig.NetworkMode = "container:gluetun"
+
+				client := mockActions.CreateMockClient(
+					&mockActions.TestData{
+						Containers: []types.Container{qbittorrent, gluetun},
+						Staleness: map[string]bool{
+							"qbittorrent": true,
+							"gluetun":     true,
+						},
+						StopOrder:   []string{},
+						CreateOrder: []string{},
+						StartOrder:  []string{},
+					},
+					false,
+					false,
+				)
+
+				report, _, err := actions.Update(testLogger(),
+					context.Background(),
+					client,
+					types.UpdateParams{Cleanup: true, CPUCopyMode: "auto"},
+				)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(report.Updated()).To(gomega.HaveLen(2))
+				gomega.Expect(gluetun.ToRestart()).To(gomega.BeTrue())
+				gomega.Expect(qbittorrent.ToRestart()).To(gomega.BeTrue())
+
+				gomega.Expect(client.TestData.StopOrder).
+					To(gomega.Equal([]string{"qbittorrent", "gluetun"}))
+				gomega.Expect(client.TestData.CreateOrder).
+					To(gomega.Equal([]string{"gluetun", "qbittorrent"}))
+			},
+		)
+
+		// Compose-default provider name: network_mode points at
+		// project-service-N rather than an explicit container_name.
+		ginkgo.It(
+			"should stop and start cross-project compose-default network_mode peers in dependency order",
+			func() {
+				gluetun := mockActions.CreateMockContainerWithConfig(
+					"gluetun-vpn-1",
+					"/gluetun-vpn-1",
+					"gluetun:latest",
+					true,
+					false,
+					time.Now().AddDate(0, 0, -1),
+					&dockerContainer.Config{
+						Labels: map[string]string{
+							"com.docker.compose.project":            "gluetun",
+							"com.docker.compose.service":            "vpn",
+							"com.centurylinklabs.watchtower.enable": "true",
+						},
+						ExposedPorts: dockerNetwork.PortSet{},
+					},
+				)
+
+				qbittorrent := mockActions.CreateMockContainerWithConfig(
+					"qbittorrent-app-1",
+					"/qbittorrent-app-1",
+					"qbittorrent:latest",
+					true,
+					false,
+					time.Now().AddDate(0, 0, -1),
+					&dockerContainer.Config{
+						Labels: map[string]string{
+							"com.docker.compose.project":            "qbittorrent",
+							"com.docker.compose.service":            "app",
+							"com.centurylinklabs.watchtower.enable": "true",
+						},
+						ExposedPorts: dockerNetwork.PortSet{},
+					},
+				)
+				qbittorrent.ContainerInfo().HostConfig.NetworkMode = "container:gluetun-vpn-1"
+
+				client := mockActions.CreateMockClient(
+					&mockActions.TestData{
+						Containers: []types.Container{qbittorrent, gluetun},
+						Staleness: map[string]bool{
+							"qbittorrent-app-1": true,
+							"gluetun-vpn-1":     true,
+						},
+						StopOrder:   []string{},
+						CreateOrder: []string{},
+						StartOrder:  []string{},
+					},
+					false,
+					false,
+				)
+
+				report, _, err := actions.Update(testLogger(),
+					context.Background(),
+					client,
+					types.UpdateParams{Cleanup: true, CPUCopyMode: "auto"},
+				)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(report.Updated()).To(gomega.HaveLen(2))
+				gomega.Expect(gluetun.ToRestart()).To(gomega.BeTrue())
+				gomega.Expect(qbittorrent.ToRestart()).To(gomega.BeTrue())
+
+				gomega.Expect(client.TestData.StopOrder).
+					To(gomega.Equal([]string{"qbittorrent-app-1", "gluetun-vpn-1"}))
+				gomega.Expect(client.TestData.CreateOrder).
+					To(gomega.Equal([]string{"gluetun-vpn-1", "qbittorrent-app-1"}))
+			},
+		)
 	})
 
 	ginkgo.When("handling cross-project dependencies", func() {

--- a/internal/actions/update_dependencies_test.go
+++ b/internal/actions/update_dependencies_test.go
@@ -2280,7 +2280,7 @@ var _ = ginkgo.Describe("the update action", func() {
 					&mockActions.TestData{
 						Containers: []types.Container{qbittorrent, gluetun},
 						Staleness: map[string]bool{
-							"qbittorrent": true,
+							"qbittorrent": false,
 							"gluetun":     true,
 						},
 						StopOrder:   []string{},
@@ -2297,7 +2297,7 @@ var _ = ginkgo.Describe("the update action", func() {
 					types.UpdateParams{Cleanup: true, CPUCopyMode: "auto"},
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(report.Updated()).To(gomega.HaveLen(2))
+				gomega.Expect(report.Updated()).To(gomega.HaveLen(1))
 				gomega.Expect(gluetun.ToRestart()).To(gomega.BeTrue())
 				gomega.Expect(qbittorrent.ToRestart()).To(gomega.BeTrue())
 
@@ -2352,7 +2352,7 @@ var _ = ginkgo.Describe("the update action", func() {
 					&mockActions.TestData{
 						Containers: []types.Container{qbittorrent, gluetun},
 						Staleness: map[string]bool{
-							"qbittorrent-app-1": true,
+							"qbittorrent-app-1": false,
 							"gluetun-vpn-1":     true,
 						},
 						StopOrder:   []string{},
@@ -2369,7 +2369,7 @@ var _ = ginkgo.Describe("the update action", func() {
 					types.UpdateParams{Cleanup: true, CPUCopyMode: "auto"},
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(report.Updated()).To(gomega.HaveLen(2))
+				gomega.Expect(report.Updated()).To(gomega.HaveLen(1))
 				gomega.Expect(gluetun.ToRestart()).To(gomega.BeTrue())
 				gomega.Expect(qbittorrent.ToRestart()).To(gomega.BeTrue())
 

--- a/internal/actions/update_dependencies_test.go
+++ b/internal/actions/update_dependencies_test.go
@@ -2379,6 +2379,102 @@ var _ = ginkgo.Describe("the update action", func() {
 					To(gomega.Equal([]string{"gluetun-vpn-1", "qbittorrent-app-1"}))
 			},
 		)
+
+		// Provider image is stale, dependents are not. Implicit restart must
+		// still pull them into the update and stop them before the provider.
+		ginkgo.It(
+			"should restart multiple cross-project network_mode dependents when the provider is stale",
+			func() {
+				gluetun := mockActions.CreateMockContainerWithConfig(
+					"gluetun",
+					"/gluetun",
+					"gluetun:latest",
+					true,
+					false,
+					time.Now().AddDate(0, 0, -1),
+					&dockerContainer.Config{
+						Labels: map[string]string{
+							"com.docker.compose.project":            "gluetun",
+							"com.docker.compose.service":            "vpn",
+							"com.centurylinklabs.watchtower.enable": "true",
+						},
+						ExposedPorts: dockerNetwork.PortSet{},
+					},
+				)
+
+				qbittorrent := mockActions.CreateMockContainerWithConfig(
+					"qbittorrent",
+					"/qbittorrent",
+					"qbittorrent:latest",
+					true,
+					false,
+					time.Now(),
+					&dockerContainer.Config{
+						Labels: map[string]string{
+							"com.docker.compose.project":            "qbittorrent",
+							"com.docker.compose.service":            "app",
+							"com.centurylinklabs.watchtower.enable": "true",
+						},
+						ExposedPorts: dockerNetwork.PortSet{},
+					},
+				)
+				qbittorrent.ContainerInfo().HostConfig.NetworkMode = "container:gluetun"
+
+				prowlarr := mockActions.CreateMockContainerWithConfig(
+					"prowlarr",
+					"/prowlarr",
+					"prowlarr:latest",
+					true,
+					false,
+					time.Now(),
+					&dockerContainer.Config{
+						Labels: map[string]string{
+							"com.docker.compose.project":            "prowlarr",
+							"com.docker.compose.service":            "app",
+							"com.centurylinklabs.watchtower.enable": "true",
+						},
+						ExposedPorts: dockerNetwork.PortSet{},
+					},
+				)
+				prowlarr.ContainerInfo().HostConfig.NetworkMode = "container:/gluetun"
+
+				client := mockActions.CreateMockClient(
+					&mockActions.TestData{
+						Containers: []types.Container{qbittorrent, prowlarr, gluetun},
+						Staleness: map[string]bool{
+							"qbittorrent": false,
+							"prowlarr":    false,
+							"gluetun":     true,
+						},
+						StopOrder:   []string{},
+						CreateOrder: []string{},
+						StartOrder:  []string{},
+					},
+					false,
+					false,
+				)
+
+				report, _, err := actions.Update(testLogger(),
+					context.Background(),
+					client,
+					types.UpdateParams{Cleanup: true, CPUCopyMode: "auto"},
+				)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(report.Updated()).To(gomega.HaveLen(1))
+				gomega.Expect(gluetun.ToRestart()).To(gomega.BeTrue())
+				gomega.Expect(qbittorrent.ToRestart()).To(gomega.BeTrue())
+				gomega.Expect(prowlarr.ToRestart()).To(gomega.BeTrue())
+
+				gomega.Expect(client.TestData.StopOrder).To(gomega.HaveLen(3))
+				gomega.Expect(client.TestData.StopOrder[2]).To(gomega.Equal("gluetun"))
+				gomega.Expect(client.TestData.StopOrder).
+					To(gomega.ContainElements("qbittorrent", "prowlarr"))
+				gomega.Expect(client.TestData.CreateOrder).To(gomega.HaveLen(3))
+				gomega.Expect(client.TestData.CreateOrder[0]).To(gomega.Equal("gluetun"))
+				gomega.Expect(client.TestData.CreateOrder).
+					To(gomega.ContainElements("qbittorrent", "prowlarr"))
+			},
+		)
 	})
 
 	ginkgo.When("handling cross-project dependencies", func() {

--- a/internal/actions/update_dependencies_test.go
+++ b/internal/actions/update_dependencies_test.go
@@ -2380,6 +2380,82 @@ var _ = ginkgo.Describe("the update action", func() {
 			},
 		)
 
+		// Inspect stores container:<id> until list rewrite. Matching and
+		// sort order must still work on that form.
+		ginkgo.It(
+			"should stop and start cross-project network_mode peers referenced by container ID",
+			func() {
+				const providerID = "25e75393800b5c450a6841212a3b92ed28fa35414a586dec9f2c8a520d4910c2"
+
+				gluetun := mockActions.CreateMockContainerWithConfig(
+					providerID,
+					"/gluetun",
+					"gluetun:latest",
+					true,
+					false,
+					time.Now().AddDate(0, 0, -1),
+					&dockerContainer.Config{
+						Labels: map[string]string{
+							"com.docker.compose.project":            "gluetun",
+							"com.docker.compose.service":            "vpn",
+							"com.centurylinklabs.watchtower.enable": "true",
+						},
+						ExposedPorts: dockerNetwork.PortSet{},
+					},
+				)
+
+				qbittorrent := mockActions.CreateMockContainerWithConfig(
+					"qbittorrent",
+					"/qbittorrent",
+					"qbittorrent:latest",
+					true,
+					false,
+					time.Now(),
+					&dockerContainer.Config{
+						Labels: map[string]string{
+							"com.docker.compose.project":            "qbittorrent",
+							"com.docker.compose.service":            "app",
+							"com.centurylinklabs.watchtower.enable": "true",
+						},
+						ExposedPorts: dockerNetwork.PortSet{},
+					},
+				)
+				qbittorrent.ContainerInfo().HostConfig.NetworkMode = dockerContainer.NetworkMode(
+					"container:" + providerID,
+				)
+
+				client := mockActions.CreateMockClient(
+					&mockActions.TestData{
+						Containers: []types.Container{qbittorrent, gluetun},
+						Staleness: map[string]bool{
+							"qbittorrent": false,
+							"gluetun":     true,
+						},
+						StopOrder:   []string{},
+						CreateOrder: []string{},
+						StartOrder:  []string{},
+					},
+					false,
+					false,
+				)
+
+				report, _, err := actions.Update(testLogger(),
+					context.Background(),
+					client,
+					types.UpdateParams{Cleanup: true, CPUCopyMode: "auto"},
+				)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(report.Updated()).To(gomega.HaveLen(1))
+				gomega.Expect(gluetun.ToRestart()).To(gomega.BeTrue())
+				gomega.Expect(qbittorrent.ToRestart()).To(gomega.BeTrue())
+
+				gomega.Expect(client.TestData.StopOrder).
+					To(gomega.Equal([]string{"qbittorrent", "gluetun"}))
+				gomega.Expect(client.TestData.CreateOrder).
+					To(gomega.Equal([]string{"gluetun", "qbittorrent"}))
+			},
+		)
+
 		// Provider image is stale, dependents are not. Implicit restart must
 		// still pull them into the update and stop them before the provider.
 		ginkgo.It(

--- a/internal/actions/update_restart_test.go
+++ b/internal/actions/update_restart_test.go
@@ -15,9 +15,43 @@ import (
 	"github.com/nicholas-fedor/watchtower/internal/actions"
 	mockActions "github.com/nicholas-fedor/watchtower/internal/actions/mocks"
 	"github.com/nicholas-fedor/watchtower/internal/metrics"
+	"github.com/nicholas-fedor/watchtower/pkg/container"
 	"github.com/nicholas-fedor/watchtower/pkg/filters"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
+
+// createNetworkModeContainer builds a container that joins another container's
+// network namespace, with Compose project and service labels applied.
+func createNetworkModeContainer(
+	id, name, project, service, networkMode string,
+) types.Container {
+	hostConfig := &dockerContainer.HostConfig{
+		PortBindings: dockerNetwork.PortMap{},
+	}
+	if networkMode != "" {
+		hostConfig.NetworkMode = dockerContainer.NetworkMode(networkMode)
+	}
+
+	content := dockerContainer.InspectResponse{
+		ID:    id,
+		Image: "image:latest",
+		Name:  name,
+		State: &dockerContainer.State{Running: true},
+		Created: time.Now().
+			AddDate(0, 0, -1).
+			Format(time.RFC3339Nano),
+		HostConfig: hostConfig,
+		Config: &dockerContainer.Config{
+			Labels: map[string]string{
+				"com.docker.compose.project": project,
+				"com.docker.compose.service": service,
+			},
+			ExposedPorts: dockerNetwork.PortSet{},
+		},
+	}
+
+	return container.NewContainer(nil, &content, mockActions.CreateMockImageInfo("image:latest"))
+}
 
 // createStaleContainersForTest creates two stale containers and returns them along with TestData.
 // This is a helper function used by tests that need to set up containers for rolling restart scenarios.
@@ -780,6 +814,27 @@ var _ = ginkgo.Describe("the update action", func() {
 				gomega.Expect(dep1.ToRestart()).To(gomega.BeTrue())
 				gomega.Expect(dep2.ToRestart()).To(gomega.BeTrue())
 				gomega.Expect(dep3.ToRestart()).To(gomega.BeTrue())
+			})
+
+			ginkgo.It("marks a container sharing a network namespace across Compose projects", func() {
+				// gluetun and qbittorrent are separate Compose projects, which is
+				// the usual layout when one VPN container is shared between
+				// several stacks.
+				gluetun := createNetworkModeContainer(
+					"gluetun-id", "/gluetun", "gluetun", "app", "",
+				)
+				qbittorrent := createNetworkModeContainer(
+					"qbittorrent-id", "/qbittorrent", "qbittorrent", "app",
+					"container:gluetun",
+				)
+
+				containers := []types.Container{gluetun, qbittorrent}
+				gluetun.SetStale(true)
+
+				actions.UpdateImplicitRestart(testLogger(), containers, containers, true)
+
+				gomega.Expect(gluetun.ToRestart()).To(gomega.BeTrue())
+				gomega.Expect(qbittorrent.ToRestart()).To(gomega.BeTrue())
 			})
 
 			ginkgo.It("should handle restarted containers with circular dependencies", func() {

--- a/internal/actions/update_restart_test.go
+++ b/internal/actions/update_restart_test.go
@@ -837,6 +837,50 @@ var _ = ginkgo.Describe("the update action", func() {
 				gomega.Expect(qbittorrent.ToRestart()).To(gomega.BeTrue())
 			})
 
+			ginkgo.It("marks a dependent whose network mode still references the provider ID", func() {
+				// Moby inspect stores container:<id> until Watchtower rewrites
+				// it to a name. Matching must accept the ID form as well.
+				const providerID = "25e75393800b5c450a6841212a3b92ed28fa35414a586dec9f2c8a520d4910c2"
+
+				gluetun := createNetworkModeContainer(
+					providerID, "/gluetun", "gluetun", "app", "",
+				)
+				qbittorrent := createNetworkModeContainer(
+					"qbittorrent-id", "/qbittorrent", "qbittorrent", "app",
+					"container:"+providerID,
+				)
+
+				containers := []types.Container{gluetun, qbittorrent}
+				gluetun.SetStale(true)
+
+				actions.UpdateImplicitRestart(testLogger(), containers, containers, true)
+
+				gomega.Expect(gluetun.ToRestart()).To(gomega.BeTrue())
+				gomega.Expect(qbittorrent.ToRestart()).To(gomega.BeTrue())
+			})
+
+			ginkgo.It("does not treat a project-prefixed peer name as the network provider", func() {
+				gluetun := createNetworkModeContainer(
+					"gluetun-id", "/gluetun", "gluetun", "app", "",
+				)
+				decoy := createNetworkModeContainer(
+					"decoy-id", "/qbittorrent-gluetun", "other", "svc", "",
+				)
+				qbittorrent := createNetworkModeContainer(
+					"qbittorrent-id", "/qbittorrent", "qbittorrent", "app",
+					"container:gluetun",
+				)
+
+				containers := []types.Container{gluetun, decoy, qbittorrent}
+				decoy.SetStale(true)
+
+				actions.UpdateImplicitRestart(testLogger(), containers, containers, true)
+
+				gomega.Expect(decoy.ToRestart()).To(gomega.BeTrue())
+				gomega.Expect(gluetun.ToRestart()).To(gomega.BeFalse())
+				gomega.Expect(qbittorrent.ToRestart()).To(gomega.BeFalse())
+			})
+
 			ginkgo.It("should handle restarted containers with circular dependencies", func() {
 				// Create circular dependency: A -> B -> A
 				containerA := mockActions.CreateMockContainerWithConfig(

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -973,7 +973,7 @@ func getLinksFromHostConfig(c *Container, clog *zerolog.Logger) []string {
 
 	networkMode := c.containerInfo.HostConfig.NetworkMode
 	if networkMode.IsContainer() {
-		capacity++
+		capacity += 2
 	}
 
 	normalizedLinks := make([]string, 0, capacity)
@@ -1005,13 +1005,19 @@ func getLinksFromHostConfig(c *Container, clog *zerolog.Logger) []string {
 	}
 
 	// Add network dependency.
+	//
+	// Unlike a Compose service reference, the network mode holds a container
+	// name that is not necessarily part of this container's project: a shared
+	// VPN or sidecar container is commonly defined in a separate Compose
+	// project. Emit the bare name in addition to the project-qualified one so
+	// dependency resolution matches either layout.
 	if networkMode.IsContainer() {
 		normalizedName := util.NormalizeContainerName(networkMode.ConnectedContainer())
-		if projectName != "" && !strings.HasPrefix(normalizedName, projectName+"-") {
-			normalizedName = projectName + "-" + normalizedName
-		}
-
 		normalizedLinks = append(normalizedLinks, normalizedName)
+
+		if projectName != "" && !strings.HasPrefix(normalizedName, projectName+"-") {
+			normalizedLinks = append(normalizedLinks, projectName+"-"+normalizedName)
+		}
 	}
 
 	clog.Debug().

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -973,7 +973,7 @@ func getLinksFromHostConfig(c *Container, clog *zerolog.Logger) []string {
 
 	networkMode := c.containerInfo.HostConfig.NetworkMode
 	if networkMode.IsContainer() {
-		capacity += 2
+		capacity++
 	}
 
 	normalizedLinks := make([]string, 0, capacity)
@@ -1006,18 +1006,13 @@ func getLinksFromHostConfig(c *Container, clog *zerolog.Logger) []string {
 
 	// Add network dependency.
 	//
-	// Unlike a Compose service reference, the network mode holds a container
-	// name that is not necessarily part of this container's project: a shared
-	// VPN or sidecar container is commonly defined in a separate Compose
-	// project. Emit the bare name in addition to the project-qualified one so
-	// dependency resolution matches either layout.
+	// Unlike a Compose service reference, network mode is a Docker identity.
+	// The daemon stores container:<id> after create. List inspect rewrites
+	// that to container:<name>. Do not prefix either form with this
+	// container's Compose project.
 	if networkMode.IsContainer() {
 		normalizedName := util.NormalizeContainerName(networkMode.ConnectedContainer())
 		normalizedLinks = append(normalizedLinks, normalizedName)
-
-		if projectName != "" && !strings.HasPrefix(normalizedName, projectName+"-") {
-			normalizedLinks = append(normalizedLinks, projectName+"-"+normalizedName)
-		}
 	}
 
 	clog.Debug().

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -785,6 +785,18 @@ var _ = ginkgo.Describe("Container", func() {
 				links := container.Links(true)
 				gomega.Expect(links).To(gomega.ContainElement("myproject-other"))
 			})
+
+			ginkgo.It("includes the bare network mode container name", func() {
+				// The network mode references a container name that may belong
+				// to another Compose project, so the unqualified name has to be
+				// offered as well.
+				container = MockContainer(
+					WithNetworkMode("container:gluetun"),
+					WithLabels(map[string]string{"com.docker.compose.project": "qbittorrent"}),
+				)
+				links := container.Links(true)
+				gomega.Expect(links).To(gomega.ContainElement("gluetun"))
+			})
 		})
 
 		ginkgo.It("returns pre and post update timeout values", func() {

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -789,13 +789,13 @@ var _ = ginkgo.Describe("Container", func() {
 			ginkgo.It("includes the bare network mode container name", func() {
 				// The network mode references a container name that may belong
 				// to another Compose project, so the unqualified name has to be
-				// offered as well.
+				// offered as well as the project-qualified candidate.
 				container = MockContainer(
 					WithNetworkMode("container:gluetun"),
 					WithLabels(map[string]string{"com.docker.compose.project": "qbittorrent"}),
 				)
 				links := container.Links(true)
-				gomega.Expect(links).To(gomega.ContainElement("gluetun"))
+				gomega.Expect(links).To(gomega.ContainElements("gluetun", "qbittorrent-gluetun"))
 			})
 		})
 

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -783,7 +783,7 @@ var _ = ginkgo.Describe("Container", func() {
 					WithLabels(map[string]string{"com.docker.compose.project": "myproject"}),
 				)
 				links := container.Links(true)
-				gomega.Expect(links).To(gomega.ContainElement("myproject-other"))
+				gomega.Expect(links).To(gomega.ContainElements("other", "myproject-other"))
 			})
 
 			ginkgo.It("includes the bare network mode container name", func() {
@@ -796,6 +796,26 @@ var _ = ginkgo.Describe("Container", func() {
 				)
 				links := container.Links(true)
 				gomega.Expect(links).To(gomega.ContainElements("gluetun", "qbittorrent-gluetun"))
+			})
+
+			ginkgo.It("strips a leading slash from the network mode container name", func() {
+				// Inspect rewrite stores container: plus the Docker name, which
+				// includes a leading slash.
+				container = MockContainer(
+					WithNetworkMode("container:/gluetun"),
+					WithLabels(map[string]string{"com.docker.compose.project": "qbittorrent"}),
+				)
+				links := container.Links(true)
+				gomega.Expect(links).To(gomega.ContainElements("gluetun", "qbittorrent-gluetun"))
+			})
+
+			ginkgo.It("does not double-prefix an already project-qualified network mode name", func() {
+				container = MockContainer(
+					WithNetworkMode("container:gluetun-vpn-1"),
+					WithLabels(map[string]string{"com.docker.compose.project": "gluetun"}),
+				)
+				links := container.Links(true)
+				gomega.Expect(links).To(gomega.ConsistOf("gluetun-vpn-1"))
 			})
 		})
 

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -783,19 +783,19 @@ var _ = ginkgo.Describe("Container", func() {
 					WithLabels(map[string]string{"com.docker.compose.project": "myproject"}),
 				)
 				links := container.Links(true)
-				gomega.Expect(links).To(gomega.ContainElements("other", "myproject-other"))
+				gomega.Expect(links).To(gomega.ContainElement("other"))
+				gomega.Expect(links).NotTo(gomega.ContainElement("myproject-other"))
 			})
 
 			ginkgo.It("includes the bare network mode container name", func() {
-				// The network mode references a container name that may belong
-				// to another Compose project, so the unqualified name has to be
-				// offered as well as the project-qualified candidate.
+				// The network mode holds a real container name, including when
+				// that container belongs to another Compose project.
 				container = MockContainer(
 					WithNetworkMode("container:gluetun"),
 					WithLabels(map[string]string{"com.docker.compose.project": "qbittorrent"}),
 				)
 				links := container.Links(true)
-				gomega.Expect(links).To(gomega.ContainElements("gluetun", "qbittorrent-gluetun"))
+				gomega.Expect(links).To(gomega.ConsistOf("gluetun"))
 			})
 
 			ginkgo.It("strips a leading slash from the network mode container name", func() {
@@ -806,7 +806,7 @@ var _ = ginkgo.Describe("Container", func() {
 					WithLabels(map[string]string{"com.docker.compose.project": "qbittorrent"}),
 				)
 				links := container.Links(true)
-				gomega.Expect(links).To(gomega.ContainElements("gluetun", "qbittorrent-gluetun"))
+				gomega.Expect(links).To(gomega.ConsistOf("gluetun"))
 			})
 
 			ginkgo.It("does not double-prefix an already project-qualified network mode name", func() {
@@ -816,6 +816,19 @@ var _ = ginkgo.Describe("Container", func() {
 				)
 				links := container.Links(true)
 				gomega.Expect(links).To(gomega.ConsistOf("gluetun-vpn-1"))
+			})
+
+			ginkgo.It("does not prefix a network mode container ID", func() {
+				// Moby inspect stores container:<id> after create. Prefixing
+				// that ID with the dependent's project would never match.
+				const providerID = "25e75393800b5c450a6841212a3b92ed28fa35414a586dec9f2c8a520d4910c2"
+
+				container = MockContainer(
+					WithNetworkMode("container:"+providerID),
+					WithLabels(map[string]string{"com.docker.compose.project": "qbittorrent"}),
+				)
+				links := container.Links(true)
+				gomega.Expect(links).To(gomega.ConsistOf(providerID))
 			})
 		})
 

--- a/pkg/sorter/dependency.go
+++ b/pkg/sorter/dependency.go
@@ -355,6 +355,10 @@ func buildLinkMatchIndexes(log *zerolog.Logger,
 			continue
 		}
 
+		if _, exists := aliasToCanonical[bareName]; exists {
+			continue
+		}
+
 		for owner := range owners {
 			aliasToCanonical[bareName] = owner
 		}

--- a/pkg/sorter/dependency.go
+++ b/pkg/sorter/dependency.go
@@ -288,7 +288,8 @@ func buildDependencyGraph(log *zerolog.Logger,
 // Each canonical ResolveContainerIdentifier is always included and never overwritten.
 // Bare container names are registered as aliases only when they uniquely identify one
 // container and do not collide with another container's canonical key, so ambiguous
-// names do not create non-deterministic edges.
+// names do not create non-deterministic edges. Docker IDs are also registered because
+// inspect stores network_mode as container:<id> until Watchtower rewrites it to a name.
 //
 // Parameters:
 //   - containerMap: Canonical identifier → container map from graph construction.
@@ -299,8 +300,8 @@ func buildDependencyGraph(log *zerolog.Logger,
 func buildLinkMatchIndexes(log *zerolog.Logger,
 	containerMap map[string]types.Container,
 ) (map[string]bool, map[string]string) {
-	// Capacity covers one canonical key plus one optional bare-name alias per container.
-	const aliasCapacityFactor = 2
+	// Capacity covers canonical key, optional bare-name alias, and Docker ID per container.
+	const aliasCapacityFactor = 3
 
 	aliasToCanonical := make(map[string]string, len(containerMap)*aliasCapacityFactor)
 
@@ -316,6 +317,15 @@ func buildLinkMatchIndexes(log *zerolog.Logger,
 	bareOwners := make(map[string]map[string]struct{})
 
 	for identifier, c := range containerMap {
+		if concrete, ok := c.(*container.Container); ok {
+			containerID := string(concrete.ID())
+			if containerID != "" && containerID != identifier {
+				if _, exists := aliasToCanonical[containerID]; !exists {
+					aliasToCanonical[containerID] = identifier
+				}
+			}
+		}
+
 		bareName := util.NormalizeContainerName(c.Name())
 		if bareName == "" || bareName == identifier {
 			continue

--- a/pkg/sorter/dependency_test.go
+++ b/pkg/sorter/dependency_test.go
@@ -16,6 +16,25 @@ import (
 
 var _ = ginkgo.Describe("DependencySorter", func() {
 	ginkgo.Describe("Sort", func() {
+		ginkgo.It("should sort a network_mode dependent after a provider referenced by Docker ID", func() {
+			const providerID = "25e75393800b5c450a6841212a3b92ed28fa35414a586dec9f2c8a520d4910c2"
+
+			gluetun := concreteLinkedContainer(providerID, "/gluetun", "gluetun", "vpn", "")
+			qbittorrent := concreteLinkedContainer(
+				"qbittorrent-id",
+				"/qbittorrent",
+				"qbittorrent",
+				"app",
+				"container:"+providerID,
+			)
+
+			containers := []types.Container{qbittorrent, gluetun}
+			err := DependencySorter{}.Sort(testLog(), containers, false)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(containers[0].Name()).To(gomega.Equal("gluetun"))
+			gomega.Expect(containers[1].Name()).To(gomega.Equal("qbittorrent"))
+		})
+
 		ginkgo.It("should sort containers with no dependencies", func() {
 			c1 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c1.EXPECT().Name().Return("c1")
@@ -1896,6 +1915,34 @@ func mockLinkedContainer(
 	return c
 }
 
+// concreteLinkedContainer builds a *container.Container so Docker ID aliases
+// in buildLinkMatchIndexes are exercised. networkMode is the HostConfig
+// NetworkMode value, such as container:<id>.
+func concreteLinkedContainer(
+	id, name, project, service, networkMode string,
+) types.Container {
+	labels := map[string]string{}
+	if project != "" {
+		labels["com.docker.compose.project"] = project
+	}
+
+	if service != "" {
+		labels["com.docker.compose.service"] = service
+	}
+
+	hostConfig := &dockerContainer.HostConfig{}
+	if networkMode != "" {
+		hostConfig.NetworkMode = dockerContainer.NetworkMode(networkMode)
+	}
+
+	return container.NewContainer(nil, &dockerContainer.InspectResponse{
+		ID:         id,
+		Name:       name,
+		HostConfig: hostConfig,
+		Config:     &dockerContainer.Config{Labels: labels},
+	}, nil)
+}
+
 var _ = ginkgo.Describe("FindMatchingIdentifiers", func() {
 	// Exhaustive link x identifier permutations across Compose stacks, multi-segment
 	// services, replicas, bare container names, and ambiguous cross-project cases.
@@ -2040,6 +2087,61 @@ var _ = ginkgo.Describe("buildLinkMatchIndexes", func() {
 		gomega.Expect(idSet).To(gomega.HaveKey("shared"))
 		gomega.Expect(idSet).To(gomega.HaveKey("project-service"))
 		gomega.Expect(idSet).To(gomega.HaveLen(2))
+	})
+
+	ginkgo.It("should map a Docker ID alias for concrete containers", func() {
+		const providerID = "25e75393800b5c450a6841212a3b92ed28fa35414a586dec9f2c8a520d4910c2"
+
+		gluetun := concreteLinkedContainer(providerID, "/gluetun", "gluetun", "vpn", "")
+
+		containerMap := map[string]types.Container{
+			"gluetun-vpn": gluetun,
+		}
+
+		idSet, aliasToCanonical := buildLinkMatchIndexes(testLog(), containerMap)
+		gomega.Expect(aliasToCanonical[providerID]).To(gomega.Equal("gluetun-vpn"))
+		gomega.Expect(idSet).To(gomega.HaveKey(providerID))
+	})
+
+	ginkgo.It("should skip an empty Docker ID", func() {
+		gluetun := concreteLinkedContainer("", "/gluetun", "gluetun", "vpn", "")
+
+		containerMap := map[string]types.Container{
+			"gluetun-vpn": gluetun,
+		}
+
+		idSet, aliasToCanonical := buildLinkMatchIndexes(testLog(), containerMap)
+		gomega.Expect(aliasToCanonical["gluetun-vpn"]).To(gomega.Equal("gluetun-vpn"))
+		gomega.Expect(aliasToCanonical["gluetun"]).To(gomega.Equal("gluetun-vpn"))
+		gomega.Expect(idSet).To(gomega.HaveLen(2))
+	})
+
+	ginkgo.It("should skip a Docker ID that equals the canonical identifier", func() {
+		const providerID = "25e75393800b5c450a6841212a3b92ed28fa35414a586dec9f2c8a520d4910c2"
+
+		gluetun := concreteLinkedContainer(providerID, "/"+providerID, "", "", "")
+
+		containerMap := map[string]types.Container{
+			providerID: gluetun,
+		}
+
+		_, aliasToCanonical := buildLinkMatchIndexes(testLog(), containerMap)
+		gomega.Expect(aliasToCanonical[providerID]).To(gomega.Equal(providerID))
+	})
+
+	ginkgo.It("should not overwrite an existing canonical key with a Docker ID", func() {
+		const providerID = "25e75393800b5c450a6841212a3b92ed28fa35414a586dec9f2c8a520d4910c2"
+
+		owner := concreteLinkedContainer("owner-id", "/owner", "owner", "svc", "")
+		claimant := concreteLinkedContainer(providerID, "/gluetun", "gluetun", "vpn", "")
+
+		containerMap := map[string]types.Container{
+			providerID:    owner,
+			"gluetun-vpn": claimant,
+		}
+
+		_, aliasToCanonical := buildLinkMatchIndexes(testLog(), containerMap)
+		gomega.Expect(aliasToCanonical[providerID]).To(gomega.Equal(providerID))
 	})
 })
 

--- a/pkg/sorter/dependency_test.go
+++ b/pkg/sorter/dependency_test.go
@@ -35,6 +35,30 @@ var _ = ginkgo.Describe("DependencySorter", func() {
 			gomega.Expect(containers[1].Name()).To(gomega.Equal("qbittorrent"))
 		})
 
+		ginkgo.It("should resolve container ID network_mode to the ID owner when a peer reuses that ID as its name", func() {
+			const providerID = "25e75393800b5c450a6841212a3b92ed28fa35414a586dec9f2c8a520d4910c2"
+
+			gluetun := concreteLinkedContainer(providerID, "/gluetun", "gluetun", "vpn", "")
+			decoy := concreteLinkedContainer("decoy-id", "/"+providerID, "other", "svc", "")
+			qbittorrent := concreteLinkedContainer(
+				"qbittorrent-id",
+				"/qbittorrent",
+				"qbittorrent",
+				"app",
+				"container:"+providerID,
+			)
+
+			_, indegree, adjacency, _, err := buildDependencyGraph(
+				testLog(),
+				[]types.Container{qbittorrent, decoy, gluetun},
+				false,
+			)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(indegree["qbittorrent-app"]).To(gomega.Equal(1))
+			gomega.Expect(adjacency["gluetun-vpn"]).To(gomega.ContainElement("qbittorrent-app"))
+			gomega.Expect(adjacency["other-svc"]).NotTo(gomega.ContainElement("qbittorrent-app"))
+		})
+
 		ginkgo.It("should sort containers with no dependencies", func() {
 			c1 := mockTypes.NewMockContainer(ginkgo.GinkgoT())
 			c1.EXPECT().Name().Return("c1")
@@ -2142,6 +2166,21 @@ var _ = ginkgo.Describe("buildLinkMatchIndexes", func() {
 
 		_, aliasToCanonical := buildLinkMatchIndexes(testLog(), containerMap)
 		gomega.Expect(aliasToCanonical[providerID]).To(gomega.Equal(providerID))
+	})
+
+	ginkgo.It("should retain a Docker ID alias when another container uses that ID as its name", func() {
+		const providerID = "25e75393800b5c450a6841212a3b92ed28fa35414a586dec9f2c8a520d4910c2"
+
+		gluetun := concreteLinkedContainer(providerID, "/gluetun", "gluetun", "vpn", "")
+		decoy := concreteLinkedContainer("decoy-id", "/"+providerID, "other", "svc", "")
+
+		containerMap := map[string]types.Container{
+			"gluetun-vpn": gluetun,
+			"other-svc":   decoy,
+		}
+
+		_, aliasToCanonical := buildLinkMatchIndexes(testLog(), containerMap)
+		gomega.Expect(aliasToCanonical[providerID]).To(gomega.Equal("gluetun-vpn"))
 	})
 })
 


### PR DESCRIPTION
This PR restores dependency tracking for containers that share a network namespace with `network_mode: container:<name|id>` when the provider lives in another Compose project. Watchtower now treats that target as a Docker identity instead of a Compose service name, so dependents restart and recreate after the provider instead of being left in `created`.

## Problem

`getLinksFromHostConfig` prefixed network-mode targets with the dependent's Compose project. A `qbittorrent` stack using `network_mode: container:gluetun` produced the link `qbittorrent-gluetun`, which does not exist.

That dangling link dropped the edge in both `UpdateImplicitRestart` and the dependency sorter. The dependent was not restarted when the provider updated, and it was not ordered after the provider when both updated in the same run.

Docker accepts `create --network container:<missing>` and only fails at start, so the dependent was left in `created`. Restart policy does not recover it, and `docker compose up -d` will not recreate it.

Moby inspect stores `container:<full ID>` after create. Compose `network_mode: service:X` is also resolved to that ID form. Prefixing the ID made matching worse, and neither implicit restart nor the sorter indexed Docker IDs up front.

## Solution

Network mode is a Docker identity, not a Compose service reference. Emit the connected container as stored (name or ID) without project qualification. List inspect still rewrites IDs to names when possible.

Matching now indexes Docker IDs as well as names. If the exact named container exists and is not restarting, do not suffix-match a different container such as `qbittorrent-gluetun`. Bare-name aliases must not overwrite an existing ID mapping.

## Changes

- Stop project-prefixing `network_mode: container:` targets in `getLinksFromHostConfig`
- Index Docker IDs in implicit-restart tracking and sorter link matching
- Skip fuzzy matching when an exact container identity exists and is not restarting
- Keep Docker ID aliases when another container reuses that ID as its name
- Add coverage for cross-project names, leading slashes, inspect IDs, provider-only stale updates, multiple dependents, and ID/name collisions