### PR TITLE
fix(registry): stop skipping GHCR images on sub-millisecond 429s

### DIFF
--- a/docs/advanced-features/image-cooldown/index.md
+++ b/docs/advanced-features/image-cooldown/index.md
@@ -309,9 +309,11 @@ Authenticating with a Docker Hub account raises the limit from 100 to 200 pulls,
 
 #### GitHub Container Registry (ghcr.io)
 
-GHCR.io does not publish Docker Hub-style pull quotas. It does advertise an undocumented edge budget (observed as `allowed: 44000/minute` with a sub-second `retry-after`) that trips on bursts of concurrent requests, including anonymous pulls of `lscr.io` images hosted there.
+GHCR.io does not publish Docker Hub-style pull quotas. Anonymous pulls of a public org share an undocumented edge token bucket, observed as `allowed: 44000/minute` with a sub-millisecond `retry-after`. That includes `lscr.io/linuxserver/*` images, which Watchtower remaps to `ghcr.io` for digest and auth.
 
-Watchtower treats that advertised figure as a fill rate, not a burst size: after a 429 it paces one request at a time for that host. Authenticating to the registry is still the most reliable way to leave a shared anonymous bucket.
+Unauthenticated GHCR checks run one at a time. Tiny waits are floored to 100ms and retried for up to 30 seconds. In-cycle retries stay at debug so they do not become notifications. If the window is exhausted, that container is **failed** for the cycle.
+
+`docker login ghcr.io` (or equivalent credentials in `config.json` / `REPO_USER` and `REPO_PASS`) uses a per-user bucket and restores parallel GHCR checks. Login to `lscr.io` alone does not count. Credential lookup uses `ghcr.io` after the remap.
 
 #### Per-Registry Impact Summary
 
@@ -320,7 +322,7 @@ Watchtower treats that advertised figure as a fill rate, not a burst size: after
 | Docker Hub (unauthenticated)    | 100 / 6 hours               | Moderate — may exceed limit with many containers on short intervals |
 | Docker Hub (authenticated free) | 200 / 6 hours               | Low — sufficient for most deployments                               |
 | Docker Hub (paid)               | Unlimited                   | None                                                                |
-| GHCR.io                         | ~44,000 / minute fill rate (small burst) | Low — paced after a 429; authenticate if you see retries |
+| GHCR.io                         | ~44,000 / minute fill rate (small burst, org-scoped when anonymous) | Low — unauthenticated checks are sequential and retry for up to 30s. Authenticate to `ghcr.io` for a per-user bucket and parallel checks. |
 
 ### Monitor-Only Containers
 

--- a/docs/configuration/registry-and-authentication/index.md
+++ b/docs/configuration/registry-and-authentication/index.md
@@ -55,6 +55,8 @@ Environment Variable: DOCKER_CONFIG
 
     See [Usage](../../getting-started/usage/index.md) and [Private Registries](../../advanced-features/private-registries/index.md).
 
+    Public `lscr.io` images are hosted on GitHub Container Registry. Watchtower remaps them to `ghcr.io` for digest checks. To leave the shared anonymous GHCR org bucket, authenticate to **`ghcr.io`** in this config (not only `lscr.io`). That also restores parallel GHCR checks.
+
 ### Skip Registry TLS Verification
 
 Disables TLS certificate verification for registry connections, useful for self-signed certificates or insecure registries.

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nicholas-fedor/watchtower/pkg/container"
 	"github.com/nicholas-fedor/watchtower/pkg/filters"
 	"github.com/nicholas-fedor/watchtower/pkg/lifecycle"
+	"github.com/nicholas-fedor/watchtower/pkg/registry/ratelimit"
 	"github.com/nicholas-fedor/watchtower/pkg/session"
 	"github.com/nicholas-fedor/watchtower/pkg/sorter"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
@@ -525,7 +526,11 @@ func Update(log *zerolog.Logger, ctx context.Context,
 					parallelStaleCheckFailed++
 				}
 
-				progress.AddSkipped(log, sourceContainer, checkErr, config)
+				if ratelimit.Is(checkErr) {
+					progress.AddFailed(log, sourceContainer, checkErr, config)
+				} else {
+					progress.AddSkipped(log, sourceContainer, checkErr, config)
+				}
 
 				// Restore rich cooldown metadata for reports/notifications (preserves the
 				// structured CooldownAge/Delay/Remaining/Passed fields that the removed

--- a/internal/actions/update_image_test.go
+++ b/internal/actions/update_image_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nicholas-fedor/watchtower/internal/actions"
 	mockActions "github.com/nicholas-fedor/watchtower/internal/actions/mocks"
 	"github.com/nicholas-fedor/watchtower/pkg/filters"
+	"github.com/nicholas-fedor/watchtower/pkg/registry/ratelimit"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
@@ -366,6 +367,46 @@ var _ = ginkgo.Describe("the update action", func() {
 				To(gomega.BeEmpty(), "No image IDs should be collected")
 			gomega.Expect(client.TestData.IsContainerStaleCount.Load()).
 				To(gomega.Equal(int32(3)), "IsContainerStale should be called for all three containers")
+		})
+
+		ginkgo.It("should count exhausted registry rate limits as failed", func() {
+			client = &mockActions.MockClient{
+				TestData: &mockActions.TestData{
+					Containers: []types.Container{
+						mockActions.CreateMockContainer(
+							"rate-limited-container",
+							"/rate-limited-container",
+							"lscr.io/linuxserver/sonarr:latest",
+							time.Now(),
+						),
+					},
+					Staleness: map[string]bool{
+						"rate-limited-container": true,
+					},
+				},
+				Stopped: make(map[string]bool),
+			}
+			client.TestData.IsContainerStaleError = &ratelimit.Error{
+				RetryAfter:    23722 * time.Nanosecond,
+				Allowed:       44000,
+				AllowedWindow: time.Minute,
+				Host:          "ghcr.io",
+			}
+
+			report, cleanupImageInfos, err := actions.Update(testLogger(),
+				context.Background(),
+				client,
+				config,
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(report.Failed()).
+				To(gomega.HaveLen(1), "Rate-limited staleness checks should be failed")
+			gomega.Expect(report.Skipped()).
+				To(gomega.BeEmpty(), "Rate-limited staleness checks should not be skipped")
+			gomega.Expect(report.Updated()).
+				To(gomega.BeEmpty())
+			gomega.Expect(cleanupImageInfos).
+				To(gomega.BeEmpty())
 		})
 	})
 })

