### PR TITLE
refactor: replace untyped maps with concrete types

### DIFF
--- a/internal/actions/ephemeral.go
+++ b/internal/actions/ephemeral.go
@@ -87,13 +87,9 @@ func EphemeralSelfUpdate(log *zerolog.Logger, ctx context.Context,
 	sourceContainer types.Container,
 	config types.UpdateParams,
 ) (types.ContainerID, bool, error) {
-	fields := map[string]any{
-		"container": sourceContainer.Name(),
-		"image":     sourceContainer.ImageName(),
-	}
-
 	clogVal := log.With().
-		Fields(fields).
+		Str("container", sourceContainer.Name()).
+		Str("image", sourceContainer.ImageName()).
 		Logger()
 	clog := &clogVal
 

--- a/internal/actions/mocks/client.go
+++ b/internal/actions/mocks/client.go
@@ -588,16 +588,15 @@ func (client MockClient) GetImageDiskUsage(ctx context.Context) (types.ImageDisk
 }
 
 // GetInfo returns mock system information for testing.
-// It provides a basic map with mock Docker/Podman info.
-func (client MockClient) GetInfo(ctx context.Context) (map[string]any, error) {
+func (client MockClient) GetInfo(ctx context.Context) (types.SystemInfo, error) {
 	if err := client.checkContextCancellation(ctx); err != nil {
-		return nil, err
+		return types.SystemInfo{}, err
 	}
 
-	return map[string]any{
-		"Name":          "docker",
-		"ServerVersion": "1.50",
-		"OSType":        "linux",
+	return types.SystemInfo{
+		Name:          "docker",
+		ServerVersion: "1.50",
+		OSType:        "linux",
 	}, nil
 }
 

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -1051,7 +1051,7 @@ func linkedIdentifierMarkedForRestart(log *zerolog.Logger, links []string,
 		}
 	}
 
-	dependentProject := getProject(log, dependentContainer)
+	dependentProject := getProject(dependentContainer)
 
 	// Collect known projects so we can distinguish bare service-name references
 	// (which may contain hyphens) from explicit project-qualified identifiers
@@ -1059,7 +1059,7 @@ func linkedIdentifierMarkedForRestart(log *zerolog.Logger, links []string,
 	knownProjects := map[string]bool{}
 
 	for _, c := range allContainers {
-		p := getProject(log, c)
+		p := getProject(c)
 		if p != "" {
 			knownProjects[p] = true
 		}
@@ -1127,7 +1127,7 @@ func linkedIdentifierMarkedForRestart(log *zerolog.Logger, links []string,
 		matches := sorter.FindMatchingIdentifiers(link, restartingNames)
 
 		if len(matches) > 0 {
-			dependentProject := getProject(log, dependentContainer)
+			dependentProject := getProject(dependentContainer)
 
 			// Prefer any candidate that shares the dependent's project (from labels).
 			for _, matchedID := range matches {
@@ -1136,7 +1136,7 @@ func linkedIdentifierMarkedForRestart(log *zerolog.Logger, links []string,
 					continue
 				}
 
-				if getProject(log, matchedContainer) == dependentProject && dependentProject != "" {
+				if getProject(matchedContainer) == dependentProject && dependentProject != "" {
 					log.Debug().
 						Str("link", link).
 						Str("matched", matchedID).
@@ -1196,7 +1196,7 @@ func linkedIdentifierMarkedForRestart(log *zerolog.Logger, links []string,
 			continue
 		}
 
-		dependentProject := getProject(log, dependentContainer)
+		dependentProject := getProject(dependentContainer)
 		linkService := sorter.ExtractServiceName(link)
 
 		// Build the list of currently restarting containers that match on service name alone.
@@ -1216,7 +1216,7 @@ func linkedIdentifierMarkedForRestart(log *zerolog.Logger, links []string,
 					continue
 				}
 
-				if getProject(log, c) == dependentProject &&
+				if getProject(c) == dependentProject &&
 					dependentProject != "" {
 					log.Debug().
 						Str("link", link).
@@ -1257,12 +1257,12 @@ func linkedIdentifierMarkedForRestart(log *zerolog.Logger, links []string,
 //
 // Returns:
 //   - string: Project name, or "" if none can be determined.
-func getProject(log *zerolog.Logger, c types.Container) string {
+func getProject(c types.Container) string {
 	monitoredContainer, ok := c.(*container.Container)
 	if ok {
 		info := monitoredContainer.ContainerInfo()
 		if info != nil && info.Config != nil {
-			project := compose.GetProjectName(log, info.Config.Labels)
+			project := compose.GetProjectName(info.Config.Labels)
 			if project != "" {
 				return project
 			}

--- a/internal/api/mocks/Server.go
+++ b/internal/api/mocks/Server.go
@@ -17,10 +17,19 @@ func NewMockServer(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockServer {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockServer{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/logging/mocks/APIVersionProvider.go
+++ b/internal/logging/mocks/APIVersionProvider.go
@@ -14,10 +14,19 @@ func NewMockAPIVersionProvider(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockAPIVersionProvider {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockAPIVersionProvider{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/internal/util/doc.go
+++ b/internal/util/doc.go
@@ -2,18 +2,15 @@
 // It includes tools for slice and map manipulation, random name generation, and SHA-256 hashing.
 //
 // Key components:
-//   - SliceEqual: Compares string slices for equality.
 //   - SliceSubtract: Removes elements from string slices.
 //   - StringMapSubtract: Removes matching key-value pairs from string maps.
 //   - StructMapSubtract: Removes matching keys from struct maps.
-//   - MinInt: Returns the smaller of two integers.
 //   - RandName: Generates random 32-character container names.
 //   - GenerateRandomSHA256: Creates random 64-character SHA-256 hashes.
 //   - ParseDiskSpace: Parses absolute disk-space strings into bytes.
 //
 // Usage example:
 //
-//	equal := util.SliceEqual(slice1, slice2)
 //	name := util.RandName()
 //	hash := util.GenerateRandomPrefixedSHA256()
 //

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -29,28 +29,6 @@ type timeUnit struct {
 	plural   string // The plural form of the unit (e.g., "hours")
 }
 
-// SliceEqual checks if two string slices are identical.
-//
-// Parameters:
-//   - slice1: First slice.
-//   - slice2: Second slice.
-//
-// Returns:
-//   - bool: True if equal, false otherwise.
-func SliceEqual(slice1, slice2 []string) bool {
-	if len(slice1) != len(slice2) {
-		return false
-	}
-
-	for i := range slice1 {
-		if slice1[i] != slice2[i] {
-			return false
-		}
-	}
-
-	return true
-}
-
 // SliceSubtract returns elements in the first slice that are not in the second slice.
 //
 // Parameters:
@@ -71,22 +49,6 @@ func SliceSubtract(slice, subtractFrom []string) []string {
 	}
 
 	return result
-}
-
-// MinInt returns the smaller of two integers.
-//
-// Parameters:
-//   - a: First integer.
-//   - b: Second integer.
-//
-// Returns:
-//   - int: The smaller of the two integers.
-func MinInt(a, b int) int {
-	if a < b {
-		return a
-	}
-
-	return b
 }
 
 // StringMapSubtract removes matching key-value pairs.

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -8,45 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSliceEqual_True verifies that identical slices are considered equal.
-// It ensures SliceEqual returns true for matching content.
-func TestSliceEqual_True(t *testing.T) {
-	t.Parallel()
-
-	slice1 := []string{"a", "b", "c"}
-	slice2 := []string{"a", "b", "c"}
-
-	result := SliceEqual(slice1, slice2)
-
-	assert.True(t, result)
-}
-
-// TestSliceEqual_DifferentLengths verifies that slices of different lengths are not equal.
-// It ensures SliceEqual returns false when lengths differ.
-func TestSliceEqual_DifferentLengths(t *testing.T) {
-	t.Parallel()
-
-	slice1 := []string{"a", "b", "c"}
-	slice2 := []string{"a", "b", "c", "d"}
-
-	result := SliceEqual(slice1, slice2)
-
-	assert.False(t, result)
-}
-
-// TestSliceEqual_DifferentContents verifies that slices with different contents are not equal.
-// It ensures SliceEqual returns false when elements differ.
-func TestSliceEqual_DifferentContents(t *testing.T) {
-	t.Parallel()
-
-	slice1 := []string{"a", "b", "c"}
-	slice2 := []string{"a", "b", "d"}
-
-	result := SliceEqual(slice1, slice2)
-
-	assert.False(t, result)
-}
-
 // TestSliceSubtract verifies that SliceSubtract correctly removes matching elements.
 // It ensures the result contains only unique elements from the first slice.
 func TestSliceSubtract(t *testing.T) {
@@ -107,46 +68,6 @@ func TestGenerateRandomPrefixedSHA256(t *testing.T) {
 
 	result := GenerateRandomPrefixedSHA256()
 	assert.Regexp(t, "sha256:[0-9|a-f]{64}", result)
-}
-
-// TestMinInt_FirstSmaller verifies that MinInt returns the smaller value when the first argument is smaller.
-func TestMinInt_FirstSmaller(t *testing.T) {
-	t.Parallel()
-
-	result := MinInt(3, 5)
-	assert.Equal(t, 3, result)
-}
-
-// TestMinInt_SecondSmaller verifies that MinInt returns the smaller value when the second argument is smaller.
-func TestMinInt_SecondSmaller(t *testing.T) {
-	t.Parallel()
-
-	result := MinInt(7, 2)
-	assert.Equal(t, 2, result)
-}
-
-// TestMinInt_Equal verifies that MinInt returns either value when both arguments are equal.
-func TestMinInt_Equal(t *testing.T) {
-	t.Parallel()
-
-	result := MinInt(4, 4)
-	assert.Equal(t, 4, result)
-}
-
-// TestMinInt_NegativeNumbers verifies that MinInt works correctly with negative numbers.
-func TestMinInt_NegativeNumbers(t *testing.T) {
-	t.Parallel()
-
-	result := MinInt(-1, -3)
-	assert.Equal(t, -3, result)
-}
-
-// TestMinInt_Zero verifies that MinInt works correctly with zero.
-func TestMinInt_Zero(t *testing.T) {
-	t.Parallel()
-
-	result := MinInt(0, 5)
-	assert.Equal(t, 0, result)
 }
 
 // TestFormatDuration_Zero verifies that FormatDuration returns "0 seconds" for zero duration.

--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -2,7 +2,8 @@ package compose
 
 import (
 	"encoding/json"
-	"sort"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/rs/zerolog"
@@ -35,62 +36,31 @@ func ParseDependsOnLabel(log *zerolog.Logger, labelValue string) []string {
 		return nil
 	}
 
-	clogVal := log.With().
-		Str("label_value", labelValue).
-		Logger()
-	clog := &clogVal
-	clog.Debug().Msg("Parsing compose depends-on label")
-
-	// Try to parse as JSON first (Docker Compose v2+ format)
 	if strings.HasPrefix(strings.TrimSpace(labelValue), "{") {
-		var dependsOn map[string]any
+		var dependsOn map[string]json.RawMessage
 
 		err := json.Unmarshal([]byte(labelValue), &dependsOn)
 		if err != nil {
-			clog.Debug().
+			log.Debug().
 				Err(err).
+				Str("label_value", labelValue).
 				Msg("Failed to parse as JSON, falling back to string parsing")
 		} else {
-			services := make([]string, 0, len(dependsOn))
-			for service := range dependsOn {
-				services = append(services, service)
-			}
-			// Sort for consistent ordering
-			sort.Strings(services)
-			clog.Debug().
-				Strs("parsed_services", services).
-				Msg("Parsed JSON format compose depends-on label")
-
-			return services
+			return slices.Sorted(maps.Keys(dependsOn))
 		}
 	}
 
-	// Fall back to string parsing (legacy format)
 	deps := strings.Split(labelValue, ",")
 	services := make([]string, 0, len(deps))
 
-	// Parse comma-separated list of service:condition:required
 	for _, dep := range deps {
-		dep = strings.TrimSpace(dep)
-		if dep == "" {
-			continue
-		}
+		serviceName, _, _ := strings.Cut(strings.TrimSpace(dep), ":")
 
-		clog.Debug().
-			Str("parsing_dep", dep).
-			Msg("Parsing individual dependency")
-		// Parse colon-separated format: service:condition:required
-		parts := strings.Split(dep, ":")
-
-		serviceName := strings.TrimSpace(parts[0])
+		serviceName = strings.TrimSpace(serviceName)
 		if serviceName != "" {
 			services = append(services, serviceName)
 		}
 	}
-
-	clog.Debug().
-		Strs("parsed_services", services).
-		Msg("Completed parsing string format compose depends-on label")
 
 	return services
 }
@@ -105,22 +75,8 @@ func ParseDependsOnLabel(log *zerolog.Logger, labelValue string) []string {
 //
 // Returns:
 //   - string: Project name if present, empty string otherwise.
-func GetProjectName(log *zerolog.Logger, labels map[string]string) string {
-	if labels == nil {
-		return ""
-	}
-
-	projectName, ok := labels[ComposeProjectLabel]
-	if !ok {
-		return ""
-	}
-
-	log.Debug().
-		Str("label", ComposeProjectLabel).
-		Str("value", projectName).
-		Msg("Retrieved compose project name")
-
-	return projectName
+func GetProjectName(labels map[string]string) string {
+	return labels[ComposeProjectLabel]
 }
 
 // GetServiceName extracts the service name from Docker Compose labels.
@@ -133,22 +89,8 @@ func GetProjectName(log *zerolog.Logger, labels map[string]string) string {
 //
 // Returns:
 //   - string: Service name if present, empty string otherwise.
-func GetServiceName(log *zerolog.Logger, labels map[string]string) string {
-	if labels == nil {
-		return ""
-	}
-
-	serviceName, ok := labels[ComposeServiceLabel]
-	if !ok {
-		return ""
-	}
-
-	log.Debug().
-		Str("label", ComposeServiceLabel).
-		Str("value", serviceName).
-		Msg("Retrieved compose service name")
-
-	return serviceName
+func GetServiceName(labels map[string]string) string {
+	return labels[ComposeServiceLabel]
 }
 
 // GetContainerNumber extracts the container number from the Docker Compose labels.
@@ -161,20 +103,6 @@ func GetServiceName(log *zerolog.Logger, labels map[string]string) string {
 //
 // Returns:
 //   - string: Container replica number if present, empty string otherwise.
-func GetContainerNumber(log *zerolog.Logger, labels map[string]string) string {
-	if labels == nil {
-		return ""
-	}
-
-	containerNumber, ok := labels[ComposeContainerNumber]
-	if !ok {
-		return ""
-	}
-
-	log.Debug().
-		Str("label", ComposeContainerNumber).
-		Str("value", containerNumber).
-		Msg("Retrieved container replica number")
-
-	return containerNumber
+func GetContainerNumber(labels map[string]string) string {
+	return labels[ComposeContainerNumber]
 }

--- a/pkg/compose/compose_test.go
+++ b/pkg/compose/compose_test.go
@@ -44,7 +44,7 @@ var _ = ginkgo.Describe("Compose", func() {
 	ginkgo.DescribeTable(
 		"GetServiceName",
 		func(labels map[string]string, expected string) {
-			result := GetServiceName(testLog(), labels)
+			result := GetServiceName(labels)
 			gomega.Expect(result).To(gomega.Equal(expected))
 		},
 		ginkgo.Entry("returns empty string for nil labels", nil, ""),
@@ -64,7 +64,7 @@ var _ = ginkgo.Describe("Compose", func() {
 	ginkgo.DescribeTable(
 		"GetProjectName",
 		func(labels map[string]string, expected string) {
-			result := GetProjectName(testLog(), labels)
+			result := GetProjectName(labels)
 			gomega.Expect(result).To(gomega.Equal(expected))
 		},
 		ginkgo.Entry("returns empty string for nil labels", nil, ""),
@@ -84,7 +84,7 @@ var _ = ginkgo.Describe("Compose", func() {
 	ginkgo.DescribeTable(
 		"GetContainerNumber",
 		func(labels map[string]string, expected string) {
-			result := GetContainerNumber(testLog(), labels)
+			result := GetContainerNumber(labels)
 			gomega.Expect(result).To(gomega.Equal(expected))
 		},
 		ginkgo.Entry("returns empty string for nil labels", nil, ""),

--- a/pkg/compose/doc.go
+++ b/pkg/compose/doc.go
@@ -7,13 +7,4 @@
 //     returns a slice of service names.
 //   - GetServiceName: Extracts the service name from Docker Compose labels
 //     using the com.docker.compose.service label.
-//
-// Usage example:
-//
-//	// Callers must provide a non-nil *zerolog.Logger (process logger).
-//	labels := map[string]string{
-//		"com.docker.compose.service": "myservice",
-//	}
-//	services := compose.ParseDependsOnLabel(log, "postgres:service_started:required,redis")
-//	serviceName := compose.GetServiceName(log, labels)
 package compose

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -282,9 +282,9 @@ type Client interface {
 	//   - ctx: Context for cancellation and timeout control.
 	//
 	// Returns:
-	//   - map[string]any: System information.
+	//   - types.SystemInfo: Daemon identity fields used for runtime detection.
 	//   - error: Non-nil if retrieval fails, nil on success.
-	GetInfo(ctx context.Context) (map[string]any, error)
+	GetInfo(ctx context.Context) (types.SystemInfo, error)
 
 	// Ping verifies connectivity to the Docker daemon.
 	//
@@ -767,10 +767,11 @@ func (c *client) StopAndRemoveContainer(ctx context.Context, container types.Con
 //   - types.ContainerID: ID of the new container.
 //   - error: Non-nil if creation fails, nil on success.
 func (c *client) CreateContainer(ctx context.Context, container types.Container) (types.ContainerID, error) {
-	fields := map[string]any{
-		"container": container.Name(),
-		"image":     container.ImageName(),
-	}
+	clogVal := c.logger().With().
+		Str("container", container.Name()).
+		Str("image", container.ImageName()).
+		Logger()
+	clog := &clogVal
 	// Determine if the container runtime is Podman to handle runtime-specific differences.
 	//
 	//nolint:contextcheck // getRuntime uses context.Background() internally for cached detection
@@ -778,15 +779,12 @@ func (c *client) CreateContainer(ctx context.Context, container types.Container)
 
 	clientVersion := c.GetVersion()
 
-	c.logger().Debug().
-		Fields(fields).
+	clog.Debug().
 		Str("client_version", clientVersion).
 		Msg("Obtaining source container network configuration")
 
-	// Get unified network config.
 	networkConfig := getNetworkConfig(c.logger(), container, clientVersion)
 
-	// Create new container with selected config.
 	newID, err := CreateTargetContainer(c.logger(),
 		ctx,
 		c.api,
@@ -799,16 +797,14 @@ func (c *client) CreateContainer(ctx context.Context, container types.Container)
 		isPodman,
 	)
 	if err != nil {
-		c.logger().Debug().
+		clog.Debug().
 			Err(err).
-			Fields(fields).
 			Msg("Failed to create new container")
 
 		return "", err
 	}
 
-	c.logger().Debug().
-		Fields(fields).
+	clog.Debug().
 		Str("new_id", newID.ShortID()).
 		Msg("Created new container")
 
@@ -826,10 +822,11 @@ func (c *client) CreateContainer(ctx context.Context, container types.Container)
 //   - types.ContainerID: ID of the new container.
 //   - error: Non-nil if creation/start fails, nil on success.
 func (c *client) StartContainer(ctx context.Context, container types.Container) (types.ContainerID, error) {
-	fields := map[string]any{
-		"container": container.Name(),
-		"image":     container.ImageName(),
-	}
+	clogVal := c.logger().With().
+		Str("container", container.Name()).
+		Str("image", container.ImageName()).
+		Logger()
+	clog := &clogVal
 
 	// Determine if the container runtime is Podman to handle runtime-specific differences.
 	//
@@ -838,15 +835,12 @@ func (c *client) StartContainer(ctx context.Context, container types.Container) 
 
 	clientVersion := c.GetVersion()
 
-	c.logger().Debug().
-		Fields(fields).
+	clog.Debug().
 		Str("client_version", clientVersion).
 		Msg("Obtaining source container network configuration")
 
-	// Get unified network config.
 	networkConfig := getNetworkConfig(c.logger(), container, clientVersion)
 
-	// Start new container with selected config.
 	newID, err := StartTargetContainer(c.logger(),
 		ctx,
 		c.api,
@@ -860,16 +854,14 @@ func (c *client) StartContainer(ctx context.Context, container types.Container) 
 		isPodman,
 	)
 	if err != nil {
-		c.logger().Debug().
+		clog.Debug().
 			Err(err).
-			Fields(fields).
 			Msg("Failed to start new container")
 
 		return "", err
 	}
 
-	c.logger().Debug().
-		Fields(fields).
+	clog.Debug().
 		Str("new_id", newID.ShortID()).
 		Msg("Started new container")
 
@@ -1424,28 +1416,25 @@ func (c *client) Ping(ctx context.Context) error {
 //   - ctx: Context for cancellation and timeout control.
 //
 // Returns:
-//   - map[string]interface{}: System information.
+//   - types.SystemInfo: Daemon identity fields used for runtime detection.
 //   - error: Non-nil if retrieval fails, nil on success.
-func (c *client) GetInfo(ctx context.Context) (map[string]any, error) {
+func (c *client) GetInfo(ctx context.Context) (types.SystemInfo, error) {
 	info, err := c.api.Info(ctx, dockerClient.InfoOptions{})
 	if err != nil {
 		c.logger().Debug().
 			Err(err).
 			Msg("Failed to get system info")
 
-		return nil, fmt.Errorf("failed to get system info: %w", err)
+		return types.SystemInfo{}, fmt.Errorf("failed to get system info: %w", err)
 	}
 
-	// Convert to map for easier access
-	infoMap := map[string]any{
-		"Name":            info.Info.Name,
-		"ServerVersion":   info.Info.ServerVersion,
-		"OSType":          info.Info.OSType,
-		"OperatingSystem": info.Info.OperatingSystem,
-		"Driver":          info.Info.Driver,
-	}
-
-	return infoMap, nil
+	return types.SystemInfo{
+		Name:            info.Info.Name,
+		ServerVersion:   info.Info.ServerVersion,
+		OSType:          info.Info.OSType,
+		OperatingSystem: info.Info.OperatingSystem,
+		Driver:          info.Info.Driver,
+	}, nil
 }
 
 // GetImageDiskUsage returns Docker image storage usage from the daemon.
@@ -1725,26 +1714,16 @@ func (c *client) detectRuntimeByAPI(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	// Check Name field
-	name, exists := info["Name"]
-	if exists && name == "podman" {
+	if info.Name == "podman" {
 		c.logger().Debug().Msg("Detected Podman via API Name field")
 
 		return true, nil
 	}
 
-	// Check ServerVersion field
-	serverVersion, exists := info["ServerVersion"]
-	if exists {
-		sv, ok := serverVersion.(string)
-		if ok && strings.Contains(
-			strings.ToLower(sv),
-			"podman",
-		) {
-			c.logger().Debug().Msg("Detected Podman via API ServerVersion field")
+	if strings.Contains(strings.ToLower(info.ServerVersion), "podman") {
+		c.logger().Debug().Msg("Detected Podman via API ServerVersion field")
 
-			return true, nil
-		}
+		return true, nil
 	}
 
 	c.logger().Debug().Msg("No Podman detection criteria met, assuming Docker")

--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -1666,8 +1666,7 @@ var _ = ginkgo.Describe("the client", func() {
 
 			info, err := testClient.GetInfo(context.Background())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(info).NotTo(gomega.BeNil())
-			gomega.Expect(info["Name"]).To(gomega.Equal("docker-server"))
+			gomega.Expect(info.Name).To(gomega.Equal("docker-server"))
 		})
 
 		ginkgo.It("GetInfo handles TLS connection failures gracefully", func() {
@@ -1713,11 +1712,13 @@ var _ = ginkgo.Describe("the client", func() {
 
 			info, err := testClient.GetInfo(context.Background())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(info).To(gomega.HaveKeyWithValue("Name", "test-docker"))
-			gomega.Expect(info).To(gomega.HaveKeyWithValue("ServerVersion", "25.0.0"))
-			gomega.Expect(info).To(gomega.HaveKeyWithValue("OSType", "linux"))
-			gomega.Expect(info).To(gomega.HaveKeyWithValue("OperatingSystem", "Alpine Linux"))
-			gomega.Expect(info).To(gomega.HaveKeyWithValue("Driver", "btrfs"))
+			gomega.Expect(info).To(gomega.Equal(types.SystemInfo{
+				Name:            "test-docker",
+				ServerVersion:   "25.0.0",
+				OSType:          "linux",
+				OperatingSystem: "Alpine Linux",
+				Driver:          "btrfs",
+			}))
 		})
 	})
 

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -3,6 +3,7 @@ package container
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 
@@ -387,15 +388,15 @@ func (c *Container) GetCreateConfig() *dockerContainer.Config {
 		config.Hostname = "" // Clear hostname for UTS mode.
 	}
 
-	if util.SliceEqual(config.Entrypoint, imageConfig.Entrypoint) {
+	if slices.Equal(config.Entrypoint, imageConfig.Entrypoint) {
 		config.Entrypoint = nil
-		if util.SliceEqual(config.Cmd, imageConfig.Cmd) {
+		if slices.Equal(config.Cmd, imageConfig.Cmd) {
 			config.Cmd = nil
 		}
 	}
 	// Clear HEALTHCHECK if it matches the image default.
 	if config.Healthcheck != nil && imageConfig.Healthcheck != nil {
-		if util.SliceEqual(config.Healthcheck.Test, imageConfig.Healthcheck.Test) {
+		if slices.Equal(config.Healthcheck.Test, imageConfig.Healthcheck.Test) {
 			config.Healthcheck.Test = nil
 		}
 
@@ -799,9 +800,9 @@ func ResolveContainerIdentifier(c types.Container) string {
 		return nameOrID(c)
 	}
 
-	projectName := compose.GetProjectName(nopLog(), labels)
-	serviceName := compose.GetServiceName(nopLog(), labels)
-	containerNumber := compose.GetContainerNumber(nopLog(), labels)
+	projectName := compose.GetProjectName(labels)
+	serviceName := compose.GetServiceName(labels)
+	containerNumber := compose.GetContainerNumber(labels)
 
 	// Handle replica containers
 	if projectName != "" && serviceName != "" &&
@@ -923,7 +924,7 @@ func getLinksFromComposeLabel(c *Container, clog *zerolog.Logger) []string {
 
 	services := compose.ParseDependsOnLabel(clog, composeDependsOnLabelValue)
 
-	projectName := compose.GetProjectName(clog, c.containerInfo.Config.Labels)
+	projectName := compose.GetProjectName(c.containerInfo.Config.Labels)
 
 	normalizedLinks := make([]string, 0, len(services))
 	for _, service := range services {
@@ -966,7 +967,7 @@ func getLinksFromHostConfig(c *Container, clog *zerolog.Logger) []string {
 		return nil
 	}
 
-	projectName := compose.GetProjectName(clog, c.containerInfo.Config.Labels)
+	projectName := compose.GetProjectName(c.containerInfo.Config.Labels)
 
 	// Pre-allocate for links plus potential network mode dependency
 	capacity := len(c.containerInfo.HostConfig.Links)

--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -395,12 +395,9 @@ func (c imageClient) PullImage(
 	warnOnHeadFailed WarningStrategy,
 	params types.UpdateParams,
 ) error {
-	fields := map[string]any{
-		"container": sourceContainer.Name(),
-		"image":     sourceContainer.ImageName(),
-	}
 	clogVal := c.logger().With().
-		Fields(fields).
+		Str("container", sourceContainer.Name()).
+		Str("image", sourceContainer.ImageName()).
 		Logger()
 	clog := &clogVal
 
@@ -429,7 +426,7 @@ func (c imageClient) PullImage(
 	}
 
 	// Skip the pull if the digest matches the current image (or local-only).
-	skip, skipErr := c.shouldSkipPull(ctx, sourceContainer, opts.RegistryAuth, warnOnHeadFailed, fields)
+	skip, skipErr := c.shouldSkipPull(ctx, sourceContainer, opts.RegistryAuth, warnOnHeadFailed)
 	if skipErr != nil {
 		return skipErr
 	}
@@ -445,7 +442,7 @@ func (c imageClient) PullImage(
 		return cooldownErr
 	}
 
-	return c.performImagePull(ctx, sourceContainer.ImageName(), opts, fields)
+	return c.performImagePull(ctx, sourceContainer.ImageName(), opts)
 }
 
 // RemoveImageByID deletes an image from the Docker host.
@@ -615,7 +612,6 @@ func newImageClient(api dockerClient.APIClient, log *zerolog.Logger) imageClient
 //   - sourceContainer: Container to check.
 //   - registryAuth: Registry authentication credentials.
 //   - warnOnHeadFailed: Strategy for logging warnings on HEAD request failures.
-//   - fields: Logging fields for context.
 //
 // Returns:
 //   - bool: True if pull can be skipped, false otherwise.
@@ -625,10 +621,10 @@ func (c imageClient) shouldSkipPull(
 	sourceContainer types.Container,
 	registryAuth string,
 	warnOnHeadFailed WarningStrategy,
-	fields map[string]any,
 ) (bool, error) {
 	clogVal := c.logger().With().
-		Fields(fields).
+		Str("container", sourceContainer.Name()).
+		Str("image", sourceContainer.ImageName()).
 		Logger()
 	clog := &clogVal
 	clog.Debug().Msg("Checking if pull is needed")
@@ -697,7 +693,6 @@ func (c imageClient) shouldSkipPull(
 //   - ctx: Context for operation control.
 //   - imageName: Image to pull.
 //   - opts: Pull options with auth.
-//   - fields: Logging fields for context.
 //
 // Returns:
 //   - error: Non-nil if pull or read fails, nil on success.
@@ -705,10 +700,9 @@ func (c imageClient) performImagePull(
 	ctx context.Context,
 	imageName string,
 	opts dockerClient.ImagePullOptions,
-	fields map[string]any,
 ) error {
 	clogVal := c.logger().With().
-		Fields(fields).
+		Str("image", imageName).
 		Logger()
 	clog := &clogVal
 	clog.Debug().Msg("Initiating image pull")

--- a/pkg/container/image_test.go
+++ b/pkg/container/image_test.go
@@ -208,7 +208,6 @@ var _ = ginkgo.Describe("the client", func() {
 				context.Background(),
 				"registry.example.com/app:latest",
 				dockerClient.ImagePullOptions{},
-				nil,
 			)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
@@ -233,7 +232,6 @@ var _ = ginkgo.Describe("the client", func() {
 				context.Background(),
 				"ghcr.io/linuxserver/nginx:latest",
 				dockerClient.ImagePullOptions{},
-				nil,
 			)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(ratelimit.Is(err)).To(gomega.BeTrue())
@@ -258,7 +256,6 @@ var _ = ginkgo.Describe("the client", func() {
 				ctx,
 				"ghcr.io/linuxserver/nginx:latest",
 				dockerClient.ImagePullOptions{},
-				nil,
 			)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(ratelimit.Is(err)).To(gomega.BeTrue())
@@ -329,7 +326,6 @@ var _ = ginkgo.Describe("the client", func() {
 					ctx,
 					"ghcr.io/linuxserver/nginx:latest",
 					dockerClient.ImagePullOptions{RegistryAuth: "e30="},
-					nil,
 				)
 			}()
 
@@ -341,7 +337,6 @@ var _ = ginkgo.Describe("the client", func() {
 					ctx,
 					"ghcr.io/linuxserver/nginx:latest",
 					dockerClient.ImagePullOptions{},
-					nil,
 				)
 			}()
 
@@ -381,7 +376,6 @@ var _ = ginkgo.Describe("the client", func() {
 					ctx,
 					"ghcr.io/linuxserver/nginx:latest",
 					dockerClient.ImagePullOptions{},
-					nil,
 				)
 			}()
 
@@ -392,7 +386,6 @@ var _ = ginkgo.Describe("the client", func() {
 				ctx,
 				"registry.example.com/app:latest",
 				dockerClient.ImagePullOptions{},
-				nil,
 			)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(time.Since(started)).To(gomega.BeNumerically("<", 300*time.Millisecond))
@@ -440,7 +433,6 @@ var _ = ginkgo.Describe("the client", func() {
 					ctx,
 					"ghcr.io/linuxserver/nginx:latest",
 					dockerClient.ImagePullOptions{},
-					nil,
 				)
 			}()
 
@@ -452,7 +444,6 @@ var _ = ginkgo.Describe("the client", func() {
 					ctx,
 					"ghcr.io/linuxserver/radarr:latest",
 					dockerClient.ImagePullOptions{},
-					nil,
 				)
 			}()
 

--- a/pkg/container/mocks/Client.go
+++ b/pkg/container/mocks/Client.go
@@ -19,10 +19,19 @@ func NewMockClient(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockClient {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockClient{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }
@@ -561,24 +570,22 @@ func (_c *MockClient_GetImageDiskUsage_Call) RunAndReturn(run func(ctx context.C
 }
 
 // GetInfo provides a mock function for the type MockClient
-func (_mock *MockClient) GetInfo(ctx context.Context) (map[string]any, error) {
+func (_mock *MockClient) GetInfo(ctx context.Context) (types.SystemInfo, error) {
 	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetInfo")
 	}
 
-	var r0 map[string]any
+	var r0 types.SystemInfo
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context) (map[string]any, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (types.SystemInfo, error)); ok {
 		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context) map[string]any); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context) types.SystemInfo); ok {
 		r0 = returnFunc(ctx)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]any)
-		}
+		r0 = ret.Get(0).(types.SystemInfo)
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
 		r1 = returnFunc(ctx)
@@ -612,12 +619,12 @@ func (_c *MockClient_GetInfo_Call) Run(run func(ctx context.Context)) *MockClien
 	return _c
 }
 
-func (_c *MockClient_GetInfo_Call) Return(stringToAnyMoqParam map[string]any, err error) *MockClient_GetInfo_Call {
-	_c.Call.Return(stringToAnyMoqParam, err)
+func (_c *MockClient_GetInfo_Call) Return(systemInfo types.SystemInfo, err error) *MockClient_GetInfo_Call {
+	_c.Call.Return(systemInfo, err)
 	return _c
 }
 
-func (_c *MockClient_GetInfo_Call) RunAndReturn(run func(ctx context.Context) (map[string]any, error)) *MockClient_GetInfo_Call {
+func (_c *MockClient_GetInfo_Call) RunAndReturn(run func(ctx context.Context) (types.SystemInfo, error)) *MockClient_GetInfo_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/container/mocks/Operations.go
+++ b/pkg/container/mocks/Operations.go
@@ -17,10 +17,19 @@ func NewMockOperations(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockOperations {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockOperations{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/pkg/notifications/mocks/router.go
+++ b/pkg/notifications/mocks/router.go
@@ -15,10 +15,19 @@ func newMockrouter(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *mockrouter {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &mockrouter{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/pkg/registry/auth/mocks/Client.go
+++ b/pkg/registry/auth/mocks/Client.go
@@ -16,10 +16,19 @@ func NewMockClient(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockClient {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockClient{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -32,45 +32,32 @@ var (
 //   - image.PullOptions: Configured pull options if successful.
 //   - error: Non-nil if auth retrieval fails, nil on success.
 func GetPullOptions(log *zerolog.Logger, imageName string) (dockerClient.ImagePullOptions, error) {
-	// Set up logging fields for consistent tracking.
-	fields := map[string]any{
-		"image": imageName,
-	}
+	clogVal := log.With().Str("image", imageName).Logger()
+	clog := &clogVal
 
-	log.Debug().
-		Fields(fields).
-		Msg("Retrieving pull options")
+	clog.Debug().Msg("Retrieving pull options")
 
-	// Fetch encoded registry credentials for the image.
 	registryCredentials, err := EncodedAuth(log, imageName)
 	if err != nil {
-		log.Debug().
+		clog.Debug().
 			Err(err).
-			Fields(fields).
 			Msg("Failed to get authentication credentials")
 
 		return dockerClient.ImagePullOptions{}, fmt.Errorf("%w: %w", errFailedGetAuth, err)
 	}
 
-	// Return empty options if no auth is available.
 	if registryCredentials == "" {
-		log.Debug().
-			Fields(fields).
-			Msg("No authentication credentials retrieved")
+		clog.Debug().Msg("No authentication credentials retrieved")
 
 		return dockerClient.ImagePullOptions{}, nil
 	}
 
-	// Log non-sensitive context only in trace mode.
-	// Never log credential payload.
-	if log.GetLevel() == zerolog.TraceLevel {
-		log.Trace().
-			Fields(fields).
+	if clog.GetLevel() == zerolog.TraceLevel {
+		clog.Trace().
 			Bool("has_credentials", true).
 			Msg("Retrieved authentication credentials")
 	}
 
-	// Configure pull options with auth and a default privilege handler.
 	pullOptions := dockerClient.ImagePullOptions{
 		RegistryAuth: registryCredentials,
 		PrivilegeFunc: func(ctx context.Context) (string, error) {
@@ -78,9 +65,7 @@ func GetPullOptions(log *zerolog.Logger, imageName string) (dockerClient.ImagePu
 		},
 	}
 
-	log.Debug().
-		Fields(fields).
-		Msg("Configured pull options")
+	clog.Debug().Msg("Configured pull options")
 
 	return pullOptions, nil
 }
@@ -112,47 +97,39 @@ func DefaultAuthHandler(log *zerolog.Logger, _ context.Context) (string, error) 
 // Returns:
 //   - bool: True if a warning is warranted, false otherwise.
 func WarnOnAPIConsumption(log *zerolog.Logger, container types.Container) bool {
-	// Set up logging fields for tracking.
-	fields := map[string]any{
-		"container": container.Name(),
-		"image":     container.ImageName(),
-	}
+	clogVal := log.With().
+		Str("container", container.Name()).
+		Str("image", container.ImageName()).
+		Logger()
+	clog := &clogVal
 
-	// Parse the image name into a normalized reference.
 	normalizedRef, err := reference.ParseNormalizedNamed(container.ImageName())
 	if err != nil {
-		log.Debug().
+		clog.Debug().
 			Err(err).
-			Fields(fields).
 			Msg("Failed to parse image reference, assuming API consumption")
 
 		return true
 	}
 
-	// Extract the registry host from the reference.
 	containerHost, err := auth.GetRegistryAddress(log, normalizedRef.Name())
 	if err != nil {
-		log.Debug().
+		clog.Debug().
 			Err(err).
-			Fields(fields).
 			Msg("Failed to get registry address, assuming API consumption")
 
 		return true
 	}
 
-	// Check if the registry is known to support HEAD requests.
 	if containerHost == hosts.DockerRegistryHost || containerHost == hosts.GitHubRegistryDomain {
-		log.Debug().
-			Fields(fields).
+		clog.Debug().
 			Str("host", containerHost).
 			Msg("Registry supports HEAD requests, warning on API consumption")
 
 		return true
 	}
 
-	// No warning if registry behavior is unknown.
-	log.Debug().
-		Fields(fields).
+	clog.Debug().
 		Str("host", containerHost).
 		Msg("Registry behavior unknown, no API consumption warning")
 

--- a/pkg/sorter/mocks/Sorter.go
+++ b/pkg/sorter/mocks/Sorter.go
@@ -16,10 +16,19 @@ func NewMockSorter(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockSorter {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockSorter{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/pkg/types/mocks/Container.go
+++ b/pkg/types/mocks/Container.go
@@ -19,10 +19,19 @@ func NewMockContainer(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockContainer {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockContainer{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/pkg/types/mocks/ContainerReport.go
+++ b/pkg/types/mocks/ContainerReport.go
@@ -15,10 +15,19 @@ func NewMockContainerReport(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockContainerReport {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockContainerReport{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/pkg/types/mocks/ConvertibleNotifier.go
+++ b/pkg/types/mocks/ConvertibleNotifier.go
@@ -15,10 +15,19 @@ func NewMockConvertibleNotifier(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockConvertibleNotifier {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockConvertibleNotifier{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/pkg/types/mocks/DelayNotifier.go
+++ b/pkg/types/mocks/DelayNotifier.go
@@ -16,10 +16,19 @@ func NewMockDelayNotifier(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockDelayNotifier {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockDelayNotifier{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/pkg/types/mocks/FilterableContainer.go
+++ b/pkg/types/mocks/FilterableContainer.go
@@ -14,10 +14,19 @@ func NewMockFilterableContainer(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockFilterableContainer {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockFilterableContainer{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/pkg/types/mocks/Notifier.go
+++ b/pkg/types/mocks/Notifier.go
@@ -16,10 +16,19 @@ func NewMockNotifier(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockNotifier {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockNotifier{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/pkg/types/mocks/Report.go
+++ b/pkg/types/mocks/Report.go
@@ -15,10 +15,19 @@ func NewMockReport(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockReport {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockReport{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/pkg/types/system_info.go
+++ b/pkg/types/system_info.go
@@ -1,0 +1,10 @@
+package types
+
+// SystemInfo is a subset of Docker/Podman daemon info used by Watchtower.
+type SystemInfo struct {
+	Name            string
+	ServerVersion   string
+	OSType          string
+	OperatingSystem string
+	Driver          string
+}


### PR DESCRIPTION
This PR stops carrying daemon info and compose labels as untyped maps and drops helpers that only existed to recover those types. Runtime detection, compose depends-on parsing, and label lookups now use concrete values. Logging at a few call sites uses typed zerolog fields instead of map[string]any.

## Problem

GetInfo converted Docker daemon info into map[string]any and then type-asserted Name and ServerVersion back out for Podman detection. Compose label getters took a logger only to debug-log map lookups, and depends-on JSON was decoded into map[string]any even though only keys are used. util.SliceEqual reimplemented slices.Equal, and MinInt was unused.

## Solution

Return a types.SystemInfo struct from GetInfo and read those fields directly. Decode compose depends-on JSON as map[string]json.RawMessage and look up label values with a plain map read. Replace SliceEqual with slices.Equal, delete MinInt, and attach container and image log fields with Str.

## Changes

- Add types.SystemInfo and return it from Client.GetInfo
- Parse compose depends-on JSON for keys only and drop logger args from label getters
- Use slices.Equal for image config comparison and remove unused util helpers
- Replace map[string]any logging maps with typed zerolog fields in container, registry, and ephemeral paths