### PR TITLE
fix(registry): reuse anonymous GHCR tokens across public images

### DIFF
--- a/docs/advanced-features/image-cooldown/index.md
+++ b/docs/advanced-features/image-cooldown/index.md
@@ -311,7 +311,7 @@ Authenticating with a Docker Hub account raises the limit from 100 to 200 pulls,
 
 GHCR.io does not publish Docker Hub-style pull quotas. Anonymous pulls of a public org share an undocumented edge token bucket, observed as `allowed: 44000/minute` with a sub-millisecond `retry-after`. That includes `lscr.io/linuxserver/*` images, which Watchtower remaps to `ghcr.io` for digest and auth.
 
-Unauthenticated GHCR checks reuse one anonymous token across public images and run one at a time. Later images in that token lifetime skip the registry challenge. Tiny waits are floored to 100ms and retried for up to 30 seconds. In-cycle retries stay at debug so they do not become notifications. If the window is exhausted, that container is **failed** for the cycle.
+Unauthenticated GHCR checks reuse one anonymous token across public images and run one at a time. Later images in that token lifetime skip the registry challenge. Tiny waits are floored to 100ms and retried for up to 30 seconds. Those retries and the exhaustion of that window stay at debug so they do not become notifications. The container is **failed** for the cycle. A Retry-After longer than 30 seconds is logged as a warning and is not retried until the next run.
 
 `docker login ghcr.io` (or equivalent credentials in `config.json` / `REPO_USER` and `REPO_PASS`) uses a per-user bucket and restores parallel GHCR checks. Login to `lscr.io` alone does not count. Credential lookup uses `ghcr.io` after the remap.
 

--- a/docs/advanced-features/image-cooldown/index.md
+++ b/docs/advanced-features/image-cooldown/index.md
@@ -311,7 +311,7 @@ Authenticating with a Docker Hub account raises the limit from 100 to 200 pulls,
 
 GHCR.io does not publish Docker Hub-style pull quotas. Anonymous pulls of a public org share an undocumented edge token bucket, observed as `allowed: 44000/minute` with a sub-millisecond `retry-after`. That includes `lscr.io/linuxserver/*` images, which Watchtower remaps to `ghcr.io` for digest and auth.
 
-Unauthenticated GHCR checks run one at a time. Tiny waits are floored to 100ms and retried for up to 30 seconds. In-cycle retries stay at debug so they do not become notifications. If the window is exhausted, that container is **failed** for the cycle.
+Unauthenticated GHCR checks reuse one anonymous token across public images and run one at a time. Later images in that token lifetime skip the registry challenge. Tiny waits are floored to 100ms and retried for up to 30 seconds. In-cycle retries stay at debug so they do not become notifications. If the window is exhausted, that container is **failed** for the cycle.
 
 `docker login ghcr.io` (or equivalent credentials in `config.json` / `REPO_USER` and `REPO_PASS`) uses a per-user bucket and restores parallel GHCR checks. Login to `lscr.io` alone does not count. Credential lookup uses `ghcr.io` after the remap.
 

--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -472,6 +472,9 @@ func handleBearerAuth(
 // instead of the canonical registry host. This enables digest checks against configured
 // Docker registry mirrors.
 //
+// Anonymous GHCR requests skip the /v2/ challenge when a shared, unexpired
+// bearer token is already cached.
+//
 // Parameters:
 //   - log: Process logger.
 //   - ctx: Context for request lifecycle control.
@@ -502,6 +505,20 @@ func GetToken(
 			Msg("Failed to parse image name")
 
 		return TokenResult{}, fmt.Errorf("%w: %w", errFailedParseImageName, err)
+	}
+
+	result, ok := cachedAnonymousGHCRToken(
+		&clog,
+		normalizedRef,
+		registryAuth,
+		endpoint,
+	)
+	if ok {
+		clog.Debug().
+			Str("challenge_host", result.ChallengeHost).
+			Msg("Using cached anonymous GHCR token, skipping challenge")
+
+		return result, nil
 	}
 
 	// Generate the challenge URL, using the endpoint override if provided.

--- a/pkg/registry/auth/auth_test.go
+++ b/pkg/registry/auth/auth_test.go
@@ -826,6 +826,102 @@ func TestGetToken(t *testing.T) {
 	}
 }
 