--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -723,11 +723,11 @@ func (c imageClient) performImagePull(
 	pullHost := ratelimit.Scope(address, opts.RegistryAuth != "")
 
 	pullErr := ratelimit.Do(ctx, clog, pullHost, func() error {
-		err := acquirePullSlot(ctx, address)
+		err := acquirePullSlot(ctx, pullHost)
 		if err != nil {
 			return err
 		}
-		defer releasePullSlot(address)
+		defer releasePullSlot(pullHost)
 
 		// A sibling pull may have recorded a 429 after this attempt passed Wait
 		// and while it was queued on the slot. Recheck cooldown without taking

--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -713,19 +713,21 @@ func (c imageClient) performImagePull(
 	clog := &clogVal
 	clog.Debug().Msg("Initiating image pull")
 
-	pullHost, hostErr := auth.GetRegistryAddress(clog, imageName)
-	if hostErr != nil || pullHost == "" {
+	address, hostErr := auth.GetRegistryAddress(clog, imageName)
+	if hostErr != nil || address == "" {
 		clog.Debug().
 			Err(hostErr).
 			Msg("Failed to resolve registry host for rate limiting")
 	}
 
+	pullHost := ratelimit.Scope(address, opts.RegistryAuth != "")
+
 	pullErr := ratelimit.Do(ctx, clog, pullHost, func() error {
-		err := acquirePullSlot(ctx, pullHost)
+		err := acquirePullSlot(ctx, address)
 		if err != nil {
 			return err
 		}
-		defer releasePullSlot(pullHost)
+		defer releasePullSlot(address)
 
 		// A sibling pull may have recorded a 429 after this attempt passed Wait
 		// and while it was queued on the slot. Recheck cooldown without taking

--- a/pkg/container/image_test.go
+++ b/pkg/container/image_test.go
@@ -281,31 +281,73 @@ var _ = ginkgo.Describe("the client", func() {
 			gomega.Expect(pullSlotFor("ghcr.io")).To(gomega.BeIdenticalTo(ghcr))
 		})
 		ginkgo.It("uses distinct slots for anonymous and authenticated GHCR pulls", func() {
+			ratelimit.ResetForTest()
+			defer ratelimit.ResetForTest()
+
 			anon := ratelimit.Scope("ghcr.io", false)
 			authed := ratelimit.Scope("ghcr.io", true)
 
 			gomega.Expect(anon).To(gomega.Equal("ghcr.io|anon"))
 			gomega.Expect(authed).To(gomega.Equal("ghcr.io"))
-			gomega.Expect(pullSlotFor(anon)).NotTo(gomega.BeIdenticalTo(pullSlotFor(authed)))
+			gomega.Expect(anon).NotTo(gomega.Equal(authed))
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			authEntered := make(chan struct{})
+			releaseAuth := make(chan struct{})
+			complete := `{"status":"Download complete"}` + "\n"
+
+			mockServer.AllowUnhandledRequests = true
+			mockServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", gomega.MatchRegexp("/images/create")),
+					func(w http.ResponseWriter, req *http.Request) {
+						close(authEntered)
+
+						select {
+						case <-releaseAuth:
+						case <-req.Context().Done():
+						}
+
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write([]byte(complete))
+					},
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", gomega.MatchRegexp("/images/create")),
+					ghttp.RespondWith(http.StatusOK, complete),
+				),
+			)
+
+			i := newImageClient(mockClient, testLog())
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			gomega.Expect(acquirePullSlot(ctx, authed)).To(gomega.Succeed())
-			defer releasePullSlot(authed)
-
-			done := make(chan error, 1)
-
+			authDone := make(chan error, 1)
 			go func() {
-				err := acquirePullSlot(ctx, anon)
-				if err == nil {
-					releasePullSlot(anon)
-				}
-
-				done <- err
+				authDone <- i.performImagePull(
+					ctx,
+					"ghcr.io/linuxserver/nginx:latest",
+					dockerClient.ImagePullOptions{RegistryAuth: "e30="},
+					nil,
+				)
 			}()
 
-			gomega.Eventually(done, "200ms").Should(gomega.Receive(gomega.BeNil()))
+			gomega.Eventually(authEntered).Should(gomega.BeClosed())
+
+			anonDone := make(chan error, 1)
+			go func() {
+				anonDone <- i.performImagePull(
+					ctx,
+					"ghcr.io/linuxserver/nginx:latest",
+					dockerClient.ImagePullOptions{},
+					nil,
+				)
+			}()
+
+			gomega.Eventually(anonDone, "1s").Should(gomega.Receive(gomega.BeNil()))
+			close(releaseAuth)
+			gomega.Eventually(authDone).Should(gomega.Receive(gomega.BeNil()))
 		})
 	})
 

--- a/pkg/container/image_test.go
+++ b/pkg/container/image_test.go
@@ -280,6 +280,33 @@ var _ = ginkgo.Describe("the client", func() {
 			gomega.Expect(ghcr).NotTo(gomega.BeIdenticalTo(hub))
 			gomega.Expect(pullSlotFor("ghcr.io")).To(gomega.BeIdenticalTo(ghcr))
 		})
+		ginkgo.It("uses distinct slots for anonymous and authenticated GHCR pulls", func() {
+			anon := ratelimit.Scope("ghcr.io", false)
+			authed := ratelimit.Scope("ghcr.io", true)
+
+			gomega.Expect(anon).To(gomega.Equal("ghcr.io|anon"))
+			gomega.Expect(authed).To(gomega.Equal("ghcr.io"))
+			gomega.Expect(pullSlotFor(anon)).NotTo(gomega.BeIdenticalTo(pullSlotFor(authed)))
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+
+			gomega.Expect(acquirePullSlot(ctx, authed)).To(gomega.Succeed())
+			defer releasePullSlot(authed)
+
+			done := make(chan error, 1)
+
+			go func() {
+				err := acquirePullSlot(ctx, anon)
+				if err == nil {
+					releasePullSlot(anon)
+				}
+
+				done <- err
+			}()
+
+			gomega.Eventually(done, "200ms").Should(gomega.Receive(gomega.BeNil()))
+		})
 	})
 
 	ginkgo.When("a host is in rate-limit cooldown", func() {

--- a/pkg/registry/age.go
+++ b/pkg/registry/age.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/nicholas-fedor/watchtower/internal/meta"
 	"github.com/nicholas-fedor/watchtower/pkg/registry/auth"
+	"github.com/nicholas-fedor/watchtower/pkg/registry/hosts"
 	"github.com/nicholas-fedor/watchtower/pkg/registry/ratelimit"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
@@ -326,8 +327,8 @@ func buildManifestURLForAge(log *zerolog.Logger,
 	originalHost := parsedURL.Host
 
 	// Handle lscr.io → ghcr.io host swap.
-	if parsedURL.Host == auth.LSCRRegistryDomain {
-		parsedURL.Host = auth.GitHubRegistryDomain
+	if parsedURL.Host == hosts.LSCRRegistryDomain {
+		parsedURL.Host = hosts.GitHubRegistryDomain
 		manifestURLStr = parsedURL.String()
 	}
 

--- a/pkg/registry/age.go
+++ b/pkg/registry/age.go
@@ -141,8 +141,14 @@ func FetchImageCreationTime(log *zerolog.Logger,
 			Msg("Failed to resolve registry host for rate limiting")
 	}
 
+	limitKey, release, holdErr := ratelimit.HoldAnonymous(ctx, limitHost, registryAuth != "")
+	if holdErr != nil {
+		return time.Time{}, fmt.Errorf("%w: %w", errFetchManifestFailed, holdErr)
+	}
+	defer release()
+
 	// Obtain an authentication token and challenge host for the registry.
-	result, err := ratelimit.DoValue(ctx, log, limitHost, func() (auth.TokenResult, error) {
+	result, err := ratelimit.DoValue(ctx, log, limitKey, func() (auth.TokenResult, error) {
 		return auth.GetToken(log,
 			ctx,
 			container,
@@ -211,6 +217,7 @@ func FetchImageCreationTime(log *zerolog.Logger,
 		targetVariant,
 		challengeHost,
 		originalHost,
+		limitKey,
 		fields,
 	)
 	if err != nil {
@@ -233,6 +240,7 @@ func FetchImageCreationTime(log *zerolog.Logger,
 		&blobURL,
 		configDigest,
 		token,
+		limitKey,
 		fields,
 	)
 	if err != nil {
@@ -345,6 +353,7 @@ func buildManifestURLForAge(log *zerolog.Logger,
 //   - token: Authentication token for the Authorization header.
 //   - challengeHost: Registry challenge host for fallback.
 //   - originalHost: The true original registry host before any redirects.
+//   - limitKey: Rate-limit host key from [ratelimit.Scope].
 //   - fields: Logging fields for context.
 //
 // Returns:
@@ -356,7 +365,7 @@ func retryManifestRequest(log *zerolog.Logger,
 	ctx context.Context,
 	client auth.Client,
 	parsedURL *url.URL,
-	manifestURL, token, challengeHost, originalHost string,
+	manifestURL, token, challengeHost, originalHost, limitKey string,
 	fields map[string]any,
 ) ([]byte, string, string, error) {
 	// Use the provided originalHost for fallback. If empty, derive from parsedURL.
@@ -441,24 +450,21 @@ func retryManifestRequest(log *zerolog.Logger,
 		}, ", "))
 		req.Header.Set("User-Agent", meta.UserAgent)
 
-		resp, err := client.Do(req)
+		resp, err := doRegistryRequest(log, ctx, client, req, limitKey)
 		if err != nil {
 			log.Debug().
 				Err(err).
 				Fields(fields).
 				Msg("Failed to execute manifest request")
 
+			if ratelimit.Is(err) {
+				return nil, "", "", err
+			}
+
 			return nil,
 				"",
 				"",
 				fmt.Errorf("%w: %w", errFetchManifestFailed, err)
-		}
-
-		rateErr := registryRateLimitError(resp)
-		if rateErr != nil {
-			resp.Body.Close()
-
-			return nil, "", "", rateErr
 		}
 
 		if resp.StatusCode != http.StatusOK {
@@ -566,6 +572,7 @@ func retryManifestRequest(log *zerolog.Logger,
 //   - targetVariant: Target variant for platform selection (empty for any variant).
 //   - challengeHost: Registry challenge host for fallback.
 //   - originalHost: The true original registry host before any redirects.
+//   - limitKey: Rate-limit host key from [ratelimit.Scope].
 //   - fields: Logging fields for context.
 //
 // Returns:
@@ -576,7 +583,7 @@ func fetchManifestForAge(log *zerolog.Logger,
 	client auth.Client,
 	manifestURL, token string,
 	parsedURL *url.URL,
-	targetOS, targetArch, targetVariant, challengeHost, originalHost string,
+	targetOS, targetArch, targetVariant, challengeHost, originalHost, limitKey string,
 	fields map[string]any,
 ) (string, string, error) {
 	body, winningHost, contentType, err := retryManifestRequest(log,
@@ -587,6 +594,7 @@ func fetchManifestForAge(log *zerolog.Logger,
 		token,
 		challengeHost,
 		originalHost,
+		limitKey,
 		fields,
 	)
 	if err != nil {
@@ -628,6 +636,7 @@ func fetchManifestForAge(log *zerolog.Logger,
 			targetArch,
 			targetVariant,
 			challengeHost,
+			limitKey,
 			fields,
 		)
 	}
@@ -810,6 +819,7 @@ func selectPlatformCandidate(log *zerolog.Logger,
 //   - token: Authentication token.
 //   - selectedDigest: Platform manifest digest to fetch.
 //   - challengeHost: Challenge host for fallback.
+//   - limitKey: Rate-limit host key from [ratelimit.Scope].
 //   - fields: Logging fields for context.
 //
 // Returns:
@@ -820,7 +830,7 @@ func fetchPlatformManifestWithRetry(log *zerolog.Logger,
 	ctx context.Context,
 	client auth.Client,
 	parsedURL *url.URL,
-	token, selectedDigest, challengeHost string,
+	token, selectedDigest, challengeHost, limitKey string,
 	fields map[string]any,
 ) (string, string, error) {
 	// Build URL path for platform-specific manifest.
@@ -912,12 +922,16 @@ func fetchPlatformManifestWithRetry(log *zerolog.Logger,
 		)
 		req.Header.Set("User-Agent", meta.UserAgent)
 
-		resp, err := client.Do(req)
+		resp, err := doRegistryRequest(log, ctx, client, req, limitKey)
 		if err != nil {
 			log.Debug().
 				Err(err).
 				Fields(fields).
 				Msg("Failed to execute platform manifest request")
+
+			if ratelimit.Is(err) {
+				return "", "", err
+			}
 
 			return "",
 				"",
@@ -926,14 +940,6 @@ func fetchPlatformManifestWithRetry(log *zerolog.Logger,
 					errFetchManifestFailed,
 					err,
 				)
-		}
-
-		// Handle non-success responses with retry logic.
-		rateErr := registryRateLimitError(resp)
-		if rateErr != nil {
-			resp.Body.Close()
-
-			return "", "", rateErr
 		}
 
 		if resp.StatusCode != http.StatusOK {
@@ -999,8 +1005,12 @@ func fetchPlatformManifestWithRetry(log *zerolog.Logger,
 				)
 				retryReq.Header.Set("User-Agent", meta.UserAgent)
 
-				retryResp, retryErr := client.Do(retryReq)
+				retryResp, retryErr := doRegistryRequest(log, ctx, client, retryReq, limitKey)
 				if retryErr != nil {
+					if ratelimit.Is(retryErr) {
+						return "", "", retryErr
+					}
+
 					return "",
 						"",
 						fmt.Errorf("%w: %w", errFetchManifestFailed, retryErr)
@@ -1127,6 +1137,7 @@ func fetchPlatformManifestWithRetry(log *zerolog.Logger,
 //   - targetArch: Target architecture for platform selection (empty for runtime.GOARCH).
 //   - targetVariant: Target variant for platform selection (empty for any variant).
 //   - challengeHost: Challenge host from auth (empty if not applicable).
+//   - limitKey: Rate-limit host key from [ratelimit.Scope].
 //   - fields: Logging fields.
 //
 // Returns:
@@ -1140,7 +1151,7 @@ func selectPlatformManifest(
 	index imageIndex,
 	parsedURL *url.URL,
 	token string,
-	targetOS, targetArch, targetVariant, challengeHost string,
+	targetOS, targetArch, targetVariant, challengeHost, limitKey string,
 	fields map[string]any,
 ) (string, string, error) {
 	// Use runtime defaults if no override is specified.
@@ -1170,6 +1181,7 @@ func selectPlatformManifest(
 		token,
 		selectedDigest,
 		challengeHost,
+		limitKey,
 		fields,
 	)
 }
@@ -1183,6 +1195,7 @@ func selectPlatformManifest(
 //   - parsedURL: Parsed manifest URL for constructing blob URL.
 //   - configDigest: Digest of the config blob.
 //   - token: Authentication token.
+//   - limitKey: Rate-limit host key from [ratelimit.Scope].
 //   - fields: Logging fields.
 //
 // Returns:
@@ -1192,7 +1205,7 @@ func fetchConfigBlob(log *zerolog.Logger,
 	ctx context.Context,
 	client auth.Client,
 	parsedURL *url.URL,
-	configDigest, token string,
+	configDigest, token, limitKey string,
 	fields map[string]any,
 ) (io.ReadCloser, error) {
 	// Extract image path from the manifest URL.
@@ -1247,12 +1260,16 @@ func fetchConfigBlob(log *zerolog.Logger,
 
 	req.Header.Set("User-Agent", meta.UserAgent)
 
-	resp, err := client.Do(req)
+	resp, err := doRegistryRequest(log, ctx, client, req, limitKey)
 	if err != nil {
 		log.Debug().
 			Err(err).
 			Fields(fields).
 			Msg("Failed to execute config blob request")
+
+		if ratelimit.Is(err) {
+			return nil, err
+		}
 
 		return nil,
 			fmt.Errorf("%w: %w", errFetchConfigFailed, err)
@@ -1311,23 +1328,20 @@ func fetchConfigBlob(log *zerolog.Logger,
 			}
 		}
 
-		resp, err = client.Do(redirectReq)
+		resp, err = doRegistryRequest(log, ctx, client, redirectReq, limitKey)
 		if err != nil {
 			log.Debug().
 				Err(err).
 				Fields(fields).
 				Msg("Failed to execute redirect request")
 
+			if ratelimit.Is(err) {
+				return nil, err
+			}
+
 			return nil,
 				fmt.Errorf("%w: %w", errFetchConfigFailed, err)
 		}
-	}
-
-	rateErr := registryRateLimitError(resp)
-	if rateErr != nil {
-		resp.Body.Close()
-
-		return nil, rateErr
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -1348,10 +1362,58 @@ func fetchConfigBlob(log *zerolog.Logger,
 	return resp.Body, nil
 }
 
+// doRegistryRequest executes req through [ratelimit.Do] so 429s honor the retry window.
+//
+// Observation is left to [ratelimit.Do]. This helper only returns a parsed
+// [ratelimit.Error] so nested callers do not Observe twice.
+//
+// Parameters:
+//   - log: Logger for retry notices. May be nil.
+//   - ctx: Context that bounds the retry loop.
+//   - client: HTTP client for the registry request.
+//   - req: Request to execute. GET requests may be retried.
+//   - limitKey: Rate-limit host key from [ratelimit.Scope].
+//
+// Returns:
+//   - *http.Response: Successful response. The caller must close the body.
+//   - error: [ratelimit.Error] when retries are exhausted, or the transport error.
+func doRegistryRequest(
+	log *zerolog.Logger,
+	ctx context.Context,
+	client auth.Client,
+	req *http.Request,
+	limitKey string,
+) (*http.Response, error) {
+	var resp *http.Response
+
+	err := ratelimit.Do(ctx, log, limitKey, func() error {
+		got, doErr := client.Do(req)
+		if doErr != nil {
+			return fmt.Errorf("registry request: %w", doErr)
+		}
+
+		rateErr := registryRateLimitError(got)
+		if rateErr != nil {
+			_ = got.Body.Close()
+
+			return rateErr
+		}
+
+		resp = got
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("registry request: %w", err)
+	}
+
+	return resp, nil
+}
+
 // registryRateLimitError returns a rate-limit error when the registry responded 429.
 //
-// The parsed error is recorded on the host limiter so sibling age fetches honor
-// the same cooldown.
+// It parses the response and does not call [ratelimit.Observe]. Callers that
+// retry through [ratelimit.Do] rely on that loop to record the 429 once.
 //
 // Parameters:
 //   - resp: HTTP response from a registry request.
@@ -1363,10 +1425,7 @@ func registryRateLimitError(resp *http.Response) error {
 		return nil
 	}
 
-	info := ratelimit.FromResponse(resp, ratelimit.ReadBody(resp, ratelimit.DefaultBodyLimit))
-	ratelimit.Observe(info.Host, info)
-
-	return info
+	return ratelimit.FromResponse(resp, ratelimit.ReadBody(resp, ratelimit.DefaultBodyLimit))
 }
 
 // isIndexMediaType checks if the media type indicates an image index (multi-platform).

--- a/pkg/registry/age_test.go
+++ b/pkg/registry/age_test.go
@@ -52,12 +52,8 @@ func TestRegistryRateLimitError(t *testing.T) {
 	require.Error(t, got)
 	require.ErrorIs(t, got, ratelimit.ErrRateLimited)
 
-	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
-	defer cancel()
-
-	waitErr := ratelimit.Wait(ctx, "ghcr.io")
-	require.Error(t, waitErr)
-	assert.ErrorIs(t, waitErr, context.DeadlineExceeded)
+	waitErr := ratelimit.Wait(t.Context(), "ghcr.io")
+	require.NoError(t, waitErr)
 }
 
 // newMockContainer creates a mockery-generated mock Container with the given image name.
@@ -179,7 +175,49 @@ func TestFetchManifestForAge_SinglePlatform(t *testing.T) {
 		"", "", "",
 		"",
 		parsedURL.Host,
+		"",
 		map[string]any{"test": "single_platform"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, configDigest, got)
+}
+
+func TestFetchManifestForAge_RetriesSubMillisecondRateLimit(t *testing.T) {
+	server := ghttp.NewServer()
+	t.Cleanup(server.Close)
+
+	configDigest := "sha256:abc123def456789012345678901234567890123456789012345678901234567890"
+	limitKey := "age-retry-ghcr.io"
+
+	server.AppendHandlers(
+		ghttp.CombineHandlers(
+			ghttp.VerifyRequest("GET", "/v2/test/manifests/latest"),
+			ghttp.RespondWith(
+				http.StatusTooManyRequests,
+				"toomanyrequests: retry-after: 23.722µs, allowed: 44000/minute",
+			),
+		),
+		ghttp.CombineHandlers(
+			ghttp.VerifyRequest("GET", "/v2/test/manifests/latest"),
+			ghttp.RespondWith(http.StatusOK, validManifestJSON(configDigest),
+				http.Header{"Content-Type": {"application/vnd.docker.distribution.manifest.v2+json"}},
+			),
+		),
+	)
+
+	parsedURL, err := url.Parse(server.URL() + "/v2/test/manifests/latest")
+	require.NoError(t, err)
+
+	got, _, err := fetchManifestForAge(testLog(), t.Context(),
+		server.HTTPTestServer.Client(),
+		parsedURL.String(),
+		"Bearer test-token",
+		parsedURL,
+		"", "", "",
+		"",
+		parsedURL.Host,
+		limitKey,
+		map[string]any{"test": "rate_limit_retry"},
 	)
 	require.NoError(t, err)
 	assert.Equal(t, configDigest, got)
@@ -220,6 +258,7 @@ func TestFetchManifestForAge_MultiPlatformIndex(t *testing.T) {
 		"", "", "",
 		"",
 		parsedURL.Host,
+		"",
 		map[string]any{"test": "multi_platform"},
 	)
 	require.NoError(t, err)
@@ -250,6 +289,7 @@ func TestFetchManifestForAge_AuthFailure(t *testing.T) {
 		"", "", "",
 		"",
 		parsedURL.Host,
+		"",
 		map[string]any{"test": "auth_failure"},
 	)
 	require.Error(t, err)
@@ -280,6 +320,7 @@ func TestFetchManifestForAge_NotFound(t *testing.T) {
 		"", "", "",
 		"",
 		parsedURL.Host,
+		"",
 		map[string]any{"test": "not_found"},
 	)
 	require.Error(t, err)
@@ -314,6 +355,7 @@ func TestFetchManifestForAge_MissingConfigDigest(t *testing.T) {
 		"", "", "",
 		"",
 		parsedURL.Host,
+		"",
 		map[string]any{"test": "missing_digest"},
 	)
 	require.Error(t, err)
@@ -345,6 +387,7 @@ func TestFetchConfigBlob_Success(t *testing.T) {
 		parsedURL,
 		configDigest,
 		"Bearer test-token",
+		"",
 		map[string]any{"test": "config_success"},
 	)
 	require.NoError(t, err)
@@ -383,6 +426,7 @@ func TestFetchConfigBlob_Failure500(t *testing.T) {
 		parsedURL,
 		configDigest,
 		"Bearer test-token",
+		"",
 		map[string]any{"test": "config_500"},
 	)
 	require.Error(t, err)
@@ -419,6 +463,7 @@ func TestFetchConfigBlob_Redirect(t *testing.T) {
 		parsedURL,
 		configDigest,
 		"Bearer test-token",
+		"",
 		map[string]any{"test": "config_redirect"},
 	)
 	require.NoError(t, err)
@@ -654,6 +699,7 @@ func TestSelectPlatformManifest_PlatformMatch(t *testing.T) {
 		"Bearer test-token",
 		"", "", "",
 		"",
+		"",
 		map[string]any{"test": "platform_match"},
 	)
 	require.NoError(t, err)
@@ -688,6 +734,7 @@ func TestSelectPlatformManifest_NoMatch(t *testing.T) {
 		parsedURL,
 		"",
 		"", "", "",
+		"",
 		"",
 		map[string]any{"test": "no_match"},
 	)
@@ -751,6 +798,7 @@ func TestSelectPlatformManifest_SkipsAttestationManifests(t *testing.T) {
 		"Bearer test-token",
 		"", "", "",
 		"",
+		"",
 		map[string]any{"test": "skips_attestation"},
 	)
 	require.NoError(t, err)
@@ -802,6 +850,7 @@ func TestSelectPlatformManifest_MissingConfigDigest(t *testing.T) {
 		"Bearer test-token",
 		"", "", "",
 		"",
+		"",
 		map[string]any{"test": "missing_digest"},
 	)
 	require.Error(t, err)
@@ -838,11 +887,11 @@ func TestPipeline_SinglePlatformManifest_ReturnsCreationTime(t *testing.T) {
 	ctx := context.Background()
 	fields := map[string]any{"test": "pipeline_single"}
 
-	digest, _, err := fetchManifestForAge(testLog(), ctx, client, parsedURL.String(), "", parsedURL, "", "", "", "", parsedURL.Host, fields)
+	digest, _, err := fetchManifestForAge(testLog(), ctx, client, parsedURL.String(), "", parsedURL, "", "", "", "", parsedURL.Host, "", fields)
 	require.NoError(t, err)
 	assert.Equal(t, configDigest, digest)
 
-	body, err := fetchConfigBlob(testLog(), ctx, client, parsedURL, digest, "", fields)
+	body, err := fetchConfigBlob(testLog(), ctx, client, parsedURL, digest, "", "", fields)
 	require.NoError(t, err)
 	t.Cleanup(func() { body.Close() })
 
@@ -892,11 +941,11 @@ func TestPipeline_MultiPlatformIndex_ReturnsCreationTime(t *testing.T) {
 	ctx := context.Background()
 	fields := map[string]any{"test": "pipeline_multi"}
 
-	digest, _, err := fetchManifestForAge(testLog(), ctx, client, parsedURL.String(), "", parsedURL, "", "", "", "", parsedURL.Host, fields)
+	digest, _, err := fetchManifestForAge(testLog(), ctx, client, parsedURL.String(), "", parsedURL, "", "", "", "", parsedURL.Host, "", fields)
 	require.NoError(t, err)
 	assert.Equal(t, configDigest, digest)
 
-	body, err := fetchConfigBlob(testLog(), ctx, client, parsedURL, digest, "", fields)
+	body, err := fetchConfigBlob(testLog(), ctx, client, parsedURL, digest, "", "", fields)
 	require.NoError(t, err)
 	t.Cleanup(func() { body.Close() })
 
@@ -938,10 +987,10 @@ func TestPipeline_MissingCreationTimestamp(t *testing.T) {
 	ctx := context.Background()
 	fields := map[string]any{"test": "pipeline_missing_created"}
 
-	digest, _, err := fetchManifestForAge(testLog(), ctx, client, parsedURL.String(), "", parsedURL, "", "", "", "", parsedURL.Host, fields)
+	digest, _, err := fetchManifestForAge(testLog(), ctx, client, parsedURL.String(), "", parsedURL, "", "", "", "", parsedURL.Host, "", fields)
 	require.NoError(t, err)
 
-	body, err := fetchConfigBlob(testLog(), ctx, client, parsedURL, digest, "", fields)
+	body, err := fetchConfigBlob(testLog(), ctx, client, parsedURL, digest, "", "", fields)
 	require.NoError(t, err)
 	t.Cleanup(func() { body.Close() })
 
@@ -982,10 +1031,10 @@ func TestPipeline_ConfigBlobNotFound(t *testing.T) {
 	ctx := context.Background()
 	fields := map[string]any{"test": "pipeline_config_fail"}
 
-	digest, _, err := fetchManifestForAge(testLog(), ctx, client, parsedURL.String(), "", parsedURL, "", "", "", "", parsedURL.Host, fields)
+	digest, _, err := fetchManifestForAge(testLog(), ctx, client, parsedURL.String(), "", parsedURL, "", "", "", "", parsedURL.Host, "", fields)
 	require.NoError(t, err)
 
-	_, err = fetchConfigBlob(testLog(), ctx, client, parsedURL, digest, "", fields)
+	_, err = fetchConfigBlob(testLog(), ctx, client, parsedURL, digest, "", "", fields)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errFetchConfigFailed)
 }
@@ -1018,10 +1067,10 @@ func TestPipeline_InvalidConfigJSON(t *testing.T) {
 	ctx := context.Background()
 	fields := map[string]any{"test": "pipeline_invalid_json"}
 
-	digest, _, err := fetchManifestForAge(testLog(), ctx, client, parsedURL.String(), "", parsedURL, "", "", "", "", parsedURL.Host, fields)
+	digest, _, err := fetchManifestForAge(testLog(), ctx, client, parsedURL.String(), "", parsedURL, "", "", "", "", parsedURL.Host, "", fields)
 	require.NoError(t, err)
 
-	body, err := fetchConfigBlob(testLog(), ctx, client, parsedURL, digest, "", fields)
+	body, err := fetchConfigBlob(testLog(), ctx, client, parsedURL, digest, "", "", fields)
 	require.NoError(t, err)
 	t.Cleanup(func() { body.Close() })
 
@@ -1067,10 +1116,10 @@ func TestPipeline_RedirectOnBlob(t *testing.T) {
 	ctx := context.Background()
 	fields := map[string]any{"test": "pipeline_redirect"}
 
-	digest, _, err := fetchManifestForAge(testLog(), ctx, client, parsedURL.String(), "", parsedURL, "", "", "", "", parsedURL.Host, fields)
+	digest, _, err := fetchManifestForAge(testLog(), ctx, client, parsedURL.String(), "", parsedURL, "", "", "", "", parsedURL.Host, "", fields)
 	require.NoError(t, err)
 
-	body, err := fetchConfigBlob(testLog(), ctx, client, parsedURL, digest, "", fields)
+	body, err := fetchConfigBlob(testLog(), ctx, client, parsedURL, digest, "", "", fields)
 	require.NoError(t, err)
 	t.Cleanup(func() { body.Close() })
 
@@ -1110,6 +1159,7 @@ func TestPipeline_ManifestNotFound(t *testing.T) {
 		"", "", "",
 		"",
 		parsedURL.Host,
+		"",
 		map[string]any{"test": "pipeline_not_found"},
 	)
 	require.Error(t, err)
@@ -1142,6 +1192,7 @@ func TestPipeline_AuthFailure(t *testing.T) {
 		"", "", "",
 		"",
 		parsedURL.Host,
+		"",
 		map[string]any{"test": "pipeline_auth_fail"},
 	)
 	require.Error(t, err)
@@ -1186,6 +1237,7 @@ func TestFetchManifestForAge_OversizedManifest(t *testing.T) {
 		"", "", "",
 		"",
 		parsedURL.Host,
+		"",
 		map[string]any{"test": "oversized_manifest"},
 	)
 	require.Error(t, err)
@@ -1233,6 +1285,7 @@ func TestSelectPlatformManifest_AmbiguousPlatformMatch(t *testing.T) {
 		parsedURL,
 		"",
 		"", "", "",
+		"",
 		"",
 		map[string]any{"test": "ambiguous_platform_match"},
 	)
@@ -1298,6 +1351,7 @@ func TestSelectPlatformManifest_VariantSelection(t *testing.T) {
 		runtime.GOOS,
 		runtime.GOARCH,
 		"v8", // Specify target variant
+		"",
 		"",
 		map[string]any{"test": "variant_selection"},
 	)
@@ -1441,6 +1495,7 @@ func TestFetchManifestForAge_IndexWithoutMediaType_ContentTypeFallback(t *testin
 		"", "", "",
 		"",
 		parsedURL.Host,
+		"",
 		map[string]any{"test": "index_no_mediatype"},
 	)
 	require.NoError(t, err)

--- a/pkg/registry/auth/registry.go
+++ b/pkg/registry/auth/registry.go
@@ -8,21 +8,12 @@ import (
 
 	"github.com/distribution/reference"
 	"github.com/rs/zerolog"
+
+	"github.com/nicholas-fedor/watchtower/pkg/registry/hosts"
 )
 
 // ChallengeHeader is the HTTP Header containing challenge instructions.
 const ChallengeHeader = "WWW-Authenticate"
-
-const (
-	// DockerRegistryDomain is the primary domain for Docker Hub image references.
-	DockerRegistryDomain = "docker.io"
-	// DockerRegistryHost is the current Docker Hub registry API endpoint.
-	DockerRegistryHost = "index.docker.io"
-	// GitHubRegistryDomain is the canonical domain for GitHub Container Registry.
-	GitHubRegistryDomain = "ghcr.io"
-	// LSCRRegistryDomain is LinuxServer's vanity domain. Images are hosted on ghcr.io.
-	LSCRRegistryDomain = "lscr.io"
-)
 
 // Errors for registry operations.
 var (
@@ -172,8 +163,8 @@ func extractChallengeHost(log *zerolog.Logger, realm string) string {
 // GetRegistryAddress extracts the registry address from an image reference.
 //
 // It returns the domain part of the reference, mapping Docker Hub's default
-// domain to its canonical host if needed. lscr.io is mapped to ghcr.io since
-// lscr.io images are hosted on GitHub Container Registry.
+// domain to its canonical host if needed. [hosts.LSCRRegistryDomain] is mapped
+// to [hosts.GitHubRegistryDomain] since those images are hosted on GHCR.
 //
 // Parameters:
 //   - log: Logger for diagnostics.
@@ -198,8 +189,8 @@ func GetRegistryAddress(log *zerolog.Logger, imageRef string) (string, error) {
 	domain := reference.Domain(normalizedRef)
 
 	// Map Docker Hub's default domain to its canonical host for registry requests.
-	if domain == DockerRegistryDomain {
-		domain = DockerRegistryHost
+	if domain == hosts.DockerRegistryDomain {
+		domain = hosts.DockerRegistryHost
 
 		log.Debug().
 			Str("image_ref", imageRef).
@@ -209,8 +200,8 @@ func GetRegistryAddress(log *zerolog.Logger, imageRef string) (string, error) {
 
 	// lscr.io images are hosted on GitHub Container Registry (ghcr.io).
 	// Map here so all callers benefit, including GetChallengeURL and GetAuthURL.
-	if domain == LSCRRegistryDomain {
-		domain = GitHubRegistryDomain
+	if domain == hosts.LSCRRegistryDomain {
+		domain = hosts.GitHubRegistryDomain
 
 		log.Debug().
 			Str("image_ref", imageRef).

--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -590,6 +590,20 @@ func fetchDigest(log *zerolog.Logger,
 		endpoints = []string{""}
 	}
 
+	limitHost, hostErr := auth.GetRegistryAddress(log, container.ImageName())
+	if hostErr != nil || limitHost == "" {
+		log.Debug().
+			Err(hostErr).
+			Fields(fields).
+			Msg("Failed to resolve registry host for rate limiting")
+	}
+
+	limitKey, release, holdErr := ratelimit.HoldAnonymous(ctx, limitHost, registryAuth != "")
+	if holdErr != nil {
+		return "", fmt.Errorf("%w: %w", errFailedGetToken, holdErr)
+	}
+	defer release()
+
 	var lastErr error
 
 	for _, endpoint := range endpoints {
@@ -608,17 +622,7 @@ func fetchDigest(log *zerolog.Logger,
 			}
 		}
 
-		// Obtain an authentication token from the current endpoint.
-		limitHost, hostErr := auth.GetRegistryAddress(log, container.ImageName())
-		if hostErr != nil || limitHost == "" {
-			log.Debug().
-				Err(hostErr).
-				Fields(fields).
-				Fields(epFields).
-				Msg("Failed to resolve registry host for rate limiting")
-		}
-
-		result, err := ratelimit.DoValue(ctx, log, limitHost, func() (auth.TokenResult, error) {
+		result, err := ratelimit.DoValue(ctx, log, limitKey, func() (auth.TokenResult, error) {
 			return auth.GetToken(log,
 				ctx,
 				container,
@@ -708,7 +712,7 @@ func fetchDigest(log *zerolog.Logger,
 			retry      bool
 		)
 
-		err = ratelimit.Do(ctx, log, parsedURL.Host, func() error {
+		err = ratelimit.Do(ctx, log, limitKey, func() error {
 			req, reqErr := makeManifestRequest(ctx, method, manifestURL, token)
 			if reqErr != nil {
 				return reqErr
@@ -765,6 +769,7 @@ func fetchDigest(log *zerolog.Logger,
 				challengeHost,
 				redirected,
 				parsedURL,
+				limitKey,
 				client,
 			)
 			if err != nil {
@@ -1310,6 +1315,7 @@ func makeManifestRequest(
 //   - challengeHost: The challenge host.
 //   - redirected: Whether authentication was redirected.
 //   - parsedURL: Parsed URL object.
+//   - limitKey: Rate-limit host key from [ratelimit.Scope]. Empty uses parsedURL.Host.
 //   - client: The HTTP client to use for the request.
 //
 // Returns:
@@ -1322,11 +1328,16 @@ func retryManifestRequest(
 	originalHost, challengeHost string,
 	redirected bool,
 	parsedURL *url.URL,
+	limitKey string,
 	client auth.Client,
 ) (string, error) {
 	var digest string
 
-	err := ratelimit.Do(ctx, log, parsedURL.Host, func() error {
+	if limitKey == "" {
+		limitKey = parsedURL.Host
+	}
+
+	err := ratelimit.Do(ctx, log, limitKey, func() error {
 		req, reqErr := makeManifestRequest(ctx, method, updatedURL, token)
 		if reqErr != nil {
 			return reqErr

--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/nicholas-fedor/watchtower/internal/meta"
 	"github.com/nicholas-fedor/watchtower/pkg/registry/auth"
+	"github.com/nicholas-fedor/watchtower/pkg/registry/hosts"
 	"github.com/nicholas-fedor/watchtower/pkg/registry/manifest"
 	"github.com/nicholas-fedor/watchtower/pkg/registry/ratelimit"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
@@ -449,7 +450,7 @@ func BuildManifestURL(log *zerolog.Logger,
 		rawDomain := reference.Domain(normalizedRef)
 
 		canonicalHost, _ := auth.GetRegistryAddress(log, container.ImageName())
-		if rawDomain == auth.LSCRRegistryDomain {
+		if rawDomain == hosts.LSCRRegistryDomain {
 			originalHost = rawDomain
 		} else if canonicalHost != "" {
 			originalHost = canonicalHost
@@ -493,8 +494,8 @@ func BuildManifestURL(log *zerolog.Logger,
 	// 2. Authentication tokens are obtained from ghcr.io using the redirected challenge
 	// 3. Manifest requests are made directly to ghcr.io (not lscr.io) to avoid 401/404 errors
 	// 4. Digest extraction succeeds from the 200 OK response
-	if parsedURL.Host == auth.LSCRRegistryDomain {
-		parsedURL.Host = auth.GitHubRegistryDomain
+	if parsedURL.Host == hosts.LSCRRegistryDomain {
+		parsedURL.Host = hosts.GitHubRegistryDomain
 		manifestURLStr = parsedURL.String()
 	}
 

--- a/pkg/registry/digest/digest_test.go
+++ b/pkg/registry/digest/digest_test.go
@@ -1745,6 +1745,7 @@ func TestRetryManifestRequest(t *testing.T) {
 				"ghcr.io",
 				false,
 				mustParseURL("https://registry.example.com/v2/manifests/latest"),
+				"",
 				client,
 			)
 			if tt.wantErr {

--- a/pkg/registry/doc.go
+++ b/pkg/registry/doc.go
@@ -6,6 +6,7 @@
 //   - auth: Manages registry authentication (token fetching, challenge handling).
 //   - digest: Retrieves and compares image digests via HTTP requests.
 //   - ratelimit: Parses registry 429 responses and retries them with backoff.
+//   - hosts: Canonical registry domain names (GHCR, LSCR, Docker Hub).
 //   - helpers: Utilities for registry address parsing and digest normalization.
 //   - manifest: Constructs manifest URLs for digest fetching.
 //   - registry: Configures pull options, API consumption checks, and image age fetching.

--- a/pkg/registry/hosts/doc.go
+++ b/pkg/registry/hosts/doc.go
@@ -1,0 +1,7 @@
+// Package hosts names the container registry domains Watchtower treats specially.
+//
+// Keep vanity-to-canonical mappings here so auth, digest, and rate limiting
+// share one source of truth. [LSCRRegistryDomain] is hosted on
+// [GitHubRegistryDomain]. [DockerRegistryDomain] is served at
+// [DockerRegistryHost].
+package hosts

--- a/pkg/registry/hosts/hosts.go
+++ b/pkg/registry/hosts/hosts.go
@@ -1,0 +1,23 @@
+package hosts
+
+const (
+	// DockerRegistryDomain is the primary domain for Docker Hub image references.
+	DockerRegistryDomain = "docker.io"
+	// DockerRegistryHost is the current Docker Hub registry API endpoint.
+	DockerRegistryHost = "index.docker.io"
+	// GitHubRegistryDomain is the canonical domain for GitHub Container Registry.
+	GitHubRegistryDomain = "ghcr.io"
+	// LSCRRegistryDomain is LinuxServer's vanity domain. Images are hosted on ghcr.io.
+	LSCRRegistryDomain = "lscr.io"
+)
+
+// IsGitHubRegistry reports whether host is GHCR or an LSCR vanity front for it.
+//
+// Parameters:
+//   - host: Registry host from an image reference or URL.
+//
+// Returns:
+//   - bool: True for [GitHubRegistryDomain] and [LSCRRegistryDomain].
+func IsGitHubRegistry(host string) bool {
+	return host == GitHubRegistryDomain || host == LSCRRegistryDomain
+}

--- a/pkg/registry/hosts/hosts_test.go
+++ b/pkg/registry/hosts/hosts_test.go
@@ -1,0 +1,17 @@
+package hosts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsGitHubRegistry(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, IsGitHubRegistry(GitHubRegistryDomain))
+	assert.True(t, IsGitHubRegistry(LSCRRegistryDomain))
+	assert.False(t, IsGitHubRegistry(DockerRegistryHost))
+	assert.False(t, IsGitHubRegistry(DockerRegistryDomain))
+	assert.False(t, IsGitHubRegistry(""))
+}

--- a/pkg/registry/ratelimit/doc.go
+++ b/pkg/registry/ratelimit/doc.go
@@ -5,5 +5,8 @@
 // Advertised quotas are treated as a fill rate.
 // After a throttle, each host is limited to one outstanding token so concurrent
 // checks cannot dump the advertised budget in a burst.
-// In-cycle retries are logged at the debug level and giving up is a warning.
+// Unauthenticated GHCR traffic is serialized from the first request onto a
+// separate limiter key from [Scope] so anonymous 429s cannot pace authenticated
+// checks. Token-bucket waits retry until the honor window. In-cycle retries are
+// debug. Giving up is a warning.
 package ratelimit

--- a/pkg/registry/ratelimit/error.go
+++ b/pkg/registry/ratelimit/error.go
@@ -14,9 +14,7 @@ const (
 	minHonorWait = 100 * time.Millisecond
 	// maxHonorWait is the longest Retry-After this process will sleep in one update cycle.
 	maxHonorWait = 30 * time.Second
-	// maxRetryTries is the attempt cap passed to cenkalti/backoff.
-	maxRetryTries = 5
-	// maxRetryElapsed bounds how long a single operation keeps retrying 429s.
+	// maxRetryElapsed is the production in-cycle bound for retrying 429s.
 	maxRetryElapsed = 30 * time.Second
 	// DefaultBodyLimit is how many response bytes we read when parsing a 429.
 	DefaultBodyLimit = 4096
@@ -27,6 +25,10 @@ const (
 	// equalJitterDivisor splits a wait into the equal-jitter half range.
 	equalJitterDivisor = 2
 )
+
+// retryElapsed bounds how long a single operation keeps retrying 429s.
+// Tests shorten it so elapsed-budget exhaustion does not sleep 30s.
+var retryElapsed = maxRetryElapsed
 
 // Error is a registry 429 with the wait and quota the registry advertised.
 type Error struct {

--- a/pkg/registry/ratelimit/limiter.go
+++ b/pkg/registry/ratelimit/limiter.go
@@ -3,6 +3,7 @@ package ratelimit
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 )
@@ -23,20 +24,164 @@ type hostState struct {
 	lastRefill time.Time
 }
 
-var (
-	hostsMu sync.Mutex
-	hosts   = map[string]*hostState{}
+const (
+	// githubRegistryHost is the GHCR API host.
+	// Keep in sync with [github.com/nicholas-fedor/watchtower/pkg/registry/auth.GitHubRegistryDomain].
+	githubRegistryHost = "ghcr.io"
+	// anonSuffix marks limiter keys for unauthenticated GHCR traffic.
+	anonSuffix = "|anon"
 )
 
-// ResetForTest clears per-host cooldown and quota state.
+var (
+	hostsMu     sync.Mutex
+	hosts       = map[string]*hostState{}
+	serialMu    sync.Mutex
+	serialSlots = map[string]chan struct{}{}
+)
+
+// ResetForTest clears per-host cooldown, quota, and serial-slot state.
 //
-// Tests call this so one case cannot leak a cooldown into the next.
+// Tests call this so one case cannot leak a cooldown or serial hold into the next.
+// It also restores the production honor window used by [Do] and [DoValue].
 func ResetForTest() {
 	hostsMu.Lock()
-	defer hostsMu.Unlock()
-
 	hosts = map[string]*hostState{}
 	retryElapsed = maxRetryElapsed
+	hostsMu.Unlock()
+
+	serialMu.Lock()
+	serialSlots = map[string]chan struct{}{}
+	serialMu.Unlock()
+}
+
+// Scope returns the limiter key for host.
+//
+// Unauthenticated GHCR uses a distinct key so anonymous 429s cannot pace
+// authenticated traffic to the same registry.
+//
+// Parameters:
+//   - host: Registry host, such as ghcr.io. Empty values return empty.
+//   - authenticated: True when the caller has registry credentials.
+//
+// Returns:
+//   - string: Limiter key. Unauthenticated GHCR is host plus "|anon".
+func Scope(host string, authenticated bool) string {
+	if host == "" {
+		return ""
+	}
+
+	if !authenticated && host == githubRegistryHost {
+		return host + anonSuffix
+	}
+
+	return host
+}
+
+// IsAnonymousScope reports whether key is the unauthenticated GHCR limiter key.
+//
+// Parameters:
+//   - key: Limiter key from [Scope].
+//
+// Returns:
+//   - bool: True when key is the anonymous GHCR scope.
+func IsAnonymousScope(key string) bool {
+	return strings.HasSuffix(key, anonSuffix)
+}
+
+// HoldAnonymous returns the limiter key for host and, for unauthenticated GHCR,
+// acquires the one-at-a-time serial slot with [AcquireSerial].
+//
+// The release function is always non-nil. Callers should defer it. Authenticated
+// GHCR and other registries do not take the serial slot.
+//
+// Parameters:
+//   - ctx: Context that can cancel the serial wait.
+//   - host: Canonical registry host. Empty hosts skip the hold.
+//   - authenticated: True when the caller has registry credentials.
+//
+// Returns:
+//   - string: Limiter key from [Scope].
+//   - func(): Release callback. A no-op when no slot was acquired.
+//   - error: [context.Context.Err] when canceled while waiting for the serial slot.
+func HoldAnonymous(ctx context.Context, host string, authenticated bool) (string, func(), error) {
+	key := Scope(host, authenticated)
+	release := func() {}
+
+	if !IsAnonymousScope(key) {
+		return key, release, nil
+	}
+
+	err := AcquireSerial(ctx, key)
+	if err != nil {
+		return key, release, err
+	}
+
+	return key, func() { ReleaseSerial(key) }, nil
+}
+
+// AcquireSerial blocks until this process may run one operation on key.
+//
+// Empty keys return immediately. [ReleaseSerial] must be called for the same key.
+//
+// Parameters:
+//   - ctx: Context that can cancel the wait.
+//   - key: Serial slot key. Empty values return immediately.
+//
+// Returns:
+//   - error: [context.Context.Err] when canceled. Nil when the caller may proceed.
+func AcquireSerial(ctx context.Context, key string) error {
+	if key == "" {
+		return nil
+	}
+
+	ctxErr := ctx.Err()
+	if ctxErr != nil {
+		return fmt.Errorf("registry serial wait canceled: %w", ctxErr)
+	}
+
+	select {
+	case serialSlotFor(key) <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("registry serial wait canceled: %w", ctx.Err())
+	}
+}
+
+// ReleaseSerial returns a serial slot acquired with [AcquireSerial].
+//
+// Empty keys and slots that are not held are ignored.
+//
+// Parameters:
+//   - key: Serial slot key passed to [AcquireSerial].
+func ReleaseSerial(key string) {
+	if key == "" {
+		return
+	}
+
+	select {
+	case <-serialSlotFor(key):
+	default:
+	}
+}
+
+// serialSlotFor returns the capacity-1 slot for key, creating it when missing.
+//
+// Parameters:
+//   - key: Serial slot key.
+//
+// Returns:
+//   - chan struct{}: Buffered channel used as a mutex. Capacity is 1.
+func serialSlotFor(key string) chan struct{} {
+	serialMu.Lock()
+	defer serialMu.Unlock()
+
+	slot := serialSlots[key]
+	if slot == nil {
+		slot = make(chan struct{}, 1)
+		serialSlots[key] = slot
+	}
+
+	return slot
 }
 
 // Observe records a 429 against host so later Wait calls honor it.

--- a/pkg/registry/ratelimit/limiter.go
+++ b/pkg/registry/ratelimit/limiter.go
@@ -36,6 +36,7 @@ func ResetForTest() {
 	defer hostsMu.Unlock()
 
 	hosts = map[string]*hostState{}
+	retryElapsed = maxRetryElapsed
 }
 
 // Observe records a 429 against host so later Wait calls honor it.

--- a/pkg/registry/ratelimit/limiter.go
+++ b/pkg/registry/ratelimit/limiter.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/nicholas-fedor/watchtower/pkg/registry/hosts"
 )
 
 // hostState holds the cooldown and token-bucket budget for one registry host.
@@ -25,17 +27,13 @@ type hostState struct {
 }
 
 const (
-	// githubRegistryHost is the GHCR API host.
-	githubRegistryHost = "ghcr.io"
-	// linuxServerRegistryHost is LinuxServer's vanity GHCR front.
-	linuxServerRegistryHost = "lscr.io"
 	// anonSuffix marks limiter keys for unauthenticated GHCR traffic.
 	anonSuffix = "|anon"
 )
 
 var (
 	hostsMu     sync.Mutex
-	hosts       = map[string]*hostState{}
+	hostStates  = map[string]*hostState{}
 	serialMu    sync.Mutex
 	serialSlots = map[string]chan struct{}{}
 )
@@ -46,7 +44,7 @@ var (
 // It also restores the production honor window used by [Do] and [DoValue].
 func ResetForTest() {
 	hostsMu.Lock()
-	hosts = map[string]*hostState{}
+	hostStates = map[string]*hostState{}
 	retryElapsed = maxRetryElapsed
 	hostsMu.Unlock()
 
@@ -58,8 +56,9 @@ func ResetForTest() {
 // Scope returns the limiter key for host.
 //
 // Unauthenticated GHCR uses a distinct key so anonymous 429s cannot pace
-// authenticated traffic to the same registry. Unauthenticated lscr.io is
-// normalized to the same key as GHCR, matching the manifest remap.
+// authenticated traffic to the same registry. Unauthenticated
+// [hosts.LSCRRegistryDomain] is normalized to the same key as GHCR, matching
+// the manifest remap.
 //
 // Parameters:
 //   - host: Registry host, such as ghcr.io. Empty values return empty.
@@ -72,8 +71,8 @@ func Scope(host string, authenticated bool) string {
 		return ""
 	}
 
-	if !authenticated && (host == githubRegistryHost || host == linuxServerRegistryHost) {
-		return githubRegistryHost + anonSuffix
+	if !authenticated && hosts.IsGitHubRegistry(host) {
+		return hosts.GitHubRegistryDomain + anonSuffix
 	}
 
 	return host
@@ -258,7 +257,7 @@ func ObserveSuccess(host string) {
 	hostsMu.Lock()
 	defer hostsMu.Unlock()
 
-	state := hosts[host]
+	state := hostStates[host]
 	if state == nil || state.allowed <= 0 || state.window <= 0 {
 		return
 	}
@@ -375,7 +374,7 @@ func nextCooldownWait(host string) time.Duration {
 	hostsMu.Lock()
 	defer hostsMu.Unlock()
 
-	state := hosts[host]
+	state := hostStates[host]
 	if state == nil || !time.Now().Before(state.cooldownUntil) {
 		return 0
 	}
@@ -393,10 +392,10 @@ func nextCooldownWait(host string) time.Duration {
 // Returns:
 //   - *hostState: Existing or newly created state for host.
 func hostLocked(host string) *hostState {
-	state := hosts[host]
+	state := hostStates[host]
 	if state == nil {
 		state = &hostState{lastRefill: time.Now()}
-		hosts[host] = state
+		hostStates[host] = state
 	}
 
 	return state

--- a/pkg/registry/ratelimit/limiter.go
+++ b/pkg/registry/ratelimit/limiter.go
@@ -26,8 +26,9 @@ type hostState struct {
 
 const (
 	// githubRegistryHost is the GHCR API host.
-	// Keep in sync with [github.com/nicholas-fedor/watchtower/pkg/registry/auth.GitHubRegistryDomain].
 	githubRegistryHost = "ghcr.io"
+	// linuxServerRegistryHost is LinuxServer's vanity GHCR front.
+	linuxServerRegistryHost = "lscr.io"
 	// anonSuffix marks limiter keys for unauthenticated GHCR traffic.
 	anonSuffix = "|anon"
 )
@@ -57,21 +58,22 @@ func ResetForTest() {
 // Scope returns the limiter key for host.
 //
 // Unauthenticated GHCR uses a distinct key so anonymous 429s cannot pace
-// authenticated traffic to the same registry.
+// authenticated traffic to the same registry. Unauthenticated lscr.io is
+// normalized to the same key as GHCR, matching the manifest remap.
 //
 // Parameters:
 //   - host: Registry host, such as ghcr.io. Empty values return empty.
 //   - authenticated: True when the caller has registry credentials.
 //
 // Returns:
-//   - string: Limiter key. Unauthenticated GHCR is host plus "|anon".
+//   - string: Limiter key. Unauthenticated GHCR is "ghcr.io|anon".
 func Scope(host string, authenticated bool) string {
 	if host == "" {
 		return ""
 	}
 
-	if !authenticated && host == githubRegistryHost {
-		return host + anonSuffix
+	if !authenticated && (host == githubRegistryHost || host == linuxServerRegistryHost) {
+		return githubRegistryHost + anonSuffix
 	}
 
 	return host

--- a/pkg/registry/ratelimit/limiter_test.go
+++ b/pkg/registry/ratelimit/limiter_test.go
@@ -348,10 +348,14 @@ func TestScopeSeparatesAnonymousGHCR(t *testing.T) {
 
 	assert.Equal(t, "ghcr.io|anon", Scope("ghcr.io", false))
 	assert.Equal(t, "ghcr.io", Scope("ghcr.io", true))
+	assert.Equal(t, "ghcr.io|anon", Scope("lscr.io", false))
+	assert.Equal(t, "lscr.io", Scope("lscr.io", true))
 	assert.Equal(t, "index.docker.io", Scope("index.docker.io", false))
 	assert.Empty(t, Scope("", false))
 	assert.True(t, IsAnonymousScope(Scope("ghcr.io", false)))
+	assert.True(t, IsAnonymousScope(Scope("lscr.io", false)))
 	assert.False(t, IsAnonymousScope(Scope("ghcr.io", true)))
+	assert.False(t, IsAnonymousScope(Scope("lscr.io", true)))
 }
 
 func TestAnonymousGHCRSerializes(t *testing.T) {

--- a/pkg/registry/ratelimit/limiter_test.go
+++ b/pkg/registry/ratelimit/limiter_test.go
@@ -3,6 +3,7 @@ package ratelimit
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -340,4 +341,93 @@ func TestWaitDoesNotAccrueBurstDuringCooldown(t *testing.T) {
 	}
 
 	assert.LessOrEqual(t, granted, 1)
+}
+
+func TestScopeSeparatesAnonymousGHCR(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "ghcr.io|anon", Scope("ghcr.io", false))
+	assert.Equal(t, "ghcr.io", Scope("ghcr.io", true))
+	assert.Equal(t, "index.docker.io", Scope("index.docker.io", false))
+	assert.Empty(t, Scope("", false))
+	assert.True(t, IsAnonymousScope(Scope("ghcr.io", false)))
+	assert.False(t, IsAnonymousScope(Scope("ghcr.io", true)))
+}
+
+func TestAnonymousGHCRSerializes(t *testing.T) {
+	ResetForTest()
+
+	key := Scope("ghcr.io", false)
+
+	var (
+		inFlight atomic.Int32
+		peak     atomic.Int32
+	)
+
+	var wg sync.WaitGroup
+
+	for range 8 {
+		wg.Go(func() {
+			require.NoError(t, AcquireSerial(t.Context(), key))
+			defer ReleaseSerial(key)
+
+			n := inFlight.Add(1)
+
+			for {
+				old := peak.Load()
+				if n <= old || peak.CompareAndSwap(old, n) {
+					break
+				}
+			}
+
+			time.Sleep(20 * time.Millisecond)
+			inFlight.Add(-1)
+		})
+	}
+
+	wg.Wait()
+	assert.Equal(t, int32(1), peak.Load())
+}
+
+func TestAuthenticatedGHCRDoesNotTakeAnonLock(t *testing.T) {
+	ResetForTest()
+
+	anonKey := Scope("ghcr.io", false)
+
+	require.NoError(t, AcquireSerial(t.Context(), anonKey))
+	defer ReleaseSerial(anonKey)
+
+	started := time.Now()
+	authKey := Scope("ghcr.io", true)
+	require.Equal(t, "ghcr.io", authKey)
+	require.NoError(t, Wait(t.Context(), authKey))
+	assert.Less(t, time.Since(started), 50*time.Millisecond)
+}
+
+func TestResetForTestSerialSlotsConcurrent(t *testing.T) {
+	t.Cleanup(ResetForTest)
+
+	var wg sync.WaitGroup
+
+	for range 32 {
+		wg.Go(func() {
+			ResetForTest()
+		})
+		wg.Go(func() {
+			_ = serialSlotFor("serial-race")
+		})
+	}
+
+	wg.Wait()
+}
+
+func TestObserveAnonDoesNotPaceAuth(t *testing.T) {
+	ResetForTest()
+
+	Observe(Scope("ghcr.io", false), &Error{RetryAfter: time.Hour})
+
+	started := time.Now()
+
+	require.NoError(t, Wait(t.Context(), Scope("ghcr.io", true)))
+	assert.Less(t, time.Since(started), 50*time.Millisecond)
 }

--- a/pkg/registry/ratelimit/retry.go
+++ b/pkg/registry/ratelimit/retry.go
@@ -13,18 +13,18 @@ import (
 
 // Do retries operation when the registry returns a 429 that is worth retrying.
 //
-// Permanent errors are not retried. A Retry-After longer than maxHonorWait
+// Permanent errors are not retried. A Retry-After longer than the honor window
 // stops retries so the next Watchtower cycle can try again. Tiny token-bucket
-// waits retry until retryElapsed.
+// waits retry until that same window elapses.
 //
 // Parameters:
 //   - ctx: Context that bounds the retry loop.
 //   - log: Logger for retry notices. May be nil.
 //   - host: Registry host used for shared cooldown and quota.
-//   - operation: Function to run. It should return a rate-limit Error on 429.
+//   - operation: Function to run. It should return an [Error] on 429.
 //
 // Returns:
-//   - error: The last operation error, or ctx.Err() when canceled.
+//   - error: The last operation error, or [context.Context.Err] when canceled.
 func Do(ctx context.Context, log *zerolog.Logger, host string, operation func() error) error {
 	_, err := DoValue(ctx, log, host, func() (struct{}, error) {
 		return struct{}{}, operation()
@@ -33,7 +33,7 @@ func Do(ctx context.Context, log *zerolog.Logger, host string, operation func() 
 	return err
 }
 
-// DoValue is Do with a successful result.
+// DoValue is [Do] with a successful result.
 //
 // Parameters:
 //   - ctx: Context that bounds the retry loop.
@@ -43,7 +43,7 @@ func Do(ctx context.Context, log *zerolog.Logger, host string, operation func() 
 //
 // Returns:
 //   - T: Value from a successful attempt.
-//   - error: The last operation error, or ctx.Err() when canceled.
+//   - error: The last operation error, or [context.Context.Err] when canceled.
 func DoValue[T any](
 	ctx context.Context,
 	log *zerolog.Logger,
@@ -136,8 +136,11 @@ func DoValue[T any](
 
 // maxRetryAttempts is a circuit breaker derived from the elapsed budget.
 //
-// Token-bucket 429s retry until retryElapsed, not a fixed handful of tries.
+// Token-bucket 429s retry until [retryElapsed], not a fixed handful of tries.
 // This cap only stops a zero-wait loop from spinning.
+//
+// Returns:
+//   - uint: Maximum attempts passed to [backoff.WithMaxTries].
 func maxRetryAttempts() uint {
 	n := retryElapsed/minHonorWait + 1
 	if n < 1 {

--- a/pkg/registry/ratelimit/retry.go
+++ b/pkg/registry/ratelimit/retry.go
@@ -14,7 +14,8 @@ import (
 // Do retries operation when the registry returns a 429 that is worth retrying.
 //
 // Permanent errors are not retried. A Retry-After longer than maxHonorWait
-// stops retries so the next Watchtower cycle can try again.
+// stops retries so the next Watchtower cycle can try again. Tiny token-bucket
+// waits retry until retryElapsed.
 //
 // Parameters:
 //   - ctx: Context that bounds the retry loop.
@@ -61,6 +62,8 @@ func DoValue[T any](
 	exp.MaxInterval = maxHonorWait
 
 	attempt := 0
+	lastHonoredWait := time.Duration(0)
+	lastRawRetryAfter := time.Duration(0)
 
 	result, err := backoff.Retry(ctx, func() (T, error) {
 		waitErr := Wait(ctx, host)
@@ -86,12 +89,15 @@ func DoValue[T any](
 			}
 
 			Observe(host, info)
+			lastRawRetryAfter = info.RetryAfter
 		}
 
 		wait, giveUp := Decision(info)
 
 		attempt++
-		if giveUp || attempt >= maxRetryTries {
+		lastHonoredWait = wait
+
+		if giveUp {
 			return zero, backoff.Permanent(opErr)
 		}
 
@@ -107,8 +113,8 @@ func DoValue[T any](
 		return zero, backoff.RetryAfter(wait, opErr)
 	},
 		backoff.WithBackOff(exp),
-		backoff.WithMaxTries(maxRetryTries),
-		backoff.WithMaxElapsedTime(maxRetryElapsed),
+		backoff.WithMaxTries(maxRetryAttempts()),
+		backoff.WithMaxElapsedTime(retryElapsed),
 	)
 	if err == nil {
 		return result, nil
@@ -119,10 +125,26 @@ func DoValue[T any](
 		log.Warn().
 			Err(err).
 			Str("host", host).
+			Int("attempts", attempt).
+			Dur("honored_wait", lastHonoredWait).
+			Dur("retry_after", lastRawRetryAfter).
 			Msg("Registry rate limited. Stopping retries")
 	}
 
 	return result, err
+}
+
+// maxRetryAttempts is a circuit breaker derived from the elapsed budget.
+//
+// Token-bucket 429s retry until retryElapsed, not a fixed handful of tries.
+// This cap only stops a zero-wait loop from spinning.
+func maxRetryAttempts() uint {
+	n := retryElapsed/minHonorWait + 1
+	if n < 1 {
+		return 1
+	}
+
+	return uint(n)
 }
 
 // lastOperationError unwraps a cenkalti RetryError to the last operation error.

--- a/pkg/registry/ratelimit/retry_test.go
+++ b/pkg/registry/ratelimit/retry_test.go
@@ -79,7 +79,7 @@ func TestDoLogsExhaustionAtWarn(t *testing.T) {
 
 	var buf bytes.Buffer
 
-	log := zerolog.New(&buf).Level(zerolog.InfoLevel)
+	log := zerolog.New(&buf).Level(zerolog.DebugLevel)
 
 	err := Do(t.Context(), &log, "registry.example", func() error {
 		return &Error{RetryAfter: 2 * time.Hour}
@@ -121,7 +121,7 @@ func TestDoGivesUpWhenTinyRetryAfterExceedsElapsedBudget(t *testing.T) {
 
 	var buf bytes.Buffer
 
-	log := zerolog.New(&buf).Level(zerolog.InfoLevel)
+	log := zerolog.New(&buf).Level(zerolog.DebugLevel)
 
 	err := Do(t.Context(), &log, "ghcr.io", func() error {
 		return &Error{
@@ -133,7 +133,7 @@ func TestDoGivesUpWhenTinyRetryAfterExceedsElapsedBudget(t *testing.T) {
 	require.ErrorIs(t, err, ErrRateLimited)
 	assert.Contains(t, buf.String(), "Registry rate limited. Stopping retries")
 	assert.Contains(t, buf.String(), `"attempts":`)
-	assert.NotContains(t, buf.String(), "Retrying after delay")
+	assert.Contains(t, buf.String(), "Retrying after delay")
 }
 
 func TestDoRetriesRateLimitedOperations(t *testing.T) {

--- a/pkg/registry/ratelimit/retry_test.go
+++ b/pkg/registry/ratelimit/retry_test.go
@@ -115,7 +115,7 @@ func TestDoRetriesPastFiveWhenRetryAfterIsTiny(t *testing.T) {
 func TestDoGivesUpWhenTinyRetryAfterExceedsElapsedBudget(t *testing.T) {
 	ResetForTest()
 
-	retryElapsed = 250 * time.Millisecond
+	retryElapsed = 450 * time.Millisecond
 
 	defer ResetForTest()
 
@@ -123,7 +123,12 @@ func TestDoGivesUpWhenTinyRetryAfterExceedsElapsedBudget(t *testing.T) {
 
 	log := zerolog.New(&buf).Level(zerolog.DebugLevel)
 
+	var attempts atomic.Int32
+
+	started := time.Now()
 	err := Do(t.Context(), &log, "ghcr.io", func() error {
+		attempts.Add(1)
+
 		return &Error{
 			RetryAfter:    23722 * time.Nanosecond,
 			Allowed:       44000,
@@ -132,8 +137,12 @@ func TestDoGivesUpWhenTinyRetryAfterExceedsElapsedBudget(t *testing.T) {
 	})
 	require.ErrorIs(t, err, ErrRateLimited)
 	assert.Contains(t, buf.String(), "Registry rate limited. Stopping retries")
-	assert.Contains(t, buf.String(), `"attempts":`)
 	assert.Contains(t, buf.String(), "Retrying after delay")
+
+	maxStep := minHonorWait + minHonorWait/equalJitterDivisor
+	minAttempts := int(retryElapsed / maxStep)
+	assert.GreaterOrEqual(t, attempts.Load(), int32(minAttempts))
+	assert.GreaterOrEqual(t, time.Since(started), time.Duration(minAttempts-1)*minHonorWait)
 }
 
 func TestDoRetriesRateLimitedOperations(t *testing.T) {

--- a/pkg/registry/ratelimit/retry_test.go
+++ b/pkg/registry/ratelimit/retry_test.go
@@ -116,6 +116,7 @@ func TestDoGivesUpWhenTinyRetryAfterExceedsElapsedBudget(t *testing.T) {
 	ResetForTest()
 
 	retryElapsed = 250 * time.Millisecond
+
 	defer ResetForTest()
 
 	var buf bytes.Buffer

--- a/pkg/registry/ratelimit/retry_test.go
+++ b/pkg/registry/ratelimit/retry_test.go
@@ -79,14 +79,60 @@ func TestDoLogsExhaustionAtWarn(t *testing.T) {
 
 	var buf bytes.Buffer
 
-	log := zerolog.New(&buf)
+	log := zerolog.New(&buf).Level(zerolog.InfoLevel)
 
 	err := Do(t.Context(), &log, "registry.example", func() error {
-		return &Error{RetryAfter: minHonorWait}
+		return &Error{RetryAfter: 2 * time.Hour}
 	})
 	require.ErrorIs(t, err, ErrRateLimited)
 	assert.Contains(t, buf.String(), `"level":"warn"`)
 	assert.Contains(t, buf.String(), "Registry rate limited. Stopping retries")
+	assert.Contains(t, buf.String(), `"attempts":1`)
+	assert.NotContains(t, buf.String(), "Retrying after delay")
+}
+
+func TestDoRetriesPastFiveWhenRetryAfterIsTiny(t *testing.T) {
+	ResetForTest()
+
+	var attempts atomic.Int32
+
+	err := Do(t.Context(), testLog(), "ghcr.io", func() error {
+		if attempts.Add(1) < 8 {
+			return &Error{
+				RetryAfter:    23722 * time.Nanosecond,
+				Allowed:       44000,
+				AllowedWindow: time.Minute,
+				Host:          "ghcr.io",
+			}
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(8), attempts.Load())
+}
+
+func TestDoGivesUpWhenTinyRetryAfterExceedsElapsedBudget(t *testing.T) {
+	ResetForTest()
+
+	retryElapsed = 250 * time.Millisecond
+	defer ResetForTest()
+
+	var buf bytes.Buffer
+
+	log := zerolog.New(&buf).Level(zerolog.InfoLevel)
+
+	err := Do(t.Context(), &log, "ghcr.io", func() error {
+		return &Error{
+			RetryAfter:    23722 * time.Nanosecond,
+			Allowed:       44000,
+			AllowedWindow: time.Minute,
+		}
+	})
+	require.ErrorIs(t, err, ErrRateLimited)
+	assert.Contains(t, buf.String(), "Registry rate limited. Stopping retries")
+	assert.Contains(t, buf.String(), `"attempts":`)
+	assert.NotContains(t, buf.String(), "Retrying after delay")
 }
 
 func TestDoRetriesRateLimitedOperations(t *testing.T) {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -11,6 +11,7 @@ import (
 	dockerClient "github.com/moby/moby/client"
 
 	"github.com/nicholas-fedor/watchtower/pkg/registry/auth"
+	"github.com/nicholas-fedor/watchtower/pkg/registry/hosts"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
 
@@ -140,7 +141,7 @@ func WarnOnAPIConsumption(log *zerolog.Logger, container types.Container) bool {
 	}
 
 	// Check if the registry is known to support HEAD requests.
-	if containerHost == auth.DockerRegistryHost || containerHost == auth.GitHubRegistryDomain {
+	if containerHost == hosts.DockerRegistryHost || containerHost == hosts.GitHubRegistryDomain {
 		log.Debug().
 			Fields(fields).
 			Str("host", containerHost).

--- a/pkg/session/progress.go
+++ b/pkg/session/progress.go
@@ -64,6 +64,24 @@ func (m Progress) AddSkipped(log *zerolog.Logger, container types.Container, err
 		Msg("Added container as skipped")
 }
 
+// AddFailed adds a container as failed with an error.
+//
+// Parameters:
+//   - log: Logger for diagnostics.
+//   - container: Container to add.
+//   - err: Failure reason error.
+//   - params: Update parameters for monitor-only check.
+func (m Progress) AddFailed(log *zerolog.Logger, container types.Container, err error, params types.UpdateParams) {
+	update := UpdateFromContainer(log, container, container.ImageID(), FailedState, params)
+	update.containerError = err
+	m.Add(log, update)
+	log.Debug().
+		Err(err).
+		Str("container_id", container.ID().ShortID()).
+		Str("name", container.Name()).
+		Msg("Added container as failed")
+}
+
 // AddScanned adds a container as scanned with a new image.
 //
 // Parameters:

--- a/pkg/session/progress_test.go
+++ b/pkg/session/progress_test.go
@@ -340,6 +340,34 @@ func TestProgress_AddSkipped(t *testing.T) {
 	}
 }
 
+func TestProgress_AddFailed(t *testing.T) {
+	mock := mockTypes.NewMockContainer(t)
+	mock.EXPECT().ID().Return(types.ContainerID("cont1"))
+	mock.EXPECT().ImageID().Return(types.ImageID("img1"))
+	mock.EXPECT().Name().Return("container1")
+	mock.EXPECT().ImageName().Return("image1:latest")
+	mock.EXPECT().
+		IsMonitorOnly(testifyMock.MatchedBy(func(_ types.UpdateParams) bool { return true })).
+		Return(false)
+
+	progress := Progress{}
+	failErr := errors.New("registry rate limited")
+	progress.AddFailed(testLog(), mock, failErr, types.UpdateParams{})
+
+	got := progress["cont1"]
+	if got == nil {
+		t.Fatal("Progress.AddFailed did not store the container")
+	}
+
+	if got.state != FailedState {
+		t.Errorf("Progress.AddFailed state = %v, want %v", got.state, FailedState)
+	}
+
+	if got.Error() != failErr.Error() {
+		t.Errorf("Progress.AddFailed error = %v, want %v", got.Error(), failErr.Error())
+	}
+}
+
 func TestProgress_AddScanned(t *testing.T) {
 	type args struct {
 		container types.Container

--- a/pkg/session/report.go
+++ b/pkg/session/report.go
@@ -208,7 +208,9 @@ func categorizeContainer(log *zerolog.Logger, report *report, update *ContainerS
 		Msg("Categorizing container status")
 
 	// Categorize based on image or state.
-	if update.newImage == update.oldImage && update.state != RestartedState {
+	if update.newImage == update.oldImage &&
+		update.state != RestartedState &&
+		update.state != FailedState {
 		log.Debug().
 			Str("container", update.containerName).
 			Str("old_state", update.State()).


### PR DESCRIPTION
This PR stops Watchtower from skipping GHCR and remapped lscr.io images when the registry advertises a sub-millisecond token-bucket retry-after. Unauthenticated GHCR checks run one at a time, those 429s retry for the honor window, and exhaustion is a failed update instead of a silent skip.

## Problem

GHCR 429 bodies such as `retry-after: 23.722µs, allowed: 44000/minute` are a token-bucket refill signal, not a ban. `Decision` already floors those waits to 100ms, but `Do` stopped after five attempts, so a brief empty org bucket skipped images until the next cron. Digest 429s abort the pull, and those errors were recorded as skipped, so session summaries looked healthy. Unauthenticated linuxserver traffic also dumped up to 20 parallel checks into the same community bucket. Authenticated GHCR uses a per-user bucket and should stay parallel.

## Solution

Keep the 100ms floor and debug in-cycle retries so they do not become notifications. Retry token-bucket 429s until the 30s honor window, still giving up immediately when Retry-After exceeds that window. Serialize unauthenticated GHCR (and lscr.io vanity hosts) on a `ghcr.io|anon` limiter key from the first request. Authenticated GHCR keeps the concurrent path. Exhausted retries are Failed, not Skipped. Age-path manifest and blob GETs go through the same `ratelimit.Do` loop so 429s are observed once.

## Changes

- Retry sub-millisecond 429s until the honor window instead of five tries, and warn once with attempts, honored wait, and raw retry-after
- Serialize unauthenticated GHCR and lscr.io onto `ghcr.io|anon` without pacing authenticated traffic to the same host
- Mark honor-window exhaustion as failed and stop recategorizing equal-image failures as fresh
- Send cooldown age fetches through `ratelimit.Do` and protect serial-slot reset with `serialMu`
- Move Docker Hub, GHCR, and LSCR domain names into `pkg/registry/hosts` and document anonymous GHCR behavior