+func TestGetToken_anonymousGHCRSkipsChallengeOnCachedToken(t *testing.T) {
+	seedAnonymousGHCRToken(t)
+
+	mockClient := mockAuth.NewMockClient(t)
+	got, err := GetToken(testLog(), context.Background(), newGHCRContainer(t), "", mockClient, "")
+	require.NoError(t, err)
+	assert.Equal(t, TokenResult{
+		Token:         testAnonymousGHCRToken,
+		ChallengeHost: "ghcr.io",
+	}, got)
+}
+
+func TestGetToken_anonymousLSCRSkipsChallengeOnCachedToken(t *testing.T) {
+	seedAnonymousGHCRToken(t)
+
+	mockClient := mockAuth.NewMockClient(t)
+	got, err := GetToken(testLog(), context.Background(), newLSCRContainer(t), "", mockClient, "")
+	require.NoError(t, err)
+	assert.Equal(t, TokenResult{
+		Token:         testAnonymousGHCRToken,
+		ChallengeHost: "ghcr.io",
+	}, got)
+}
+
+func TestGetToken_anonymousGHCRChallengesWhenCacheEmpty(t *testing.T) {
+	resetTokenCache(t)
+
+	mockClient := mockAuth.NewMockClient(t)
+	challengeURL, err := url.Parse("https://ghcr.io/v2/")
+	require.NoError(t, err)
+
+	mockClient.On("Do", mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusUnauthorized,
+		Body:       http.NoBody,
+		Header:     http.Header{"Www-Authenticate": []string{`Bearer realm="https://ghcr.io/token",service="ghcr.io"`}},
+		Request:    &http.Request{URL: challengeURL},
+	}, nil).Once()
+	mockClient.On("Do", mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"token":"fresh-ghcr-token","expires_in":3600}`)),
+		Header:     make(http.Header),
+		Request:    &http.Request{URL: mustParseURL("https://ghcr.io/token")},
+	}, nil).Once()
+
+	got, err := GetToken(testLog(), context.Background(), newGHCRContainer(t), "", mockClient, "")
+	require.NoError(t, err)
+	assert.Equal(t, TokenResult{
+		Token:         "Bearer fresh-ghcr-token",
+		ChallengeHost: "ghcr.io",
+	}, got)
+}
+
+func TestGetToken_anonymousGHCRDoesNotSkipMirrorOrCredentials(t *testing.T) {
+	seedAnonymousGHCRToken(t)
+
+	tests := []struct {
+		name         string
+		registryAuth string
+		endpoint     string
+		challengeURL string
+	}{
+		{
+			name:         "credentials still challenge",
+			registryAuth: "dXNlcjpwYXNz",
+			challengeURL: "https://ghcr.io/v2/",
+		},
+		{
+			name:         "mirror endpoint still challenge",
+			endpoint:     "https://mirror.example.com",
+			challengeURL: "https://mirror.example.com/v2/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := mockAuth.NewMockClient(t)
+			challengeURL, err := url.Parse(tt.challengeURL)
+			require.NoError(t, err)
+
+			mockClient.On("Do", mock.Anything).Return(&http.Response{
+				StatusCode: http.StatusOK,
+				Body:       http.NoBody,
+				Header:     make(http.Header),
+				Request:    &http.Request{URL: challengeURL},
+			}, nil).Once()
+
+			got, err := GetToken(testLog(), context.Background(), newGHCRContainer(t), tt.registryAuth, mockClient, tt.endpoint)
+			require.NoError(t, err)
+			assert.Equal(t, TokenResult{
+				Redirected:   false,
+				RedirectHost: "",
+			}, got)
+		})
+	}
+}
+
 func newNoPullContainer(t *testing.T) types.Container {
 	t.Helper()
 
@@ -855,6 +951,30 @@ func newRemoteContainer(t *testing.T) types.Container {
 
 	container := mockTypes.NewMockContainer(t)
 	container.On("ImageName").Return("test/image:latest").Maybe()
+	container.On("IsNoPull", mock.Anything).Return(false).Maybe()
+	container.On("IsStale").Return(false).Maybe()
+	container.On("IsRunning").Return(true).Maybe()
+
+	return container
+}
+
+func newGHCRContainer(t *testing.T) types.Container {
+	t.Helper()
+
+	container := mockTypes.NewMockContainer(t)
+	container.On("ImageName").Return("ghcr.io/linuxserver/sonarr:latest").Maybe()
+	container.On("IsNoPull", mock.Anything).Return(false).Maybe()
+	container.On("IsStale").Return(false).Maybe()
+	container.On("IsRunning").Return(true).Maybe()
+
+	return container
+}
+
+func newLSCRContainer(t *testing.T) types.Container {
+	t.Helper()
+
+	container := mockTypes.NewMockContainer(t)
+	container.On("ImageName").Return("lscr.io/linuxserver/sonarr:latest").Maybe()
 	container.On("IsNoPull", mock.Anything).Return(false).Maybe()
 	container.On("IsStale").Return(false).Maybe()
 	container.On("IsRunning").Return(true).Maybe()

--- a/pkg/registry/auth/bearer.go
+++ b/pkg/registry/auth/bearer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/spf13/viper"
 
+	"github.com/nicholas-fedor/watchtower/pkg/registry/hosts"
 	"github.com/nicholas-fedor/watchtower/pkg/registry/ratelimit"
 	"github.com/nicholas-fedor/watchtower/pkg/types"
 )
@@ -98,6 +99,8 @@ func initTokenCache(log *zerolog.Logger) {
 //
 // It parses the challenge header, constructs the auth URL, and retrieves a bearer token.
 // The token is cached to avoid redundant HTTP requests for the same challenge.
+// Anonymous GHCR tokens are reused across public images because GHCR does not
+// bind those tokens to the requested repository scope.
 //
 // Parameters:
 //   - ctx: Context for request lifecycle control, enabling cancellation or timeouts.
@@ -151,6 +154,7 @@ func GetBearerToken(log *zerolog.Logger,
 //
 // It checks the token cache for a valid, unexpired entry. On a cache miss or expiry,
 // it executes the HTTP request, parses the response, and populates the cache.
+// Anonymous GHCR entries share a cache key that omits repository scope.
 //
 // Parameters:
 //   - ctx: Context for request lifecycle control.
@@ -171,7 +175,8 @@ func executeBearerTokenRequest(log *zerolog.Logger,
 ) (string, error) {
 	initTokenCache(log)
 
-	cacheKeyStr := authURL.String() + "|" + registryAuth
+	// Anonymous GHCR requests share a cache key that omits repository scope.
+	cacheKeyStr := bearerCacheKey(authURL, registryAuth)
 
 	// Attempt cache lookup.
 	entry, ok := tokenCache.GetIfPresent(cacheKeyStr)
@@ -222,6 +227,124 @@ func executeBearerTokenRequest(log *zerolog.Logger,
 		Msg("Retrieved and cached bearer token")
 
 	return fullToken, nil
+}
+
+// bearerCacheKey returns the cache key for a bearer token request.
+//
+// Anonymous GHCR tokens are reusable across public repositories, so the
+// repository scope is omitted from the key. Authenticated GHCR tokens and
+// tokens for other registries remain scoped to the full token URL.
+//
+// Parameters:
+//   - authURL: Token endpoint URL, including service and scope query parameters.
+//   - registryAuth: Base64-encoded credentials. Empty for anonymous pulls.
+//
+// Returns:
+//   - string: Cache key used by the bearer token cache.
+func bearerCacheKey(authURL *url.URL, registryAuth string) string {
+	if sharedAnonymousGHCRToken(authURL, registryAuth) {
+		shared := *authURL
+		query := shared.Query()
+		query.Del("scope")
+		shared.RawQuery = query.Encode()
+
+		return shared.String() + "|"
+	}
+
+	return authURL.String() + "|" + registryAuth
+}
+
+// sharedAnonymousGHCRToken reports whether authURL and registryAuth identify
+// an anonymous GitHub Container Registry token that can be reused across
+// public images.
+//
+// Parameters:
+//   - authURL: Token endpoint URL.
+//   - registryAuth: Base64-encoded credentials. Empty for anonymous pulls.
+//
+// Returns:
+//   - bool: True when the token should use the shared anonymous GHCR cache key.
+func sharedAnonymousGHCRToken(authURL *url.URL, registryAuth string) bool {
+	return registryAuth == "" && hosts.IsGitHubRegistry(authURL.Hostname())
+}
+
+// anonymousGHCRTokenURL returns the GHCR token endpoint used for the shared
+// anonymous cache key.
+//
+// Returns:
+//   - *url.URL: https://ghcr.io/token?service=ghcr.io
+func anonymousGHCRTokenURL() *url.URL {
+	query := url.Values{}
+	query.Set("service", hosts.GitHubRegistryDomain)
+
+	return &url.URL{
+		Scheme:   "https",
+		Host:     hosts.GitHubRegistryDomain,
+		Path:     "/token",
+		RawQuery: query.Encode(),
+	}
+}
+
+// lookupAnonymousGHCRToken returns a cached anonymous GHCR bearer token when
+// one is present and unexpired.
+//
+// Parameters:
+//   - log: Logger used to initialize the token cache on first use.
+//
+// Returns:
+//   - string: Cached bearer token header (for example "Bearer ...").
+//   - bool: True when a valid cached token was found.
+func lookupAnonymousGHCRToken(log *zerolog.Logger) (string, bool) {
+	initTokenCache(log)
+
+	entry, ok := tokenCache.GetIfPresent(
+		bearerCacheKey(anonymousGHCRTokenURL(), ""),
+	)
+	if !ok || !time.Now().Before(entry.expiresAt) {
+		return "", false
+	}
+
+	return entry.token, true
+}
+
+// cachedAnonymousGHCRToken returns a TokenResult for a cached anonymous GHCR
+// token when the request can skip the registry challenge.
+//
+// Credentials, registry mirrors, and non-GHCR hosts still require a live
+// challenge. A cache miss or expired token also falls through.
+//
+// Parameters:
+//   - log: Logger used for cache initialization.
+//   - imageRef: Normalized image reference whose registry host is inspected.
+//   - registryAuth: Base64-encoded credentials. Empty for anonymous pulls.
+//   - endpoint: Optional registry mirror override. Empty uses the canonical host.
+//
+// Returns:
+//   - TokenResult: Cached token and ghcr.io challenge host when skipping.
+//   - bool: True when the caller may skip the /v2/ challenge.
+func cachedAnonymousGHCRToken(
+	log *zerolog.Logger,
+	imageRef reference.Named,
+	registryAuth string,
+	endpoint string,
+) (TokenResult, bool) {
+	if endpoint != "" || registryAuth != "" {
+		return TokenResult{}, false
+	}
+
+	if !hosts.IsGitHubRegistry(reference.Domain(imageRef)) {
+		return TokenResult{}, false
+	}
+
+	token, ok := lookupAnonymousGHCRToken(log)
+	if !ok {
+		return TokenResult{}, false
+	}
+
+	return TokenResult{
+		Token:         token,
+		ChallengeHost: hosts.GitHubRegistryDomain,
+	}, true
 }
 
 // performBearerTokenFetch executes the HTTP request to fetch a bearer token.

--- a/pkg/registry/auth/bearer_test.go
+++ b/pkg/registry/auth/bearer_test.go
@@ -583,8 +583,7 @@ func Test_executeBearerTokenRequest_cacheHit(t *testing.T) {
 	imageName := "test/image"
 	mockClient := mockAuth.NewMockClient(t)
 
-	initTokenCache(testLog())
-	tokenCache.InvalidateAll()
+	resetTokenCache(t)
 
 	cacheKey := authURL.String() + "|"
 	tokenCache.SetIfAbsent(cacheKey, tokenCacheEntry{
@@ -595,6 +594,177 @@ func Test_executeBearerTokenRequest_cacheHit(t *testing.T) {
 	got, err := executeBearerTokenRequest(testLog(), ctx, authURL, imageName, "", mockClient)
 	require.NoError(t, err)
 	assert.Equal(t, "Bearer cached-token", got)
+}
+
+func resetTokenCache(t *testing.T) {
+	t.Helper()
+	initTokenCache(testLog())
+	tokenCache.InvalidateAll()
+}
+
+const testAnonymousGHCRToken = "Bearer cached-ghcr-token"
+
+func seedAnonymousGHCRToken(t *testing.T) {
+	t.Helper()
+	resetTokenCache(t)
+
+	authURL := mustParseURL("https://ghcr.io/token?service=ghcr.io")
+	tokenCache.SetIfAbsent(bearerCacheKey(authURL, ""), tokenCacheEntry{
+		token:     testAnonymousGHCRToken,
+		expiresAt: time.Now().Add(time.Hour),
+	})
+}
+
+func Test_bearerCacheKey(t *testing.T) {
+	tests := []struct {
+		name         string
+		rawURL       string
+		registryAuth string
+		want         string
+	}{
+		{
+			name:         "anonymous GHCR drops repository scope",
+			rawURL:       "https://ghcr.io/token?scope=repository%3Alinuxserver%2Fprowlarr%3Apull&service=ghcr.io",
+			registryAuth: "",
+			want:         "https://ghcr.io/token?service=ghcr.io|",
+		},
+		{
+			name:         "anonymous GHCR shares key across images",
+			rawURL:       "https://ghcr.io/token?scope=repository%3Alinuxserver%2Fsonarr%3Apull&service=ghcr.io",
+			registryAuth: "",
+			want:         "https://ghcr.io/token?service=ghcr.io|",
+		},
+		{
+			name:         "anonymous lscr.io token host shares with GHCR mapping",
+			rawURL:       "https://lscr.io/token?scope=repository%3Alinuxserver%2Fsonarr%3Apull&service=ghcr.io",
+			registryAuth: "",
+			want:         "https://lscr.io/token?service=ghcr.io|",
+		},
+		{
+			name:         "authenticated GHCR keeps per-image scope",
+			rawURL:       "https://ghcr.io/token?scope=repository%3Alinuxserver%2Fprowlarr%3Apull&service=ghcr.io",
+			registryAuth: "dXNlcjpwYXNz",
+			want:         "https://ghcr.io/token?scope=repository%3Alinuxserver%2Fprowlarr%3Apull&service=ghcr.io|dXNlcjpwYXNz",
+		},
+		{
+			name:         "anonymous Docker Hub keeps per-image scope",
+			rawURL:       "https://auth.docker.io/token?scope=repository%3Alibrary%2Falpine%3Apull&service=registry.docker.io",
+			registryAuth: "",
+			want:         "https://auth.docker.io/token?scope=repository%3Alibrary%2Falpine%3Apull&service=registry.docker.io|",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authURL, err := url.Parse(tt.rawURL)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, bearerCacheKey(authURL, tt.registryAuth))
+		})
+	}
+}
+
+func Test_executeBearerTokenRequest_anonymousGHCRSharesToken(t *testing.T) {
+	resetTokenCache(t)
+
+	ctx := context.Background()
+	mockClient := mockAuth.NewMockClient(t)
+	prowlarr := mustParseURL("https://ghcr.io/token?scope=repository%3Alinuxserver%2Fprowlarr%3Apull&service=ghcr.io")
+	sonarr := mustParseURL("https://ghcr.io/token?scope=repository%3Alinuxserver%2Fsonarr%3Apull&service=ghcr.io")
+
+	mockClient.On("Do", mock.MatchedBy(func(req *http.Request) bool {
+		return req.URL.Host == "ghcr.io" &&
+			req.URL.Query().Get("scope") == "repository:linuxserver/prowlarr:pull"
+	})).Return(&http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"token":"shared-anon-token","expires_in":3600}`)),
+	}, nil).Once()
+
+	first, err := executeBearerTokenRequest(testLog(), ctx, prowlarr, "ghcr.io/linuxserver/prowlarr", "", mockClient)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer shared-anon-token", first)
+
+	second, err := executeBearerTokenRequest(testLog(), ctx, sonarr, "ghcr.io/linuxserver/sonarr", "", mockClient)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer shared-anon-token", second)
+}
+
+func Test_executeBearerTokenRequest_authenticatedGHCRDoesNotShare(t *testing.T) {
+	resetTokenCache(t)
+
+	ctx := context.Background()
+	mockClient := mockAuth.NewMockClient(t)
+	registryAuth := "dXNlcjpwYXNz"
+	prowlarr := mustParseURL("https://ghcr.io/token?scope=repository%3Alinuxserver%2Fprowlarr%3Apull&service=ghcr.io")
+	sonarr := mustParseURL("https://ghcr.io/token?scope=repository%3Alinuxserver%2Fsonarr%3Apull&service=ghcr.io")
+
+	mockClient.On("Do", mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"token":"scoped-token","expires_in":3600}`)),
+	}, nil).Once()
+	mockClient.On("Do", mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"token":"scoped-token","expires_in":3600}`)),
+	}, nil).Once()
+
+	first, err := executeBearerTokenRequest(testLog(), ctx, prowlarr, "ghcr.io/linuxserver/prowlarr", registryAuth, mockClient)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer scoped-token", first)
+
+	second, err := executeBearerTokenRequest(testLog(), ctx, sonarr, "ghcr.io/linuxserver/sonarr", registryAuth, mockClient)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer scoped-token", second)
+}
+
+func Test_executeBearerTokenRequest_anonymousNonGHCRDoesNotShare(t *testing.T) {
+	resetTokenCache(t)
+
+	ctx := context.Background()
+	mockClient := mockAuth.NewMockClient(t)
+	alpine := mustParseURL("https://auth.docker.io/token?scope=repository%3Alibrary%2Falpine%3Apull&service=registry.docker.io")
+	nginx := mustParseURL("https://auth.docker.io/token?scope=repository%3Alibrary%2Fnginx%3Apull&service=registry.docker.io")
+
+	mockClient.On("Do", mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"token":"hub-token","expires_in":3600}`)),
+	}, nil).Once()
+	mockClient.On("Do", mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"token":"hub-token","expires_in":3600}`)),
+	}, nil).Once()
+
+	first, err := executeBearerTokenRequest(testLog(), ctx, alpine, "library/alpine", "", mockClient)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer hub-token", first)
+
+	second, err := executeBearerTokenRequest(testLog(), ctx, nginx, "library/nginx", "", mockClient)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer hub-token", second)
+}
+
+func TestGetBearerToken_anonymousGHCRSharesAcrossImages(t *testing.T) {
+	resetTokenCache(t)
+
+	ctx := context.Background()
+	mockClient := mockAuth.NewMockClient(t)
+	prowlarr, err := reference.ParseNormalizedNamed("ghcr.io/linuxserver/prowlarr:latest")
+	require.NoError(t, err)
+	sonarr, err := reference.ParseNormalizedNamed("ghcr.io/linuxserver/sonarr:latest")
+	require.NoError(t, err)
+	watchtower, err := reference.ParseNormalizedNamed("ghcr.io/nicholas-fedor/watchtower:latest")
+	require.NoError(t, err)
+
+	challenge := `bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:linuxserver/prowlarr:pull"`
+
+	mockClient.On("Do", mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"token":"shared-anon-token","expires_in":3600}`)),
+	}, nil).Once()
+
+	for _, image := range []reference.Named{prowlarr, sonarr, watchtower} {
+		got, getErr := GetBearerToken(testLog(), ctx, challenge, image, "", mockClient)
+		require.NoError(t, getErr)
+		assert.Equal(t, "Bearer shared-anon-token", got)
+	}
 }
 
 func Test_performBearerTokenFetch(t *testing.T) {
@@ -690,6 +860,103 @@ func Test_performBearerTokenFetch(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_lookupAnonymousGHCRToken(t *testing.T) {
+	t.Run("miss when cache is empty", func(t *testing.T) {
+		resetTokenCache(t)
+
+		got, ok := lookupAnonymousGHCRToken(testLog())
+		assert.False(t, ok)
+		assert.Empty(t, got)
+	})
+
+	t.Run("hit returns unexpired shared token", func(t *testing.T) {
+		seedAnonymousGHCRToken(t)
+
+		got, ok := lookupAnonymousGHCRToken(testLog())
+		assert.True(t, ok)
+		assert.Equal(t, testAnonymousGHCRToken, got)
+	})
+
+	t.Run("expired entry is not returned", func(t *testing.T) {
+		resetTokenCache(t)
+
+		authURL := mustParseURL("https://ghcr.io/token?service=ghcr.io")
+		tokenCache.SetIfAbsent(bearerCacheKey(authURL, ""), tokenCacheEntry{
+			token:     "Bearer stale-token",
+			expiresAt: time.Now().Add(-time.Minute),
+		})
+
+		got, ok := lookupAnonymousGHCRToken(testLog())
+		assert.False(t, ok)
+		assert.Empty(t, got)
+	})
+}
+
+func Test_cachedAnonymousGHCRToken(t *testing.T) {
+	ghcrRef, err := reference.ParseNormalizedNamed("ghcr.io/linuxserver/sonarr:latest")
+	require.NoError(t, err)
+	lscrRef, err := reference.ParseNormalizedNamed("lscr.io/linuxserver/sonarr:latest")
+	require.NoError(t, err)
+	hubRef, err := reference.ParseNormalizedNamed("library/nginx:latest")
+	require.NoError(t, err)
+
+	seedAnonymousGHCRToken(t)
+
+	tests := []struct {
+		name         string
+		imageRef     reference.Named
+		registryAuth string
+		endpoint     string
+		wantOK       bool
+	}{
+		{
+			name:     "anonymous GHCR cache hit",
+			imageRef: ghcrRef,
+			wantOK:   true,
+		},
+		{
+			name:     "anonymous lscr.io cache hit",
+			imageRef: lscrRef,
+			wantOK:   true,
+		},
+		{
+			name:         "authenticated GHCR does not skip",
+			imageRef:     ghcrRef,
+			registryAuth: "dXNlcjpwYXNz",
+			wantOK:       false,
+		},
+		{
+			name:     "mirror endpoint does not skip",
+			imageRef: ghcrRef,
+			endpoint: "https://mirror.example.com",
+			wantOK:   false,
+		},
+		{
+			name:     "Docker Hub does not skip",
+			imageRef: hubRef,
+			wantOK:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := cachedAnonymousGHCRToken(testLog(), tt.imageRef, tt.registryAuth, tt.endpoint)
+			assert.Equal(t, tt.wantOK, ok)
+
+			if !tt.wantOK {
+				assert.Equal(t, TokenResult{}, got)
+
+				return
+			}
+
+			assert.Equal(t, TokenResult{
+				Token:         testAnonymousGHCRToken,
+				ChallengeHost: "ghcr.io",
+			}, got)
 		})
 	}
 }

--- a/pkg/registry/auth/doc.go
+++ b/pkg/registry/auth/doc.go
@@ -10,4 +10,6 @@
 //   - lscr.io images are hosted on ghcr.io, so auth challenges are remapped
 //   - Docker Hub's docker.io maps to index.docker.io
 //   - Basic auth is supported when credentials are provided
+//   - Anonymous GHCR bearer tokens are reused across public images
+//   - A cached anonymous GHCR token skips the /v2/ challenge
 package auth

--- a/pkg/registry/ratelimit/retry.go
+++ b/pkg/registry/ratelimit/retry.go
@@ -122,7 +122,7 @@ func DoValue[T any](
 
 	err = lastOperationError(err)
 	if log != nil && Is(err) {
-		log.Warn().
+		log.WithLevel(exhaustionLevel(err)).
 			Err(err).
 			Str("host", host).
 			Int("attempts", attempt).
@@ -132,6 +132,27 @@ func DoValue[T any](
 	}
 
 	return result, err
+}
+
+// exhaustionLevel chooses the log level when in-cycle 429 retries stop.
+//
+// A Retry-After longer than the honor window is a real registry backoff and
+// is logged at warn. Tiny token-bucket waits that exhaust the retry budget
+// stay at debug so they do not become notifications. The container is still
+// Failed on the session report.
+//
+// Parameters:
+//   - err: Last rate-limit error from the retry loop.
+//
+// Returns:
+//   - zerolog.Level: Warn for long Retry-After, debug otherwise.
+func exhaustionLevel(err error) zerolog.Level {
+	info, ok := errors.AsType[*Error](err)
+	if ok && info != nil && info.RetryAfter > maxHonorWait {
+		return zerolog.WarnLevel
+	}
+
+	return zerolog.DebugLevel
 }
 
 // maxRetryAttempts is a circuit breaker derived from the elapsed budget.

--- a/pkg/registry/ratelimit/retry_test.go
+++ b/pkg/registry/ratelimit/retry_test.go
@@ -91,6 +91,31 @@ func TestDoLogsExhaustionAtWarn(t *testing.T) {
 	assert.NotContains(t, buf.String(), "Retrying after delay")
 }
 
+func TestDoLogsTinyTokenBucketExhaustionAtDebug(t *testing.T) {
+	ResetForTest()
+
+	retryElapsed = 250 * time.Millisecond
+
+	defer ResetForTest()
+
+	var buf bytes.Buffer
+
+	log := zerolog.New(&buf).Level(zerolog.DebugLevel)
+
+	err := Do(t.Context(), &log, "ghcr.io", func() error {
+		return &Error{
+			RetryAfter:    975 * time.Microsecond,
+			Allowed:       44000,
+			AllowedWindow: time.Minute,
+			Host:          "ghcr.io",
+		}
+	})
+	require.ErrorIs(t, err, ErrRateLimited)
+	assert.Contains(t, buf.String(), "Registry rate limited. Stopping retries")
+	assert.Contains(t, buf.String(), `"level":"debug"`)
+	assert.NotContains(t, buf.String(), `"level":"warn"`)
+}
+
 func TestDoRetriesPastFiveWhenRetryAfterIsTiny(t *testing.T) {
 	ResetForTest()
 
@@ -138,6 +163,8 @@ func TestDoGivesUpWhenTinyRetryAfterExceedsElapsedBudget(t *testing.T) {
 	require.ErrorIs(t, err, ErrRateLimited)
 	assert.Contains(t, buf.String(), "Registry rate limited. Stopping retries")
 	assert.Contains(t, buf.String(), "Retrying after delay")
+	assert.Contains(t, buf.String(), `"level":"debug"`)
+	assert.NotContains(t, buf.String(), `"level":"warn"`)
 
 	maxStep := minHonorWait + minHonorWait/equalJitterDivisor
 	minAttempts := int(retryElapsed / maxStep)


### PR DESCRIPTION
This PR reduces unauthenticated GHCR digest-check pressure that was minting one bearer token per image and notifying at warn-level the exhaustion for GitHub's shared token bucket. One anonymous token is reused across public GHCR and lscr.io images, later images skip the registry challenge while that token is valid, and tiny 429 exhaustion stays at the debug logging level.

## Problem

Unauthenticated GHCR, including lscr.io, shares an undocumented community token bucket. Watchtower requested a new token per image even though GHCR does not bind anonymous tokens to repository scope, which burned extra quota. Most checks succeeded while a handful failed with `allowed 44000 per 1m0s` and a sub-millisecond retry-after. Exhaustion was logged at the warn level, so those failures became notifications.

## Solution

Cache anonymous GHCR bearer tokens without repository scope, so one mint covers public images for the token lifetime. Skip the registry challenge when that cached token is still unexpired. Keep Docker Hub, authenticated GHCR, and mirror endpoints on per-image tokens. Log honor-window exhaustion of tiny token-bucket waits at the debug log level. Keep `Failed` on the session report. Log at the warn level only when Retry-After exceeds 30 seconds.

## Changes

- Share unauthenticated GHCR tokens across images and skip `/v2/` when the cached token is unexpired
- Leave Docker Hub, authenticated GHCR, and registry mirrors on per-image tokens
- Log tiny token-bucket retry exhaustion at debug level and long Retry-After at warn level
- Document anonymous GHCR token reuse, skipped challenges, and notification-level behavior